### PR TITLE
Lint static function order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,12 @@ repos:
     files: \.c$
     exclude: ^src/tests/
 
+  - id: lint-module-static
+    name: Module functions are static
+    entry: tools/lint/checks/module_static
+    language: python
+    files: \.c$
+
   - id: lint-gameflow-schema
     name: Gameflow files match the schema
     entry: tools/lint/checks/gameflow_schema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,13 @@ repos:
     language: python
     files: \.c$
 
+  - id: lint-static-order
+    name: Static functions come before public ones
+    entry: tools/lint/checks/static_order
+    language: python
+    files: \.c$
+    exclude: ^src/tests/
+
   - id: lint-gameflow-schema
     name: Gameflow files match the schema
     entry: tools/lint/checks/gameflow_schema

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -54,6 +54,77 @@ __attribute__((destructor)) static void M_Shutdown(void)
     ConfigOverride_Shutdown();
 }
 
+static bool M_RestoreOptionDefault(const void *const target, const bool force)
+{
+    if (target == nullptr) {
+        return false;
+    }
+    const CONFIG_OPTION *option = Config_GetOption(target);
+    if (option == nullptr) {
+        return false;
+    }
+    if (!force && Config_IsOptionEnforced(target)) {
+        return false;
+    }
+    // The string default is stored inline, so it is not a `char **` that
+    // Value_CopyPtr could read; copy it here. The free-after-allocate order (so
+    // subscribers see the pointer move) lives in Value_CopyPtr for the rest.
+    if (option->type == TVT_STRING || option->type == TVT_DYNAMIC_ENUM) {
+        char **const p = (char **)option->target;
+        const char *const def = (const char *)option->default_value;
+        char *const old = *p;
+        *p = def != nullptr ? Memory_DupStr(def) : nullptr;
+        Memory_Free(old);
+        return true;
+    }
+    Value_CopyPtr(option->type, (void *)option->target, option->default_value);
+    return true;
+}
+
+// The extra argument the value parse and format calls need: the EnumMap name
+// for an enum, the dynamic enum registry token for a dynamic enum, nothing
+// else.
+static const void *M_ValueParam(const CONFIG_OPTION *const option)
+{
+    return option->type == TVT_DYNAMIC_ENUM ? option->target : option->param;
+}
+
+// The two presentations Value_Format does not carry, because each reaches past
+// the stored value: a bool as a localized on/off, and a float as a percentage.
+static const char *M_FormatBoolHuman(const bool value)
+{
+    return value ? GS("general/misc/on") : GS("general/misc/off");
+}
+
+static const char *M_FormatFloatPercent(const float value)
+{
+    return String_FormatStatic("%.0f%%", value);
+}
+
+static bool M_SetOptionValueFromString(
+    const CONFIG_OPTION *const option, const char *const new_value,
+    const bool force)
+{
+    ASSERT(option != nullptr);
+    ASSERT(option->target != nullptr);
+    if (!force && Config_IsOptionEnforced(option->target)) {
+        return false;
+    }
+    TRX_VALUE parsed;
+    if (!Value_Parse(option->type, M_ValueParam(option), new_value, &parsed)) {
+        return false;
+    }
+    if (option->type == TVT_STRING || option->type == TVT_DYNAMIC_ENUM) {
+        Value_CopyPtr(option->type, (void *)option->target, &parsed.as_str);
+        return true;
+    }
+    if (option->percent) {
+        parsed.as_num /= 100.0;
+    }
+    return Value_WritePtr(option->type, (void *)option->target, &parsed)
+        == nullptr;
+}
+
 void Config_ApplyDefaultSettings(void)
 {
     const CONFIG_OPTION *option = Config_GetOptionMap();
@@ -219,33 +290,6 @@ bool Config_IsOptionAtDefault(const void *const target)
     return Value_EqualPtr(option->type, option->target, option->default_value);
 }
 
-static bool M_RestoreOptionDefault(const void *const target, const bool force)
-{
-    if (target == nullptr) {
-        return false;
-    }
-    const CONFIG_OPTION *option = Config_GetOption(target);
-    if (option == nullptr) {
-        return false;
-    }
-    if (!force && Config_IsOptionEnforced(target)) {
-        return false;
-    }
-    // The string default is stored inline, so it is not a `char **` that
-    // Value_CopyPtr could read; copy it here. The free-after-allocate order (so
-    // subscribers see the pointer move) lives in Value_CopyPtr for the rest.
-    if (option->type == TVT_STRING || option->type == TVT_DYNAMIC_ENUM) {
-        char **const p = (char **)option->target;
-        const char *const def = (const char *)option->default_value;
-        char *const old = *p;
-        *p = def != nullptr ? Memory_DupStr(def) : nullptr;
-        Memory_Free(old);
-        return true;
-    }
-    Value_CopyPtr(option->type, (void *)option->target, option->default_value);
-    return true;
-}
-
 bool Config_RestoreOptionDefault(const void *const target)
 {
     return M_RestoreOptionDefault(target, false);
@@ -254,26 +298,6 @@ bool Config_RestoreOptionDefault(const void *const target)
 bool Config_RestoreOptionDefaultForce(const void *const target)
 {
     return M_RestoreOptionDefault(target, true);
-}
-
-// The extra argument the value parse and format calls need: the EnumMap name
-// for an enum, the dynamic enum registry token for a dynamic enum, nothing
-// else.
-static const void *M_ValueParam(const CONFIG_OPTION *const option)
-{
-    return option->type == TVT_DYNAMIC_ENUM ? option->target : option->param;
-}
-
-// The two presentations Value_Format does not carry, because each reaches past
-// the stored value: a bool as a localized on/off, and a float as a percentage.
-static const char *M_FormatBoolHuman(const bool value)
-{
-    return value ? GS("general/misc/on") : GS("general/misc/off");
-}
-
-static const char *M_FormatFloatPercent(const float value)
-{
-    return String_FormatStatic("%.0f%%", value);
 }
 
 const char *Config_GetOptionValueAsString(
@@ -333,30 +357,6 @@ char *Config_NormalizeOptionValueString(
     }
     return Memory_DupStr(Value_Format(
         option->type, M_ValueParam(option), &parsed, human_readable));
-}
-
-static bool M_SetOptionValueFromString(
-    const CONFIG_OPTION *const option, const char *const new_value,
-    const bool force)
-{
-    ASSERT(option != nullptr);
-    ASSERT(option->target != nullptr);
-    if (!force && Config_IsOptionEnforced(option->target)) {
-        return false;
-    }
-    TRX_VALUE parsed;
-    if (!Value_Parse(option->type, M_ValueParam(option), new_value, &parsed)) {
-        return false;
-    }
-    if (option->type == TVT_STRING || option->type == TVT_DYNAMIC_ENUM) {
-        Value_CopyPtr(option->type, (void *)option->target, &parsed.as_str);
-        return true;
-    }
-    if (option->percent) {
-        parsed.as_num /= 100.0;
-    }
-    return Value_WritePtr(option->type, (void *)option->target, &parsed)
-        == nullptr;
 }
 
 bool Config_SetOptionValueFromString(

--- a/src/trx/core/colors.c
+++ b/src/trx/core/colors.c
@@ -8,6 +8,22 @@
     #define M_PI 3.14159265358979323846
 #endif
 
+static float M_SRGBToLinear(const float c)
+{
+    if (c <= 0.04045f) {
+        return c / 12.92f;
+    }
+    return powf((c + 0.055f) / 1.055f, 2.4f);
+}
+
+static float M_LinearToSRGB(const float c)
+{
+    if (c <= 0.0031308f) {
+        return c * 12.92f;
+    }
+    return 1.055f * powf(c, 1.0f / 2.4f) - 0.055f;
+}
+
 RGBA_8888 Color_RGB888ToRGBA8888_Impl(const RGB_888 color)
 {
     return Color_RGB888ToRGBA8888Ex_Impl(color, 255);
@@ -171,22 +187,6 @@ void Color_RGBToHSL(
     *out_h = hue;
     *out_s = sat;
     *out_l = light;
-}
-
-static float M_SRGBToLinear(const float c)
-{
-    if (c <= 0.04045f) {
-        return c / 12.92f;
-    }
-    return powf((c + 0.055f) / 1.055f, 2.4f);
-}
-
-static float M_LinearToSRGB(const float c)
-{
-    if (c <= 0.0031308f) {
-        return c * 12.92f;
-    }
-    return 1.055f * powf(c, 1.0f / 2.4f) - 0.055f;
 }
 
 RGB_888 Color_OKLCHToRGB(const float l, const float c, const float h)

--- a/src/trx/core/json/util/read_io.c
+++ b/src/trx/core/json/util/read_io.c
@@ -254,45 +254,6 @@ static bool M_ReadStringCurrent(
     return *target != nullptr;
 }
 
-bool JSON_ReadIO_ReadXYZ32Current(
-    JSON_READ_IO *const io, void *const target_void)
-{
-    XYZ_32 *const target = target_void;
-    JSON_ARRAY *const tuple = JSON_ValueAsArray(io->current);
-    if (tuple != nullptr) {
-        const int32_t tuple_len = tuple->length;
-        if (tuple_len != 3) {
-            M_SetError(io, "XYZ tuple must have exactly 3 values");
-            JSON_FAIL();
-        }
-        JSON_MUST(JSON_READ_A(io, 0, &target->x));
-        JSON_MUST(JSON_READ_A(io, 1, &target->y));
-        JSON_MUST(JSON_READ_A(io, 2, &target->z));
-    } else {
-        JSON_MUST(JSON_READ(io, "x", &target->x));
-        JSON_MUST(JSON_READ(io, "y", &target->y));
-        JSON_MUST(JSON_READ(io, "z", &target->z));
-    }
-    JSON_FINISH();
-}
-
-bool JSON_ReadIO_ReadXYZ16Current(
-    JSON_READ_IO *const io, void *const target_void)
-{
-    XYZ_32 tmp;
-    JSON_MUST(JSON_ReadIO_ReadXYZ32Current(io, &tmp));
-    if (tmp.x < INT16_MIN || tmp.x > INT16_MAX || tmp.y < INT16_MIN
-        || tmp.y > INT16_MAX || tmp.z < INT16_MIN || tmp.z > INT16_MAX) {
-        M_SetError(io, "XYZ16 value out of range");
-        JSON_FAIL();
-    }
-    XYZ_16 *const target = target_void;
-    target->x = tmp.x;
-    target->y = tmp.y;
-    target->z = tmp.z;
-    JSON_FINISH();
-}
-
 static bool M_ReadRGB888Current(JSON_READ_IO *const io, RGB_888 *const target)
 {
     JSON_ARRAY *const tuple = JSON_ValueAsArray(io->current);
@@ -339,6 +300,45 @@ static bool M_ReadRGBA8888Current(
         M_SetError(io, "invalid RGBA color string");
         JSON_FAIL();
     }
+    JSON_FINISH();
+}
+
+bool JSON_ReadIO_ReadXYZ32Current(
+    JSON_READ_IO *const io, void *const target_void)
+{
+    XYZ_32 *const target = target_void;
+    JSON_ARRAY *const tuple = JSON_ValueAsArray(io->current);
+    if (tuple != nullptr) {
+        const int32_t tuple_len = tuple->length;
+        if (tuple_len != 3) {
+            M_SetError(io, "XYZ tuple must have exactly 3 values");
+            JSON_FAIL();
+        }
+        JSON_MUST(JSON_READ_A(io, 0, &target->x));
+        JSON_MUST(JSON_READ_A(io, 1, &target->y));
+        JSON_MUST(JSON_READ_A(io, 2, &target->z));
+    } else {
+        JSON_MUST(JSON_READ(io, "x", &target->x));
+        JSON_MUST(JSON_READ(io, "y", &target->y));
+        JSON_MUST(JSON_READ(io, "z", &target->z));
+    }
+    JSON_FINISH();
+}
+
+bool JSON_ReadIO_ReadXYZ16Current(
+    JSON_READ_IO *const io, void *const target_void)
+{
+    XYZ_32 tmp;
+    JSON_MUST(JSON_ReadIO_ReadXYZ32Current(io, &tmp));
+    if (tmp.x < INT16_MIN || tmp.x > INT16_MAX || tmp.y < INT16_MIN
+        || tmp.y > INT16_MAX || tmp.z < INT16_MIN || tmp.z > INT16_MAX) {
+        M_SetError(io, "XYZ16 value out of range");
+        JSON_FAIL();
+    }
+    XYZ_16 *const target = target_void;
+    target->x = tmp.x;
+    target->y = tmp.y;
+    target->z = tmp.z;
     JSON_FINISH();
 }
 

--- a/src/trx/core/json/write.c
+++ b/src/trx/core/json/write.c
@@ -557,48 +557,6 @@ static char *M_WriteValue_Minified(const JSON_VALUE *value, char *data)
     }
 }
 
-void *JSON_WriteMinified(const JSON_VALUE *value, size_t *out_size)
-{
-    size_t size = 0;
-    char *data = nullptr;
-    char *data_end = nullptr;
-
-    if (nullptr == value) {
-        return nullptr;
-    }
-
-    if (M_GetValueSize_Minified(value, &size)) {
-        /* value was malformed! */
-        return nullptr;
-    }
-
-    size += 1; /* for the '\0' null terminating character. */
-
-    data = (char *)Memory_Alloc(size);
-
-    if (nullptr == data) {
-        /* malloc failed! */
-        return nullptr;
-    }
-
-    data_end = M_WriteValue_Minified(value, data);
-
-    if (nullptr == data_end) {
-        /* bad chi occurred! */
-        Memory_Free(data);
-        return nullptr;
-    }
-
-    /* null terminated the string. */
-    *data_end = '\0';
-
-    if (nullptr != out_size) {
-        *out_size = size;
-    }
-
-    return data;
-}
-
 static int M_GetArraySize_Pretty(
     const JSON_ARRAY *array, size_t depth, size_t indent_size,
     size_t newline_size, size_t *size)
@@ -874,6 +832,48 @@ static char *M_WriteValue_Pretty(
         data[3] = 'l';
         return data + 4;
     }
+}
+
+void *JSON_WriteMinified(const JSON_VALUE *value, size_t *out_size)
+{
+    size_t size = 0;
+    char *data = nullptr;
+    char *data_end = nullptr;
+
+    if (nullptr == value) {
+        return nullptr;
+    }
+
+    if (M_GetValueSize_Minified(value, &size)) {
+        /* value was malformed! */
+        return nullptr;
+    }
+
+    size += 1; /* for the '\0' null terminating character. */
+
+    data = (char *)Memory_Alloc(size);
+
+    if (nullptr == data) {
+        /* malloc failed! */
+        return nullptr;
+    }
+
+    data_end = M_WriteValue_Minified(value, data);
+
+    if (nullptr == data_end) {
+        /* bad chi occurred! */
+        Memory_Free(data);
+        return nullptr;
+    }
+
+    /* null terminated the string. */
+    *data_end = '\0';
+
+    if (nullptr != out_size) {
+        *out_size = size;
+    }
+
+    return data;
 }
 
 void *JSON_WritePretty(

--- a/src/trx/game/camera/binoculars.c
+++ b/src/trx/game/camera/binoculars.c
@@ -181,22 +181,6 @@ static void M_EmitTorch(const XYZ_32 start, const XYZ_32 end)
     }
 }
 
-void Camera_Binoculars_Reset(void)
-{
-    m_Active = false;
-    m_Pending = false;
-    m_TorchActive = false;
-#define M_RESET_SUPPRESS_FLAG(name, field) m_Suppress##name = false;
-    M_FOR_EACH_EXIT_INPUT(M_RESET_SUPPRESS_FLAG)
-#undef M_RESET_SUPPRESS_FLAG
-    m_Range = M_MIN_RANGE;
-}
-
-void Camera_Binoculars_Request(void)
-{
-    m_Pending = true;
-}
-
 // Swallow the key that closed the binoculars until it is released, so that
 // it does not trigger an immediate action (e.g. drawing a weapon, entering
 // look mode, or opening the inventory ring).
@@ -213,6 +197,22 @@ static void M_SuppressExitInputs(void)
     }
     M_FOR_EACH_EXIT_INPUT(M_SUPPRESS_EXIT_INPUT)
 #undef M_SUPPRESS_EXIT_INPUT
+}
+
+void Camera_Binoculars_Reset(void)
+{
+    m_Active = false;
+    m_Pending = false;
+    m_TorchActive = false;
+#define M_RESET_SUPPRESS_FLAG(name, field) m_Suppress##name = false;
+    M_FOR_EACH_EXIT_INPUT(M_RESET_SUPPRESS_FLAG)
+#undef M_RESET_SUPPRESS_FLAG
+    m_Range = M_MIN_RANGE;
+}
+
+void Camera_Binoculars_Request(void)
+{
+    m_Pending = true;
 }
 
 void Camera_Binoculars_Control(void)

--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -62,160 +62,6 @@ static XYZ_32 M_GetMidPos(const ITEM *const item)
     return pos;
 }
 
-// This routine transforms the world-space LOS segment [start,target] into the
-// object's local coordinates (undoing its translation and Y-rotation), then
-// performs a slab intersection test against that local AABB. The first
-// smashable item hit is returned, or NO_ITEM if none.
-//
-// (AABB = Axis-Aligned Bounding Box. It's the rectangular box defined by
-// bounds->min/max along X,Y,Z in the object's local space (no rotation).)
-//
-// @param start  World-space ray origin
-// @param target World-space ray end
-// @param item   Item to check
-// @return       Whether the item collides with the segment
-bool LOS_CheckItemIntersectSegment(
-    const GAME_VECTOR *const start, GAME_VECTOR *const target,
-    const ITEM *const item)
-{
-    const double dx = target->x - start->x;
-    const double dy = target->y - start->y;
-    const double dz = target->z - start->z;
-
-    // Translate into object-local space
-    const double ox = start->x - item->pos.x;
-    const double oy = start->y - item->pos.y;
-    const double oz = start->z - item->pos.z;
-
-    // Unrotate by -rot.y around Y axis
-    const float c = cosf(-item->rot.y * M_PI / DEG_180);
-    const float s = sinf(-item->rot.y * M_PI / DEG_180);
-    const double lx = ox * c + oz * s;
-    const double ly = oy;
-    const double lz = oz * c - ox * s;
-    const double ldx = dx * c + dz * s;
-    const double ldy = dy;
-    const double ldz = dz * c - dx * s;
-
-    // Local AABB extents from item's bounds
-    const BOUNDS_16 *const orig_bounds = Item_GetBoundsAccurate(item);
-    BOUNDS_16 patched_bounds = *orig_bounds;
-
-    const BOUNDS_16 *const bounds = &patched_bounds;
-
-    // Parametric interval [t0..t1] in Q14 fixed-point
-    double t0 = 0.0;
-    double t1 = 1.0;
-
-    // X slab
-    if (ldx != 0) {
-        double t_near = (double)(bounds->min.x - lx) / ldx;
-        double t_far = (double)(bounds->max.x - lx) / ldx;
-        if (t_near > t_far) {
-            SWAP(t_near, t_far);
-        }
-        if (t_near > t1 || t_far < t0) {
-            return false;
-        }
-        CLAMPL(t0, t_near);
-        CLAMPG(t1, t_far);
-    } else if (lx < bounds->min.x || lx > bounds->max.x) {
-        return false;
-    }
-
-    // Y slab
-    if (ldy != 0) {
-        double t_near = (double)(bounds->min.y - ly) / ldy;
-        double t_far = (double)(bounds->max.y - ly) / ldy;
-        if (t_near > t_far) {
-            SWAP(t_near, t_far);
-        }
-        if (t_near > t1 || t_far < t0) {
-            return false;
-        }
-        CLAMPL(t0, t_near);
-        CLAMPG(t1, t_far);
-    } else if (ly < bounds->min.y || ly > bounds->max.y) {
-        return false;
-    }
-
-    // Z slab
-    if (ldz != 0) {
-        double t_near = (double)(bounds->min.z - lz) / ldz;
-        double t_far = (double)(bounds->max.z - lz) / ldz;
-        if (t_near > t_far) {
-            SWAP(t_near, t_far);
-        }
-        if (t_near > t1 || t_far < t0) {
-            return false;
-        }
-        CLAMPL(t0, t_near);
-        CLAMPG(t1, t_far);
-    } else if (lz < bounds->min.z || lz > bounds->max.z) {
-        return false;
-    }
-
-    // world-space hit position = start + t0 * (target-start)
-    target->x = start->x + t0 * dx;
-    target->y = start->y + t0 * dy;
-    target->z = start->z + t0 * dz;
-
-    return true;
-}
-
-// Smashes all objects along the ray path.
-//
-// @param start  World-space ray origin
-// @param target World-space ray end
-// @return       First smashable item's index, or NO_ITEM if none hit
-int32_t LOS_CheckSmashable(
-    const GAME_VECTOR start, const GAME_VECTOR target,
-    XYZ_32 *const out_hit_pos)
-{
-    int32_t best_dist = INT32_MAX;
-    int16_t best_item_num = NO_ITEM;
-
-    for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
-        const ITEM *const item = Item_Get(item_num);
-        if (item->is_finished) {
-            continue;
-        }
-        if (!Object_IsType(item->object_id, g_SmashableObjects)
-            && !Object_IsType(item->object_id, g_ShatterableObjects)
-            && !Object_IsType(item->object_id, g_HeavyShatterableObjects)) {
-            continue;
-        }
-
-        GAME_VECTOR hit_pos = target;
-        if (!LOS_CheckItemIntersectSegment(&start, &hit_pos, item)) {
-            continue;
-        }
-
-        // Confirm item is reachable via visible rooms
-        {
-            GAME_VECTOR start_tmp = start;
-            GAME_VECTOR target_tmp = {
-                .pos = M_GetMidPos(item),
-            };
-            if (!LOS_Check(&start_tmp, &target_tmp, false)) {
-                continue;
-            }
-        }
-
-        // Ray segment intersects the object's local AABB
-        const int32_t dist = Item_GetDistance(item, start.pos);
-        if (dist < best_dist) {
-            best_dist = dist;
-            best_item_num = item_num;
-            if (out_hit_pos != nullptr) {
-                *out_hit_pos = hit_pos.pos;
-            }
-        }
-    }
-
-    return best_item_num;
-}
-
 static int32_t M_CheckX(
     const GAME_VECTOR *const start, GAME_VECTOR *const target)
 {
@@ -517,6 +363,160 @@ static int32_t M_ClipTargetWithSlopes(
     }
 
     return 1;
+}
+
+// This routine transforms the world-space LOS segment [start,target] into the
+// object's local coordinates (undoing its translation and Y-rotation), then
+// performs a slab intersection test against that local AABB. The first
+// smashable item hit is returned, or NO_ITEM if none.
+//
+// (AABB = Axis-Aligned Bounding Box. It's the rectangular box defined by
+// bounds->min/max along X,Y,Z in the object's local space (no rotation).)
+//
+// @param start  World-space ray origin
+// @param target World-space ray end
+// @param item   Item to check
+// @return       Whether the item collides with the segment
+bool LOS_CheckItemIntersectSegment(
+    const GAME_VECTOR *const start, GAME_VECTOR *const target,
+    const ITEM *const item)
+{
+    const double dx = target->x - start->x;
+    const double dy = target->y - start->y;
+    const double dz = target->z - start->z;
+
+    // Translate into object-local space
+    const double ox = start->x - item->pos.x;
+    const double oy = start->y - item->pos.y;
+    const double oz = start->z - item->pos.z;
+
+    // Unrotate by -rot.y around Y axis
+    const float c = cosf(-item->rot.y * M_PI / DEG_180);
+    const float s = sinf(-item->rot.y * M_PI / DEG_180);
+    const double lx = ox * c + oz * s;
+    const double ly = oy;
+    const double lz = oz * c - ox * s;
+    const double ldx = dx * c + dz * s;
+    const double ldy = dy;
+    const double ldz = dz * c - dx * s;
+
+    // Local AABB extents from item's bounds
+    const BOUNDS_16 *const orig_bounds = Item_GetBoundsAccurate(item);
+    BOUNDS_16 patched_bounds = *orig_bounds;
+
+    const BOUNDS_16 *const bounds = &patched_bounds;
+
+    // Parametric interval [t0..t1] in Q14 fixed-point
+    double t0 = 0.0;
+    double t1 = 1.0;
+
+    // X slab
+    if (ldx != 0) {
+        double t_near = (double)(bounds->min.x - lx) / ldx;
+        double t_far = (double)(bounds->max.x - lx) / ldx;
+        if (t_near > t_far) {
+            SWAP(t_near, t_far);
+        }
+        if (t_near > t1 || t_far < t0) {
+            return false;
+        }
+        CLAMPL(t0, t_near);
+        CLAMPG(t1, t_far);
+    } else if (lx < bounds->min.x || lx > bounds->max.x) {
+        return false;
+    }
+
+    // Y slab
+    if (ldy != 0) {
+        double t_near = (double)(bounds->min.y - ly) / ldy;
+        double t_far = (double)(bounds->max.y - ly) / ldy;
+        if (t_near > t_far) {
+            SWAP(t_near, t_far);
+        }
+        if (t_near > t1 || t_far < t0) {
+            return false;
+        }
+        CLAMPL(t0, t_near);
+        CLAMPG(t1, t_far);
+    } else if (ly < bounds->min.y || ly > bounds->max.y) {
+        return false;
+    }
+
+    // Z slab
+    if (ldz != 0) {
+        double t_near = (double)(bounds->min.z - lz) / ldz;
+        double t_far = (double)(bounds->max.z - lz) / ldz;
+        if (t_near > t_far) {
+            SWAP(t_near, t_far);
+        }
+        if (t_near > t1 || t_far < t0) {
+            return false;
+        }
+        CLAMPL(t0, t_near);
+        CLAMPG(t1, t_far);
+    } else if (lz < bounds->min.z || lz > bounds->max.z) {
+        return false;
+    }
+
+    // world-space hit position = start + t0 * (target-start)
+    target->x = start->x + t0 * dx;
+    target->y = start->y + t0 * dy;
+    target->z = start->z + t0 * dz;
+
+    return true;
+}
+
+// Smashes all objects along the ray path.
+//
+// @param start  World-space ray origin
+// @param target World-space ray end
+// @return       First smashable item's index, or NO_ITEM if none hit
+int32_t LOS_CheckSmashable(
+    const GAME_VECTOR start, const GAME_VECTOR target,
+    XYZ_32 *const out_hit_pos)
+{
+    int32_t best_dist = INT32_MAX;
+    int16_t best_item_num = NO_ITEM;
+
+    for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
+        const ITEM *const item = Item_Get(item_num);
+        if (item->is_finished) {
+            continue;
+        }
+        if (!Object_IsType(item->object_id, g_SmashableObjects)
+            && !Object_IsType(item->object_id, g_ShatterableObjects)
+            && !Object_IsType(item->object_id, g_HeavyShatterableObjects)) {
+            continue;
+        }
+
+        GAME_VECTOR hit_pos = target;
+        if (!LOS_CheckItemIntersectSegment(&start, &hit_pos, item)) {
+            continue;
+        }
+
+        // Confirm item is reachable via visible rooms
+        {
+            GAME_VECTOR start_tmp = start;
+            GAME_VECTOR target_tmp = {
+                .pos = M_GetMidPos(item),
+            };
+            if (!LOS_Check(&start_tmp, &target_tmp, false)) {
+                continue;
+            }
+        }
+
+        // Ray segment intersects the object's local AABB
+        const int32_t dist = Item_GetDistance(item, start.pos);
+        if (dist < best_dist) {
+            best_dist = dist;
+            best_item_num = item_num;
+            if (out_hit_pos != nullptr) {
+                *out_hit_pos = hit_pos.pos;
+            }
+        }
+    }
+
+    return best_item_num;
 }
 
 bool LOS_Check(

--- a/src/trx/game/console/registry.c
+++ b/src/trx/game/console/registry.c
@@ -96,23 +96,6 @@ static bool M_AliasesContain(
     return false;
 }
 
-const CONSOLE_COMMAND *Console_Registry_Get(const char *const cmdline)
-{
-    const size_t word_len = M_WordLen(cmdline);
-    const M_NODE *current = m_List;
-    while (current != nullptr) {
-        const M_NODE *const next = current->next;
-        if (M_RangeEquals(
-                cmdline, word_len, current->cmd.prefix,
-                strlen(current->cmd.prefix))
-            || M_AliasesContain(current->cmd.aliases, cmdline, word_len)) {
-            return &current->cmd;
-        }
-        current = next;
-    }
-    return nullptr;
-}
-
 // Whether the nul-terminated `s` equals `name`'s first `name_len` bytes,
 // case-insensitively, with nothing past them.
 static bool M_NameEqualsN(
@@ -164,6 +147,23 @@ static void M_AddSuggestion(
         }
     }
     Completion_AddN(out, name, name_len);
+}
+
+const CONSOLE_COMMAND *Console_Registry_Get(const char *const cmdline)
+{
+    const size_t word_len = M_WordLen(cmdline);
+    const M_NODE *current = m_List;
+    while (current != nullptr) {
+        const M_NODE *const next = current->next;
+        if (M_RangeEquals(
+                cmdline, word_len, current->cmd.prefix,
+                strlen(current->cmd.prefix))
+            || M_AliasesContain(current->cmd.aliases, cmdline, word_len)) {
+            return &current->cmd;
+        }
+        current = next;
+    }
+    return nullptr;
 }
 
 void Console_Registry_Suggest(

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -215,7 +215,47 @@ static bool M_SwitchToLand(
     return true;
 }
 
-const ITEM *M_GetBaddieOverlap(const int16_t item_num)
+static bool M_TestDrowned(
+    const ITEM *const item, const BOUNDS_16 *const bounds,
+    const int16_t room_num)
+{
+    if (item->hit_points <= 0) {
+        return false;
+    }
+
+    switch (g_Config.gameplay.creature_drown_policy) {
+    case CREATURE_DROWN_POLICY_DEFAULT:
+        return Room_Get(room_num)->flags.underwater;
+    case CREATURE_DROWN_POLICY_SUBMERGED:
+        const int32_t water_height = Room_GetWaterHeight(item->pos, room_num);
+        return water_height != NO_HEIGHT
+            && water_height + STEP_L <= item->pos.y - ABS(bounds->min.y);
+    default:
+        return false;
+    }
+}
+
+static bool M_SameZone(const CREATURE *const creature, ITEM *const target_item)
+{
+    if (creature->lot.setup.fly != 0) {
+        return true;
+    }
+
+    int16_t *const zone = Box_GetGroundZone(
+        Room_GetFlipStatus(), (creature->lot.setup.step >> 8) - 1);
+    ITEM *const item = Item_Get(creature->item_num);
+
+    const ROOM *room = Room_Get(item->room_num);
+    item->box_num = Room_GetWorldSector(room, item->pos.x, item->pos.z)->box;
+
+    room = Room_Get(target_item->room_num);
+    target_item->box_num =
+        Room_GetWorldSector(room, target_item->pos.x, target_item->pos.z)->box;
+
+    return zone[item->box_num] == zone[target_item->box_num];
+}
+
+static const ITEM *M_GetBaddieOverlap(const int16_t item_num)
 {
     const ITEM *item = Item_Get(item_num);
     if (item->speed == 0 || item->hit_points <= 0) {
@@ -261,26 +301,6 @@ const ITEM *M_GetBaddieOverlap(const int16_t item_num)
     }
 
     return nullptr;
-}
-
-static bool M_TestDrowned(
-    const ITEM *const item, const BOUNDS_16 *const bounds,
-    const int16_t room_num)
-{
-    if (item->hit_points <= 0) {
-        return false;
-    }
-
-    switch (g_Config.gameplay.creature_drown_policy) {
-    case CREATURE_DROWN_POLICY_DEFAULT:
-        return Room_Get(room_num)->flags.underwater;
-    case CREATURE_DROWN_POLICY_SUBMERGED:
-        const int32_t water_height = Room_GetWaterHeight(item->pos, room_num);
-        return water_height != NO_HEIGHT
-            && water_height + STEP_L <= item->pos.y - ABS(bounds->min.y);
-    default:
-        return false;
-    }
 }
 
 void Creature_Initialise(const int16_t item_num)
@@ -1420,26 +1440,6 @@ int16_t Creature_AIGuard(CREATURE *const creature)
         return DEG_90;
     }
     return 0;
-}
-
-static bool M_SameZone(const CREATURE *const creature, ITEM *const target_item)
-{
-    if (creature->lot.setup.fly != 0) {
-        return true;
-    }
-
-    int16_t *const zone = Box_GetGroundZone(
-        Room_GetFlipStatus(), (creature->lot.setup.step >> 8) - 1);
-    ITEM *const item = Item_Get(creature->item_num);
-
-    const ROOM *room = Room_Get(item->room_num);
-    item->box_num = Room_GetWorldSector(room, item->pos.x, item->pos.z)->box;
-
-    room = Room_Get(target_item->room_num);
-    target_item->box_num =
-        Room_GetWorldSector(room, target_item->pos.x, target_item->pos.z)->box;
-
-    return zone[item->box_num] == zone[target_item->box_num];
 }
 
 void Creature_GetAITarget(CREATURE *const creature)

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -80,6 +80,231 @@ static bool M_GetUnderwaterBloodColor(
     return false;
 }
 
+static RGBA_8888 M_Gray(int32_t c)
+{
+    CLAMP(c, 0, 255);
+    return (RGBA_8888) { c, c, c, 255 };
+}
+
+static void M_DrawSplash(const FX_WATER_SPLASH *s)
+{
+    const int32_t big_splash_idx = Sparks_GetSpriteIndex(SPARK_TYPE_BIG_SPLASH);
+    const int32_t small_splash_idx =
+        Sparks_GetSpriteIndex(SPARK_TYPE_SMALL_SPLASH);
+    if (big_splash_idx == NO_ITEM || small_splash_idx == NO_ITEM) {
+        return;
+    }
+
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
+    const int32_t time4 = Output_GetTimeInGame() * 4;
+
+    XYZ_32 points[48];
+    for (int32_t i = 0; i < 48; i++) {
+        const FX_WATER_SPLASH_VERT *const v = &s->v[i];
+        points[i] = (XYZ_32) {
+            .x = s->x
+                + ((do_interp ? (int16_t)LERP(v->prev_wx, v->wx, ratio) : v->wx)
+                   >> 4),
+            .y = s->y
+                + (do_interp ? (int16_t)LERP(v->prev_wy, v->wy, ratio) : v->wy),
+            .z = s->z
+                + ((do_interp ? (int16_t)LERP(v->prev_wz, v->wz, ratio) : v->wz)
+                   >> 4),
+        };
+    }
+
+    for (int32_t ring = 0; ring < 3; ring++) {
+        int32_t sprite_idx = big_splash_idx;
+        if (ring == 2 || (ring == 0 && (s->flags & 4U) != 0U)
+            || (ring == 1 && (s->flags & 8U) != 0U)) {
+            sprite_idx = small_splash_idx + ((time4 >> 4) & 3);
+        }
+
+        const int32_t life = do_interp
+            ? (int32_t)LERP(s->prev_life, s->life, ratio)
+            : (int32_t)s->life;
+
+        int32_t c = life << 1;
+        CLAMPG(c, 255);
+        const RGBA_8888 c1 = M_Gray(c);
+
+        c = (life - (life >> 2)) << 1;
+        CLAMPG(c, 255);
+        const RGBA_8888 c2 = M_Gray(c);
+
+        const int32_t base = ring * 16;
+        for (int32_t quad = 0; quad < 8; quad++) {
+            const int32_t i0 = m_SplashQuadLinks[quad * 4 + 0] + base;
+            const int32_t i1 = m_SplashQuadLinks[quad * 4 + 1] + base;
+            const int32_t i2 = m_SplashQuadLinks[quad * 4 + 2] + base;
+            const int32_t i3 = m_SplashQuadLinks[quad * 4 + 3] + base;
+
+            const XYZ_32 quad_pos[4] = {
+                points[i0],
+                points[i1],
+                points[i3],
+                points[i2],
+            };
+            const RGBA_8888 quad_color[4] = { c1, c1, c2, c2 };
+            OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+                sprite_idx, quad_pos, quad_color, M_SPLASH_Z_DEPTH_ADJUST,
+                DRAW_BLEND_ADD);
+        }
+    }
+}
+
+static void M_DrawRipple(const FX_WATER_RIPPLE *r)
+{
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
+    const int32_t size = do_interp ? (int32_t)LERP(r->prev_size, r->size, ratio)
+                                   : (int32_t)r->size;
+    const int32_t init = do_interp ? (int32_t)LERP(r->prev_init, r->init, ratio)
+                                   : (int32_t)r->init;
+    const int32_t life = do_interp ? (int32_t)LERP(r->prev_life, r->life, ratio)
+                                   : (int32_t)r->life;
+    const int32_t n = size << 2;
+    int32_t sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_RIPPLE);
+    RGBA_8888 color;
+
+    if ((r->flags & 0x10U) != 0U) {
+        if ((r->flags & 0x20U) != 0U) {
+            sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
+            if (!M_GetUnderwaterBloodColor(&color, life)) {
+                return;
+            }
+        } else {
+            int32_t c1 = init != 0 ? (init >> 2) : (life >> 2);
+            c1 <<= 3;
+            CLAMPG(c1, 255);
+            color = M_Gray(c1);
+        }
+    } else {
+        int32_t c1 = init != 0 ? (init >> 1) : (life >> 1);
+        c1 <<= 3;
+        CLAMPG(c1, 255);
+        color = M_Gray(c1);
+    }
+
+    if (sprite_idx == NO_ITEM) {
+        return;
+    }
+
+    const XYZ_32 quad_pos[4] = {
+        { r->x - n, r->y, r->z - n },
+        { r->x + n, r->y, r->z - n },
+        { r->x + n, r->y, r->z + n },
+        { r->x - n, r->y, r->z + n },
+    };
+    const RGBA_8888 quad_color[4] = { color, color, color, color };
+    OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+        sprite_idx, quad_pos, quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
+        DRAW_BLEND_ADD);
+}
+
+static void M_Draw(void)
+{
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Splashes); i++) {
+        const FX_WATER_SPLASH *const splash = &m_Splashes[i];
+        if ((splash->flags & 1U) == 0U) {
+            continue;
+        }
+        M_DrawSplash(splash);
+    }
+
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
+        const FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
+        if ((ripple->flags & 1U) == 0U) {
+            continue;
+        }
+        M_DrawRipple(ripple);
+    }
+}
+
+static void M_Control(void)
+{
+    if (m_SplashCount > 0) {
+        m_SplashCount--;
+    }
+
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Splashes); i++) {
+        FX_WATER_SPLASH *const splash = &m_Splashes[i];
+        if ((splash->flags & 1U) == 0U) {
+            continue;
+        }
+
+        M_RememberSplash(splash);
+
+        bool set = false;
+        for (int32_t j = 0; j < 48; j++) {
+            FX_WATER_SPLASH_VERT *const v = &splash->v[j];
+            v->wx += v->xv >> 2;
+            v->wy += (int16_t)(v->yv >> 6);
+            v->wz += v->zv >> 2;
+            v->xv -= v->xv >> v->friction;
+            v->zv -= v->zv >> v->friction;
+
+            if ((v->oxv < 0 && v->xv > v->oxv)
+                || (v->oxv > 0 && v->xv < v->oxv)) {
+                v->xv = v->oxv;
+            } else if (
+                (v->ozv < 0 && v->zv > v->ozv)
+                || (v->ozv > 0 && v->zv < v->ozv)) {
+                v->zv = v->ozv;
+            }
+
+            v->yv += (int32_t)v->gravity << 3;
+            CLAMPG(v->yv, 0x10000);
+
+            if (v->wy > 0) {
+                if (j < 16) {
+                    splash->flags |= 4U;
+                } else if (j < 32) {
+                    splash->flags |= 8U;
+                }
+
+                v->wy = 0;
+                set = true;
+            }
+        }
+
+        if (set) {
+            splash->life--;
+            if (splash->life == 0U) {
+                splash->flags = 0U;
+            }
+        }
+    }
+
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
+        FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
+        if ((ripple->flags & 1U) == 0U) {
+            continue;
+        }
+
+        M_RememberRipple(ripple);
+
+        if (ripple->size < 254U) {
+            ripple->size += 2U;
+        }
+
+        if (ripple->init == 0U) {
+            ripple->life -= 2U;
+            if (ripple->life > 250U) {
+                ripple->flags = 0U;
+            }
+        } else if (ripple->init < ripple->life) {
+            ripple->init += 4U;
+            if (ripple->init >= ripple->life) {
+                ripple->init = 0U;
+            }
+        }
+    }
+}
+
 FX_WATER_RIPPLE *FX_Water_SetupRipple(
     const int32_t x, const int32_t y, const int32_t z, int32_t size,
     const bool is_still)
@@ -402,231 +627,6 @@ void FX_Water_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
     ripple->y = pos.y;
     ripple->z = pos.z + (Random_GetDraw() & 0x3F) - 32;
     M_RememberRipple(ripple);
-}
-
-static RGBA_8888 M_Gray(int32_t c)
-{
-    CLAMP(c, 0, 255);
-    return (RGBA_8888) { c, c, c, 255 };
-}
-
-static void M_DrawSplash(const FX_WATER_SPLASH *s)
-{
-    const int32_t big_splash_idx = Sparks_GetSpriteIndex(SPARK_TYPE_BIG_SPLASH);
-    const int32_t small_splash_idx =
-        Sparks_GetSpriteIndex(SPARK_TYPE_SMALL_SPLASH);
-    if (big_splash_idx == NO_ITEM || small_splash_idx == NO_ITEM) {
-        return;
-    }
-
-    const double ratio = Interpolation_GetWorldRate();
-    const bool do_interp =
-        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
-    const int32_t time4 = Output_GetTimeInGame() * 4;
-
-    XYZ_32 points[48];
-    for (int32_t i = 0; i < 48; i++) {
-        const FX_WATER_SPLASH_VERT *const v = &s->v[i];
-        points[i] = (XYZ_32) {
-            .x = s->x
-                + ((do_interp ? (int16_t)LERP(v->prev_wx, v->wx, ratio) : v->wx)
-                   >> 4),
-            .y = s->y
-                + (do_interp ? (int16_t)LERP(v->prev_wy, v->wy, ratio) : v->wy),
-            .z = s->z
-                + ((do_interp ? (int16_t)LERP(v->prev_wz, v->wz, ratio) : v->wz)
-                   >> 4),
-        };
-    }
-
-    for (int32_t ring = 0; ring < 3; ring++) {
-        int32_t sprite_idx = big_splash_idx;
-        if (ring == 2 || (ring == 0 && (s->flags & 4U) != 0U)
-            || (ring == 1 && (s->flags & 8U) != 0U)) {
-            sprite_idx = small_splash_idx + ((time4 >> 4) & 3);
-        }
-
-        const int32_t life = do_interp
-            ? (int32_t)LERP(s->prev_life, s->life, ratio)
-            : (int32_t)s->life;
-
-        int32_t c = life << 1;
-        CLAMPG(c, 255);
-        const RGBA_8888 c1 = M_Gray(c);
-
-        c = (life - (life >> 2)) << 1;
-        CLAMPG(c, 255);
-        const RGBA_8888 c2 = M_Gray(c);
-
-        const int32_t base = ring * 16;
-        for (int32_t quad = 0; quad < 8; quad++) {
-            const int32_t i0 = m_SplashQuadLinks[quad * 4 + 0] + base;
-            const int32_t i1 = m_SplashQuadLinks[quad * 4 + 1] + base;
-            const int32_t i2 = m_SplashQuadLinks[quad * 4 + 2] + base;
-            const int32_t i3 = m_SplashQuadLinks[quad * 4 + 3] + base;
-
-            const XYZ_32 quad_pos[4] = {
-                points[i0],
-                points[i1],
-                points[i3],
-                points[i2],
-            };
-            const RGBA_8888 quad_color[4] = { c1, c1, c2, c2 };
-            OutputSource_PolyFX_StageSpriteQuadWorldDepth(
-                sprite_idx, quad_pos, quad_color, M_SPLASH_Z_DEPTH_ADJUST,
-                DRAW_BLEND_ADD);
-        }
-    }
-}
-
-static void M_DrawRipple(const FX_WATER_RIPPLE *r)
-{
-    const double ratio = Interpolation_GetWorldRate();
-    const bool do_interp =
-        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
-    const int32_t size = do_interp ? (int32_t)LERP(r->prev_size, r->size, ratio)
-                                   : (int32_t)r->size;
-    const int32_t init = do_interp ? (int32_t)LERP(r->prev_init, r->init, ratio)
-                                   : (int32_t)r->init;
-    const int32_t life = do_interp ? (int32_t)LERP(r->prev_life, r->life, ratio)
-                                   : (int32_t)r->life;
-    const int32_t n = size << 2;
-    int32_t sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_RIPPLE);
-    RGBA_8888 color;
-
-    if ((r->flags & 0x10U) != 0U) {
-        if ((r->flags & 0x20U) != 0U) {
-            sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
-            if (!M_GetUnderwaterBloodColor(&color, life)) {
-                return;
-            }
-        } else {
-            int32_t c1 = init != 0 ? (init >> 2) : (life >> 2);
-            c1 <<= 3;
-            CLAMPG(c1, 255);
-            color = M_Gray(c1);
-        }
-    } else {
-        int32_t c1 = init != 0 ? (init >> 1) : (life >> 1);
-        c1 <<= 3;
-        CLAMPG(c1, 255);
-        color = M_Gray(c1);
-    }
-
-    if (sprite_idx == NO_ITEM) {
-        return;
-    }
-
-    const XYZ_32 quad_pos[4] = {
-        { r->x - n, r->y, r->z - n },
-        { r->x + n, r->y, r->z - n },
-        { r->x + n, r->y, r->z + n },
-        { r->x - n, r->y, r->z + n },
-    };
-    const RGBA_8888 quad_color[4] = { color, color, color, color };
-    OutputSource_PolyFX_StageSpriteQuadWorldDepth(
-        sprite_idx, quad_pos, quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
-        DRAW_BLEND_ADD);
-}
-
-static void M_Draw(void)
-{
-    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Splashes); i++) {
-        const FX_WATER_SPLASH *const splash = &m_Splashes[i];
-        if ((splash->flags & 1U) == 0U) {
-            continue;
-        }
-        M_DrawSplash(splash);
-    }
-
-    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
-        const FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
-        if ((ripple->flags & 1U) == 0U) {
-            continue;
-        }
-        M_DrawRipple(ripple);
-    }
-}
-
-static void M_Control(void)
-{
-    if (m_SplashCount > 0) {
-        m_SplashCount--;
-    }
-
-    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Splashes); i++) {
-        FX_WATER_SPLASH *const splash = &m_Splashes[i];
-        if ((splash->flags & 1U) == 0U) {
-            continue;
-        }
-
-        M_RememberSplash(splash);
-
-        bool set = false;
-        for (int32_t j = 0; j < 48; j++) {
-            FX_WATER_SPLASH_VERT *const v = &splash->v[j];
-            v->wx += v->xv >> 2;
-            v->wy += (int16_t)(v->yv >> 6);
-            v->wz += v->zv >> 2;
-            v->xv -= v->xv >> v->friction;
-            v->zv -= v->zv >> v->friction;
-
-            if ((v->oxv < 0 && v->xv > v->oxv)
-                || (v->oxv > 0 && v->xv < v->oxv)) {
-                v->xv = v->oxv;
-            } else if (
-                (v->ozv < 0 && v->zv > v->ozv)
-                || (v->ozv > 0 && v->zv < v->ozv)) {
-                v->zv = v->ozv;
-            }
-
-            v->yv += (int32_t)v->gravity << 3;
-            CLAMPG(v->yv, 0x10000);
-
-            if (v->wy > 0) {
-                if (j < 16) {
-                    splash->flags |= 4U;
-                } else if (j < 32) {
-                    splash->flags |= 8U;
-                }
-
-                v->wy = 0;
-                set = true;
-            }
-        }
-
-        if (set) {
-            splash->life--;
-            if (splash->life == 0U) {
-                splash->flags = 0U;
-            }
-        }
-    }
-
-    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
-        FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
-        if ((ripple->flags & 1U) == 0U) {
-            continue;
-        }
-
-        M_RememberRipple(ripple);
-
-        if (ripple->size < 254U) {
-            ripple->size += 2U;
-        }
-
-        if (ripple->init == 0U) {
-            ripple->life -= 2U;
-            if (ripple->life > 250U) {
-                ripple->flags = 0U;
-            }
-        } else if (ripple->init < ripple->life) {
-            ripple->init += 4U;
-            if (ripple->init >= ripple->life) {
-                ripple->init = 0U;
-            }
-        }
-    }
 }
 
 static const FX_MODULE m_Module = {

--- a/src/trx/game/game_strings/manager.c
+++ b/src/trx/game/game_strings/manager.c
@@ -174,6 +174,36 @@ static void M_ReorderLanguages(void)
     }
 }
 
+// Recursive load of language chain (handles 'extends' fallback between
+// dialects)
+static bool M_ReloadLangRec(const char *const lang, VECTOR *const visited)
+{
+    for (int32_t i = 0; i < visited->count; i++) {
+        const char *const prev = *(char **)Vector_Get(visited, i);
+        if (String_Equivalent(prev, lang)) {
+            LOG_WARNING("cyclic language extends detected: %s", lang);
+            return false;
+        }
+    }
+    Vector_Add(visited, &lang);
+    M_LANG_ENTRY *const entry = M_FindLangEntry(lang);
+    if (entry == nullptr) {
+        return false;
+    }
+    if (entry->extends) {
+        if (!M_ReloadLangRec(entry->extends, visited)) {
+            return false;
+        }
+    }
+    for (int32_t i = 0; i < entry->files->count; i++) {
+        const M_FILE_ENTRY *const fe = Vector_Get(entry->files, i);
+        if (!GameStringTable_Load(fe->path, fe->load_levels)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void GameStringManager_Init(void)
 {
     m_EventManager = EventManager_Create();
@@ -288,36 +318,6 @@ VECTOR *GameStringManager_GetAvailableLanguages(void)
         Vector_Add(out, &c);
     }
     return out;
-}
-
-// Recursive load of language chain (handles 'extends' fallback between
-// dialects)
-static bool M_ReloadLangRec(const char *const lang, VECTOR *const visited)
-{
-    for (int32_t i = 0; i < visited->count; i++) {
-        const char *const prev = *(char **)Vector_Get(visited, i);
-        if (String_Equivalent(prev, lang)) {
-            LOG_WARNING("cyclic language extends detected: %s", lang);
-            return false;
-        }
-    }
-    Vector_Add(visited, &lang);
-    M_LANG_ENTRY *const entry = M_FindLangEntry(lang);
-    if (entry == nullptr) {
-        return false;
-    }
-    if (entry->extends) {
-        if (!M_ReloadLangRec(entry->extends, visited)) {
-            return false;
-        }
-    }
-    for (int32_t i = 0; i < entry->files->count; i++) {
-        const M_FILE_ENTRY *const fe = Vector_Get(entry->files, i);
-        if (!GameStringTable_Load(fe->path, fe->load_levels)) {
-            return false;
-        }
-    }
-    return true;
 }
 
 bool GameStringManager_ReloadLanguage(const char *lang)

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -118,26 +118,6 @@ static void M_ConsiderTarget(M_TARGET_CONTEXT *const ctx, ITEM *const item)
     }
 }
 
-void Gun_ApplyFlashSemiTransparency(void)
-{
-    // TR3+ level data already flags the flash faces as semi-transparent;
-    // never touch it there.
-    if (g_TRVersion >= 3) {
-        return;
-    }
-    // The PS1 versions drew the muzzle flashes and the flare fire
-    // semi-transparent; the PC data has them as plain opaque meshes.
-    static const OBJECT_ID flash_objects[] = {
-        O_GUN_FLASH,
-        O_M16_FLASH,
-        O_FLARE_FIRE,
-    };
-    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(flash_objects); i++) {
-        Object_SetSemiTransparent(
-            flash_objects[i], g_Config.visuals.enable_gun_glow);
-    }
-}
-
 static void M_DrawGunGlow(
     const WEAPON_INFO *const weapon, const bool interpolated)
 {
@@ -180,6 +160,26 @@ static void M_DrawGunGlow(
         pos.x, pos.y, pos.z, glow_obj->mesh_idx, shade,
         Color_RGBToRGBA(weapon->glow_color), DRAW_BLEND_ADD,
         weapon->glow_scale);
+}
+
+void Gun_ApplyFlashSemiTransparency(void)
+{
+    // TR3+ level data already flags the flash faces as semi-transparent;
+    // never touch it there.
+    if (g_TRVersion >= 3) {
+        return;
+    }
+    // The PS1 versions drew the muzzle flashes and the flare fire
+    // semi-transparent; the PC data has them as plain opaque meshes.
+    static const OBJECT_ID flash_objects[] = {
+        O_GUN_FLASH,
+        O_M16_FLASH,
+        O_FLARE_FIRE,
+    };
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(flash_objects); i++) {
+        Object_SetSemiTransparent(
+            flash_objects[i], g_Config.visuals.enable_gun_glow);
+    }
 }
 
 void Gun_FindTargetPoint(const ITEM *const item, GAME_VECTOR *const target)

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -131,52 +131,6 @@ static bool M_IsOnQuadBike(void)
     return vehicle != nullptr && vehicle->object_id == O_QUAD_BIKE;
 }
 
-void Gym_SetInventoryOpenEnabled(const bool enabled)
-{
-    M_PRIV *const p = &m_Priv;
-    p->is_inventory_open_enabled = enabled;
-}
-
-bool Gym_IsInventoryOpenEnabled(void)
-{
-    M_PRIV *const p = &m_Priv;
-    if (p->is_inventory_open_enabled == -1) {
-        p->is_inventory_open_enabled = g_TRVersion >= 2;
-    }
-    return p->is_inventory_open_enabled;
-}
-
-void Gym_Control(void)
-{
-    if (g_TRVersion < 3) {
-        return;
-    }
-
-    M_PRIV *const p = &m_Priv;
-
-    if (p->assault_course.pad_lock
-        && !p->assault_course.pad_touched_this_frame) {
-        p->assault_course.pad_lock = false;
-    }
-    p->assault_course.pad_touched_this_frame = false;
-
-    if (p->assault_course.penalty_display_timer > 0) {
-        p->assault_course.penalty_display_timer--;
-    }
-    if (!p->assault_course.timer_active && p->assault_course.timer_display
-        && p->assault_course.timer_auto_hide_timer > 0) {
-        p->assault_course.timer_auto_hide_timer--;
-        if (p->assault_course.timer_auto_hide_timer == 0) {
-            p->assault_course.timer_display = false;
-            p->active_track_type = GYM_TRACK_NONE;
-        }
-    }
-
-    if (p->quad_course.lap_time_display_timer > 0) {
-        p->quad_course.lap_time_display_timer--;
-    }
-}
-
 static void M_Assault_Finish(void)
 {
     M_PRIV *const p = &m_Priv;
@@ -254,6 +208,52 @@ static void M_Racetrack_Finish(void)
     p->quad_course.lap_time_display_timer = 10 * LOGIC_FPS;
     M_StoreCourseTime(&g_Config.profile.racetrack_stats, final_time);
     p->quad_course.timer_active = false;
+}
+
+void Gym_SetInventoryOpenEnabled(const bool enabled)
+{
+    M_PRIV *const p = &m_Priv;
+    p->is_inventory_open_enabled = enabled;
+}
+
+bool Gym_IsInventoryOpenEnabled(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->is_inventory_open_enabled == -1) {
+        p->is_inventory_open_enabled = g_TRVersion >= 2;
+    }
+    return p->is_inventory_open_enabled;
+}
+
+void Gym_Control(void)
+{
+    if (g_TRVersion < 3) {
+        return;
+    }
+
+    M_PRIV *const p = &m_Priv;
+
+    if (p->assault_course.pad_lock
+        && !p->assault_course.pad_touched_this_frame) {
+        p->assault_course.pad_lock = false;
+    }
+    p->assault_course.pad_touched_this_frame = false;
+
+    if (p->assault_course.penalty_display_timer > 0) {
+        p->assault_course.penalty_display_timer--;
+    }
+    if (!p->assault_course.timer_active && p->assault_course.timer_display
+        && p->assault_course.timer_auto_hide_timer > 0) {
+        p->assault_course.timer_auto_hide_timer--;
+        if (p->assault_course.timer_auto_hide_timer == 0) {
+            p->assault_course.timer_display = false;
+            p->active_track_type = GYM_TRACK_NONE;
+        }
+    }
+
+    if (p->quad_course.lap_time_display_timer > 0) {
+        p->quad_course.lap_time_display_timer--;
+    }
 }
 
 GYM_TRACK_TYPE Gym_TrackManager_GetActiveTrackType(void)

--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -119,20 +119,6 @@ static const GAME_STRING_ID m_LayoutMap[INPUT_LAYOUT_NUMBER_OF] = {
         GS_ID("general/settings/controls/layout/custom_3"),
 };
 
-const INPUT_BACKEND_IMPL *Input_GetBackendImpl(const INPUT_BACKEND backend)
-{
-    switch (backend) {
-    case INPUT_BACKEND_KEYBOARD:
-        return &g_Input_Keyboard;
-    case INPUT_BACKEND_CONTROLLER:
-        return &g_Input_Controller;
-    case INPUT_BACKEND_TOUCH:
-        return &g_Input_Touch;
-    default:
-        return nullptr;
-    }
-}
-
 static bool M_IsPressed(const INPUT_STATE input, const INPUT_ROLE role)
 {
     switch (role) {
@@ -161,6 +147,20 @@ static INPUT_STATE M_SetPressed(
         break;
     }
     return input;
+}
+
+const INPUT_BACKEND_IMPL *Input_GetBackendImpl(const INPUT_BACKEND backend)
+{
+    switch (backend) {
+    case INPUT_BACKEND_KEYBOARD:
+        return &g_Input_Keyboard;
+    case INPUT_BACKEND_CONTROLLER:
+        return &g_Input_Controller;
+    case INPUT_BACKEND_TOUCH:
+        return &g_Input_Touch;
+    default:
+        return nullptr;
+    }
 }
 
 void Input_Reset(void)

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -48,11 +48,6 @@ static INV_RING *m_ActiveRing = nullptr;
 // InvRing_Open/M_TransitionToRing show is affected.
 static INVENTORY_ITEM *m_VisibleRingItems[RT_NUMBER_OF][INV_RING_MAX_ITEMS];
 
-INV_RING *InvRing_GetActiveRing(void)
-{
-    return m_ActiveRing;
-}
-
 static bool M_IsRuntimeHidden(const OBJECT_ID object_id)
 {
     return object_id == O_BINOCULARS_OPTION
@@ -801,6 +796,11 @@ static GF_COMMAND M_Control(INV_RING *const ring)
 
     Interpolation_Remember();
     return (GF_COMMAND) { .action = GF_NOOP };
+}
+
+INV_RING *InvRing_GetActiveRing(void)
+{
+    return m_ActiveRing;
 }
 
 void InvRing_RemoveAllText(void)

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -181,6 +181,16 @@ static void M_MotionItemDeselect(
     motion->item_z_trans_rate = -(inv_item->z_trans_sel / ring->status_frames);
 }
 
+// The crystal's tint follows the save crystal mode, so it cannot be baked into
+// inv_ring.json5.
+static uint32_t M_GetIdleMeshes(const INVENTORY_ITEM *const inv_item)
+{
+    if (inv_item->object_id == O_SAVE_CRYSTAL_OPTION) {
+        return SaveCrystal_GetMeshBits(O_SAVE_CRYSTAL_OPTION, -1);
+    }
+    return inv_item->meshes_sel;
+}
+
 void InvRing_AdjustMusicVolume(const INV_RING *const ring)
 {
     if (ring->mode == INV_TITLE_MODE) {
@@ -276,16 +286,6 @@ void InvRing_InitRing(
     m_ShowUseItemButton = false;
     m_ButtonHintDrawFunc = nullptr;
     m_ButtonHintUserData = nullptr;
-}
-
-// The crystal's tint follows the save crystal mode, so it cannot be baked into
-// inv_ring.json5.
-static uint32_t M_GetIdleMeshes(const INVENTORY_ITEM *const inv_item)
-{
-    if (inv_item->object_id == O_SAVE_CRYSTAL_OPTION) {
-        return SaveCrystal_GetMeshBits(O_SAVE_CRYSTAL_OPTION, -1);
-    }
-    return inv_item->meshes_sel;
 }
 
 void InvRing_InitInvItem(INVENTORY_ITEM *const inv_item)

--- a/src/trx/game/items/actions/common.c
+++ b/src/trx/game/items/actions/common.c
@@ -7,6 +7,23 @@ static void (*m_Routines[ITEM_ACTION_NUMBER_OF])(ITEM *item) = {};
 static int16_t m_FXType = 0;
 static ITEM_ACTION_INTERCEPTOR m_Interceptor = nullptr;
 
+static void M_RunWithFX(
+    const ITEM_TRX_ACTION action_id, ITEM *const item, const int16_t fx_type)
+{
+    m_FXType = fx_type;
+    ItemAction_Run(action_id, item);
+    m_FXType = 0;
+}
+
+// An animation command carries no trigger field, so the timer is 0. The stored
+// floor effect reaches here through RunActive with a null item, but a claimed
+// number is never stored, so that path never intercepts.
+static bool M_InterceptDirect(const ITEM_ACTION action_id, ITEM *const item)
+{
+    const int16_t item_num = item != nullptr ? Item_GetIndex(item) : NO_ITEM;
+    return ItemAction_Intercept(action_id, 0, item_num);
+}
+
 int16_t ItemAction_GetFXType(void)
 {
     return m_FXType;
@@ -26,14 +43,6 @@ void ItemAction_Run(const ITEM_TRX_ACTION action_id, ITEM *const item)
     }
 }
 
-static void M_RunWithFX(
-    const ITEM_TRX_ACTION action_id, ITEM *const item, const int16_t fx_type)
-{
-    m_FXType = fx_type;
-    ItemAction_Run(action_id, item);
-    m_FXType = 0;
-}
-
 void ItemAction_SetInterceptor(const ITEM_ACTION_INTERCEPTOR interceptor)
 {
     m_Interceptor = interceptor;
@@ -44,15 +53,6 @@ bool ItemAction_Intercept(
 {
     return m_Interceptor != nullptr
         && m_Interceptor(effect_num, timer, item_num);
-}
-
-// An animation command carries no trigger field, so the timer is 0. The stored
-// floor effect reaches here through RunActive with a null item, but a claimed
-// number is never stored, so that path never intercepts.
-static bool M_InterceptDirect(const ITEM_ACTION action_id, ITEM *const item)
-{
-    const int16_t item_num = item != nullptr ? Item_GetIndex(item) : NO_ITEM;
-    return ItemAction_Intercept(action_id, 0, item_num);
 }
 
 void ItemAction_RunDirect(const ITEM_ACTION action_id, ITEM *const item)

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -105,6 +105,26 @@ static void M_UnlinkChain(const int16_t item_num, const int16_t room_num)
     }
 }
 
+// A body leaves the active list as it dies, so the fade cannot ride on the
+// loop below. The OG counts it off while drawing the room, which leaves a
+// corpse nobody is looking at hanging around; this runs either way.
+static void M_ControlFades(void)
+{
+    // Read every frame, so changing the rule mid-fade changes the slope from
+    // here on.
+    const int32_t speed = g_Rules.corpse.fade_speed;
+    for (int16_t item_num = 0; item_num < m_MaxUsedItemCount; item_num++) {
+        ITEM *const item = &m_Items[item_num];
+        if (item->fade <= 0) {
+            continue;
+        }
+        item->fade -= speed;
+        if (item->fade <= 0) {
+            Item_Destroy(item_num);
+        }
+    }
+}
+
 void Item_InitialiseItems(const int32_t num_items)
 {
     // From here until live play begins, the level's cast and any save overlaid
@@ -395,26 +415,6 @@ void Item_StartFade(ITEM *const item)
 bool Item_IsFading(const ITEM *const item)
 {
     return item->fade > 0;
-}
-
-// A body leaves the active list as it dies, so the fade cannot ride on the
-// loop below. The OG counts it off while drawing the room, which leaves a
-// corpse nobody is looking at hanging around; this runs either way.
-static void M_ControlFades(void)
-{
-    // Read every frame, so changing the rule mid-fade changes the slope from
-    // here on.
-    const int32_t speed = g_Rules.corpse.fade_speed;
-    for (int16_t item_num = 0; item_num < m_MaxUsedItemCount; item_num++) {
-        ITEM *const item = &m_Items[item_num];
-        if (item->fade <= 0) {
-            continue;
-        }
-        item->fade -= speed;
-        if (item->fade <= 0) {
-            Item_Destroy(item_num);
-        }
-    }
 }
 
 void Item_Control(void)

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -34,6 +34,29 @@ static bool M_IsFloating(const ITEM *const item)
         && Object_Get(item->object_id)->intelligent && item->hit_points <= 0;
 }
 
+static bool M_ShouldCountKill(
+    const ITEM *const item, const ITEM_DAMAGE_FLAGS flags,
+    const ITEM *const sender)
+{
+    if (!item->include_in_kill_stats) {
+        return false;
+    }
+
+    if (item == Lara_GetItem()) {
+        return false;
+    }
+    if (sender == Lara_GetItem()) {
+        return true;
+    }
+    if (sender != nullptr && Creature_IsAlly(sender)) {
+        return g_Config.gameplay.enable_ally_kill_count;
+    }
+    if (sender != nullptr && Creature_IsHostile(sender)) {
+        return false;
+    }
+    return g_Config.gameplay.enable_environment_kill_count;
+}
+
 // Running, in the world, and not spent: simulated, visible, unfinished. Named
 // apart from Item_IsAlive, which is the looser has-HP-or-simulated damage
 // check.
@@ -120,29 +143,6 @@ bool Item_CanBeProjectileTarget(const ITEM *const item)
     }
 
     return Item_IsTargetable(item);
-}
-
-static bool M_ShouldCountKill(
-    const ITEM *const item, const ITEM_DAMAGE_FLAGS flags,
-    const ITEM *const sender)
-{
-    if (!item->include_in_kill_stats) {
-        return false;
-    }
-
-    if (item == Lara_GetItem()) {
-        return false;
-    }
-    if (sender == Lara_GetItem()) {
-        return true;
-    }
-    if (sender != nullptr && Creature_IsAlly(sender)) {
-        return g_Config.gameplay.enable_ally_kill_count;
-    }
-    if (sender != nullptr && Creature_IsHostile(sender)) {
-        return false;
-    }
-    return g_Config.gameplay.enable_environment_kill_count;
 }
 
 void Item_TakeDamage(

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -228,149 +228,6 @@ static bool M_TestHangStop(
         || *height_diff > SLOPE_DIF;
 }
 
-// Returns true when the tested hang position is invalid and Lara was
-// snapped back to where she was.
-bool Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
-{
-    coll->bad_pos = NO_BAD_POS;
-    coll->bad_neg = NO_BAD_NEG;
-    coll->bad_ceiling = 0;
-    Lara_Col_GetInfo(item, coll);
-    const bool flag = coll->side_front.floor < 200;
-
-    item->gravity = false;
-    item->fall_speed = 0;
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    lara->move_angle = item->rot.y;
-
-    const DIRECTION dir = Math_GetDirection(item->rot.y);
-    switch (dir) {
-    case DIR_NORTH:
-        item->pos.z += M_HANG_SHIFT;
-        break;
-    case DIR_EAST:
-        item->pos.x += M_HANG_SHIFT;
-        break;
-    case DIR_SOUTH:
-        item->pos.z -= M_HANG_SHIFT;
-        break;
-    case DIR_WEST:
-        item->pos.x -= M_HANG_SHIFT;
-        break;
-    default:
-        break;
-    }
-
-    coll->bad_pos = NO_BAD_POS;
-    coll->bad_neg = -STEPUP_HEIGHT;
-    coll->bad_ceiling = 0;
-    Lara_Col_GetInfo(item, coll);
-
-    if (lara->climb_status) {
-        if (!g_Input.action || item->hit_points <= 0) {
-            XYZ_32 pos = {
-                .x = 0,
-                .y = 0,
-                .z = 0,
-            };
-            Collide_GetJointAbsPosition(item, &pos, 0);
-            if (dir == DIR_NORTH || dir == DIR_SOUTH) {
-                item->pos.x = pos.x;
-            } else {
-                item->pos.z = pos.z;
-            }
-
-            item->goal_anim_state = LS(LS_JUMP_FORWARD);
-            item->current_anim_state = LS(LS_JUMP_FORWARD);
-            Item_SwitchToAnim(item, LA(LA_FALL_START), 0);
-            item->pos.y += STEP_L;
-            item->gravity = true;
-            item->speed = 2;
-            item->fall_speed = 1;
-            lara->gun_status = LGS_ARMLESS;
-            return false;
-        }
-
-        if (!Lara_Col_TestLadderHang(item, coll)) {
-            int32_t height_diff = 0;
-            if ((item->current_anim_state != LS(LS_SHIMMY_LEFT)
-                 && item->current_anim_state != LS(LS_SHIMMY_RIGHT))
-                || M_TestHangStop(item, coll, flag, &height_diff)) {
-                item->pos = coll->old_pos;
-                item->goal_anim_state = LS(LS_HANG);
-                item->current_anim_state = LS(LS_HANG);
-                Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), M_LF_HANG);
-            }
-            return true;
-        }
-
-        if (Item_TestAnimEqual(item, LA(LA_REACH_TO_HANG))
-            && Item_TestFrameEqual(item, M_LF_HANG)
-            && Lara_Col_TestClimbStance(item, coll)) {
-            item->goal_anim_state = LS(LS_CLIMB_STANCE);
-        }
-        return false;
-    }
-
-    if (!g_Input.action || item->hit_points <= 0
-        || coll->side_front.floor > 0) {
-        item->goal_anim_state = LS(LS_JUMP_UP);
-        item->current_anim_state = LS(LS_JUMP_UP);
-        Item_SwitchToAnim(item, LA(LA_JUMP_UP), M_LF_STOP_HANG);
-        const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
-        if (g_Config.gameplay.enable_swing_cancel && item->hit_points > 0) {
-            item->pos.y += bounds->max.y;
-        } else {
-            item->pos.y += coll->side_front.floor - bounds->min.y + 2;
-        }
-        item->pos.x += coll->shift.x;
-        item->pos.z += coll->shift.z;
-        item->gravity = true;
-        item->speed = 2;
-        item->fall_speed = 1;
-        lara->gun_status = LGS_ARMLESS;
-        return false;
-    }
-
-    int32_t height_diff = 0;
-    if (M_TestHangStop(item, coll, flag, &height_diff)) {
-        item->pos = coll->old_pos;
-        if (item->current_anim_state == LS(LS_SHIMMY_LEFT)
-            || item->current_anim_state == LS(LS_SHIMMY_RIGHT)) {
-            item->goal_anim_state = LS(LS_HANG);
-            item->current_anim_state = LS(LS_HANG);
-            Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), M_LF_HANG);
-        }
-        return true;
-    }
-
-    switch (dir) {
-    case DIR_NORTH:
-    case DIR_SOUTH:
-        item->pos.z += coll->shift.z;
-        break;
-
-    case DIR_EAST:
-    case DIR_WEST:
-        item->pos.x += coll->shift.x;
-        break;
-
-    default:
-        break;
-    }
-
-    if (g_TRVersion >= 2 || (height_diff >= -STEP_L && height_diff <= STEP_L)) {
-        item->pos.y += height_diff;
-    }
-    return false;
-}
-
-bool Lara_Col_IsCornerShimmyActive(void)
-{
-    return g_Config.gameplay.enable_corner_shimmying
-        && LS(LS_SHIMMY_OUTER_LEFT) != LS_INVALID;
-}
-
 static bool M_CanHangSideways(
     ITEM *const item, COLL_INFO *const coll, const int16_t angle)
 {
@@ -1306,6 +1163,161 @@ static void M_DownLadder(ITEM *const item, COLL_INFO *const coll)
     item->pos.y -= yshift;
 }
 
+static void M_ShimmyCorner(ITEM *const item, COLL_INFO *const coll)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->move_angle = item->rot.y;
+    coll->bad_pos = STEPUP_HEIGHT;
+    coll->bad_neg = -STEPUP_HEIGHT;
+    coll->bad_ceiling = 0;
+    coll->slopes_are_walls = 1;
+    coll->slopes_are_pits = 1;
+    Lara_Col_GetInfo(item, coll);
+}
+
+// Returns true when the tested hang position is invalid and Lara was
+// snapped back to where she was.
+bool Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
+{
+    coll->bad_pos = NO_BAD_POS;
+    coll->bad_neg = NO_BAD_NEG;
+    coll->bad_ceiling = 0;
+    Lara_Col_GetInfo(item, coll);
+    const bool flag = coll->side_front.floor < 200;
+
+    item->gravity = false;
+    item->fall_speed = 0;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->move_angle = item->rot.y;
+
+    const DIRECTION dir = Math_GetDirection(item->rot.y);
+    switch (dir) {
+    case DIR_NORTH:
+        item->pos.z += M_HANG_SHIFT;
+        break;
+    case DIR_EAST:
+        item->pos.x += M_HANG_SHIFT;
+        break;
+    case DIR_SOUTH:
+        item->pos.z -= M_HANG_SHIFT;
+        break;
+    case DIR_WEST:
+        item->pos.x -= M_HANG_SHIFT;
+        break;
+    default:
+        break;
+    }
+
+    coll->bad_pos = NO_BAD_POS;
+    coll->bad_neg = -STEPUP_HEIGHT;
+    coll->bad_ceiling = 0;
+    Lara_Col_GetInfo(item, coll);
+
+    if (lara->climb_status) {
+        if (!g_Input.action || item->hit_points <= 0) {
+            XYZ_32 pos = {
+                .x = 0,
+                .y = 0,
+                .z = 0,
+            };
+            Collide_GetJointAbsPosition(item, &pos, 0);
+            if (dir == DIR_NORTH || dir == DIR_SOUTH) {
+                item->pos.x = pos.x;
+            } else {
+                item->pos.z = pos.z;
+            }
+
+            item->goal_anim_state = LS(LS_JUMP_FORWARD);
+            item->current_anim_state = LS(LS_JUMP_FORWARD);
+            Item_SwitchToAnim(item, LA(LA_FALL_START), 0);
+            item->pos.y += STEP_L;
+            item->gravity = true;
+            item->speed = 2;
+            item->fall_speed = 1;
+            lara->gun_status = LGS_ARMLESS;
+            return false;
+        }
+
+        if (!Lara_Col_TestLadderHang(item, coll)) {
+            int32_t height_diff = 0;
+            if ((item->current_anim_state != LS(LS_SHIMMY_LEFT)
+                 && item->current_anim_state != LS(LS_SHIMMY_RIGHT))
+                || M_TestHangStop(item, coll, flag, &height_diff)) {
+                item->pos = coll->old_pos;
+                item->goal_anim_state = LS(LS_HANG);
+                item->current_anim_state = LS(LS_HANG);
+                Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), M_LF_HANG);
+            }
+            return true;
+        }
+
+        if (Item_TestAnimEqual(item, LA(LA_REACH_TO_HANG))
+            && Item_TestFrameEqual(item, M_LF_HANG)
+            && Lara_Col_TestClimbStance(item, coll)) {
+            item->goal_anim_state = LS(LS_CLIMB_STANCE);
+        }
+        return false;
+    }
+
+    if (!g_Input.action || item->hit_points <= 0
+        || coll->side_front.floor > 0) {
+        item->goal_anim_state = LS(LS_JUMP_UP);
+        item->current_anim_state = LS(LS_JUMP_UP);
+        Item_SwitchToAnim(item, LA(LA_JUMP_UP), M_LF_STOP_HANG);
+        const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
+        if (g_Config.gameplay.enable_swing_cancel && item->hit_points > 0) {
+            item->pos.y += bounds->max.y;
+        } else {
+            item->pos.y += coll->side_front.floor - bounds->min.y + 2;
+        }
+        item->pos.x += coll->shift.x;
+        item->pos.z += coll->shift.z;
+        item->gravity = true;
+        item->speed = 2;
+        item->fall_speed = 1;
+        lara->gun_status = LGS_ARMLESS;
+        return false;
+    }
+
+    int32_t height_diff = 0;
+    if (M_TestHangStop(item, coll, flag, &height_diff)) {
+        item->pos = coll->old_pos;
+        if (item->current_anim_state == LS(LS_SHIMMY_LEFT)
+            || item->current_anim_state == LS(LS_SHIMMY_RIGHT)) {
+            item->goal_anim_state = LS(LS_HANG);
+            item->current_anim_state = LS(LS_HANG);
+            Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), M_LF_HANG);
+        }
+        return true;
+    }
+
+    switch (dir) {
+    case DIR_NORTH:
+    case DIR_SOUTH:
+        item->pos.z += coll->shift.z;
+        break;
+
+    case DIR_EAST:
+    case DIR_WEST:
+        item->pos.x += coll->shift.x;
+        break;
+
+    default:
+        break;
+    }
+
+    if (g_TRVersion >= 2 || (height_diff >= -STEP_L && height_diff <= STEP_L)) {
+        item->pos.y += height_diff;
+    }
+    return false;
+}
+
+bool Lara_Col_IsCornerShimmyActive(void)
+{
+    return g_Config.gameplay.enable_corner_shimmying
+        && LS(LS_SHIMMY_OUTER_LEFT) != LS_INVALID;
+}
+
 bool Lara_Col_TestLadderHang(ITEM *const item, const COLL_INFO *const coll)
 {
     const LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -1392,18 +1404,6 @@ bool Lara_Col_TestClimbStance(ITEM *const item, const COLL_INFO *const coll)
 
     item->pos.y += shift;
     return true;
-}
-
-static void M_ShimmyCorner(ITEM *const item, COLL_INFO *const coll)
-{
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    lara->move_angle = item->rot.y;
-    coll->bad_pos = STEPUP_HEIGHT;
-    coll->bad_neg = -STEPUP_HEIGHT;
-    coll->bad_ceiling = 0;
-    coll->slopes_are_walls = 1;
-    coll->slopes_are_pits = 1;
-    Lara_Col_GetInfo(item, coll);
 }
 
 // clang-format off

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -23,76 +23,6 @@ static bool M_IsAbyssLanding(
     return Room_IsAbyssHeight(item->pos.y + coll->side_mid.floor);
 }
 
-EDGE_CATCH Lara_Col_TestEdgeCatch(
-    const ITEM *const item, const COLL_INFO *const coll, int32_t *const edge)
-{
-    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
-    int32_t hdif1 = coll->side_front.floor - bounds->min.y;
-    int32_t hdif2 = hdif1 + item->fall_speed;
-    if ((hdif1 < 0 && hdif2 < 0) || (hdif1 > 0 && hdif2 > 0)) {
-        hdif1 = item->pos.y + bounds->min.y;
-        hdif2 = hdif1 + item->fall_speed;
-        if ((hdif1 >> (WALL_SHIFT - 2)) == (hdif2 >> (WALL_SHIFT - 2))) {
-            return EDGE_CATCH_NONE;
-        }
-        if (item->fall_speed > 0) {
-            *edge = hdif2 & ~(STEP_L - 1);
-        } else {
-            *edge = hdif1 & ~(STEP_L - 1);
-        }
-        return EDGE_CATCH_NEG;
-    }
-
-    return ABS(coll->side_left2.floor - coll->side_right2.floor) < SLOPE_DIF
-        ? EDGE_CATCH_POS
-        : EDGE_CATCH_NONE;
-}
-
-SWING_CATCH Lara_Col_TestHangSwingIn(
-    const ITEM *const item, const int16_t angle)
-{
-    // Tests whether a forward hang grab should transition into thin-ledge
-    // swing ("swinging inwards"). The probe samples one click ahead in the
-    // hang direction and requires:
-    // - valid floor at probe point;
-    // - probe floor above Lara;
-    // - enough overhead clearance for swing-in.
-    // The extra clearance guard follows TR3-5 logic: `y - ceiling - 819 > -72`
-    // but uses a relaxed threshold to preserve the animation on certain slope
-    // edge cases.
-
-    XYZ_32 pos = item->pos;
-    int16_t room_num = item->room_num;
-    switch (angle) {
-    case 0:
-        pos.z += STEP_L;
-        break;
-    case DEG_90:
-        pos.x += STEP_L;
-        break;
-    case -DEG_180:
-        pos.z -= STEP_L;
-        break;
-    case -DEG_90:
-        pos.x -= STEP_L;
-        break;
-    }
-
-    const SECTOR *const sector = Room_GetSector(pos, &room_num);
-    int32_t height = Room_GetHeight(sector, pos);
-    int32_t ceiling = Room_GetCeiling(sector, pos);
-    const bool has_height = height != NO_HEIGHT;
-    const int32_t height_delta = height - pos.y;
-    const int32_t ceiling_delta = ceiling - pos.y;
-    if (!has_height || height_delta <= 0 || ceiling_delta >= -400) {
-        return SWING_CATCH_NONE;
-    }
-    const bool thin_ledge = pos.y - ceiling - 819 > -110;
-    return thin_ledge && g_Config.gameplay.enable_slow_ledge_swing
-        ? SWING_CATCH_SLOW
-        : SWING_CATCH_FAST;
-}
-
 static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -637,6 +567,76 @@ static void M_FastFall(ITEM *const item, COLL_INFO *const coll)
     item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
+}
+
+EDGE_CATCH Lara_Col_TestEdgeCatch(
+    const ITEM *const item, const COLL_INFO *const coll, int32_t *const edge)
+{
+    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
+    int32_t hdif1 = coll->side_front.floor - bounds->min.y;
+    int32_t hdif2 = hdif1 + item->fall_speed;
+    if ((hdif1 < 0 && hdif2 < 0) || (hdif1 > 0 && hdif2 > 0)) {
+        hdif1 = item->pos.y + bounds->min.y;
+        hdif2 = hdif1 + item->fall_speed;
+        if ((hdif1 >> (WALL_SHIFT - 2)) == (hdif2 >> (WALL_SHIFT - 2))) {
+            return EDGE_CATCH_NONE;
+        }
+        if (item->fall_speed > 0) {
+            *edge = hdif2 & ~(STEP_L - 1);
+        } else {
+            *edge = hdif1 & ~(STEP_L - 1);
+        }
+        return EDGE_CATCH_NEG;
+    }
+
+    return ABS(coll->side_left2.floor - coll->side_right2.floor) < SLOPE_DIF
+        ? EDGE_CATCH_POS
+        : EDGE_CATCH_NONE;
+}
+
+SWING_CATCH Lara_Col_TestHangSwingIn(
+    const ITEM *const item, const int16_t angle)
+{
+    // Tests whether a forward hang grab should transition into thin-ledge
+    // swing ("swinging inwards"). The probe samples one click ahead in the
+    // hang direction and requires:
+    // - valid floor at probe point;
+    // - probe floor above Lara;
+    // - enough overhead clearance for swing-in.
+    // The extra clearance guard follows TR3-5 logic: `y - ceiling - 819 > -72`
+    // but uses a relaxed threshold to preserve the animation on certain slope
+    // edge cases.
+
+    XYZ_32 pos = item->pos;
+    int16_t room_num = item->room_num;
+    switch (angle) {
+    case 0:
+        pos.z += STEP_L;
+        break;
+    case DEG_90:
+        pos.x += STEP_L;
+        break;
+    case -DEG_180:
+        pos.z -= STEP_L;
+        break;
+    case -DEG_90:
+        pos.x -= STEP_L;
+        break;
+    }
+
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    int32_t height = Room_GetHeight(sector, pos);
+    int32_t ceiling = Room_GetCeiling(sector, pos);
+    const bool has_height = height != NO_HEIGHT;
+    const int32_t height_delta = height - pos.y;
+    const int32_t ceiling_delta = ceiling - pos.y;
+    if (!has_height || height_delta <= 0 || ceiling_delta >= -400) {
+        return SWING_CATCH_NONE;
+    }
+    const bool thin_ledge = pos.y - ceiling - 819 > -110;
+    return thin_ledge && g_Config.gameplay.enable_slow_ledge_swing
+        ? SWING_CATCH_SLOW
+        : SWING_CATCH_FAST;
 }
 
 void Lara_Col_DeflectEdgeJump(ITEM *const item, COLL_INFO *const coll)

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -135,89 +135,6 @@ static bool M_CanControlDrop(
     }
 }
 
-bool Lara_Col_Fallen(ITEM *const item, const COLL_INFO *const coll)
-{
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (coll->side_mid.floor <= STEPUP_HEIGHT
-        || lara->water_status == LWS_WADE) {
-        return false;
-    }
-    if (M_CanControlDrop(item, coll)) {
-        item->current_anim_state = LS(LS_REACH);
-        item->goal_anim_state = LS(LS_REACH);
-        Item_SwitchToAnim(item, LA(LA_CONTROLLED_DROP), 0);
-        item->speed = 2;
-    } else {
-        item->current_anim_state = LS(LS_JUMP_FORWARD);
-        item->goal_anim_state = LS(LS_JUMP_FORWARD);
-        Item_SwitchToAnim(item, LA(LA_FALL_START), 0);
-    }
-    item->gravity = true;
-    item->fall_speed = 0;
-    lara->sprinting = false;
-    lara->crouching = false;
-    return true;
-}
-
-bool Lara_Col_TestSlide(ITEM *const item, COLL_INFO *const coll)
-{
-    if (ABS(coll->tilt.x) <= MAX_SLOPE && ABS(coll->tilt.z) <= MAX_SLOPE) {
-        return false;
-    }
-
-    const ROOM *const room = Room_Get(item->room_num);
-    if (room->flags.swamp) {
-        return false;
-    }
-
-    int16_t angle = 0;
-    if (coll->tilt.x > MAX_SLOPE) {
-        angle = -DEG_90;
-    } else if (coll->tilt.x < -MAX_SLOPE) {
-        angle = DEG_90;
-    }
-
-    if (coll->tilt.z > 2 && coll->tilt.z > ABS(coll->tilt.x)) {
-        angle = -DEG_180;
-    } else if (coll->tilt.z < -2 && -coll->tilt.z > ABS(coll->tilt.x)) {
-        angle = 0;
-    }
-
-    const int16_t angle_dif = angle - item->rot.y;
-    Lara_Col_Shift(coll);
-
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (angle_dif >= -DEG_90 && angle_dif <= DEG_90) {
-        if (item->current_anim_state == LS(LS_SLIDE)
-            && m_OldSlideAngle == angle) {
-            lara->sprinting = false;
-            lara->crouching = false;
-            return true;
-        }
-        item->goal_anim_state = LS(LS_SLIDE);
-        item->current_anim_state = LS(LS_SLIDE);
-        Item_SwitchToAnim(item, LA(LA_SLIDE_FORWARD), 0);
-        item->rot.y = angle;
-    } else {
-        if (item->current_anim_state == LS(LS_SLIDE_BACK)
-            && m_OldSlideAngle == angle) {
-            lara->sprinting = false;
-            lara->crouching = false;
-            return true;
-        }
-        item->goal_anim_state = LS(LS_SLIDE_BACK);
-        item->current_anim_state = LS(LS_SLIDE_BACK);
-        Item_SwitchToAnim(item, LA(LA_SLIDE_BACKWARD_START), 0);
-        item->rot.y = angle + DEG_180;
-    }
-
-    lara->move_angle = angle;
-    lara->sprinting = false;
-    lara->crouching = false;
-    m_OldSlideAngle = angle;
-    return true;
-}
-
 static bool M_DeflectEdge(ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -245,26 +162,6 @@ static bool M_DeflectEdge(ITEM *const item, COLL_INFO *const coll)
     default:
         return false;
     }
-}
-
-bool Lara_Col_TestCeiling(ITEM *const item, const COLL_INFO *const coll)
-{
-    if (coll->coll_type != COLL_TOP && coll->coll_type != COLL_CLAMP) {
-        return false;
-    }
-
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    lara->sprinting = false;
-    lara->crouching = false;
-
-    item->pos = coll->old_pos;
-    item->goal_anim_state = LS(LS_STOP);
-    item->current_anim_state = LS(LS_STOP);
-    Item_SwitchToAnim(item, LA(LA_STAND_STILL), 0);
-    item->speed = 0;
-    item->gravity = false;
-    item->fall_speed = 0;
-    return true;
 }
 
 static void M_CollideStop(ITEM *const item, const COLL_INFO *const coll)
@@ -955,6 +852,109 @@ static void M_SprintRoll(ITEM *const item, COLL_INFO *const coll)
 
     Lara_Col_Shift(coll);
     item->pos.y += coll->side_mid.floor;
+}
+
+bool Lara_Col_Fallen(ITEM *const item, const COLL_INFO *const coll)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (coll->side_mid.floor <= STEPUP_HEIGHT
+        || lara->water_status == LWS_WADE) {
+        return false;
+    }
+    if (M_CanControlDrop(item, coll)) {
+        item->current_anim_state = LS(LS_REACH);
+        item->goal_anim_state = LS(LS_REACH);
+        Item_SwitchToAnim(item, LA(LA_CONTROLLED_DROP), 0);
+        item->speed = 2;
+    } else {
+        item->current_anim_state = LS(LS_JUMP_FORWARD);
+        item->goal_anim_state = LS(LS_JUMP_FORWARD);
+        Item_SwitchToAnim(item, LA(LA_FALL_START), 0);
+    }
+    item->gravity = true;
+    item->fall_speed = 0;
+    lara->sprinting = false;
+    lara->crouching = false;
+    return true;
+}
+
+bool Lara_Col_TestSlide(ITEM *const item, COLL_INFO *const coll)
+{
+    if (ABS(coll->tilt.x) <= MAX_SLOPE && ABS(coll->tilt.z) <= MAX_SLOPE) {
+        return false;
+    }
+
+    const ROOM *const room = Room_Get(item->room_num);
+    if (room->flags.swamp) {
+        return false;
+    }
+
+    int16_t angle = 0;
+    if (coll->tilt.x > MAX_SLOPE) {
+        angle = -DEG_90;
+    } else if (coll->tilt.x < -MAX_SLOPE) {
+        angle = DEG_90;
+    }
+
+    if (coll->tilt.z > 2 && coll->tilt.z > ABS(coll->tilt.x)) {
+        angle = -DEG_180;
+    } else if (coll->tilt.z < -2 && -coll->tilt.z > ABS(coll->tilt.x)) {
+        angle = 0;
+    }
+
+    const int16_t angle_dif = angle - item->rot.y;
+    Lara_Col_Shift(coll);
+
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (angle_dif >= -DEG_90 && angle_dif <= DEG_90) {
+        if (item->current_anim_state == LS(LS_SLIDE)
+            && m_OldSlideAngle == angle) {
+            lara->sprinting = false;
+            lara->crouching = false;
+            return true;
+        }
+        item->goal_anim_state = LS(LS_SLIDE);
+        item->current_anim_state = LS(LS_SLIDE);
+        Item_SwitchToAnim(item, LA(LA_SLIDE_FORWARD), 0);
+        item->rot.y = angle;
+    } else {
+        if (item->current_anim_state == LS(LS_SLIDE_BACK)
+            && m_OldSlideAngle == angle) {
+            lara->sprinting = false;
+            lara->crouching = false;
+            return true;
+        }
+        item->goal_anim_state = LS(LS_SLIDE_BACK);
+        item->current_anim_state = LS(LS_SLIDE_BACK);
+        Item_SwitchToAnim(item, LA(LA_SLIDE_BACKWARD_START), 0);
+        item->rot.y = angle + DEG_180;
+    }
+
+    lara->move_angle = angle;
+    lara->sprinting = false;
+    lara->crouching = false;
+    m_OldSlideAngle = angle;
+    return true;
+}
+
+bool Lara_Col_TestCeiling(ITEM *const item, const COLL_INFO *const coll)
+{
+    if (coll->coll_type != COLL_TOP && coll->coll_type != COLL_CLAMP) {
+        return false;
+    }
+
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->sprinting = false;
+    lara->crouching = false;
+
+    item->pos = coll->old_pos;
+    item->goal_anim_state = LS(LS_STOP);
+    item->current_anim_state = LS(LS_STOP);
+    Item_SwitchToAnim(item, LA(LA_STAND_STILL), 0);
+    item->speed = 0;
+    item->gravity = false;
+    item->fall_speed = 0;
+    return true;
 }
 
 // clang-format off

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -56,6 +56,18 @@ static bool M_IsInvalidInterpAnim(const LARA_TRX_ANIMATION anim_idx)
     return false;
 }
 
+static int32_t M_GetStartingHitPoints(void)
+{
+    if (g_Config.gameplay.disable_healing_between_levels) {
+        const GF_LEVEL *const current_level = Game_GetCurrentLevel();
+        RESUME_INFO *const resume = Savegame_GetCurrentInfo(current_level);
+        if (resume != nullptr) {
+            return resume->lara_hitpoints;
+        }
+    }
+    return g_Config.gameplay.start_lara_hitpoints;
+}
+
 LARA_INFO *Lara_GetLaraInfo(void)
 {
     return &m_Lara;
@@ -74,18 +86,6 @@ void Lara_InitialiseLoad(int16_t item_num)
     } else {
         m_LaraItem = Item_Get(item_num);
     }
-}
-
-static int32_t M_GetStartingHitPoints(void)
-{
-    if (g_Config.gameplay.disable_healing_between_levels) {
-        const GF_LEVEL *const current_level = Game_GetCurrentLevel();
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(current_level);
-        if (resume != nullptr) {
-            return resume->lara_hitpoints;
-        }
-    }
-    return g_Config.gameplay.start_lara_hitpoints;
 }
 
 void Lara_Initialise(const GF_LEVEL *const level)

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -249,29 +249,6 @@ static void M_ReduceTorsoSphere(void)
         (m_HairSpheres[1].pos.z + m_HairSpheres[2].pos.z) >> 1;
 }
 
-void Lara_Hair_Initialise(void)
-{
-    for (int32_t i = 0; i < M_MAX_BRAIDS; i++) {
-        const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase(i);
-        if (bones == nullptr) {
-            continue;
-        }
-
-        m_IsFirstHair[i] = true;
-        m_HairSegments[i][0].rot.x = -DEG_90;
-        m_HairSegments[i][0].rot.y = 0;
-
-        for (int32_t j = 1; j <= M_HAIR_SEGMENTS; j++) {
-            const ANIM_BONE *const bone = &bones[M_BONE_IDX(j)];
-            m_HairSegments[i][j].pos = bone->pos;
-            m_HairSegments[i][j].rot.x = -DEG_90;
-            m_HairSegments[i][j].rot.y = 0;
-            m_HairSegments[i][j].rot.z = 0;
-            m_HairVelocity[i][j - 1] = (XYZ_32) {};
-        }
-    }
-}
-
 static void M_Control(
     const bool in_cutscene, const int32_t braid_idx, const XYZ_32 offset_pos,
     const bool is_twin_setup)
@@ -470,18 +447,6 @@ static void M_Control(
     }
 }
 
-void Lara_Hair_Control(const bool in_cutscene)
-{
-    if (!Lara_Hair_IsActive()) {
-        return;
-    }
-
-    const LARA_SKIN_BRAID *const braid = Lara_Skin_GetBraid();
-    for (int32_t i = 0; i < braid->count; i++) {
-        M_Control(in_cutscene, i, braid->setup[i].position, braid->count > 1);
-    }
-}
-
 static void M_EnsureScratch(const int32_t vertex_count)
 {
     if (vertex_count <= m_Joints.scratch.capacity) {
@@ -583,92 +548,6 @@ static void M_SortSeamRing(
                 seam->pairs[a] = seam->pairs[b];
                 seam->pairs[b] = p;
             }
-        }
-    }
-}
-
-void Lara_Hair_InitJoints(const LARA_SKIN_OUTFIT *const outfit)
-{
-    M_ResetJoints();
-
-    // Braid welding rides on the body-joint feature; outfits that do not opt
-    // into joints (every TR1-TR3 outfit) keep their braid untouched.
-    if (outfit->joints_obj_id == NO_OBJECT || !Lara_Skin_IsBraidSupported()) {
-        return;
-    }
-
-    const int32_t braid_base = Lara_Skin_GetBraidMeshIdx(0);
-    const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase(0);
-    if (braid_base < 0 || bones == nullptr) {
-        return;
-    }
-
-    // At rest every segment shares one orientation, so a shared ring reduces
-    // to a translation by the bone between the two meshes. Only the lower
-    // rings are sorted: the weld rotates their pairing, which needs the pairs
-    // to walk the ring's perimeter.
-    const XYZ_32 zero = {};
-    int32_t total_pairs = 0;
-    int32_t max_vertices = 0;
-    for (int32_t j = 0; j < M_HAIR_SEGMENTS; j += 2) {
-        const OBJECT_MESH *const mesh = Object_GetMesh(braid_base + j);
-        max_vertices = MAX(max_vertices, mesh->num_vertices);
-        if (j > 0) {
-            const OBJECT_MESH *const prev = Object_GetMesh(braid_base + j - 1);
-            const XYZ_32 offset = bones[M_BONE_IDX(j)].pos;
-            Lara_Seam_FindSharedVertices(
-                m_Joints.upper[j].pairs, &m_Joints.upper[j].count,
-                SEAM_MAX_VERTEX_PAIRS, mesh, prev, &offset, &zero);
-            total_pairs += m_Joints.upper[j].count;
-        }
-        if (j + 1 < M_HAIR_SEGMENTS) {
-            const OBJECT_MESH *const next = Object_GetMesh(braid_base + j + 1);
-            const XYZ_32 offset = bones[M_BONE_IDX(j + 1)].pos;
-            Lara_Seam_FindSharedVertices(
-                m_Joints.lower[j].pairs, &m_Joints.lower[j].count,
-                SEAM_MAX_VERTEX_PAIRS, mesh, next, &zero, &offset);
-            M_SortSeamRing(&m_Joints.lower[j], mesh);
-            total_pairs += m_Joints.lower[j].count;
-        }
-    }
-
-    if (total_pairs == 0) {
-        LOG_INFO("braid segments share no ring; welding disabled");
-        return;
-    }
-
-    M_EnsureScratch(max_vertices);
-    m_Joints.enabled = true;
-
-    // A second pigtail shares the first's meshes, so give it its own copies to
-    // deform; otherwise the two would fight over one buffer and only the last
-    // drawn would close. The refresh builds the copies' render buffers.
-    const LARA_SKIN_BRAID *const braid = Lara_Skin_GetBraid();
-
-    // Copy the authored head-attach ring for each pigtail, dropping any pair
-    // that names a vertex past either mesh, so the weld does not have to
-    // bounds-check every frame.
-    const OBJECT_MESH *const head_mesh = Lara_Mesh_Get(LM_HEAD);
-    const OBJECT_MESH *const seg0_mesh = Object_GetMesh(braid_base);
-    for (int32_t i = 0; i < braid->count; i++) {
-        const LARA_SKIN_BRAID_HEAD_SEAM *const src = &braid->setup[i].head_seam;
-        m_Joints.head[i].count = 0;
-        for (int32_t k = 0; k < src->count; k++) {
-            if (src->pairs[k].vertex_a >= seg0_mesh->num_vertices
-                || src->pairs[k].vertex_b >= head_mesh->num_vertices) {
-                continue;
-            }
-            m_Joints.head[i].pairs[m_Joints.head[i].count++] = src->pairs[k];
-        }
-    }
-
-    // Record which meshes the draw will deform - the bridges - so a later
-    // outfit can restore them. Restoring a mesh that was never deformed is a
-    // no-op.
-    for (int32_t i = 0; i < braid->count; i++) {
-        const int32_t seg_base = Lara_Skin_GetBraidMeshIdx(i);
-        for (int32_t j = 0; j < M_HAIR_SEGMENTS; j += 2) {
-            m_Joints.welded_indices[m_Joints.welded_count++] = seg_base + j;
         }
     }
 }
@@ -903,6 +782,127 @@ static void M_CalculateRenderRolls(
         rx = ax * rc + bx * rs;
         ry = ay * rc + by * rs;
         rz = az * rc + bz * rs;
+    }
+}
+
+void Lara_Hair_Initialise(void)
+{
+    for (int32_t i = 0; i < M_MAX_BRAIDS; i++) {
+        const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase(i);
+        if (bones == nullptr) {
+            continue;
+        }
+
+        m_IsFirstHair[i] = true;
+        m_HairSegments[i][0].rot.x = -DEG_90;
+        m_HairSegments[i][0].rot.y = 0;
+
+        for (int32_t j = 1; j <= M_HAIR_SEGMENTS; j++) {
+            const ANIM_BONE *const bone = &bones[M_BONE_IDX(j)];
+            m_HairSegments[i][j].pos = bone->pos;
+            m_HairSegments[i][j].rot.x = -DEG_90;
+            m_HairSegments[i][j].rot.y = 0;
+            m_HairSegments[i][j].rot.z = 0;
+            m_HairVelocity[i][j - 1] = (XYZ_32) {};
+        }
+    }
+}
+
+void Lara_Hair_Control(const bool in_cutscene)
+{
+    if (!Lara_Hair_IsActive()) {
+        return;
+    }
+
+    const LARA_SKIN_BRAID *const braid = Lara_Skin_GetBraid();
+    for (int32_t i = 0; i < braid->count; i++) {
+        M_Control(in_cutscene, i, braid->setup[i].position, braid->count > 1);
+    }
+}
+
+void Lara_Hair_InitJoints(const LARA_SKIN_OUTFIT *const outfit)
+{
+    M_ResetJoints();
+
+    // Braid welding rides on the body-joint feature; outfits that do not opt
+    // into joints (every TR1-TR3 outfit) keep their braid untouched.
+    if (outfit->joints_obj_id == NO_OBJECT || !Lara_Skin_IsBraidSupported()) {
+        return;
+    }
+
+    const int32_t braid_base = Lara_Skin_GetBraidMeshIdx(0);
+    const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase(0);
+    if (braid_base < 0 || bones == nullptr) {
+        return;
+    }
+
+    // At rest every segment shares one orientation, so a shared ring reduces
+    // to a translation by the bone between the two meshes. Only the lower
+    // rings are sorted: the weld rotates their pairing, which needs the pairs
+    // to walk the ring's perimeter.
+    const XYZ_32 zero = {};
+    int32_t total_pairs = 0;
+    int32_t max_vertices = 0;
+    for (int32_t j = 0; j < M_HAIR_SEGMENTS; j += 2) {
+        const OBJECT_MESH *const mesh = Object_GetMesh(braid_base + j);
+        max_vertices = MAX(max_vertices, mesh->num_vertices);
+        if (j > 0) {
+            const OBJECT_MESH *const prev = Object_GetMesh(braid_base + j - 1);
+            const XYZ_32 offset = bones[M_BONE_IDX(j)].pos;
+            Lara_Seam_FindSharedVertices(
+                m_Joints.upper[j].pairs, &m_Joints.upper[j].count,
+                SEAM_MAX_VERTEX_PAIRS, mesh, prev, &offset, &zero);
+            total_pairs += m_Joints.upper[j].count;
+        }
+        if (j + 1 < M_HAIR_SEGMENTS) {
+            const OBJECT_MESH *const next = Object_GetMesh(braid_base + j + 1);
+            const XYZ_32 offset = bones[M_BONE_IDX(j + 1)].pos;
+            Lara_Seam_FindSharedVertices(
+                m_Joints.lower[j].pairs, &m_Joints.lower[j].count,
+                SEAM_MAX_VERTEX_PAIRS, mesh, next, &zero, &offset);
+            M_SortSeamRing(&m_Joints.lower[j], mesh);
+            total_pairs += m_Joints.lower[j].count;
+        }
+    }
+
+    if (total_pairs == 0) {
+        LOG_INFO("braid segments share no ring; welding disabled");
+        return;
+    }
+
+    M_EnsureScratch(max_vertices);
+    m_Joints.enabled = true;
+
+    // A second pigtail shares the first's meshes, so give it its own copies to
+    // deform; otherwise the two would fight over one buffer and only the last
+    // drawn would close. The refresh builds the copies' render buffers.
+    const LARA_SKIN_BRAID *const braid = Lara_Skin_GetBraid();
+
+    // Copy the authored head-attach ring for each pigtail, dropping any pair
+    // that names a vertex past either mesh, so the weld does not have to
+    // bounds-check every frame.
+    const OBJECT_MESH *const head_mesh = Lara_Mesh_Get(LM_HEAD);
+    const OBJECT_MESH *const seg0_mesh = Object_GetMesh(braid_base);
+    for (int32_t i = 0; i < braid->count; i++) {
+        const LARA_SKIN_BRAID_HEAD_SEAM *const src = &braid->setup[i].head_seam;
+        m_Joints.head[i].count = 0;
+        for (int32_t k = 0; k < src->count; k++) {
+            if (src->pairs[k].vertex_a >= seg0_mesh->num_vertices
+                || src->pairs[k].vertex_b >= head_mesh->num_vertices) {
+                continue;
+            }
+            m_Joints.head[i].pairs[m_Joints.head[i].count++] = src->pairs[k];
+        }
+    }
+
+    // Record which meshes the draw will deform - the bridges - so a later
+    // outfit can restore them. Restoring a mesh that was never deformed is a
+    // no-op.
+    for (int32_t i = 0; i < braid->count; i++) {
+        const int32_t seg_base = Lara_Skin_GetBraidMeshIdx(i);
+        for (int32_t j = 0; j < M_HAIR_SEGMENTS; j += 2) {
+            m_Joints.welded_indices[m_Joints.welded_count++] = seg_base + j;
+        }
     }
 }
 

--- a/src/trx/game/lara/skin/joints.c
+++ b/src/trx/game/lara/skin/joints.c
@@ -141,6 +141,66 @@ __attribute__((destructor)) static void M_Shutdown(void)
     M_Reset();
 }
 
+// Welds the joint sleeve to the two limbs it bridges. The joint is drawn with
+// the child's matrix, so the child-side ring is snapped straight onto the
+// child mesh's own vertices; the parent-side ring lives in a different frame
+// and is transformed across. Both rings track the limbs exactly as the joint
+// bends, closing the gap the static sleeve would otherwise leave.
+static void M_PinSeam(
+    const OBJECT_MESH *const mesh, const M_JOINT *const joint,
+    const MATRIX *const parent, const MATRIX *const child)
+{
+    const bool joint_has_normals = mesh->num_lights > 0;
+    for (int32_t i = 0; i < joint->vertex_count; i++) {
+        joint->positions[i] = (XYZ_F) {
+            mesh->vertices[i].x,
+            mesh->vertices[i].y,
+            mesh->vertices[i].z,
+        };
+        joint->normals[i] = joint_has_normals && i < mesh->num_lights
+            ? (XYZ_F) { mesh->lighting.normals[i].x,
+                        mesh->lighting.normals[i].y,
+                        mesh->lighting.normals[i].z }
+            : (XYZ_F) { 0.0f, 0.0f, 0.0f };
+    }
+
+    const OBJECT_MESH *const child_mesh = Lara_Mesh_Get(joint->child_mesh);
+    const bool child_has_normals = child_mesh->num_lights > 0;
+    for (int32_t i = 0; i < joint->child.count; i++) {
+        const SEAM_VERTEX_PAIR *const pair = &joint->child.pairs[i];
+        if (pair->vertex_a >= child_mesh->num_vertices) {
+            continue;
+        }
+        joint->positions[pair->vertex_b] = (XYZ_F) {
+            child_mesh->vertices[pair->vertex_a].x,
+            child_mesh->vertices[pair->vertex_a].y,
+            child_mesh->vertices[pair->vertex_a].z,
+        };
+        // The joint is drawn in the child's frame, so its child-side normal is
+        // copied straight across.
+        if (child_has_normals && pair->vertex_a < child_mesh->num_lights) {
+            const XYZ_16 n = child_mesh->lighting.normals[pair->vertex_a];
+            joint->normals[pair->vertex_b] = (XYZ_F) { n.x, n.y, n.z };
+        }
+    }
+
+    const OBJECT_MESH *const parent_mesh = Lara_Mesh_Get(joint->parent_mesh);
+    const bool parent_has_normals = parent_mesh->num_lights > 0;
+    for (int32_t i = 0; i < joint->parent.count; i++) {
+        const SEAM_VERTEX_PAIR *const pair = &joint->parent.pairs[i];
+        if (pair->vertex_a >= parent_mesh->num_vertices) {
+            continue;
+        }
+        joint->positions[pair->vertex_b] = Lara_Seam_TransformPos(
+            parent, child,
+            XYZ_32_From16(parent_mesh->vertices[pair->vertex_a]));
+        if (parent_has_normals && pair->vertex_a < parent_mesh->num_lights) {
+            joint->normals[pair->vertex_b] = Lara_Seam_TransformNormal(
+                parent, child, parent_mesh->lighting.normals[pair->vertex_a]);
+        }
+    }
+}
+
 void Lara_Joints_Initialise(const LARA_SKIN_OUTFIT *const outfit)
 {
     M_Reset();
@@ -212,66 +272,6 @@ void Lara_Joints_StashMatrix(const LARA_MESH mesh_idx, const bool interpolated)
         Matrix_Pop();
     } else {
         m_State.mesh_matrices[mesh_idx] = *g_WMatrixPtr;
-    }
-}
-
-// Welds the joint sleeve to the two limbs it bridges. The joint is drawn with
-// the child's matrix, so the child-side ring is snapped straight onto the
-// child mesh's own vertices; the parent-side ring lives in a different frame
-// and is transformed across. Both rings track the limbs exactly as the joint
-// bends, closing the gap the static sleeve would otherwise leave.
-static void M_PinSeam(
-    const OBJECT_MESH *const mesh, const M_JOINT *const joint,
-    const MATRIX *const parent, const MATRIX *const child)
-{
-    const bool joint_has_normals = mesh->num_lights > 0;
-    for (int32_t i = 0; i < joint->vertex_count; i++) {
-        joint->positions[i] = (XYZ_F) {
-            mesh->vertices[i].x,
-            mesh->vertices[i].y,
-            mesh->vertices[i].z,
-        };
-        joint->normals[i] = joint_has_normals && i < mesh->num_lights
-            ? (XYZ_F) { mesh->lighting.normals[i].x,
-                        mesh->lighting.normals[i].y,
-                        mesh->lighting.normals[i].z }
-            : (XYZ_F) { 0.0f, 0.0f, 0.0f };
-    }
-
-    const OBJECT_MESH *const child_mesh = Lara_Mesh_Get(joint->child_mesh);
-    const bool child_has_normals = child_mesh->num_lights > 0;
-    for (int32_t i = 0; i < joint->child.count; i++) {
-        const SEAM_VERTEX_PAIR *const pair = &joint->child.pairs[i];
-        if (pair->vertex_a >= child_mesh->num_vertices) {
-            continue;
-        }
-        joint->positions[pair->vertex_b] = (XYZ_F) {
-            child_mesh->vertices[pair->vertex_a].x,
-            child_mesh->vertices[pair->vertex_a].y,
-            child_mesh->vertices[pair->vertex_a].z,
-        };
-        // The joint is drawn in the child's frame, so its child-side normal is
-        // copied straight across.
-        if (child_has_normals && pair->vertex_a < child_mesh->num_lights) {
-            const XYZ_16 n = child_mesh->lighting.normals[pair->vertex_a];
-            joint->normals[pair->vertex_b] = (XYZ_F) { n.x, n.y, n.z };
-        }
-    }
-
-    const OBJECT_MESH *const parent_mesh = Lara_Mesh_Get(joint->parent_mesh);
-    const bool parent_has_normals = parent_mesh->num_lights > 0;
-    for (int32_t i = 0; i < joint->parent.count; i++) {
-        const SEAM_VERTEX_PAIR *const pair = &joint->parent.pairs[i];
-        if (pair->vertex_a >= parent_mesh->num_vertices) {
-            continue;
-        }
-        joint->positions[pair->vertex_b] = Lara_Seam_TransformPos(
-            parent, child,
-            XYZ_32_From16(parent_mesh->vertices[pair->vertex_a]));
-        if (parent_has_normals && pair->vertex_a < parent_mesh->num_lights) {
-            joint->normals[pair->vertex_b] = Lara_Seam_TransformNormal(
-                parent, child, parent_mesh->lighting.normals[pair->vertex_a]);
-        }
     }
 }
 

--- a/src/trx/game/lara/skin/seam.c
+++ b/src/trx/game/lara/skin/seam.c
@@ -10,6 +10,36 @@ static bool M_VertexMatches(const XYZ_32 a, const XYZ_32 b)
     return ABS(a.x - b.x) <= 1 && ABS(a.y - b.y) <= 1 && ABS(a.z - b.z) <= 1;
 }
 
+// Applies the exact inverse of "to"'s rotation to a world-space vector. The
+// entries are quantized to 1/(1<<W2V_SHIFT), so the transpose is only an
+// approximate inverse, and the leftover error reads as a hairline crack
+// between welded meshes; the adjugate stays exact for whatever rotation the
+// matrix holds.
+static XYZ_F M_UndoRotation(
+    const MATRIX *const to, const double dx, const double dy, const double dz)
+{
+    const double r00 = to->_00, r01 = to->_01, r02 = to->_02;
+    const double r10 = to->_10, r11 = to->_11, r12 = to->_12;
+    const double r20 = to->_20, r21 = to->_21, r22 = to->_22;
+
+    const double c00 = r11 * r22 - r12 * r21;
+    const double c01 = r12 * r20 - r10 * r22;
+    const double c02 = r10 * r21 - r11 * r20;
+    const double c10 = r02 * r21 - r01 * r22;
+    const double c11 = r00 * r22 - r02 * r20;
+    const double c12 = r01 * r20 - r00 * r21;
+    const double c20 = r01 * r12 - r02 * r11;
+    const double c21 = r02 * r10 - r00 * r12;
+    const double c22 = r00 * r11 - r01 * r10;
+
+    const double det = r00 * c00 + r01 * c01 + r02 * c02;
+    return (XYZ_F) {
+        (float)((c00 * dx + c10 * dy + c20 * dz) / det),
+        (float)((c01 * dx + c11 * dy + c21 * dz) / det),
+        (float)((c02 * dx + c12 * dy + c22 * dz) / det),
+    };
+}
+
 void Lara_Seam_FindSharedVertices(
     SEAM_VERTEX_PAIR *const pairs, int32_t *const pair_count,
     const int32_t max_pairs, const OBJECT_MESH *const mesh_a,
@@ -39,36 +69,6 @@ void Lara_Seam_FindSharedVertices(
             (*pair_count)++;
         }
     }
-}
-
-// Applies the exact inverse of "to"'s rotation to a world-space vector. The
-// entries are quantized to 1/(1<<W2V_SHIFT), so the transpose is only an
-// approximate inverse, and the leftover error reads as a hairline crack
-// between welded meshes; the adjugate stays exact for whatever rotation the
-// matrix holds.
-static XYZ_F M_UndoRotation(
-    const MATRIX *const to, const double dx, const double dy, const double dz)
-{
-    const double r00 = to->_00, r01 = to->_01, r02 = to->_02;
-    const double r10 = to->_10, r11 = to->_11, r12 = to->_12;
-    const double r20 = to->_20, r21 = to->_21, r22 = to->_22;
-
-    const double c00 = r11 * r22 - r12 * r21;
-    const double c01 = r12 * r20 - r10 * r22;
-    const double c02 = r10 * r21 - r11 * r20;
-    const double c10 = r02 * r21 - r01 * r22;
-    const double c11 = r00 * r22 - r02 * r20;
-    const double c12 = r01 * r20 - r00 * r21;
-    const double c20 = r01 * r12 - r02 * r11;
-    const double c21 = r02 * r10 - r00 * r12;
-    const double c22 = r00 * r11 - r01 * r10;
-
-    const double det = r00 * c00 + r01 * c01 + r02 * c02;
-    return (XYZ_F) {
-        (float)((c00 * dx + c10 * dy + c20 * dz) / det),
-        (float)((c01 * dx + c11 * dy + c21 * dz) / det),
-        (float)((c02 * dx + c12 * dy + c22 * dz) / det),
-    };
 }
 
 XYZ_F Lara_Seam_TransformPos(

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -83,26 +83,6 @@ static void M_ResetOutfits(void)
     m_OutfitLookup = nullptr;
 }
 
-LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
-{
-    if (name == nullptr) {
-        return LARA_SKIN_TYPE_DEFAULT;
-    }
-
-    M_OUTFIT_LOOKUP *entry = nullptr;
-    HASH_FIND_STR(m_OutfitLookup, name, entry);
-    if (entry == nullptr) {
-        return -1;
-    }
-
-    return entry->index;
-}
-
-LARA_SKIN_TYPE Lara_Skin_GetDefaultType(void)
-{
-    return m_OutfitCount > 0 ? 0 : LARA_SKIN_TYPE_DEFAULT;
-}
-
 static bool M_ReadGunMaps(JSON_READ_IO *const io)
 {
     JSON_MUST(JSON_PUSH(io, "gun_maps"));
@@ -460,6 +440,26 @@ static bool M_LoadFile(JSON_READ_IO *const io)
     JSON_MUST(M_ReadExtraMeshes(io));
     JSON_MUST(M_ReadOutfits(io));
     JSON_FINISH();
+}
+
+LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
+{
+    if (name == nullptr) {
+        return LARA_SKIN_TYPE_DEFAULT;
+    }
+
+    M_OUTFIT_LOOKUP *entry = nullptr;
+    HASH_FIND_STR(m_OutfitLookup, name, entry);
+    if (entry == nullptr) {
+        return -1;
+    }
+
+    return entry->index;
+}
+
+LARA_SKIN_TYPE Lara_Skin_GetDefaultType(void)
+{
+    return m_OutfitCount > 0 ? 0 : LARA_SKIN_TYPE_DEFAULT;
 }
 
 void Lara_Skin_LoadFromFile(const char *const path)

--- a/src/trx/game/level/cache.c
+++ b/src/trx/game/level/cache.c
@@ -110,6 +110,18 @@ static uint64_t M_GetLevelHash(const GF_LEVEL *const level)
     return entry->hash;
 }
 
+static const char *M_GetPath(const char *const filename)
+{
+    const SHELL_ARGS *const args = Shell_GetArgs();
+    if (args == nullptr || args->startup.mod == nullptr
+        || args->startup.mod->name == nullptr) {
+        return nullptr;
+    }
+
+    return String_FormatStatic(
+        "%s/%s/%s", Shell_GetCacheDir(), args->startup.mod->name, filename);
+}
+
 uint64_t LevelCache_InitChecksum(
     const char *const scope, const uint32_t version)
 {
@@ -178,18 +190,6 @@ const char *LevelCache_GetLevelKey(const GF_LEVEL *const level)
     const size_t stem_len = strcspn(name, ".");
     return String_FormatStatic(
         "%c%d_%.*s", type_key, level->num, (int)stem_len, name);
-}
-
-static const char *M_GetPath(const char *const filename)
-{
-    const SHELL_ARGS *const args = Shell_GetArgs();
-    if (args == nullptr || args->startup.mod == nullptr
-        || args->startup.mod->name == nullptr) {
-        return nullptr;
-    }
-
-    return String_FormatStatic(
-        "%s/%s/%s", Shell_GetCacheDir(), args->startup.mod->name, filename);
 }
 
 MYFILE *LevelCache_OpenBinaryRead(

--- a/src/trx/game/level/format/pipeline.c
+++ b/src/trx/game/level/format/pipeline.c
@@ -23,6 +23,19 @@ __attribute__((destructor)) static void M_Shutdown(void)
     }
 }
 
+static int32_t M_GetRegisteredLoaderCount(void)
+{
+    if (m_Loaders == nullptr) {
+        return 0;
+    }
+    return m_Loaders->count;
+}
+
+static const LEVEL_FORMAT_LOADER *M_GetRegisteredLoader(const int32_t index)
+{
+    return ((M_REGISTERED_LOADER *)Vector_Get(m_Loaders, index))->loader;
+}
+
 void Level_Format_RegisterLoader(
     const int32_t priority, const LEVEL_FORMAT_LOADER *const loader)
 {
@@ -44,19 +57,6 @@ void Level_Format_RegisterLoader(
         }
     }
     Vector_Insert(m_Loaders, insert_idx, &registered);
-}
-
-static int32_t M_GetRegisteredLoaderCount(void)
-{
-    if (m_Loaders == nullptr) {
-        return 0;
-    }
-    return m_Loaders->count;
-}
-
-static const LEVEL_FORMAT_LOADER *M_GetRegisteredLoader(const int32_t index)
-{
-    return ((M_REGISTERED_LOADER *)Vector_Get(m_Loaders, index))->loader;
 }
 
 const LEVEL_FORMAT_LOADER *Level_Format_GuessLoader(VFILE *const file)

--- a/src/trx/game/lua/capi/api.c
+++ b/src/trx/game/lua/capi/api.c
@@ -31,6 +31,16 @@ static int M_L_SetEntrypoint(lua_State *const L)
     return 0;
 }
 
+static const luaL_Reg m_Module[] = {
+    { "set_entrypoint", M_L_SetEntrypoint },
+    { nullptr, nullptr },
+};
+
+static void M_Create(lua_State *const L)
+{
+    LUA_RegisterModule(L, "api", m_Module);
+}
+
 bool LUA_API_PushEntrypoint(lua_State *const L, const char *const name)
 {
     if (lua_getfield(L, LUA_REGISTRYINDEX, m_EntrypointsKey) != LUA_TTABLE) {
@@ -44,16 +54,6 @@ bool LUA_API_PushEntrypoint(lua_State *const L, const char *const name)
         return false;
     }
     return true;
-}
-
-static const luaL_Reg m_Module[] = {
-    { "set_entrypoint", M_L_SetEntrypoint },
-    { nullptr, nullptr },
-};
-
-static void M_Create(lua_State *const L)
-{
-    LUA_RegisterModule(L, "api", m_Module);
 }
 
 REGISTER_LUA_CAPI(.create = M_Create)

--- a/src/trx/game/lua/capi/events.c
+++ b/src/trx/game/lua/capi/events.c
@@ -284,40 +284,6 @@ static void M_Create(lua_State *const L)
     ItemAction_SetInterceptor(M_InterceptFlipEffect);
 }
 
-void LUA_ClearLevelListeners(void)
-{
-    lua_State *const L = m_L;
-    if (L == nullptr) {
-        return;
-    }
-
-    if (m_Claims != nullptr) {
-        for (int32_t i = 0; i < m_Claims->count;) {
-            const M_CLAIM *const claim = Vector_Get(m_Claims, i);
-            if (claim->level_scoped) {
-                Vector_RemoveAt(m_Claims, i);
-            } else {
-                i++;
-            }
-        }
-    }
-
-    if (m_Listeners == nullptr) {
-        return;
-    }
-    for (int32_t i = 0; i < m_Listeners->count;) {
-        const M_LISTENER *const lst = Vector_Get(m_Listeners, i);
-        if (!lst->level_scoped || lst->dead) {
-            i++;
-            continue;
-        }
-        M_RemoveListener(L, i);
-        if (m_DispatchDepth > 0) {
-            i++;
-        }
-    }
-}
-
 static void M_FireEvent(
     const LUA_EVENT_TYPE ev, const int32_t key, const LUA_EVENT_ARG *const args,
     const int32_t arg_count)
@@ -362,6 +328,40 @@ static void M_FireEvent(
     m_DispatchDepth--;
     if (m_DispatchDepth == 0) {
         M_CompactListeners();
+    }
+}
+
+void LUA_ClearLevelListeners(void)
+{
+    lua_State *const L = m_L;
+    if (L == nullptr) {
+        return;
+    }
+
+    if (m_Claims != nullptr) {
+        for (int32_t i = 0; i < m_Claims->count;) {
+            const M_CLAIM *const claim = Vector_Get(m_Claims, i);
+            if (claim->level_scoped) {
+                Vector_RemoveAt(m_Claims, i);
+            } else {
+                i++;
+            }
+        }
+    }
+
+    if (m_Listeners == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < m_Listeners->count;) {
+        const M_LISTENER *const lst = Vector_Get(m_Listeners, i);
+        if (!lst->level_scoped || lst->dead) {
+            i++;
+            continue;
+        }
+        M_RemoveListener(L, i);
+        if (m_DispatchDepth > 0) {
+            i++;
+        }
     }
 }
 

--- a/src/trx/game/lua/capi/struct.c
+++ b/src/trx/game/lua/capi/struct.c
@@ -252,124 +252,6 @@ static int M_PropertyGetNames(lua_State *const L)
     return 1;
 }
 
-LUA_STRUCT_REF *LUA_Struct_CheckRef(
-    lua_State *const L, const int idx, const TYPE_DESC *const type)
-{
-    return luaL_checkudata(L, idx, type->name);
-}
-
-void *LUA_Struct_Deref(lua_State *const L, LUA_STRUCT_REF *const ref)
-{
-    void *const self = ref->resolve(ref);
-    if (self == nullptr) {
-        luaL_error(L, "stale %s handle", ref->type->name);
-    }
-    return self;
-}
-
-void LUA_Struct_Register(
-    lua_State *const L, const TYPE_DESC *const type,
-    const luaL_Reg *const methods)
-{
-    Field_ValidateType(type);
-
-    luaL_newmetatable(L, type->name);
-
-    // Everything C could offer, for Lua to select from. Not reachable from a
-    // handle.
-    lua_newtable(L);
-    if (methods != nullptr) {
-        luaL_setfuncs(L, methods, 0);
-    }
-    lua_pushlightuserdata(L, (void *)type);
-    lua_pushcclosure(L, M_IsValid, 1);
-    lua_setfield(L, -2, "is_valid");
-    lua_setfield(L, -2, m_KeyRawMethods);
-
-    // The public surface: empty until a script declares it. `writable` is the
-    // subset of `fields` the declaration allows a script to set.
-    lua_newtable(L); // fields
-    lua_newtable(L); // writable
-    lua_newtable(L); // methods
-    lua_newtable(L); // ext
-
-    lua_pushvalue(L, -4);
-    lua_setfield(L, -6, m_KeyFields);
-    lua_pushvalue(L, -3);
-    lua_setfield(L, -6, m_KeyWritable);
-    lua_pushvalue(L, -2);
-    lua_setfield(L, -6, m_KeyMethods);
-    lua_pushvalue(L, -1);
-    lua_setfield(L, -6, m_KeyExt);
-
-    // __index and __newindex close over these tables. Populating them later
-    // from Lua is visible here, because the upvalues are the tables themselves.
-    lua_pushvalue(L, -4); // fields
-    lua_pushvalue(L, -3); // methods
-    lua_pushvalue(L, -3); // ext
-    lua_pushcclosure(L, M_Index, 3);
-    lua_setfield(L, -6, "__index");
-
-    lua_pushvalue(L, -3); // writable
-    lua_pushvalue(L, -5); // fields
-    lua_pushcclosure(L, M_NewIndex, 2);
-    lua_setfield(L, -6, "__newindex");
-
-    lua_pop(L, 4); // fields, writable, methods, ext
-
-    lua_pushcfunction(L, M_Pairs);
-    lua_setfield(L, -2, "__pairs");
-
-    lua_pushlightuserdata(L, (void *)type);
-    lua_pushcclosure(L, M_Eq, 1);
-    lua_setfield(L, -2, "__eq");
-
-    // Protect the metatable. Without this, getmetatable(item).__raw_methods
-    // hands a script every C method the type could offer, including the ones no
-    // declaration exposed - which would make the opt-in surface a fiction.
-    lua_pushstring(L, type->name);
-    lua_setfield(L, -2, "__metatable");
-
-    lua_pop(L, 1);
-}
-
-void LUA_Struct_Push(
-    lua_State *const L, const TYPE_DESC *const type,
-    void *(*const resolve)(const LUA_STRUCT_REF *), const TRX_HANDLE handle)
-{
-    LUA_STRUCT_REF *const ref = lua_newuserdatauv(L, sizeof(LUA_STRUCT_REF), 0);
-    *ref = (LUA_STRUCT_REF) {
-        .type = type,
-        .resolve = resolve,
-        .handle = handle,
-    };
-    luaL_setmetatable(L, type->name);
-}
-
-void LUA_Property_Register(
-    lua_State *const L, const LUA_PROPERTY_DESC *const desc)
-{
-    static const struct {
-        const char *name;
-        lua_CFunction fn;
-    } bridges[] = {
-        { "get_property", M_PropertyGet },
-        { "set_property", M_PropertySet },
-        { "get_property_names", M_PropertyGetNames },
-    };
-
-    luaL_getmetatable(L, desc->type->name);
-    lua_getfield(L, -1, m_KeyRawMethods);
-    for (size_t i = 0; i < sizeof(bridges) / sizeof(bridges[0]); i++) {
-        lua_pushlightuserdata(L, (void *)desc);
-        lua_pushcclosure(L, bridges[i].fn, 1);
-        lua_setfield(L, -2, bridges[i].name);
-    }
-    lua_pop(L, 2);
-}
-
-// --- trxc.struct: how Lua declares the public surface -----------------------
-
 static const TYPE_DESC *M_CheckType(lua_State *const L, const int idx)
 {
     const char *const name = luaL_checkstring(L, idx);
@@ -524,6 +406,122 @@ static const luaL_Reg m_Module[] = {
 static void M_Create(lua_State *const L)
 {
     LUA_RegisterModule(L, "struct", m_Module);
+}
+
+LUA_STRUCT_REF *LUA_Struct_CheckRef(
+    lua_State *const L, const int idx, const TYPE_DESC *const type)
+{
+    return luaL_checkudata(L, idx, type->name);
+}
+
+void *LUA_Struct_Deref(lua_State *const L, LUA_STRUCT_REF *const ref)
+{
+    void *const self = ref->resolve(ref);
+    if (self == nullptr) {
+        luaL_error(L, "stale %s handle", ref->type->name);
+    }
+    return self;
+}
+
+void LUA_Struct_Register(
+    lua_State *const L, const TYPE_DESC *const type,
+    const luaL_Reg *const methods)
+{
+    Field_ValidateType(type);
+
+    luaL_newmetatable(L, type->name);
+
+    // Everything C could offer, for Lua to select from. Not reachable from a
+    // handle.
+    lua_newtable(L);
+    if (methods != nullptr) {
+        luaL_setfuncs(L, methods, 0);
+    }
+    lua_pushlightuserdata(L, (void *)type);
+    lua_pushcclosure(L, M_IsValid, 1);
+    lua_setfield(L, -2, "is_valid");
+    lua_setfield(L, -2, m_KeyRawMethods);
+
+    // The public surface: empty until a script declares it. `writable` is the
+    // subset of `fields` the declaration allows a script to set.
+    lua_newtable(L); // fields
+    lua_newtable(L); // writable
+    lua_newtable(L); // methods
+    lua_newtable(L); // ext
+
+    lua_pushvalue(L, -4);
+    lua_setfield(L, -6, m_KeyFields);
+    lua_pushvalue(L, -3);
+    lua_setfield(L, -6, m_KeyWritable);
+    lua_pushvalue(L, -2);
+    lua_setfield(L, -6, m_KeyMethods);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -6, m_KeyExt);
+
+    // __index and __newindex close over these tables. Populating them later
+    // from Lua is visible here, because the upvalues are the tables themselves.
+    lua_pushvalue(L, -4); // fields
+    lua_pushvalue(L, -3); // methods
+    lua_pushvalue(L, -3); // ext
+    lua_pushcclosure(L, M_Index, 3);
+    lua_setfield(L, -6, "__index");
+
+    lua_pushvalue(L, -3); // writable
+    lua_pushvalue(L, -5); // fields
+    lua_pushcclosure(L, M_NewIndex, 2);
+    lua_setfield(L, -6, "__newindex");
+
+    lua_pop(L, 4); // fields, writable, methods, ext
+
+    lua_pushcfunction(L, M_Pairs);
+    lua_setfield(L, -2, "__pairs");
+
+    lua_pushlightuserdata(L, (void *)type);
+    lua_pushcclosure(L, M_Eq, 1);
+    lua_setfield(L, -2, "__eq");
+
+    // Protect the metatable. Without this, getmetatable(item).__raw_methods
+    // hands a script every C method the type could offer, including the ones no
+    // declaration exposed - which would make the opt-in surface a fiction.
+    lua_pushstring(L, type->name);
+    lua_setfield(L, -2, "__metatable");
+
+    lua_pop(L, 1);
+}
+
+void LUA_Struct_Push(
+    lua_State *const L, const TYPE_DESC *const type,
+    void *(*const resolve)(const LUA_STRUCT_REF *), const TRX_HANDLE handle)
+{
+    LUA_STRUCT_REF *const ref = lua_newuserdatauv(L, sizeof(LUA_STRUCT_REF), 0);
+    *ref = (LUA_STRUCT_REF) {
+        .type = type,
+        .resolve = resolve,
+        .handle = handle,
+    };
+    luaL_setmetatable(L, type->name);
+}
+
+void LUA_Property_Register(
+    lua_State *const L, const LUA_PROPERTY_DESC *const desc)
+{
+    static const struct {
+        const char *name;
+        lua_CFunction fn;
+    } bridges[] = {
+        { "get_property", M_PropertyGet },
+        { "set_property", M_PropertySet },
+        { "get_property_names", M_PropertyGetNames },
+    };
+
+    luaL_getmetatable(L, desc->type->name);
+    lua_getfield(L, -1, m_KeyRawMethods);
+    for (size_t i = 0; i < sizeof(bridges) / sizeof(bridges[0]); i++) {
+        lua_pushlightuserdata(L, (void *)desc);
+        lua_pushcclosure(L, bridges[i].fn, 1);
+        lua_setfield(L, -2, bridges[i].name);
+    }
+    lua_pop(L, 2);
 }
 
 REGISTER_LUA_CAPI(.create = M_Create)

--- a/src/trx/game/matrix.c
+++ b/src/trx/game/matrix.c
@@ -364,37 +364,6 @@ static void M_TranslateSet(MATRIX *const m, const XYZ_32 pos)
     m->_23 = (int64_t)pos.z * scale;
 }
 
-void Matrix_Mul3x3_M(
-    MATRIX *const out, const MATRIX *const lhs, const MATRIX *const rhs)
-{
-#define L_MUL(r_, c_)                                                          \
-    (((lhs->_##r_##0 * rhs->_0##c_) + (lhs->_##r_##1 * rhs->_1##c_)            \
-      + (lhs->_##r_##2 * rhs->_2##c_))                                         \
-     >> W2V_SHIFT)
-
-    const int64_t r00 = L_MUL(0, 0);
-    const int64_t r01 = L_MUL(0, 1);
-    const int64_t r02 = L_MUL(0, 2);
-    const int64_t r10 = L_MUL(1, 0);
-    const int64_t r11 = L_MUL(1, 1);
-    const int64_t r12 = L_MUL(1, 2);
-    const int64_t r20 = L_MUL(2, 0);
-    const int64_t r21 = L_MUL(2, 1);
-    const int64_t r22 = L_MUL(2, 2);
-
-    out->_00 = r00;
-    out->_01 = r01;
-    out->_02 = r02;
-    out->_10 = r10;
-    out->_11 = r11;
-    out->_12 = r12;
-    out->_20 = r20;
-    out->_21 = r21;
-    out->_22 = r22;
-
-#undef L_MUL
-}
-
 static void M_InterpolateArm(MATRIX *const m, const MATRIX *const mi)
 {
     m->_00 = m[-2]._00;
@@ -426,6 +395,37 @@ static void M_Interpolate(
     result->_03 = (int32_t)llround(m1->_03 + (m2->_03 - m1->_03) * rate);
     result->_13 = (int32_t)llround(m1->_13 + (m2->_13 - m1->_13) * rate);
     result->_23 = (int32_t)llround(m1->_23 + (m2->_23 - m1->_23) * rate);
+}
+
+void Matrix_Mul3x3_M(
+    MATRIX *const out, const MATRIX *const lhs, const MATRIX *const rhs)
+{
+#define L_MUL(r_, c_)                                                          \
+    (((lhs->_##r_##0 * rhs->_0##c_) + (lhs->_##r_##1 * rhs->_1##c_)            \
+      + (lhs->_##r_##2 * rhs->_2##c_))                                         \
+     >> W2V_SHIFT)
+
+    const int64_t r00 = L_MUL(0, 0);
+    const int64_t r01 = L_MUL(0, 1);
+    const int64_t r02 = L_MUL(0, 2);
+    const int64_t r10 = L_MUL(1, 0);
+    const int64_t r11 = L_MUL(1, 1);
+    const int64_t r12 = L_MUL(1, 2);
+    const int64_t r20 = L_MUL(2, 0);
+    const int64_t r21 = L_MUL(2, 1);
+    const int64_t r22 = L_MUL(2, 2);
+
+    out->_00 = r00;
+    out->_01 = r01;
+    out->_02 = r02;
+    out->_10 = r10;
+    out->_11 = r11;
+    out->_12 = r12;
+    out->_20 = r20;
+    out->_21 = r21;
+    out->_22 = r22;
+
+#undef L_MUL
 }
 
 void Matrix_ResetStack(void)

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -298,6 +298,33 @@ static bool M_GetMainTrackState(MUSIC_STREAM_STATE *const state)
     return false;
 }
 
+// Slot 0 is the main stream; slots 1.. are the overlays.
+static M_MUSIC_STREAM *M_GetStreamBySlot(const int32_t slot)
+{
+    if (slot == 0) {
+        return &m_MainStream;
+    }
+    if (slot >= 1 && slot <= MUSIC_MAX_OVERLAY_TRACKS) {
+        return &m_OverlayStreams[slot - 1];
+    }
+    return nullptr;
+}
+
+static bool M_IsSpeechTrack(const MUSIC_ID track_id)
+{
+    switch (Music_FromGameID(track_id)) {
+    case MX_BALDY_SPEECH:
+    case MX_COWBOY_SPEECH:
+    case MX_LARSON_SPEECH:
+    case MX_NATLA_SPEECH:
+    case MX_PIERRE_SPEECH:
+    case MX_SKATEKID_SPEECH:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool Music_Init(void)
 {
     m_Initialised = true;
@@ -575,18 +602,6 @@ bool Music_GetStreamState(
     return false;
 }
 
-// Slot 0 is the main stream; slots 1.. are the overlays.
-static M_MUSIC_STREAM *M_GetStreamBySlot(const int32_t slot)
-{
-    if (slot == 0) {
-        return &m_MainStream;
-    }
-    if (slot >= 1 && slot <= MUSIC_MAX_OVERLAY_TRACKS) {
-        return &m_OverlayStreams[slot - 1];
-    }
-    return nullptr;
-}
-
 int32_t Music_GetStreamSlotCount(void)
 {
     return 1 + MUSIC_MAX_OVERLAY_TRACKS;
@@ -718,21 +733,6 @@ void Music_ResetTrackStates(void)
 MUSIC_TRACK_STATE *Music_GetTrackState(const MUSIC_ID track_id)
 {
     return &m_TrackStates[track_id];
-}
-
-static bool M_IsSpeechTrack(const MUSIC_ID track_id)
-{
-    switch (Music_FromGameID(track_id)) {
-    case MX_BALDY_SPEECH:
-    case MX_COWBOY_SPEECH:
-    case MX_LARSON_SPEECH:
-    case MX_NATLA_SPEECH:
-    case MX_PIERRE_SPEECH:
-    case MX_SKATEKID_SPEECH:
-        return true;
-    default:
-        return false;
-    }
 }
 
 void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -486,7 +486,7 @@ static void M_Control(const int16_t item_num)
     Creature_Animate(item_num, angle, 0);
 }
 
-bool M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
     M_PRIV *const p = item->priv;
 

--- a/src/trx/game/objects/creatures/tony_fire_ball.c
+++ b/src/trx/game/objects/creatures/tony_fire_ball.c
@@ -107,77 +107,6 @@ static void M_TriggerFireBallFlame(
     Sparks_FinishSetup(spark);
 }
 
-void TonyBoss_TriggerFireBall(
-    ITEM *const item, const int32_t type, const XYZ_32 *const pos,
-    const int16_t room_num, int16_t angle, int32_t speed)
-{
-    XYZ_32 effect_pos = {};
-    int32_t fall_speed;
-
-    switch (type) {
-    case 0:
-        Collide_GetJointAbsPosition(item, &effect_pos, 10);
-        angle = item->rot.y;
-        fall_speed = -16;
-        speed = 0;
-        break;
-    case 1:
-        Collide_GetJointAbsPosition(item, &effect_pos, 13);
-        angle = item->rot.y;
-        fall_speed = -16;
-        speed = 0;
-        break;
-    case 2:
-        Collide_GetJointAbsPosition(item, &effect_pos, 13);
-        speed = 160;
-        fall_speed = -32 - (Random_GetControl() & 7);
-        break;
-    case 3:
-        effect_pos = *pos;
-        speed = 0;
-        fall_speed = (Random_GetControl() & 3) + 4;
-        break;
-    case 4:
-        effect_pos = *pos;
-        speed += (Random_GetControl() & 3);
-        angle = Random_GetControl() << 1;
-        fall_speed = (Random_GetControl() & 3) - 2;
-        break;
-    case 5:
-        effect_pos = *pos;
-        speed = (Random_GetControl() & 7) + 48;
-        angle += (Random_GetControl() & 0x1FFF) + 0x7000;
-        fall_speed = -16 - (Random_GetControl() & 0xF);
-        break;
-    default:
-        effect_pos = *pos;
-        speed = (Random_GetControl() & 0x1F) + 32;
-        angle = Random_GetControl() << 1;
-        fall_speed = -32 - (Random_GetControl() & 0x1F);
-        break;
-    }
-
-    const int16_t fx_num = Effect_Create(room_num);
-    if (fx_num == NO_EFFECT) {
-        return;
-    }
-
-    EFFECT *const effect = Effect_Get(fx_num);
-    effect->pos = effect_pos;
-    effect->rot.y = angle;
-    effect->object_id = O_TONY_FIRE_BALL;
-    effect->speed = speed;
-    effect->fall_speed = fall_speed;
-    effect->flag1 = type;
-    effect->flag2 = (Random_GetControl() & 3) + 1;
-
-    if (type == 5) {
-        effect->flag2 <<= 1;
-    } else if (type == 2) {
-        effect->flag2 = 0;
-    }
-}
-
 static void M_Control(const int16_t effect_num)
 {
     const ITEM *const lara_item = Lara_GetItem();
@@ -315,6 +244,77 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = nullptr;
+}
+
+void TonyBoss_TriggerFireBall(
+    ITEM *const item, const int32_t type, const XYZ_32 *const pos,
+    const int16_t room_num, int16_t angle, int32_t speed)
+{
+    XYZ_32 effect_pos = {};
+    int32_t fall_speed;
+
+    switch (type) {
+    case 0:
+        Collide_GetJointAbsPosition(item, &effect_pos, 10);
+        angle = item->rot.y;
+        fall_speed = -16;
+        speed = 0;
+        break;
+    case 1:
+        Collide_GetJointAbsPosition(item, &effect_pos, 13);
+        angle = item->rot.y;
+        fall_speed = -16;
+        speed = 0;
+        break;
+    case 2:
+        Collide_GetJointAbsPosition(item, &effect_pos, 13);
+        speed = 160;
+        fall_speed = -32 - (Random_GetControl() & 7);
+        break;
+    case 3:
+        effect_pos = *pos;
+        speed = 0;
+        fall_speed = (Random_GetControl() & 3) + 4;
+        break;
+    case 4:
+        effect_pos = *pos;
+        speed += (Random_GetControl() & 3);
+        angle = Random_GetControl() << 1;
+        fall_speed = (Random_GetControl() & 3) - 2;
+        break;
+    case 5:
+        effect_pos = *pos;
+        speed = (Random_GetControl() & 7) + 48;
+        angle += (Random_GetControl() & 0x1FFF) + 0x7000;
+        fall_speed = -16 - (Random_GetControl() & 0xF);
+        break;
+    default:
+        effect_pos = *pos;
+        speed = (Random_GetControl() & 0x1F) + 32;
+        angle = Random_GetControl() << 1;
+        fall_speed = -32 - (Random_GetControl() & 0x1F);
+        break;
+    }
+
+    const int16_t fx_num = Effect_Create(room_num);
+    if (fx_num == NO_EFFECT) {
+        return;
+    }
+
+    EFFECT *const effect = Effect_Get(fx_num);
+    effect->pos = effect_pos;
+    effect->rot.y = angle;
+    effect->object_id = O_TONY_FIRE_BALL;
+    effect->speed = speed;
+    effect->fall_speed = fall_speed;
+    effect->flag1 = type;
+    effect->flag2 = (Random_GetControl() & 3) + 1;
+
+    if (type == 5) {
+        effect->flag2 <<= 1;
+    } else if (type == 2) {
+        effect->flag2 = 0;
+    }
 }
 
 REGISTER_OBJECT(O_TONY_FIRE_BALL, M_Setup)

--- a/src/trx/game/objects/general/area_51_rocket.c
+++ b/src/trx/game/objects/general/area_51_rocket.c
@@ -446,11 +446,6 @@ static void M_ControlMain(const int16_t item_num)
     M_ControlBlast(item);
 }
 
-void M_InitialiseSupport(const int16_t item_num)
-{
-    m_SupportFallen = false;
-}
-
 static void M_ControlSupport(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -482,6 +477,11 @@ static void M_SetupBlast(OBJECT *const obj)
     obj->draw_func = nullptr;
     obj->save_flags = true;
     obj->save_anim = true;
+}
+
+static void M_InitialiseSupport(const int16_t item_num)
+{
+    m_SupportFallen = false;
 }
 
 static void M_SetupSupport(OBJECT *const obj)

--- a/src/trx/game/objects/general/combat_end.c
+++ b/src/trx/game/objects/general/combat_end.c
@@ -136,6 +136,15 @@ static void M_Control(const int16_t item_num)
     }
 }
 
+static void M_Setup(OBJECT *const obj)
+{
+    obj->control_func = M_Control;
+    obj->draw_func = nullptr;
+    obj->save_flags = true;
+
+    m_BossTimer = 0;
+}
+
 OBJECT_ID CombatEnd_GetBossType(void)
 {
     return M_BOSS_TYPE;
@@ -154,15 +163,6 @@ bool CombatEnd_IsWaitingForBoss(void)
 bool CombatEnd_IsComplete(void)
 {
     return m_BossTimer >= M_CUTSCENE_DELAY;
-}
-
-static void M_Setup(OBJECT *const obj)
-{
-    obj->control_func = M_Control;
-    obj->draw_func = nullptr;
-    obj->save_flags = true;
-
-    m_BossTimer = 0;
 }
 
 REGISTER_OBJECT(O_COMBAT_END, M_Setup)

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -166,72 +166,6 @@ static void M_InitialisePortal(
     door_pos->old_sector = *door_pos->sector;
 }
 
-void Door_Initialise(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-
-    p->crowbar = false;
-    p->lift = false;
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "crowbar", &value)) {
-        p->crowbar = value.as_bool;
-    }
-    if (ObjectProperty_GetItemValue(item, "lift", &value)) {
-        p->lift = value.as_bool;
-    }
-    p->lift_count = 0;
-    p->lift_base_y = item->pos.y;
-
-    int32_t dx = 0;
-    int32_t dz = 0;
-    if (item->rot.y == 0) {
-        dz = -1;
-    } else if (item->rot.y == -DEG_180) {
-        dz = 1;
-    } else if (item->rot.y == DEG_90) {
-        dx = -1;
-    } else {
-        dx = 1;
-    }
-
-    int16_t room_num = item->room_num;
-    const ROOM *room = Room_Get(room_num);
-    M_InitialisePortal(room, item, dx, dz, &p->d1);
-
-    if (room->flipped_room == NO_ROOM) {
-        p->d1flip.sector = nullptr;
-    } else {
-        room = Room_Get(room->flipped_room);
-        M_InitialisePortal(room, item, dx, dz, &p->d1flip);
-    }
-
-    room_num = p->d1.sector->portal_room.wall;
-    M_Shut(&p->d1);
-    M_Shut(&p->d1flip);
-
-    if (room_num == NO_ROOM) {
-        p->d2.sector = nullptr;
-        p->d2flip.sector = nullptr;
-    } else {
-        room = Room_Get(room_num);
-        M_InitialisePortal(room, item, 0, 0, &p->d2);
-        if (room->flipped_room == NO_ROOM) {
-            p->d2flip.sector = nullptr;
-        } else {
-            room = Room_Get(room->flipped_room);
-            M_InitialisePortal(room, item, 0, 0, &p->d2flip);
-        }
-
-        M_Shut(&p->d2);
-        M_Shut(&p->d2flip);
-
-        const int16_t prev_room = item->room_num;
-        Item_UpdateRoom(item_num, room_num);
-        item->room_num = prev_room;
-    }
-}
-
 static void M_ControlLift(ITEM *const item)
 {
     M_PRIV *const p = item->priv;
@@ -376,6 +310,72 @@ static void M_Setup(OBJECT *const obj)
             "lift", false,
             "Whether the door rises vertically while activated instead of "
             "playing its open animation."));
+}
+
+void Door_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+
+    p->crowbar = false;
+    p->lift = false;
+    TRX_VALUE value = {};
+    if (ObjectProperty_GetItemValue(item, "crowbar", &value)) {
+        p->crowbar = value.as_bool;
+    }
+    if (ObjectProperty_GetItemValue(item, "lift", &value)) {
+        p->lift = value.as_bool;
+    }
+    p->lift_count = 0;
+    p->lift_base_y = item->pos.y;
+
+    int32_t dx = 0;
+    int32_t dz = 0;
+    if (item->rot.y == 0) {
+        dz = -1;
+    } else if (item->rot.y == -DEG_180) {
+        dz = 1;
+    } else if (item->rot.y == DEG_90) {
+        dx = -1;
+    } else {
+        dx = 1;
+    }
+
+    int16_t room_num = item->room_num;
+    const ROOM *room = Room_Get(room_num);
+    M_InitialisePortal(room, item, dx, dz, &p->d1);
+
+    if (room->flipped_room == NO_ROOM) {
+        p->d1flip.sector = nullptr;
+    } else {
+        room = Room_Get(room->flipped_room);
+        M_InitialisePortal(room, item, dx, dz, &p->d1flip);
+    }
+
+    room_num = p->d1.sector->portal_room.wall;
+    M_Shut(&p->d1);
+    M_Shut(&p->d1flip);
+
+    if (room_num == NO_ROOM) {
+        p->d2.sector = nullptr;
+        p->d2flip.sector = nullptr;
+    } else {
+        room = Room_Get(room_num);
+        M_InitialisePortal(room, item, 0, 0, &p->d2);
+        if (room->flipped_room == NO_ROOM) {
+            p->d2flip.sector = nullptr;
+        } else {
+            room = Room_Get(room->flipped_room);
+            M_InitialisePortal(room, item, 0, 0, &p->d2flip);
+        }
+
+        M_Shut(&p->d2);
+        M_Shut(&p->d2flip);
+
+        const int16_t prev_room = item->room_num;
+        Item_UpdateRoom(item_num, room_num);
+        item->room_num = prev_room;
+    }
 }
 
 void Door_OpenPortals(ITEM *const item)

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -391,6 +391,29 @@ static bool M_GenerateLight_TR4(const XYZ_32 pos, const int32_t flare_age)
     return lit;
 }
 
+static void M_Setup(OBJECT *const obj)
+{
+    obj->collision_func = Pickup_Collision;
+    obj->bounds_func = Pickup_Bounds;
+    obj->control_func = M_Control;
+    obj->draw_func = M_Draw;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->save_position = true;
+    obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_DOUBLE(
+            "burn_time", M_DEFAULT_FLARE_TIME,
+            "How long the flare burns for, in seconds."));
+
+    if (obj->loaded) {
+        for (int32_t i = 0; i < obj->mesh_count; i++) {
+            OBJECT_MESH *const obj_mesh = Object_GetMesh(obj->mesh_idx + i);
+            obj_mesh->depth_adjustment = -0.5;
+        }
+    }
+}
+
 void Flare_GenerateEffects(
     const XYZ_32 *const sound_pos, const XYZ_32 flare_pos, int16_t room_num)
 {
@@ -441,29 +464,6 @@ void FlareItem_SetAge(
     p->raw_age = flare_age & 0x7FFF;
     if (is_active) {
         p->raw_age |= 0x8000;
-    }
-}
-
-static void M_Setup(OBJECT *const obj)
-{
-    obj->collision_func = Pickup_Collision;
-    obj->bounds_func = Pickup_Bounds;
-    obj->control_func = M_Control;
-    obj->draw_func = M_Draw;
-    obj->priv_size = sizeof(M_PRIV);
-    obj->save_position = true;
-    obj->save_flags = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_DOUBLE(
-            "burn_time", M_DEFAULT_FLARE_TIME,
-            "How long the flare burns for, in seconds."));
-
-    if (obj->loaded) {
-        for (int32_t i = 0; i < obj->mesh_count; i++) {
-            OBJECT_MESH *const obj_mesh = Object_GetMesh(obj->mesh_idx + i);
-            obj_mesh->depth_adjustment = -0.5;
-        }
     }
 }
 

--- a/src/trx/game/objects/general/lights/strobe_light.c
+++ b/src/trx/game/objects/general/lights/strobe_light.c
@@ -38,7 +38,7 @@ static void M_Initialise(const int16_t item_num)
     }
 }
 
-void M_TriggerAlertLight(
+static void M_TriggerAlertLight(
     const XYZ_32 pos, const RGB_888 color, const int16_t angle,
     const int16_t room_num)
 {

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -93,12 +93,6 @@ typedef struct {
     PICKUP_MODE pickup_mode;
 } M_PRIV;
 
-uint32_t Pickup_GetSecretMask(const ITEM *const item)
-{
-    const M_PRIV *const p = item->priv;
-    return p->secret_mask;
-}
-
 static void M_Initialise(int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -688,6 +682,12 @@ const OBJECT_BOUNDS *Pickup_Bounds(void)
     } else {
         return &m_PickUpBounds;
     }
+}
+
+uint32_t Pickup_GetSecretMask(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->secret_mask;
 }
 
 bool Pickup_Trigger(const int16_t item_num)

--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -100,29 +100,6 @@ static const OBJECT_BOUNDS *M_Bounds(void)
         : &m_UW_Bounds;
 }
 
-// The mesh count guard keeps older crystal injections working.
-uint32_t SaveCrystal_GetMeshBits(const OBJECT_ID object_id, int32_t mesh_index)
-{
-    const SAVE_CRYSTAL_MODE mode = g_Config.gameplay.save_crystal_mode;
-    if (mesh_index < 0) {
-        if (g_TRVersion == 3) {
-            mesh_index =
-                mode == SAVE_CRYSTAL_HEAL ? M_MESH_TR3_HEAL : M_MESH_TR3_SAVE;
-        } else if (mode == SAVE_CRYSTAL_HEAL) {
-            mesh_index = M_MESH_HEAL;
-        } else if (g_Config.visuals.enable_ps1_crystals) {
-            mesh_index = M_MESH_PS1;
-        } else {
-            mesh_index = M_MESH_PC;
-        }
-    }
-
-    if (mesh_index >= Object_Get(object_id)->mesh_count) {
-        mesh_index = 0;
-    }
-    return 1 << mesh_index;
-}
-
 // Every crystal needs this from the start: a crystal that is never simulated
 // would otherwise keep the default mesh_bits and draw all of its tints at once.
 static void M_ApplyMesh(ITEM *const item)
@@ -400,6 +377,29 @@ static void M_Setup(OBJECT *const obj)
         Object_SetReflective(O_SAVE_CRYSTAL_ITEM, true);
         Object_SetReflective(O_SAVE_CRYSTAL_OPTION, true);
     }
+}
+
+// The mesh count guard keeps older crystal injections working.
+uint32_t SaveCrystal_GetMeshBits(const OBJECT_ID object_id, int32_t mesh_index)
+{
+    const SAVE_CRYSTAL_MODE mode = g_Config.gameplay.save_crystal_mode;
+    if (mesh_index < 0) {
+        if (g_TRVersion == 3) {
+            mesh_index =
+                mode == SAVE_CRYSTAL_HEAL ? M_MESH_TR3_HEAL : M_MESH_TR3_SAVE;
+        } else if (mode == SAVE_CRYSTAL_HEAL) {
+            mesh_index = M_MESH_HEAL;
+        } else if (g_Config.visuals.enable_ps1_crystals) {
+            mesh_index = M_MESH_PS1;
+        } else {
+            mesh_index = M_MESH_PC;
+        }
+    }
+
+    if (mesh_index >= Object_Get(object_id)->mesh_count) {
+        mesh_index = 0;
+    }
+    return 1 << mesh_index;
 }
 
 REGISTER_OBJECT(O_SAVE_CRYSTAL_ITEM, M_Setup)

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -1329,6 +1329,43 @@ static bool M_UserControl(ITEM *item, int32_t height, int32_t *pitch)
     return false;
 }
 
+static void M_Setup(OBJECT *const obj)
+{
+    if (!obj->loaded) {
+        return;
+    }
+
+    obj->initialise_func = M_Initialise;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
+    obj->collision_func = M_Collision;
+    obj->draw_func = Object_DrawAnimatingItem;
+    obj->event_func = Vehicle_HandleEvent;
+    obj->save_position = true;
+    obj->save_flags = true;
+    obj->save_anim = true;
+
+    M_EnableWheelExtraRotations(obj);
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "track_1", -1, "Random music track pool, slot 1. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."),
+        OBJECT_PROPERTY_BOOL(
+            "test_static_collision", false,
+            "Whether or not this vehicle can collide with static meshes."));
+}
+
 bool QuadBike_Control(void)
 {
     ITEM *const item = Lara_Vehicle_GetItem();
@@ -1519,43 +1556,6 @@ bool QuadBike_Control(void)
     }
 
     return M_CheckGetOff();
-}
-
-static void M_Setup(OBJECT *const obj)
-{
-    if (!obj->loaded) {
-        return;
-    }
-
-    obj->initialise_func = M_Initialise;
-    obj->priv_size = sizeof(M_PRIV);
-    obj->priv_load_func = M_LoadPriv;
-    obj->priv_save_func = M_SavePriv;
-    obj->collision_func = M_Collision;
-    obj->draw_func = Object_DrawAnimatingItem;
-    obj->event_func = Vehicle_HandleEvent;
-    obj->save_position = true;
-    obj->save_flags = true;
-    obj->save_anim = true;
-
-    M_EnableWheelExtraRotations(obj);
-
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_INT(
-            "track_1", -1, "Random music track pool, slot 1. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
-            "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
-            "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
-            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
-        OBJECT_PROPERTY_BOOL(
-            "is_heavy", true,
-            "Whether or not this vehicle can activate heavy triggers."),
-        OBJECT_PROPERTY_BOOL(
-            "test_static_collision", false,
-            "Whether or not this vehicle can collide with static meshes."));
 }
 
 REGISTER_OBJECT(O_QUAD_BIKE, M_Setup)

--- a/src/trx/game/objects/vehicles/skidoo_armed.c
+++ b/src/trx/game/objects/vehicles/skidoo_armed.c
@@ -28,6 +28,30 @@ static void M_Collision(
     }
 }
 
+static void M_Setup(OBJECT *const obj)
+{
+    if (!obj->loaded) {
+        return;
+    }
+
+    obj->collision_func = M_Collision;
+
+    obj->radius = M_ARMED_RADIUS;
+    obj->shadow_size = UNIT_SHADOW / 2;
+    obj->pivot_length = 0;
+    obj->lot_setup = LOT_Setup(LOT_SETUP_JUMPER);
+
+    obj->intelligent = true;
+    obj->save_position = true;
+    obj->save_hitpoints = true;
+    obj->save_flags = true;
+    obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "max_hit_points", SKIDOO_DRIVER_HITPOINTS, "Maximum hit points."));
+}
+
 void SkidooArmed_Push(
     const ITEM *const item, ITEM *const lara_item, const int32_t radius)
 {
@@ -68,30 +92,6 @@ void SkidooArmed_Push(
 
     lara_item->pos.x = item->pos.x + ((rz * sy + rx * cy) >> W2V_SHIFT);
     lara_item->pos.z = item->pos.z + ((rz * cy - rx * sy) >> W2V_SHIFT);
-}
-
-static void M_Setup(OBJECT *const obj)
-{
-    if (!obj->loaded) {
-        return;
-    }
-
-    obj->collision_func = M_Collision;
-
-    obj->radius = M_ARMED_RADIUS;
-    obj->shadow_size = UNIT_SHADOW / 2;
-    obj->pivot_length = 0;
-    obj->lot_setup = LOT_Setup(LOT_SETUP_JUMPER);
-
-    obj->intelligent = true;
-    obj->save_position = true;
-    obj->save_hitpoints = true;
-    obj->save_flags = true;
-    obj->save_anim = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_INT(
-            "max_hit_points", SKIDOO_DRIVER_HITPOINTS, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_SKIDOO_ARMED, M_Setup)

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -864,6 +864,27 @@ static void M_Control(int16_t item_num)
     }
 }
 
+static void M_Setup(OBJECT *const obj)
+{
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
+    obj->initialise_func = M_Initialise;
+    obj->control_func = M_Control;
+    obj->collision_func = M_Collision;
+    obj->draw_func = M_Draw;
+
+    obj->save_position = true;
+    obj->save_flags = true;
+    obj->save_anim = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
+}
+
 bool UPV_Control(void)
 {
     ITEM *const item = Lara_Vehicle_GetItem();
@@ -994,27 +1015,6 @@ bool UPV_Control(void)
     item->speed = 0;
     Item_Animate(item);
     return true;
-}
-
-static void M_Setup(OBJECT *const obj)
-{
-    obj->priv_size = sizeof(M_PRIV);
-    obj->priv_load_func = M_LoadPriv;
-    obj->priv_save_func = M_SavePriv;
-    obj->initialise_func = M_Initialise;
-    obj->control_func = M_Control;
-    obj->collision_func = M_Collision;
-    obj->draw_func = M_Draw;
-
-    obj->save_position = true;
-    obj->save_flags = true;
-    obj->save_anim = true;
-
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_BOOL(
-            "is_heavy", true,
-            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 REGISTER_OBJECT(O_UPV, M_Setup)

--- a/src/trx/game/output/lights/tr3.c
+++ b/src/trx/game/output/lights/tr3.c
@@ -439,39 +439,6 @@ static void M_CalculateStaticMeshLight(
         Output_Lights_ShadeFromMul((ambient.r + ambient.g + ambient.b) / 3.0f));
 }
 
-void Output_Lights_TR3_AddDynamicLight(
-    const XYZ_32 pos, const int32_t intensity, const int32_t falloff)
-{
-    int32_t safe_intensity = intensity;
-    int32_t safe_falloff = falloff;
-    CLAMP(safe_intensity, 0, 30);
-    CLAMP(safe_falloff, 0, 30);
-
-    int32_t max_shade = 1 << safe_intensity;
-    int32_t c = max_shade >> 4;
-    CLAMPG(c, 255);
-
-    int32_t radius = 1 << safe_falloff;
-    int32_t falloff_param = radius >> 7;
-    CLAMP(falloff_param, 1, 255);
-
-    const OUTPUT_DYNAMIC_LIGHT light = {
-        .light = {
-            .pos = pos,
-            .color = (RGB_888) { c, c, c },
-            .layout = LIGHT_LAYOUT_LEGACY,
-            .type = LIGHT_TYPE_POINT,
-            .u.legacy =
-                {
-                    .falloff.value_1 = falloff_param
-                        << OUTPUT_DYNAMIC_FALLOFF_SHIFT,
-                },
-        },
-        .kind = OUTPUT_DYNAMIC_LIGHT_RGB,
-    };
-    Vector_Add(Output_GetDynamicLights(), &light);
-}
-
 static void M_UploadCPULight(
     const OUTPUT_UNIFORMS *const uniforms, const OUTPUT_LIGHT_INFO *const info)
 {
@@ -550,6 +517,39 @@ static void M_Init(void)
 static void M_ObserveLevelLoad(void)
 {
     memset(m_ItemLights, 0, sizeof(m_ItemLights));
+}
+
+void Output_Lights_TR3_AddDynamicLight(
+    const XYZ_32 pos, const int32_t intensity, const int32_t falloff)
+{
+    int32_t safe_intensity = intensity;
+    int32_t safe_falloff = falloff;
+    CLAMP(safe_intensity, 0, 30);
+    CLAMP(safe_falloff, 0, 30);
+
+    int32_t max_shade = 1 << safe_intensity;
+    int32_t c = max_shade >> 4;
+    CLAMPG(c, 255);
+
+    int32_t radius = 1 << safe_falloff;
+    int32_t falloff_param = radius >> 7;
+    CLAMP(falloff_param, 1, 255);
+
+    const OUTPUT_DYNAMIC_LIGHT light = {
+        .light = {
+            .pos = pos,
+            .color = (RGB_888) { c, c, c },
+            .layout = LIGHT_LAYOUT_LEGACY,
+            .type = LIGHT_TYPE_POINT,
+            .u.legacy =
+                {
+                    .falloff.value_1 = falloff_param
+                        << OUTPUT_DYNAMIC_FALLOFF_SHIFT,
+                },
+        },
+        .kind = OUTPUT_DYNAMIC_LIGHT_RGB,
+    };
+    Vector_Add(Output_GetDynamicLights(), &light);
 }
 
 const LIGHTING_MODEL g_LightingModelTR3 = {

--- a/src/trx/game/output/lights/tr4.c
+++ b/src/trx/game/output/lights/tr4.c
@@ -1029,37 +1029,6 @@ static void M_PrepareScene(void)
     TRX_GL_CheckError();
 }
 
-// Port of the OG TriggerFXFogBulb (polyinsert.cpp:439).
-void Output_TriggerFXFogBulb(
-    const XYZ_32 pos, const int32_t fx_rad, const int32_t density,
-    const RGB_888 color)
-{
-    if (g_TRVersion != 4) {
-        return;
-    }
-
-    int32_t num = 0;
-    while (m_FXFogBulbs[num].active) {
-        num++;
-        if (num >= M_MAX_FX_FOG_BULBS) {
-            return;
-        }
-    }
-
-    M_FOG_BULB *const bulb = &m_FXFogBulbs[num];
-    *bulb = (M_FOG_BULB) {
-        .world_pos = { (float)pos.x, (float)pos.y, (float)pos.z },
-        .density = density,
-        .color = color,
-        .rad = 0.0f,
-        .sqrad = 0.0f,
-        .inv_sqrad = 0.0f,
-        .timer = 50,
-        .fx_rad = fx_rad,
-        .active = true,
-    };
-}
-
 static void M_Init(void)
 {
     if (m_StagedPool == nullptr) {
@@ -1099,6 +1068,37 @@ static void M_BeginScene(void)
         Vector_Clear(m_StagedPool);
     }
     m_PoolGeneration++;
+}
+
+// Port of the OG TriggerFXFogBulb (polyinsert.cpp:439).
+void Output_TriggerFXFogBulb(
+    const XYZ_32 pos, const int32_t fx_rad, const int32_t density,
+    const RGB_888 color)
+{
+    if (g_TRVersion != 4) {
+        return;
+    }
+
+    int32_t num = 0;
+    while (m_FXFogBulbs[num].active) {
+        num++;
+        if (num >= M_MAX_FX_FOG_BULBS) {
+            return;
+        }
+    }
+
+    M_FOG_BULB *const bulb = &m_FXFogBulbs[num];
+    *bulb = (M_FOG_BULB) {
+        .world_pos = { (float)pos.x, (float)pos.y, (float)pos.z },
+        .density = density,
+        .color = color,
+        .rad = 0.0f,
+        .sqrad = 0.0f,
+        .inv_sqrad = 0.0f,
+        .timer = 50,
+        .fx_rad = fx_rad,
+        .active = true,
+    };
 }
 
 void Output_SetInventoryLightingMode(const bool enabled)

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -180,6 +180,12 @@ static void M_RenderScenePasses(const M_PRIV *const p)
     }
 }
 
+static bool M_IsActive(void)
+{
+    return !Output_IsHeadless() || Shell_GetArgs()->debug_render_performance
+        || TRX_GL_Context_GetScheduledScreenshotPath() != nullptr;
+}
+
 void SceneCompositor_Init(void)
 {
     M_PRIV *const p = &m_Priv;
@@ -203,12 +209,6 @@ void SceneCompositor_Shutdown(void)
         glDeleteSamplers(1, &p->sampler_id);
         p->sampler_id = 0;
     }
-}
-
-bool M_IsActive(void)
-{
-    return !Output_IsHeadless() || Shell_GetArgs()->debug_render_performance
-        || TRX_GL_Context_GetScheduledScreenshotPath() != nullptr;
 }
 
 void SceneCompositor_BeginScene(void)

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -43,6 +43,31 @@ static OUTPUT_SHADER *M_GetVariantBase(
     return shader->base[variant_idx];
 }
 
+// TR4 samples the env map out of the atlas, so the variant needs to know which
+// patch of it to use. The rect only changes on level load; the TR1-3 variants
+// don't declare the uniforms at all.
+static void M_UploadEnvMapRect(
+    OUTPUT_MESH_SHADER *const shader, const int32_t variant_idx)
+{
+    const OUTPUT_ATLAS_RECT rect = Output_Textures_GetEnvMapRect();
+    if (memcmp(&shader->env_map_rect[variant_idx], &rect, sizeof(rect)) == 0) {
+        return;
+    }
+    shader->env_map_rect[variant_idx] = rect;
+
+    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
+    GLint loc = -1;
+    if (Output_Shader_TryLookupUniform(base, "uEnvMapUV0", &loc)) {
+        TRX_GL_TRACK_UNIFORM(glUniform2f, loc, rect.uv0[0], rect.uv0[1]);
+    }
+    if (Output_Shader_TryLookupUniform(base, "uEnvMapUV1", &loc)) {
+        TRX_GL_TRACK_UNIFORM(glUniform2f, loc, rect.uv1[0], rect.uv1[1]);
+    }
+    if (Output_Shader_TryLookupUniform(base, "uEnvMapLayer", &loc)) {
+        TRX_GL_TRACK_UNIFORM(glUniform1i, loc, rect.layer);
+    }
+}
+
 OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
 {
     OUTPUT_MESH_SHADER *const shader = Memory_Alloc(sizeof(*shader));
@@ -71,31 +96,6 @@ OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
         }
     }
     return shader;
-}
-
-// TR4 samples the env map out of the atlas, so the variant needs to know which
-// patch of it to use. The rect only changes on level load; the TR1-3 variants
-// don't declare the uniforms at all.
-static void M_UploadEnvMapRect(
-    OUTPUT_MESH_SHADER *const shader, const int32_t variant_idx)
-{
-    const OUTPUT_ATLAS_RECT rect = Output_Textures_GetEnvMapRect();
-    if (memcmp(&shader->env_map_rect[variant_idx], &rect, sizeof(rect)) == 0) {
-        return;
-    }
-    shader->env_map_rect[variant_idx] = rect;
-
-    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
-    GLint loc = -1;
-    if (Output_Shader_TryLookupUniform(base, "uEnvMapUV0", &loc)) {
-        TRX_GL_TRACK_UNIFORM(glUniform2f, loc, rect.uv0[0], rect.uv0[1]);
-    }
-    if (Output_Shader_TryLookupUniform(base, "uEnvMapUV1", &loc)) {
-        TRX_GL_TRACK_UNIFORM(glUniform2f, loc, rect.uv1[0], rect.uv1[1]);
-    }
-    if (Output_Shader_TryLookupUniform(base, "uEnvMapLayer", &loc)) {
-        TRX_GL_TRACK_UNIFORM(glUniform1i, loc, rect.layer);
-    }
 }
 
 void Output_MeshShader_Bind(OUTPUT_MESH_SHADER *const shader)

--- a/src/trx/game/output/sky.c
+++ b/src/trx/game/output/sky.c
@@ -81,6 +81,108 @@ static void M_UpdateLightning(void)
     }
 }
 
+// TR4 skybox quads flagged in their texture info use a vertical alpha
+// gradient to fade the horizon mesh into the flat sky layers, unless the
+// level requests additive blending for the whole mesh.
+static bool M_IsGradientFace(const FACE *const face)
+{
+    return g_TRVersion == 4 && (face->effects & 0x1u) != 0u && !m_ColorAdd;
+}
+
+static bool M_GetFacePass(const FACE *const face, SCENE_PASS *const pass)
+{
+    if (!M_IsGradientFace(face)) {
+        return false;
+    }
+    *pass = SCENE_PASS_TRANSPARENT;
+    return true;
+}
+
+static bool M_GetVertexColor(
+    const FACE *const face, const int32_t vertex_idx, RGBA_8888 *const color)
+{
+    if (face->vertex_count != 4 || !M_IsGradientFace(face)) {
+        return false;
+    }
+    // Top edge fades out to reveal the flat sky layers.
+    *color = (RGBA_8888) { 0, 0, 0, vertex_idx < 2 ? 0 : 255 };
+    return true;
+}
+
+// The OG engines light the skybox with a flat ambient of 128 and no lights,
+// which the vertex color split then doubles to 255 - i.e. the mesh texture is
+// drawn at full brightness. Model that with a 1.0 ambient and no per-vertex
+// shade dimming.
+static bool M_GetVertexShade(
+    const FACE *const face, const int32_t vertex_idx, int32_t *const shade)
+{
+    // TR1/2 spell "no dimming" as SHADE_NEUTRAL: their shade multiplier is
+    // 2 - shade / SHADE_NEUTRAL, so a 0 shade would double the texture.
+    *shade = g_TRVersion < 3 ? SHADE_NEUTRAL : 0;
+    return true;
+}
+
+// Applies the flat, direction-less skybox lighting (TR3+ only).
+static void M_AdjustLightInfo(OUTPUT_LIGHT_INFO *const info)
+{
+    if (g_TRVersion < 3) {
+        return;
+    }
+    if (g_TRVersion == 4) {
+        // Neutral full brightness (the OG flat ambient of 128), expressed in
+        // the convention of whichever path the mesh data selects: meshes
+        // with normals are object-lit and read the ambient as a 128-neutral
+        // color (1.0 here, scaled by 128/255 on upload); prelit meshes are
+        // own-lit and read it as a multiplier over the vertex prelight.
+        const OBJECT *const skybox = Object_Get(O_SKYBOX);
+        const OBJECT_MESH *const mesh = Object_GetMesh(skybox->mesh_idx);
+        const float ambient = mesh->num_lights > 0 ? 1.0f : 128.0f / 255.0f;
+        info->tr3_ambient = (RGB_F) { ambient, ambient, ambient };
+    } else {
+        info->tr3_ambient = (RGB_F) { 0.5f, 0.5f, 0.5f };
+    }
+    for (int32_t i = 0; i < 3; i++) {
+        info->tr3_light_color[i] = (RGB_F) { 0.0f, 0.0f, 0.0f };
+        info->tr3_light_dir_view[i] = (XYZ_32) { 0, 0, 0 };
+    }
+}
+
+// The scroll advances on the 30 FPS logic tick; interpolate it between ticks
+// so the clouds move smoothly at higher render frame rates.
+static int32_t M_GetInterpolatedLayerPos(const int32_t layer_idx)
+{
+    const int32_t pos = m_LayerPos[layer_idx];
+    int32_t delta = pos - m_LayerPosPrev[layer_idx];
+    if (delta > OUTPUT_SKY_WRAP / 2) {
+        delta -= OUTPUT_SKY_WRAP;
+    } else if (delta < -OUTPUT_SKY_WRAP / 2) {
+        delta += OUTPUT_SKY_WRAP;
+    }
+    return pos - delta + (int32_t)(delta * Interpolation_GetWorldRate());
+}
+
+static void M_StageLayers(void)
+{
+    for (int32_t i = 0; i < OUTPUT_SKY_LAYER_COUNT; i++) {
+        const OUTPUT_SKY_LAYER *const layer = &m_Layers[i];
+        if (!layer->enabled) {
+            continue;
+        }
+        Matrix_PushUnit();
+        Matrix_TranslateAbs32(g_ViewPos);
+        if (m_Layers[0].enabled) {
+            // OG rotates layer 1 by ~180 degrees and never pops that rotation
+            // before drawing layer 2, so with layer 1 enabled both layers face
+            // this way.
+            Matrix_Rot16((XYZ_16) { .y = 32760 });
+        }
+        Matrix_TranslateRel(M_GetInterpolatedLayerPos(i), -1536, 0);
+        OutputSource_Sky_StageLayer(
+            g_WMatrixPtr, Output_Sky_GetLayerDrawColor(i), i == 1);
+        Matrix_Pop();
+    }
+}
+
 void Output_Sky_Reset(void)
 {
     for (int32_t i = 0; i < OUTPUT_SKY_LAYER_COUNT; i++) {
@@ -204,72 +306,6 @@ void Output_Sky_Update(void)
     }
 }
 
-// TR4 skybox quads flagged in their texture info use a vertical alpha
-// gradient to fade the horizon mesh into the flat sky layers, unless the
-// level requests additive blending for the whole mesh.
-static bool M_IsGradientFace(const FACE *const face)
-{
-    return g_TRVersion == 4 && (face->effects & 0x1u) != 0u && !m_ColorAdd;
-}
-
-static bool M_GetFacePass(const FACE *const face, SCENE_PASS *const pass)
-{
-    if (!M_IsGradientFace(face)) {
-        return false;
-    }
-    *pass = SCENE_PASS_TRANSPARENT;
-    return true;
-}
-
-static bool M_GetVertexColor(
-    const FACE *const face, const int32_t vertex_idx, RGBA_8888 *const color)
-{
-    if (face->vertex_count != 4 || !M_IsGradientFace(face)) {
-        return false;
-    }
-    // Top edge fades out to reveal the flat sky layers.
-    *color = (RGBA_8888) { 0, 0, 0, vertex_idx < 2 ? 0 : 255 };
-    return true;
-}
-
-// The OG engines light the skybox with a flat ambient of 128 and no lights,
-// which the vertex color split then doubles to 255 - i.e. the mesh texture is
-// drawn at full brightness. Model that with a 1.0 ambient and no per-vertex
-// shade dimming.
-static bool M_GetVertexShade(
-    const FACE *const face, const int32_t vertex_idx, int32_t *const shade)
-{
-    // TR1/2 spell "no dimming" as SHADE_NEUTRAL: their shade multiplier is
-    // 2 - shade / SHADE_NEUTRAL, so a 0 shade would double the texture.
-    *shade = g_TRVersion < 3 ? SHADE_NEUTRAL : 0;
-    return true;
-}
-
-// Applies the flat, direction-less skybox lighting (TR3+ only).
-static void M_AdjustLightInfo(OUTPUT_LIGHT_INFO *const info)
-{
-    if (g_TRVersion < 3) {
-        return;
-    }
-    if (g_TRVersion == 4) {
-        // Neutral full brightness (the OG flat ambient of 128), expressed in
-        // the convention of whichever path the mesh data selects: meshes
-        // with normals are object-lit and read the ambient as a 128-neutral
-        // color (1.0 here, scaled by 128/255 on upload); prelit meshes are
-        // own-lit and read it as a multiplier over the vertex prelight.
-        const OBJECT *const skybox = Object_Get(O_SKYBOX);
-        const OBJECT_MESH *const mesh = Object_GetMesh(skybox->mesh_idx);
-        const float ambient = mesh->num_lights > 0 ? 1.0f : 128.0f / 255.0f;
-        info->tr3_ambient = (RGB_F) { ambient, ambient, ambient };
-    } else {
-        info->tr3_ambient = (RGB_F) { 0.5f, 0.5f, 0.5f };
-    }
-    for (int32_t i = 0; i < 3; i++) {
-        info->tr3_light_color[i] = (RGB_F) { 0.0f, 0.0f, 0.0f };
-        info->tr3_light_dir_view[i] = (XYZ_32) { 0, 0, 0 };
-    }
-}
-
 static OUTPUT_OBJECT_MESH_POLICY m_SkyboxMeshPolicy = {
     .vertex_flags = 0,
     .get_face_pass = M_GetFacePass,
@@ -298,42 +334,6 @@ void Output_Sky_ObserveLevelLoad(void)
 void Output_Sky_ObserveLevelUnload(void)
 {
     OutputSource_Objects_RemoveMeshPolicy(&m_SkyboxMeshPolicy);
-}
-
-// The scroll advances on the 30 FPS logic tick; interpolate it between ticks
-// so the clouds move smoothly at higher render frame rates.
-static int32_t M_GetInterpolatedLayerPos(const int32_t layer_idx)
-{
-    const int32_t pos = m_LayerPos[layer_idx];
-    int32_t delta = pos - m_LayerPosPrev[layer_idx];
-    if (delta > OUTPUT_SKY_WRAP / 2) {
-        delta -= OUTPUT_SKY_WRAP;
-    } else if (delta < -OUTPUT_SKY_WRAP / 2) {
-        delta += OUTPUT_SKY_WRAP;
-    }
-    return pos - delta + (int32_t)(delta * Interpolation_GetWorldRate());
-}
-
-static void M_StageLayers(void)
-{
-    for (int32_t i = 0; i < OUTPUT_SKY_LAYER_COUNT; i++) {
-        const OUTPUT_SKY_LAYER *const layer = &m_Layers[i];
-        if (!layer->enabled) {
-            continue;
-        }
-        Matrix_PushUnit();
-        Matrix_TranslateAbs32(g_ViewPos);
-        if (m_Layers[0].enabled) {
-            // OG rotates layer 1 by ~180 degrees and never pops that rotation
-            // before drawing layer 2, so with layer 1 enabled both layers face
-            // this way.
-            Matrix_Rot16((XYZ_16) { .y = 32760 });
-        }
-        Matrix_TranslateRel(M_GetInterpolatedLayerPos(i), -1536, 0);
-        OutputSource_Sky_StageLayer(
-            g_WMatrixPtr, Output_Sky_GetLayerDrawColor(i), i == 1);
-        Matrix_Pop();
-    }
 }
 
 bool Output_Sky_Draw(void)

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -825,6 +825,17 @@ static bool M_IsDirty(const SCENE_SOURCE *const src, const SCENE_PASS pass)
     return false;
 }
 
+static void M_FinishSnapshotCapture(M_PRIV *const p)
+{
+    p->snapshot.state.has_content = true;
+
+    // Remove the captured brightness so we can reapply the current multiplier.
+    p->snapshot.state.captured_brightness = g_Config.visuals.ui_brightness;
+    CLAMPL(p->snapshot.state.captured_brightness, 0.001f);
+    Output_Quad_SetBrightnessScale(
+        p->snapshot.renderer, 1.0f / p->snapshot.state.captured_brightness);
+}
+
 bool Output_Overlay_LoadImage(const char *const file_name)
 {
     if (file_name == nullptr || file_name[0] == '\0') {
@@ -854,17 +865,6 @@ void Output_Overlay_DrawImageMono(
     const char *const file_name, const float intensity)
 {
     M_DrawImageImpl(file_name, intensity, TEXTURE_FILTER_POINT);
-}
-
-static void M_FinishSnapshotCapture(M_PRIV *const p)
-{
-    p->snapshot.state.has_content = true;
-
-    // Remove the captured brightness so we can reapply the current multiplier.
-    p->snapshot.state.captured_brightness = g_Config.visuals.ui_brightness;
-    CLAMPL(p->snapshot.state.captured_brightness, 0.001f);
-    Output_Quad_SetBrightnessScale(
-        p->snapshot.renderer, 1.0f / p->snapshot.state.captured_brightness);
 }
 
 void Output_Overlay_CaptureSnapshot(void)

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -382,6 +382,60 @@ static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
     return false;
 }
 
+static void M_StagePrim(
+    const int32_t sprite_idx, const uint8_t corner_count,
+    const XYZ_32 *const world_pos, const float (*disp)[2],
+    const RGBA_8888 *const color, const uint16_t flags,
+    const float z_depth_adjust, const float shade,
+    const OUTPUT_LIGHT_INFO *const light_info, VECTOR *const target)
+{
+    M_PRIM prim;
+    prim.sprite_idx = sprite_idx;
+    prim.use_custom_uv = false;
+    prim.use_own_light = light_info != nullptr;
+    prim.corner_count = corner_count;
+    prim.z_depth_adjust = z_depth_adjust;
+    prim.shade = shade;
+    prim.tint = Output_GetTint();
+    memset(prim.world_pos, 0, sizeof(prim.world_pos));
+    memcpy(prim.world_pos, world_pos, sizeof(prim.world_pos[0]) * corner_count);
+    memset(prim.uvw, 0, sizeof(prim.uvw));
+    memset(prim.texture_size, 0, sizeof(prim.texture_size));
+    if (disp != nullptr) {
+        memset(prim.disp, 0, sizeof(prim.disp));
+        memcpy(prim.disp, disp, sizeof(prim.disp[0]) * corner_count);
+    } else {
+        memset(prim.disp, 0, sizeof(prim.disp));
+    }
+    memset(prim.color, 0, sizeof(prim.color));
+    memcpy(prim.color, color, sizeof(prim.color[0]) * corner_count);
+    prim.flags = flags;
+    // The OG draws additive polys with specular disabled (HWR_DrawSortList
+    // drawtype 2); the flag tells the shader to drop the overbright excess,
+    // as the mesh batcher does for its blend-add pass.
+    if (target == m_Priv.scheduled_blend_add) {
+        prim.flags |= VERT_ADDITIVE;
+    }
+    if (light_info != nullptr) {
+        prim.light_info = *light_info;
+    } else {
+        prim.light_info = (OUTPUT_LIGHT_INFO) {};
+    }
+    Vector_Add(target, &prim);
+}
+
+static VECTOR *M_GetScheduledVectorForDrawType(
+    M_PRIV *const p, const DRAW_TYPE draw_type)
+{
+    if (draw_type == DRAW_BLEND_ADD || draw_type == DRAW_REFLECTIVE_BLEND_ADD) {
+        return p->scheduled_blend_add;
+    }
+    if (draw_type == DRAW_BLEND_SUB) {
+        return p->scheduled_blend_sub;
+    }
+    return p->scheduled_transparent;
+}
+
 void OutputSource_PolyFX_Init(void)
 {
     M_PRIV *const p = &m_Priv;
@@ -471,60 +525,6 @@ void OutputSource_PolyFX_Shutdown(void)
         glDeleteBuffers(1, &p->vbo);
         p->vbo = 0;
     }
-}
-
-static void M_StagePrim(
-    const int32_t sprite_idx, const uint8_t corner_count,
-    const XYZ_32 *const world_pos, const float (*disp)[2],
-    const RGBA_8888 *const color, const uint16_t flags,
-    const float z_depth_adjust, const float shade,
-    const OUTPUT_LIGHT_INFO *const light_info, VECTOR *const target)
-{
-    M_PRIM prim;
-    prim.sprite_idx = sprite_idx;
-    prim.use_custom_uv = false;
-    prim.use_own_light = light_info != nullptr;
-    prim.corner_count = corner_count;
-    prim.z_depth_adjust = z_depth_adjust;
-    prim.shade = shade;
-    prim.tint = Output_GetTint();
-    memset(prim.world_pos, 0, sizeof(prim.world_pos));
-    memcpy(prim.world_pos, world_pos, sizeof(prim.world_pos[0]) * corner_count);
-    memset(prim.uvw, 0, sizeof(prim.uvw));
-    memset(prim.texture_size, 0, sizeof(prim.texture_size));
-    if (disp != nullptr) {
-        memset(prim.disp, 0, sizeof(prim.disp));
-        memcpy(prim.disp, disp, sizeof(prim.disp[0]) * corner_count);
-    } else {
-        memset(prim.disp, 0, sizeof(prim.disp));
-    }
-    memset(prim.color, 0, sizeof(prim.color));
-    memcpy(prim.color, color, sizeof(prim.color[0]) * corner_count);
-    prim.flags = flags;
-    // The OG draws additive polys with specular disabled (HWR_DrawSortList
-    // drawtype 2); the flag tells the shader to drop the overbright excess,
-    // as the mesh batcher does for its blend-add pass.
-    if (target == m_Priv.scheduled_blend_add) {
-        prim.flags |= VERT_ADDITIVE;
-    }
-    if (light_info != nullptr) {
-        prim.light_info = *light_info;
-    } else {
-        prim.light_info = (OUTPUT_LIGHT_INFO) {};
-    }
-    Vector_Add(target, &prim);
-}
-
-static VECTOR *M_GetScheduledVectorForDrawType(
-    M_PRIV *const p, const DRAW_TYPE draw_type)
-{
-    if (draw_type == DRAW_BLEND_ADD || draw_type == DRAW_REFLECTIVE_BLEND_ADD) {
-        return p->scheduled_blend_add;
-    }
-    if (draw_type == DRAW_BLEND_SUB) {
-        return p->scheduled_blend_sub;
-    }
-    return p->scheduled_transparent;
 }
 
 void OutputSource_PolyFX_StageSpriteQuadWorld(

--- a/src/trx/game/output/sources/sky.c
+++ b/src/trx/game/output/sources/sky.c
@@ -197,6 +197,52 @@ static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
         || (pass == SCENE_PASS_TRANSPARENT && p->gradient_staged);
 }
 
+// The gradient geometry only depends on the mesh and the fog color, both
+// fixed for the level's duration - rebuild the buffer only when they change.
+static void M_UploadFogGradient(
+    M_PRIV *const p, const OBJECT_MESH *const mesh, const RGBA_F color)
+{
+    M_GRADIENT_VERTEX vertices[M_GRADIENT_MAX_QUADS * OUTPUT_QUAD_VERTICES];
+    const int32_t quad_count =
+        MIN(mesh->tex_face4s.count, M_GRADIENT_MAX_QUADS);
+    int32_t v = 0;
+    for (int32_t i = 0; i < quad_count; i++) {
+        const FACE *const face = &mesh->tex_face4s.data[i];
+        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
+            const int32_t k = OUTPUT_QUAD_TO_FAN(j);
+            const XYZ_16 pos = mesh->vertices[face->vertices[k]];
+            // OG paints half fog on each quad's first two vertices and full
+            // fog on the last two (the mesh's bottom edge). OG's values
+            // *replace* the mesh's distance fog, but this overlay composites
+            // on top of it - the shader fog stays active on the skybox mesh
+            // and already contributes about that much at the top edge - so
+            // start from zero to avoid a visible half-fogged seam.
+            const float fog = k < 2 ? 0.0f : 1.0f;
+            vertices[v++] = (M_GRADIENT_VERTEX) {
+                .pos = {
+                    .x = pos.x,
+                    .y = pos.y,
+                    .z = pos.z,
+                    .w = M_GRADIENT_DEPTH_ADJUSTMENT,
+                },
+                .color = {
+                    .r = color.r,
+                    .g = color.g,
+                    .b = color.b,
+                    .a = color.a * fog,
+                },
+            };
+        }
+    }
+    glBindBuffer(GL_ARRAY_BUFFER, p->gradient_vbo);
+    TRX_GL_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER, v * sizeof(M_GRADIENT_VERTEX), vertices,
+        GL_STATIC_DRAW);
+    p->gradient_mesh = mesh;
+    p->gradient_color = color;
+    p->gradient_vertex_count = v;
+}
+
 void OutputSource_Sky_Init(void)
 {
     M_PRIV *const p = &m_Priv;
@@ -282,52 +328,6 @@ void OutputSource_Sky_StageLayer(
         .color = color,
         .additive = additive,
     };
-}
-
-// The gradient geometry only depends on the mesh and the fog color, both
-// fixed for the level's duration - rebuild the buffer only when they change.
-static void M_UploadFogGradient(
-    M_PRIV *const p, const OBJECT_MESH *const mesh, const RGBA_F color)
-{
-    M_GRADIENT_VERTEX vertices[M_GRADIENT_MAX_QUADS * OUTPUT_QUAD_VERTICES];
-    const int32_t quad_count =
-        MIN(mesh->tex_face4s.count, M_GRADIENT_MAX_QUADS);
-    int32_t v = 0;
-    for (int32_t i = 0; i < quad_count; i++) {
-        const FACE *const face = &mesh->tex_face4s.data[i];
-        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
-            const int32_t k = OUTPUT_QUAD_TO_FAN(j);
-            const XYZ_16 pos = mesh->vertices[face->vertices[k]];
-            // OG paints half fog on each quad's first two vertices and full
-            // fog on the last two (the mesh's bottom edge). OG's values
-            // *replace* the mesh's distance fog, but this overlay composites
-            // on top of it - the shader fog stays active on the skybox mesh
-            // and already contributes about that much at the top edge - so
-            // start from zero to avoid a visible half-fogged seam.
-            const float fog = k < 2 ? 0.0f : 1.0f;
-            vertices[v++] = (M_GRADIENT_VERTEX) {
-                .pos = {
-                    .x = pos.x,
-                    .y = pos.y,
-                    .z = pos.z,
-                    .w = M_GRADIENT_DEPTH_ADJUSTMENT,
-                },
-                .color = {
-                    .r = color.r,
-                    .g = color.g,
-                    .b = color.b,
-                    .a = color.a * fog,
-                },
-            };
-        }
-    }
-    glBindBuffer(GL_ARRAY_BUFFER, p->gradient_vbo);
-    TRX_GL_TRACK_DATA(
-        glBufferData, GL_ARRAY_BUFFER, v * sizeof(M_GRADIENT_VERTEX), vertices,
-        GL_STATIC_DRAW);
-    p->gradient_mesh = mesh;
-    p->gradient_color = color;
-    p->gradient_vertex_count = v;
 }
 
 void OutputSource_Sky_InvalidateFogGradient(void)

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -56,36 +56,6 @@ static RGBA_F M_ToRGBA_F(const RGBA_8888 color)
     };
 }
 
-VIEWPORT_RECT OutputSource_UI_GetPickupRect(
-    const OUTPUT_UI_PICKUP *const pickup)
-{
-    const VIEWPORT_RECT viewport = Viewport_GetRect(VIEWPORT_UI);
-
-    const float pickup_h = viewport.h * g_Config.ui.pickup_scale / 6;
-    const float pickup_w = pickup_h * 5 / 4;
-    const float window_padding_y = viewport.h / 16;
-    const float window_padding_x = window_padding_y * 4 / 3;
-    const float grid_padding_x = pickup_w / 8;
-    const float grid_padding_y = pickup_h / 8;
-
-    const float src_x = viewport.w + window_padding_x + pickup_w;
-    const float src_y = viewport.h - window_padding_y - pickup_h / 2;
-
-    const float dst_x = viewport.w - window_padding_x - pickup_w / 2
-        - (pickup_w + grid_padding_x) * pickup->grid_x;
-    const float dst_y = viewport.h - window_padding_y - pickup_h / 2
-        - (pickup_h + grid_padding_y) * pickup->grid_y;
-
-    const float x = src_x + (dst_x - src_x) * pickup->ease;
-    const float y = src_y + (dst_y - src_y) * pickup->ease;
-    return (VIEWPORT_RECT) {
-        .x = x - pickup_w / 2,
-        .y = y - pickup_h / 2,
-        .w = pickup_w,
-        .h = pickup_h,
-    };
-}
-
 static float M_Get3DPickupScale(
     const VIEWPORT_RECT pickup_rect, const ANIM_FRAME *const frame)
 {
@@ -359,6 +329,77 @@ static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
             || p->binocular_mask);
 }
 
+// Emit a ring band from r_inner to r_outer with per-edge vertex colors.
+// inner_color is applied to the vertices at r_inner, outer_color to r_outer.
+// Fading inner/outer colors to alpha=0 produces antialiased edges.
+static void M_StageRingBand(
+    M_PRIV *const p, const float cx, const float cy, const float ri,
+    const float ro, const float z, const RGBA_F inner_color,
+    const RGBA_F outer_color)
+{
+    const int32_t n = 32;
+    for (int32_t i = 0; i < n; i++) {
+        const float a0 = (float)(2.0 * M_PI) * i / n;
+        const float a1 = (float)(2.0 * M_PI) * (i + 1) / n;
+        const float cos0 = cosf(a0);
+        const float sin0 = sinf(a0);
+        const float cos1 = cosf(a1);
+        const float sin1 = sinf(a1);
+
+        // v[0]/v[1] = outer edge, v[2]/v[3] = inner edge
+        M_VERTEX v[4] = {};
+        v[0].pos = (XYZW_F) { cx + ro * cos0, cy + ro * sin0, z, 0.0f };
+        v[1].pos = (XYZW_F) { cx + ro * cos1, cy + ro * sin1, z, 0.0f };
+        v[2].pos = (XYZW_F) { cx + ri * cos0, cy + ri * sin0, z, 0.0f };
+        v[3].pos = (XYZW_F) { cx + ri * cos1, cy + ri * sin1, z, 0.0f };
+        v[0].flags = VERT_FLAT_SHADED;
+        v[1].flags = VERT_FLAT_SHADED;
+        v[2].flags = VERT_FLAT_SHADED;
+        v[3].flags = VERT_FLAT_SHADED;
+        v[0].color = outer_color;
+        v[1].color = outer_color;
+        v[2].color = inner_color;
+        v[3].color = inner_color;
+
+        Vector_Add(p->vertices, &v[0]);
+        Vector_Add(p->vertices, &v[1]);
+        Vector_Add(p->vertices, &v[2]);
+        Vector_Add(p->vertices, &v[2]);
+        Vector_Add(p->vertices, &v[1]);
+        Vector_Add(p->vertices, &v[3]);
+    }
+}
+
+VIEWPORT_RECT OutputSource_UI_GetPickupRect(
+    const OUTPUT_UI_PICKUP *const pickup)
+{
+    const VIEWPORT_RECT viewport = Viewport_GetRect(VIEWPORT_UI);
+
+    const float pickup_h = viewport.h * g_Config.ui.pickup_scale / 6;
+    const float pickup_w = pickup_h * 5 / 4;
+    const float window_padding_y = viewport.h / 16;
+    const float window_padding_x = window_padding_y * 4 / 3;
+    const float grid_padding_x = pickup_w / 8;
+    const float grid_padding_y = pickup_h / 8;
+
+    const float src_x = viewport.w + window_padding_x + pickup_w;
+    const float src_y = viewport.h - window_padding_y - pickup_h / 2;
+
+    const float dst_x = viewport.w - window_padding_x - pickup_w / 2
+        - (pickup_w + grid_padding_x) * pickup->grid_x;
+    const float dst_y = viewport.h - window_padding_y - pickup_h / 2
+        - (pickup_h + grid_padding_y) * pickup->grid_y;
+
+    const float x = src_x + (dst_x - src_x) * pickup->ease;
+    const float y = src_y + (dst_y - src_y) * pickup->ease;
+    return (VIEWPORT_RECT) {
+        .x = x - pickup_w / 2,
+        .y = y - pickup_h / 2,
+        .w = pickup_w,
+        .h = pickup_h,
+    };
+}
+
 void OutputSource_UI_Init(void)
 {
     M_PRIV *const p = &m_Priv;
@@ -497,47 +538,6 @@ void OutputSource_UI_StageQuad(const OUTPUT_UI_QUAD quad)
     for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
         const int32_t j = OUTPUT_QUAD_TO_FAN(i);
         Vector_Add(p->vertices, &vertices[j]);
-    }
-}
-
-// Emit a ring band from r_inner to r_outer with per-edge vertex colors.
-// inner_color is applied to the vertices at r_inner, outer_color to r_outer.
-// Fading inner/outer colors to alpha=0 produces antialiased edges.
-static void M_StageRingBand(
-    M_PRIV *const p, const float cx, const float cy, const float ri,
-    const float ro, const float z, const RGBA_F inner_color,
-    const RGBA_F outer_color)
-{
-    const int32_t n = 32;
-    for (int32_t i = 0; i < n; i++) {
-        const float a0 = (float)(2.0 * M_PI) * i / n;
-        const float a1 = (float)(2.0 * M_PI) * (i + 1) / n;
-        const float cos0 = cosf(a0);
-        const float sin0 = sinf(a0);
-        const float cos1 = cosf(a1);
-        const float sin1 = sinf(a1);
-
-        // v[0]/v[1] = outer edge, v[2]/v[3] = inner edge
-        M_VERTEX v[4] = {};
-        v[0].pos = (XYZW_F) { cx + ro * cos0, cy + ro * sin0, z, 0.0f };
-        v[1].pos = (XYZW_F) { cx + ro * cos1, cy + ro * sin1, z, 0.0f };
-        v[2].pos = (XYZW_F) { cx + ri * cos0, cy + ri * sin0, z, 0.0f };
-        v[3].pos = (XYZW_F) { cx + ri * cos1, cy + ri * sin1, z, 0.0f };
-        v[0].flags = VERT_FLAT_SHADED;
-        v[1].flags = VERT_FLAT_SHADED;
-        v[2].flags = VERT_FLAT_SHADED;
-        v[3].flags = VERT_FLAT_SHADED;
-        v[0].color = outer_color;
-        v[1].color = outer_color;
-        v[2].color = inner_color;
-        v[3].color = inner_color;
-
-        Vector_Add(p->vertices, &v[0]);
-        Vector_Add(p->vertices, &v[1]);
-        Vector_Add(p->vertices, &v[2]);
-        Vector_Add(p->vertices, &v[2]);
-        Vector_Add(p->vertices, &v[1]);
-        Vector_Add(p->vertices, &v[3]);
     }
 }
 

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -425,6 +425,12 @@ static void M_DrawSingleRoom(const ROOM *const room)
     bind->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
 }
 
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    Vector_Free(m_RoomsToDraw);
+    m_RoomsToDraw = nullptr;
+}
+
 void Room_DrawReset(void)
 {
     M_EnsureRoomsToDraw();
@@ -540,10 +546,4 @@ void Room_RemoveDrawnItem(const int16_t room_num, const int16_t item_num)
         ROOM *const room = Room_Get(room_num);
         M_DrawSet_Remove(&room->drawn_items, item_num);
     }
-}
-
-__attribute__((destructor)) static void M_Shutdown(void)
-{
-    Vector_Free(m_RoomsToDraw);
-    m_RoomsToDraw = nullptr;
 }

--- a/src/trx/game/rope.c
+++ b/src/trx/game/rope.c
@@ -190,6 +190,98 @@ static void M_SetPendulumPoint(ROPE *const rope, const int32_t node)
     m_Pendulum.node = node;
 }
 
+static void M_DrawRope(const ROPE *const rope, const int32_t sprite_idx)
+{
+    const double rate = (Interpolation_IsActive() && Game_IsPlaying())
+        ? Interpolation_GetRate()
+        : 1.0;
+    XYZ_F points[ROPE_SEGMENTS];
+    for (int32_t n = 0; n < ROPE_SEGMENTS; n++) {
+        const XYZ_32 *const prev = &rope->prev_mesh_segments[n];
+        const XYZ_32 *const cur = &rope->mesh_segments[n];
+        points[n] = (XYZ_F) {
+            .x = rope->pos.x
+                + (prev->x + (cur->x - prev->x) * rate)
+                    / (1 << (W2V_SHIFT + 2)),
+            .y = rope->pos.y
+                + (prev->y + (cur->y - prev->y) * rate)
+                    / (1 << (W2V_SHIFT + 2)),
+            .z = rope->pos.z
+                + (prev->z + (cur->z - prev->z) * rate)
+                    / (1 << (W2V_SHIFT + 2)),
+        };
+    }
+
+    // Extrude a camera-facing ribbon along the rope nodes. OG builds the
+    // equivalent quad strip in screen space with a constant world width.
+    XYZ_F offsets[ROPE_SEGMENTS];
+    for (int32_t n = 0; n < ROPE_SEGMENTS; n++) {
+        const int32_t seg = MIN(n, ROPE_SEGMENTS - 2);
+        const XYZ_F dir = {
+            .x = points[seg + 1].x - points[seg].x,
+            .y = points[seg + 1].y - points[seg].y,
+            .z = points[seg + 1].z - points[seg].z,
+        };
+        const XYZ_F to_cam = {
+            .x = points[n].x - g_Camera.pos.x,
+            .y = points[n].y - g_Camera.pos.y,
+            .z = points[n].z - g_Camera.pos.z,
+        };
+        // cross(to_cam, dir), not cross(dir, to_cam): OG's DrawRope takes the
+        // screen-space perpendicular (-dy, dx) with Y pointing down, which
+        // ends up on the opposite side of the rope from the world-space
+        // cross. Getting this backwards mirrors the sprite's U axis and the
+        // rope's weave leans the wrong way.
+        XYZ_F perp = {
+            .x = to_cam.y * dir.z - to_cam.z * dir.y,
+            .y = to_cam.z * dir.x - to_cam.x * dir.z,
+            .z = to_cam.x * dir.y - to_cam.y * dir.x,
+        };
+        const float length =
+            sqrtf(SQUARE(perp.x) + SQUARE(perp.y) + SQUARE(perp.z));
+        if (length < 1.0f) {
+            offsets[n] = (XYZ_F) { .x = M_HALF_WIDTH, .y = 0.0f, .z = 0.0f };
+            continue;
+        }
+        offsets[n] = (XYZ_F) {
+            .x = perp.x * M_HALF_WIDTH / length,
+            .y = perp.y * M_HALF_WIDTH / length,
+            .z = perp.z * M_HALF_WIDTH / length,
+        };
+    }
+
+    for (int32_t n = 0; n < ROPE_SEGMENTS - 1; n++) {
+        // The sprite's V axis must run along the rope like in OG's
+        // DrawRope, so the ribbon crosses the rope between corners 0-1.
+        const XYZ_32 quad[4] = {
+            {
+                .x = points[n].x - offsets[n].x,
+                .y = points[n].y - offsets[n].y,
+                .z = points[n].z - offsets[n].z,
+            },
+            {
+                .x = points[n].x + offsets[n].x,
+                .y = points[n].y + offsets[n].y,
+                .z = points[n].z + offsets[n].z,
+            },
+            {
+                .x = points[n + 1].x + offsets[n + 1].x,
+                .y = points[n + 1].y + offsets[n + 1].y,
+                .z = points[n + 1].z + offsets[n + 1].z,
+            },
+            {
+                .x = points[n + 1].x - offsets[n + 1].x,
+                .y = points[n + 1].y - offsets[n + 1].y,
+                .z = points[n + 1].z - offsets[n + 1].z,
+            },
+        };
+        const RGBA_8888 colors[4] = { m_RopeColor, m_RopeColor, m_RopeColor,
+                                      m_RopeColor };
+        OutputSource_PolyFX_StageSpriteQuadWorld(
+            sprite_idx, quad, colors, DRAW_BLEND);
+    }
+}
+
 void Rope_Reset(void)
 {
     memset(m_Ropes, 0, sizeof(m_Ropes));
@@ -589,98 +681,6 @@ void Rope_AlignLara(ITEM *const item)
     item->rot.x = angles[0];
     item->rot.y = angles[1];
     item->rot.z = angles[2];
-}
-
-static void M_DrawRope(const ROPE *const rope, const int32_t sprite_idx)
-{
-    const double rate = (Interpolation_IsActive() && Game_IsPlaying())
-        ? Interpolation_GetRate()
-        : 1.0;
-    XYZ_F points[ROPE_SEGMENTS];
-    for (int32_t n = 0; n < ROPE_SEGMENTS; n++) {
-        const XYZ_32 *const prev = &rope->prev_mesh_segments[n];
-        const XYZ_32 *const cur = &rope->mesh_segments[n];
-        points[n] = (XYZ_F) {
-            .x = rope->pos.x
-                + (prev->x + (cur->x - prev->x) * rate)
-                    / (1 << (W2V_SHIFT + 2)),
-            .y = rope->pos.y
-                + (prev->y + (cur->y - prev->y) * rate)
-                    / (1 << (W2V_SHIFT + 2)),
-            .z = rope->pos.z
-                + (prev->z + (cur->z - prev->z) * rate)
-                    / (1 << (W2V_SHIFT + 2)),
-        };
-    }
-
-    // Extrude a camera-facing ribbon along the rope nodes. OG builds the
-    // equivalent quad strip in screen space with a constant world width.
-    XYZ_F offsets[ROPE_SEGMENTS];
-    for (int32_t n = 0; n < ROPE_SEGMENTS; n++) {
-        const int32_t seg = MIN(n, ROPE_SEGMENTS - 2);
-        const XYZ_F dir = {
-            .x = points[seg + 1].x - points[seg].x,
-            .y = points[seg + 1].y - points[seg].y,
-            .z = points[seg + 1].z - points[seg].z,
-        };
-        const XYZ_F to_cam = {
-            .x = points[n].x - g_Camera.pos.x,
-            .y = points[n].y - g_Camera.pos.y,
-            .z = points[n].z - g_Camera.pos.z,
-        };
-        // cross(to_cam, dir), not cross(dir, to_cam): OG's DrawRope takes the
-        // screen-space perpendicular (-dy, dx) with Y pointing down, which
-        // ends up on the opposite side of the rope from the world-space
-        // cross. Getting this backwards mirrors the sprite's U axis and the
-        // rope's weave leans the wrong way.
-        XYZ_F perp = {
-            .x = to_cam.y * dir.z - to_cam.z * dir.y,
-            .y = to_cam.z * dir.x - to_cam.x * dir.z,
-            .z = to_cam.x * dir.y - to_cam.y * dir.x,
-        };
-        const float length =
-            sqrtf(SQUARE(perp.x) + SQUARE(perp.y) + SQUARE(perp.z));
-        if (length < 1.0f) {
-            offsets[n] = (XYZ_F) { .x = M_HALF_WIDTH, .y = 0.0f, .z = 0.0f };
-            continue;
-        }
-        offsets[n] = (XYZ_F) {
-            .x = perp.x * M_HALF_WIDTH / length,
-            .y = perp.y * M_HALF_WIDTH / length,
-            .z = perp.z * M_HALF_WIDTH / length,
-        };
-    }
-
-    for (int32_t n = 0; n < ROPE_SEGMENTS - 1; n++) {
-        // The sprite's V axis must run along the rope like in OG's
-        // DrawRope, so the ribbon crosses the rope between corners 0-1.
-        const XYZ_32 quad[4] = {
-            {
-                .x = points[n].x - offsets[n].x,
-                .y = points[n].y - offsets[n].y,
-                .z = points[n].z - offsets[n].z,
-            },
-            {
-                .x = points[n].x + offsets[n].x,
-                .y = points[n].y + offsets[n].y,
-                .z = points[n].z + offsets[n].z,
-            },
-            {
-                .x = points[n + 1].x + offsets[n + 1].x,
-                .y = points[n + 1].y + offsets[n + 1].y,
-                .z = points[n + 1].z + offsets[n + 1].z,
-            },
-            {
-                .x = points[n + 1].x - offsets[n + 1].x,
-                .y = points[n + 1].y - offsets[n + 1].y,
-                .z = points[n + 1].z - offsets[n + 1].z,
-            },
-        };
-        const RGBA_8888 colors[4] = { m_RopeColor, m_RopeColor, m_RopeColor,
-                                      m_RopeColor };
-        OutputSource_PolyFX_StageSpriteQuadWorld(
-            sprite_idx, quad, colors, DRAW_BLEND);
-    }
 }
 
 // Like OG's DrawRopeList, ropes draw in a global pass independent of the

--- a/src/trx/game/rules.c
+++ b/src/trx/game/rules.c
@@ -38,6 +38,13 @@ static const RULE m_Rules[] = {
 #undef X_GROUP_BEGIN
 #undef X_GROUP_END
 
+// A rule can ship with a different number from game to game. Rules_Reset runs
+// once a level is loaded, so the version has settled by the time this does.
+static void M_ApplyGameDefaults(void)
+{
+    m_Defaults.corpse.fade_speed = g_TRVersion >= 4 ? 2 : 0;
+}
+
 const RULE *Rules_GetMap(void)
 {
     return m_Rules;
@@ -56,13 +63,6 @@ const RULE *Rules_GetByName(const char *const name)
 void Rules_ResetOne(const RULE *const rule)
 {
     Value_CopyPtr(rule->type, rule->target, rule->default_value);
-}
-
-// A rule can ship with a different number from game to game. Rules_Reset runs
-// once a level is loaded, so the version has settled by the time this does.
-static void M_ApplyGameDefaults(void)
-{
-    m_Defaults.corpse.fade_speed = g_TRVersion >= 4 ? 2 : 0;
 }
 
 void Rules_Reset(void)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -310,6 +310,20 @@ static void M_DetermineLegacyGunTypes(RESUME_INFO *const resume)
     }
 }
 
+static bool M_IsQuickSlotSortedBefore(
+    const SAVEGAME_SLOT_REF left, const SAVEGAME_SLOT_REF right)
+{
+    const SAVEGAME_INFO *const left_info = Savegame_GetSavegameInfo(left);
+    const SAVEGAME_INFO *const right_info = Savegame_GetSavegameInfo(right);
+    if (left_info == nullptr || right_info == nullptr) {
+        return false;
+    }
+    if (left_info->counter != right_info->counter) {
+        return left_info->counter > right_info->counter;
+    }
+    return left.index < right.index;
+}
+
 SAVEGAME_VERSION Savegame_GetInitialVersion(void)
 {
     return m_InitialVersion;
@@ -494,20 +508,6 @@ SAVEGAME_SLOT_REF Savegame_GetNextQuickSlot(void)
         m_NextQuickSlot = 0;
     }
     return Savegame_QuickSlot(m_NextQuickSlot);
-}
-
-static bool M_IsQuickSlotSortedBefore(
-    const SAVEGAME_SLOT_REF left, const SAVEGAME_SLOT_REF right)
-{
-    const SAVEGAME_INFO *const left_info = Savegame_GetSavegameInfo(left);
-    const SAVEGAME_INFO *const right_info = Savegame_GetSavegameInfo(right);
-    if (left_info == nullptr || right_info == nullptr) {
-        return false;
-    }
-    if (left_info->counter != right_info->counter) {
-        return left_info->counter > right_info->counter;
-    }
-    return left.index < right.index;
 }
 
 int32_t Savegame_GetQuickVisualCount(void)

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -26,22 +26,6 @@
 
 static JSON_VALUE *M_ReadRaw(MYFILE *fp, int32_t *version_out);
 
-const char *SG_File_GetSaveFilePattern(void)
-{
-    return g_GameFlow.savegame_file_fmt;
-}
-
-const char *SG_File_GetQuickSaveFilePattern(void)
-{
-    const char *const pattern = SG_File_GetSaveFilePattern();
-    const char *const placeholder = strchr(pattern, '%');
-    if (placeholder == nullptr) {
-        return String_FormatStatic("%s_q", pattern);
-    }
-    const int32_t prefix_size = placeholder - pattern;
-    return String_FormatStatic("%.*sq%s", prefix_size, pattern, placeholder);
-}
-
 static JSON_VALUE *M_ParseFromBuffer(
     const char *const buffer, int32_t *const version_out)
 {
@@ -127,6 +111,22 @@ static void M_SaveRaw(
 
     Memory_FreePointer(&uncompressed);
     Memory_FreePointer(&compressed);
+}
+
+const char *SG_File_GetSaveFilePattern(void)
+{
+    return g_GameFlow.savegame_file_fmt;
+}
+
+const char *SG_File_GetQuickSaveFilePattern(void)
+{
+    const char *const pattern = SG_File_GetSaveFilePattern();
+    const char *const placeholder = strchr(pattern, '%');
+    if (placeholder == nullptr) {
+        return String_FormatStatic("%s_q", pattern);
+    }
+    const int32_t prefix_size = placeholder - pattern;
+    return String_FormatStatic("%.*sq%s", prefix_size, pattern, placeholder);
 }
 
 bool SG_File_LoadFromFile(MYFILE *const fp)

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -136,38 +136,6 @@ static void M_LoadCatalog(
     }
 }
 
-void Shell_RequestModSwitch(const char *const mod_name)
-{
-    Memory_FreePointer(&m_PendingMod);
-    m_PendingMod = Memory_DupStr(mod_name);
-}
-
-const char *Shell_GetPendingMod(void)
-{
-    return m_PendingMod;
-}
-
-void Shell_ClearPendingMod(void)
-{
-    Memory_FreePointer(&m_PendingMod);
-}
-
-bool Shell_GetPrevHeadless(void)
-{
-    return m_PrevHeadless;
-}
-
-bool Shell_GetPrevQuiet(void)
-{
-    return m_PrevQuiet;
-}
-
-const SHELL_ARGS *Shell_GetArgs(void)
-{
-    ASSERT(m_Session != nullptr);
-    return m_Session->args;
-}
-
 static void M_InitModules(void)
 {
     Shell_SetupHiDPI();
@@ -333,6 +301,38 @@ static void M_PrepareSystem(void)
                                                       : Clock_GetCurrentFPS();
         Clock_EnableHeadlessFixedFPS(fps);
     }
+}
+
+void Shell_RequestModSwitch(const char *const mod_name)
+{
+    Memory_FreePointer(&m_PendingMod);
+    m_PendingMod = Memory_DupStr(mod_name);
+}
+
+const char *Shell_GetPendingMod(void)
+{
+    return m_PendingMod;
+}
+
+void Shell_ClearPendingMod(void)
+{
+    Memory_FreePointer(&m_PendingMod);
+}
+
+bool Shell_GetPrevHeadless(void)
+{
+    return m_PrevHeadless;
+}
+
+bool Shell_GetPrevQuiet(void)
+{
+    return m_PrevQuiet;
+}
+
+const SHELL_ARGS *Shell_GetArgs(void)
+{
+    ASSERT(m_Session != nullptr);
+    return m_Session->args;
 }
 
 SDL_Window *Shell_GetWindow(void)

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -234,6 +234,25 @@ __attribute__((destructor)) static void M_Shutdown(void)
     m_Mods = nullptr;
 }
 
+static bool M_MatchesEngineVersion(
+    const SHELL_MOD *const mod, const int32_t engine_version)
+{
+    return engine_version == 0 || mod->engine_version == engine_version;
+}
+
+static const SHELL_MOD *M_GetFirstAvailableMod(const int32_t engine_version)
+{
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        const SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        if (!Shell_CanSwitchToMod(mod)
+            || !M_MatchesEngineVersion(mod, engine_version)) {
+            continue;
+        }
+        return mod;
+    }
+    return nullptr;
+}
+
 void Shell_ScanAvailableMods(void)
 {
     if (m_Mods != nullptr) {
@@ -319,25 +338,6 @@ const SHELL_MOD *Shell_GetModByName(const char *const name)
         if (mod->is_available && strcmp(mod->name, name) == 0) {
             return mod;
         }
-    }
-    return nullptr;
-}
-
-static bool M_MatchesEngineVersion(
-    const SHELL_MOD *const mod, const int32_t engine_version)
-{
-    return engine_version == 0 || mod->engine_version == engine_version;
-}
-
-static const SHELL_MOD *M_GetFirstAvailableMod(const int32_t engine_version)
-{
-    for (int32_t i = 0; i < m_Mods->count; i++) {
-        const SHELL_MOD *const mod = Vector_Get(m_Mods, i);
-        if (!Shell_CanSwitchToMod(mod)
-            || !M_MatchesEngineVersion(mod, engine_version)) {
-            continue;
-        }
-        return mod;
     }
     return nullptr;
 }

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -70,6 +70,11 @@ typedef struct {
     bool found;
 } M_RESOLVE_CACHE_ENTRY;
 
+typedef struct {
+    const M_DYNAMIC_PATH_POLICY *policy;
+    const char *resolved;
+} M_RESOLVE_VISITOR_CONTEXT;
+
 typedef bool (*M_RESOLVE_ATTEMPT_CALLBACK)(
     const char *attempt_path, void *user_data);
 
@@ -696,56 +701,6 @@ static char *M_ReplacePathTokens(
     return result;
 }
 
-char *TRXPath_ExpandVars(const char *const in)
-{
-    if (in == nullptr) {
-        return nullptr;
-    }
-    if (!m_Context.inited) {
-        TRXPath_Init(m_Context.args);
-    }
-
-    char *result = Memory_DupStr(in);
-    const char *const mod_id = M_GetCurrentModID();
-    const char *const base_mod_id = M_GetBaseModID();
-    char *mod_dir = M_GetCurrentModDir();
-    char *levels_dir = M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_LEVEL_FILE);
-    char *images_dir = M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_IMAGE_FILE);
-    char *injections_dir =
-        M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_INJECTION_FILE);
-    char *scripts_dir =
-        M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_SCRIPT_FILE);
-    char *base_mod_dir = M_GetBaseModDir();
-    char *tr_version = String_Format("%d", g_TRVersion);
-
-    const M_PATH_TOKEN tokens[] = {
-#define M_PATH_TOKEN_ITEM(name, field, token) { token, m_Context.field },
-        TRX_PATH_DIR_LIST(M_PATH_TOKEN_ITEM)
-#undef M_PATH_TOKEN_ITEM
-            { "%mod_dir%", mod_dir },
-        { "%mod%", mod_id != nullptr ? mod_id : "" },
-        { "%levels_dir%", levels_dir },
-        { "%images_dir%", images_dir },
-        { "%injections_dir%", injections_dir },
-        { "%scripts_dir%", scripts_dir },
-        { "%base_mod_dir%", base_mod_dir },
-        { "%base_mod%", base_mod_id != nullptr ? base_mod_id : "" },
-        { "%direct_level%", M_GetDirectLevelArg() },
-        { "%tr_version%", tr_version },
-    };
-
-    result = M_ReplacePathTokens(result, tokens, ARRAY_SIZE(tokens));
-
-    Memory_FreePointer(&tr_version);
-    Memory_FreePointer(&base_mod_dir);
-    Memory_FreePointer(&scripts_dir);
-    Memory_FreePointer(&injections_dir);
-    Memory_FreePointer(&images_dir);
-    Memory_FreePointer(&levels_dir);
-    Memory_FreePointer(&mod_dir);
-    return result;
-}
-
 static void M_BuildModChain(const SHELL_ARGS *const args)
 {
     m_Context.mod_chain_count = 0;
@@ -864,76 +819,6 @@ __attribute__((destructor)) static void M_Shutdown(void)
     m_Context.args = nullptr;
     m_Context.mod_chain_count = 0;
     m_Context.inited = false;
-}
-
-void TRXPath_Init(const SHELL_ARGS *const args)
-{
-    M_Shutdown();
-
-    m_Context.args = args;
-    m_ResolveCacheGeneration++;
-
-    if (m_Context.trx_dir == nullptr) {
-        const char *const base = SDL_GetBasePath();
-        if (base != nullptr) {
-            m_Context.trx_dir = Memory_DupStr(base);
-            SDL_free((void *)base);
-        } else {
-            m_Context.trx_dir = Memory_DupStr(".");
-        }
-        M_TrimTrailingSeparators(m_Context.trx_dir);
-    }
-
-    M_SetDirFromEnv(
-        &m_Context.config_dir, getenv("TRX_CONFIG_DIR"), "cfg", false);
-    M_SetDirFromEnv(
-        &m_Context.cache_dir, getenv("TRX_CACHE_DIR"), "cache", false);
-
-    if (!M_SetDirFromEnv(
-            &m_Context.games_dir, getenv("TRX_GAMES_DIR"), "games", true)) {
-        M_SetDirFromEnv(&m_Context.games_dir, nullptr, "cfg", false);
-    }
-
-    M_SetDirFromEnv(
-        &m_Context.screenshots_dir, getenv("TRX_SCREENSHOTS_DIR"),
-        "screenshots", false);
-
-    M_SetDirFromEnv(
-        &m_Context.saves_dir, getenv("TRX_SAVES_DIR"), "saves", false);
-
-    Memory_FreePointer(&m_Context.legacy_saves_dir);
-    m_Context.legacy_saves_dir = String_Format("%s/saves", m_Context.trx_dir);
-
-    M_BuildModChain(args);
-    M_SeedResolverCaches();
-    m_Context.inited = true;
-}
-
-const char *TRXPath_Get(const TRX_PATH path)
-{
-    if (!m_Context.inited) {
-        TRXPath_Init(m_Context.args);
-    }
-
-    switch (path) {
-#define M_GET_CASE(name, field, token)                                         \
-    case TRX_PATH_##name:                                                      \
-        return m_Context.field;
-        TRX_PATH_DIR_LIST(M_GET_CASE)
-#undef M_GET_CASE
-    default:
-        ASSERT_FAIL_FMT("Unknown TRX_PATH %d", path);
-        return nullptr;
-    }
-}
-
-char *TRXPath_Join(const TRX_PATH path, const char *const rel)
-{
-    const char *const root = TRXPath_Get(path);
-    if (root == nullptr || rel == nullptr || String_IsEmpty(rel)) {
-        return root != nullptr ? Memory_DupStr(root) : nullptr;
-    }
-    return M_JoinPath(root, rel);
 }
 
 static char *M_ExpandDynamicPattern(
@@ -1055,11 +940,6 @@ static bool M_ForEachResolveAttempt(
     Memory_FreePointer(&expanded_rel);
     return true;
 }
-
-typedef struct {
-    const M_DYNAMIC_PATH_POLICY *policy;
-    const char *resolved;
-} M_RESOLVE_VISITOR_CONTEXT;
 
 static bool M_ResolveAttemptVisitor(
     const char *const attempt_path, void *const user_data)
@@ -1184,6 +1064,126 @@ static const char *M_PeekResolvedUserPathCandidate(
     const char *const resolved = String_FormatStatic("%s", full_path);
     Memory_FreePointer(&full_path);
     return resolved;
+}
+
+char *TRXPath_ExpandVars(const char *const in)
+{
+    if (in == nullptr) {
+        return nullptr;
+    }
+    if (!m_Context.inited) {
+        TRXPath_Init(m_Context.args);
+    }
+
+    char *result = Memory_DupStr(in);
+    const char *const mod_id = M_GetCurrentModID();
+    const char *const base_mod_id = M_GetBaseModID();
+    char *mod_dir = M_GetCurrentModDir();
+    char *levels_dir = M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_LEVEL_FILE);
+    char *images_dir = M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_IMAGE_FILE);
+    char *injections_dir =
+        M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_INJECTION_FILE);
+    char *scripts_dir =
+        M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_SCRIPT_FILE);
+    char *base_mod_dir = M_GetBaseModDir();
+    char *tr_version = String_Format("%d", g_TRVersion);
+
+    const M_PATH_TOKEN tokens[] = {
+#define M_PATH_TOKEN_ITEM(name, field, token) { token, m_Context.field },
+        TRX_PATH_DIR_LIST(M_PATH_TOKEN_ITEM)
+#undef M_PATH_TOKEN_ITEM
+            { "%mod_dir%", mod_dir },
+        { "%mod%", mod_id != nullptr ? mod_id : "" },
+        { "%levels_dir%", levels_dir },
+        { "%images_dir%", images_dir },
+        { "%injections_dir%", injections_dir },
+        { "%scripts_dir%", scripts_dir },
+        { "%base_mod_dir%", base_mod_dir },
+        { "%base_mod%", base_mod_id != nullptr ? base_mod_id : "" },
+        { "%direct_level%", M_GetDirectLevelArg() },
+        { "%tr_version%", tr_version },
+    };
+
+    result = M_ReplacePathTokens(result, tokens, ARRAY_SIZE(tokens));
+
+    Memory_FreePointer(&tr_version);
+    Memory_FreePointer(&base_mod_dir);
+    Memory_FreePointer(&scripts_dir);
+    Memory_FreePointer(&injections_dir);
+    Memory_FreePointer(&images_dir);
+    Memory_FreePointer(&levels_dir);
+    Memory_FreePointer(&mod_dir);
+    return result;
+}
+
+void TRXPath_Init(const SHELL_ARGS *const args)
+{
+    M_Shutdown();
+
+    m_Context.args = args;
+    m_ResolveCacheGeneration++;
+
+    if (m_Context.trx_dir == nullptr) {
+        const char *const base = SDL_GetBasePath();
+        if (base != nullptr) {
+            m_Context.trx_dir = Memory_DupStr(base);
+            SDL_free((void *)base);
+        } else {
+            m_Context.trx_dir = Memory_DupStr(".");
+        }
+        M_TrimTrailingSeparators(m_Context.trx_dir);
+    }
+
+    M_SetDirFromEnv(
+        &m_Context.config_dir, getenv("TRX_CONFIG_DIR"), "cfg", false);
+    M_SetDirFromEnv(
+        &m_Context.cache_dir, getenv("TRX_CACHE_DIR"), "cache", false);
+
+    if (!M_SetDirFromEnv(
+            &m_Context.games_dir, getenv("TRX_GAMES_DIR"), "games", true)) {
+        M_SetDirFromEnv(&m_Context.games_dir, nullptr, "cfg", false);
+    }
+
+    M_SetDirFromEnv(
+        &m_Context.screenshots_dir, getenv("TRX_SCREENSHOTS_DIR"),
+        "screenshots", false);
+
+    M_SetDirFromEnv(
+        &m_Context.saves_dir, getenv("TRX_SAVES_DIR"), "saves", false);
+
+    Memory_FreePointer(&m_Context.legacy_saves_dir);
+    m_Context.legacy_saves_dir = String_Format("%s/saves", m_Context.trx_dir);
+
+    M_BuildModChain(args);
+    M_SeedResolverCaches();
+    m_Context.inited = true;
+}
+
+const char *TRXPath_Get(const TRX_PATH path)
+{
+    if (!m_Context.inited) {
+        TRXPath_Init(m_Context.args);
+    }
+
+    switch (path) {
+#define M_GET_CASE(name, field, token)                                         \
+    case TRX_PATH_##name:                                                      \
+        return m_Context.field;
+        TRX_PATH_DIR_LIST(M_GET_CASE)
+#undef M_GET_CASE
+    default:
+        ASSERT_FAIL_FMT("Unknown TRX_PATH %d", path);
+        return nullptr;
+    }
+}
+
+char *TRXPath_Join(const TRX_PATH path, const char *const rel)
+{
+    const char *const root = TRXPath_Get(path);
+    if (root == nullptr || rel == nullptr || String_IsEmpty(rel)) {
+        return root != nullptr ? Memory_DupStr(root) : nullptr;
+    }
+    return M_JoinPath(root, rel);
 }
 
 const char *TRXPath_PeekResolve(

--- a/src/trx/game/shell/platform.c
+++ b/src/trx/game/shell/platform.c
@@ -12,29 +12,6 @@
 #include <libavcodec/version.h>
 #include <libavutil/log.h>
 
-void Shell_SetupHiDPI(void)
-{
-#ifdef _WIN32
-    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
-    SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "0");
-#endif
-}
-
-void Shell_SetupLibAV(void)
-{
-#ifdef _WIN32
-    // necessary for SDL_OpenAudioDevice to work with WASAPI
-    // https://www.mail-archive.com/ffmpeg-trac@avcodec.org/msg43300.html
-    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR <= 57
-    av_register_all();
-#endif
-
-    av_log_set_level(AV_LOG_ERROR);
-}
-
 #ifdef _WIN32
 // NOTE – taken from SDL3:
 // From 8994878767cfb9403f525d12c0770c1e149a4d08 Mon Sep 17 00:00:00 2001
@@ -94,7 +71,32 @@ M_DarkModeWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     }
     return CallWindowProc(m_OldWndProc, hwnd, msg, wParam, lParam);
 }
+#endif
 
+void Shell_SetupHiDPI(void)
+{
+#ifdef _WIN32
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "0");
+#endif
+}
+
+void Shell_SetupLibAV(void)
+{
+#ifdef _WIN32
+    // necessary for SDL_OpenAudioDevice to work with WASAPI
+    // https://www.mail-archive.com/ffmpeg-trac@avcodec.org/msg43300.html
+    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+#endif
+
+#if LIBAVCODEC_VERSION_MAJOR <= 57
+    av_register_all();
+#endif
+
+    av_log_set_level(AV_LOG_ERROR);
+}
+
+#ifdef _WIN32
 void Shell_EnableThemeSupport(SDL_Window *const window)
 {
     SDL_SysWMinfo info;

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -287,6 +287,17 @@ static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
     sound->pan = M_GetPan(sound->sample, sound->pos_ptr);
 }
 
+// A slot holds a voice while its handle is set; a paused voice counts, so this
+// tests the handle rather than whether it is audibly playing.
+static M_ACTIVE_SOUND *M_GetActiveSlot(const int32_t slot)
+{
+    if (slot < 0 || slot >= M_MAX_ACTIVE_SOUNDS
+        || m_ActiveSounds[slot].handle == AUDIO_NO_SOUND) {
+        return nullptr;
+    }
+    return &m_ActiveSounds[slot];
+}
+
 bool Sound_Init(void)
 {
     m_MasterVolume = g_Config.audio.sound_volume;
@@ -695,17 +706,6 @@ void Sound_StopAll(void)
     }
     Audio_Sample_CloseAll();
     M_ClearAllActiveSounds();
-}
-
-// A slot holds a voice while its handle is set; a paused voice counts, so this
-// tests the handle rather than whether it is audibly playing.
-static M_ACTIVE_SOUND *M_GetActiveSlot(const int32_t slot)
-{
-    if (slot < 0 || slot >= M_MAX_ACTIVE_SOUNDS
-        || m_ActiveSounds[slot].handle == AUDIO_NO_SOUND) {
-        return nullptr;
-    }
-    return &m_ActiveSounds[slot];
 }
 
 int32_t Sound_GetActiveSlotCount(void)

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -46,6 +46,100 @@ static const BITE m_NodeOffsets[16] = {
     { .pos = { 0, 0, 0 }, .mesh_num = 0 },
 };
 
+static int32_t M_GetFreeSpark(void)
+{
+    int32_t idx = m_NextSpark;
+    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
+        if (!m_Sparks[idx].on) {
+            m_NextSpark = (idx + 1) & 0xBF;
+            return idx;
+        }
+        idx = idx == (M_MAX_SPARKS - 1) ? 0 : idx + 1;
+    }
+
+    int32_t free = 0;
+    int32_t min_life = INT32_MAX;
+    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
+        const SPARK *const spark = &m_Sparks[i];
+        if ((int32_t)spark->life < min_life && spark->dynamic == -1
+            && ((spark->flags & SPARK_F_BLOOD) == 0U || (i & 1) != 0)) {
+            free = i;
+            min_life = (int32_t)spark->life;
+        }
+    }
+
+    m_NextSpark = (free + 1) & 0xBF;
+    return free;
+}
+
+static void M_UpdateWind(void)
+{
+    if (g_Config.visuals.breeze_mode == BREEZE_MODE_OFF) {
+        m_SmokeWind = (XZ_32) {};
+        m_HairWindZ = 0;
+        return;
+    }
+
+    if (g_Config.visuals.breeze_mode == BREEZE_MODE_TR2) {
+        const ITEM *const lara_item = Lara_GetItem();
+        if (lara_item == nullptr) {
+            m_HairWindZ = 0;
+            return;
+        }
+
+        const ROOM *const room = Room_Get(lara_item->room_num);
+        if (room == nullptr || !room->flags.wind) {
+            m_HairWindZ = 0;
+            return;
+        }
+
+        const int32_t random = Random_GetDraw() & 7;
+        if (random != 0) {
+            m_HairWindZ += random - 4;
+            if (m_HairWindZ < 0) {
+                m_HairWindZ = 0;
+            } else if (m_HairWindZ >= 8) {
+                m_HairWindZ--;
+            }
+        }
+        m_SmokeWind = (XZ_32) {
+            .x = 0,
+            .z = m_HairWindZ << 1,
+        };
+        return;
+    }
+
+    // TR3 wind logic: a small random wind magnitude with a slowly-changing
+    // direction, biased to the [90°, 270°] range.
+    m_TR3Wind += (Random_GetControl() & 7) - 3;
+    if (m_TR3Wind <= -2) {
+        m_TR3Wind++;
+    } else if (m_TR3Wind >= 9) {
+        m_TR3Wind--;
+    }
+
+    // Original TR3 uses a 0..4095 angle space; keep the calculations faithful.
+    m_TR3DWindAngle =
+        (m_TR3DWindAngle + (((Random_GetControl() & 0x3F) - 32) * 2)) & 0x1FFE;
+
+    if (m_TR3DWindAngle < 1024) { // DEG_90
+        m_TR3DWindAngle += (1024 - m_TR3DWindAngle) << 1;
+    } else if (m_TR3DWindAngle > 3072) { // DEG_270
+        m_TR3DWindAngle -= (m_TR3DWindAngle - 3072) << 1;
+    }
+    m_TR3DWindAngle &= 0x1FFE;
+    m_TR3WindAngle =
+        (m_TR3WindAngle + ((m_TR3DWindAngle - m_TR3WindAngle) >> 3)) & 0x1FFE;
+
+    // Promote to DEG_360 for Math_Sin/Cos just at the end.
+    m_SmokeWind = (XZ_32) {
+        .x = (m_TR3Wind * Math_Sin(m_TR3WindAngle << 3)) >> W2V_SHIFT,
+        .z = (m_TR3Wind * Math_Cos(m_TR3WindAngle << 3)) >> W2V_SHIFT,
+    };
+
+    m_HairWindZ = 0;
+}
+
 XYZ_32 Sparks_GetWorldPos(const SPARK *const spark)
 {
     if (spark == nullptr) {
@@ -90,32 +184,6 @@ XYZ_32 Sparks_GetWorldPos(const SPARK *const spark)
     }
 
     return spark->pos;
-}
-
-static int32_t M_GetFreeSpark(void)
-{
-    int32_t idx = m_NextSpark;
-    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
-        if (!m_Sparks[idx].on) {
-            m_NextSpark = (idx + 1) & 0xBF;
-            return idx;
-        }
-        idx = idx == (M_MAX_SPARKS - 1) ? 0 : idx + 1;
-    }
-
-    int32_t free = 0;
-    int32_t min_life = INT32_MAX;
-    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
-        const SPARK *const spark = &m_Sparks[i];
-        if ((int32_t)spark->life < min_life && spark->dynamic == -1
-            && ((spark->flags & SPARK_F_BLOOD) == 0U || (i & 1) != 0)) {
-            free = i;
-            min_life = (int32_t)spark->life;
-        }
-    }
-
-    m_NextSpark = (free + 1) & 0xBF;
-    return free;
 }
 
 SPARK *Sparks_GetFreeSpark(void)
@@ -231,74 +299,6 @@ void Sparks_SetSmokeWind(const XZ_32 wind)
 int32_t Sparks_GetHairWindZ(void)
 {
     return m_HairWindZ;
-}
-
-static void M_UpdateWind(void)
-{
-    if (g_Config.visuals.breeze_mode == BREEZE_MODE_OFF) {
-        m_SmokeWind = (XZ_32) {};
-        m_HairWindZ = 0;
-        return;
-    }
-
-    if (g_Config.visuals.breeze_mode == BREEZE_MODE_TR2) {
-        const ITEM *const lara_item = Lara_GetItem();
-        if (lara_item == nullptr) {
-            m_HairWindZ = 0;
-            return;
-        }
-
-        const ROOM *const room = Room_Get(lara_item->room_num);
-        if (room == nullptr || !room->flags.wind) {
-            m_HairWindZ = 0;
-            return;
-        }
-
-        const int32_t random = Random_GetDraw() & 7;
-        if (random != 0) {
-            m_HairWindZ += random - 4;
-            if (m_HairWindZ < 0) {
-                m_HairWindZ = 0;
-            } else if (m_HairWindZ >= 8) {
-                m_HairWindZ--;
-            }
-        }
-        m_SmokeWind = (XZ_32) {
-            .x = 0,
-            .z = m_HairWindZ << 1,
-        };
-        return;
-    }
-
-    // TR3 wind logic: a small random wind magnitude with a slowly-changing
-    // direction, biased to the [90°, 270°] range.
-    m_TR3Wind += (Random_GetControl() & 7) - 3;
-    if (m_TR3Wind <= -2) {
-        m_TR3Wind++;
-    } else if (m_TR3Wind >= 9) {
-        m_TR3Wind--;
-    }
-
-    // Original TR3 uses a 0..4095 angle space; keep the calculations faithful.
-    m_TR3DWindAngle =
-        (m_TR3DWindAngle + (((Random_GetControl() & 0x3F) - 32) * 2)) & 0x1FFE;
-
-    if (m_TR3DWindAngle < 1024) { // DEG_90
-        m_TR3DWindAngle += (1024 - m_TR3DWindAngle) << 1;
-    } else if (m_TR3DWindAngle > 3072) { // DEG_270
-        m_TR3DWindAngle -= (m_TR3DWindAngle - 3072) << 1;
-    }
-    m_TR3DWindAngle &= 0x1FFE;
-    m_TR3WindAngle =
-        (m_TR3WindAngle + ((m_TR3DWindAngle - m_TR3WindAngle) >> 3)) & 0x1FFE;
-
-    // Promote to DEG_360 for Math_Sin/Cos just at the end.
-    m_SmokeWind = (XZ_32) {
-        .x = (m_TR3Wind * Math_Sin(m_TR3WindAngle << 3)) >> W2V_SHIFT,
-        .z = (m_TR3Wind * Math_Cos(m_TR3WindAngle << 3)) >> W2V_SHIFT,
-    };
-
-    m_HairWindZ = 0;
 }
 
 void Sparks_Control(void)

--- a/src/trx/game/ui/dialogs/controls_editor.c
+++ b/src/trx/game/ui/dialogs/controls_editor.c
@@ -514,6 +514,20 @@ static void M_Footer(UI_CONTROLS_EDITOR_STATE *const s)
     UI_EndStack();
 }
 
+static void M_Header(void *const user_data)
+{
+    UI_CONTROLS_EDITOR_STATE *const s = user_data;
+    UI_BeginStackEx((UI_STACK_SETTINGS) {
+        .orientation = UI_STACK_VERTICAL,
+        .align = { .h = UI_STACK_H_ALIGN_SPAN },
+        .spacing = { .v = 4.0f },
+    });
+    M_CurrentLayout(s);
+    M_GroupsHeader(s);
+    UI_EndStack();
+    UI_Spacer(0.0f, 5.0f);
+}
+
 void UI_ControlsEditor_Init(
     UI_CONTROLS_EDITOR_STATE *const s, const INPUT_BACKEND backend,
     const int32_t layout, EVENT_MANAGER *const events)
@@ -613,20 +627,6 @@ UI_CONTROLS_CHOICE UI_ControlsEditor_Control(UI_CONTROLS_EDITOR_STATE *const s)
     default:
         return UI_CONTROLS_CHOICE_NOOP;
     }
-}
-
-static void M_Header(void *const user_data)
-{
-    UI_CONTROLS_EDITOR_STATE *const s = user_data;
-    UI_BeginStackEx((UI_STACK_SETTINGS) {
-        .orientation = UI_STACK_VERTICAL,
-        .align = { .h = UI_STACK_H_ALIGN_SPAN },
-        .spacing = { .v = 4.0f },
-    });
-    M_CurrentLayout(s);
-    M_GroupsHeader(s);
-    UI_EndStack();
-    UI_Spacer(0.0f, 5.0f);
 }
 
 void UI_ControlsEditor(UI_CONTROLS_EDITOR_STATE *const s)

--- a/src/trx/game/ui/dialogs/new_game.c
+++ b/src/trx/game/ui/dialogs/new_game.c
@@ -103,11 +103,6 @@ static M_FEATURES M_CheckFeatures(const bool check_save_features)
     return features;
 }
 
-bool UI_NewGame_HasModChoices(void)
-{
-    return M_HasSwitchModChoice();
-}
-
 static bool M_OptionVisible(
     const M_FEATURES *const features, const M_OPTION *const option)
 {
@@ -122,6 +117,11 @@ static bool M_OptionVisible(
     }
     return Option_Passport_AreGameModesAvailable()
         || option->choice == UI_NEW_GAME_CHOICE_NG;
+}
+
+bool UI_NewGame_HasModChoices(void)
+{
+    return M_HasSwitchModChoice();
 }
 
 UI_NEW_GAME_STATE *UI_NewGame_Init(const bool show_play_prev_levels)

--- a/src/trx/game/ui/dialogs/settings_editor.c
+++ b/src/trx/game/ui/dialogs/settings_editor.c
@@ -446,33 +446,6 @@ changed:
     return true;
 }
 
-UI_SETTINGS_EDITOR_STATE *UI_SettingsEditor_Init(
-    const UI_SETTINGS_OPTION *const options)
-{
-    UI_SETTINGS_EDITOR_STATE *const s = Memory_Alloc(sizeof(*s));
-    s->options = options;
-    s->scroll = (UI_SCROLLABLE) {
-        .first_item = 0,
-        .sel_item = -1,
-        .max_items = 0,
-        .vis_items = 0,
-    };
-    s->color_editor = UI_ColorEditorDialog_Init();
-    return s;
-}
-
-void UI_SettingsEditor_Free(UI_SETTINGS_EDITOR_STATE *const s)
-{
-    if (s->description.show) {
-        UI_TextDialog_Free(s->description.state);
-        s->description.state = nullptr;
-        s->description.show = false;
-    }
-    UI_ColorEditorDialog_Free(s->color_editor);
-    s->color_editor = nullptr;
-    Memory_Free(s);
-}
-
 static float M_GetMaxLabelWidth(const UI_SETTINGS_EDITOR_STATE *const s)
 {
     float result = -1.0f;
@@ -501,6 +474,53 @@ static float M_GetMaxValueWidth(const UI_SETTINGS_EDITOR_STATE *const s)
     result += UI_Label_MeasureW("\\{button right}");
     result += UI_ROW_ARROWS_TIGHT * 2;
     return result;
+}
+
+static void M_OptionLabel(
+    const UI_SETTINGS_OPTION *const option, const char *const text,
+    const bool star_if_enforced)
+{
+    const bool is_available = option == nullptr
+        || option->custom_handler.is_available == nullptr
+        || option->custom_handler.is_available(option);
+    const bool is_enforced = star_if_enforced && option != nullptr
+        && Config_IsOptionEnforced(option->target);
+    const char *const suffix = is_enforced ? "*" : "";
+
+    if (!is_available) {
+        UI_LabelFmt("\\{dim}%s%s\\{/dim}", text, suffix);
+    } else if (is_enforced) {
+        UI_LabelFmt("%s%s", text, suffix);
+    } else {
+        UI_Label(text);
+    }
+}
+
+UI_SETTINGS_EDITOR_STATE *UI_SettingsEditor_Init(
+    const UI_SETTINGS_OPTION *const options)
+{
+    UI_SETTINGS_EDITOR_STATE *const s = Memory_Alloc(sizeof(*s));
+    s->options = options;
+    s->scroll = (UI_SCROLLABLE) {
+        .first_item = 0,
+        .sel_item = -1,
+        .max_items = 0,
+        .vis_items = 0,
+    };
+    s->color_editor = UI_ColorEditorDialog_Init();
+    return s;
+}
+
+void UI_SettingsEditor_Free(UI_SETTINGS_EDITOR_STATE *const s)
+{
+    if (s->description.show) {
+        UI_TextDialog_Free(s->description.state);
+        s->description.state = nullptr;
+        s->description.show = false;
+    }
+    UI_ColorEditorDialog_Free(s->color_editor);
+    s->color_editor = nullptr;
+    Memory_Free(s);
 }
 
 float UI_SettingsEditor_GetContentWidth(const UI_SETTINGS_EDITOR_STATE *const s)
@@ -726,26 +746,6 @@ void UI_SettingsEditor_DrawOverlay(UI_SETTINGS_EDITOR_STATE *const s)
                 UI_TextDialog(s->description.state, title, text);
             }
         }
-    }
-}
-
-static void M_OptionLabel(
-    const UI_SETTINGS_OPTION *const option, const char *const text,
-    const bool star_if_enforced)
-{
-    const bool is_available = option == nullptr
-        || option->custom_handler.is_available == nullptr
-        || option->custom_handler.is_available(option);
-    const bool is_enforced = star_if_enforced && option != nullptr
-        && Config_IsOptionEnforced(option->target);
-    const char *const suffix = is_enforced ? "*" : "";
-
-    if (!is_available) {
-        UI_LabelFmt("\\{dim}%s%s\\{/dim}", text, suffix);
-    } else if (is_enforced) {
-        UI_LabelFmt("%s%s", text, suffix);
-    } else {
-        UI_Label(text);
     }
 }
 

--- a/src/trx/game/ui/dialogs/settings_tabs.c
+++ b/src/trx/game/ui/dialogs/settings_tabs.c
@@ -72,16 +72,6 @@ static const UI_SETTINGS_TAB_OPS m_EditorOps = {
     .get_item_count = M_EditorGetItemCount,
 };
 
-UI_SETTINGS_TAB UI_SettingsTab_MakeEditor(
-    const GAME_STRING_ID header_gs, const UI_SETTINGS_OPTION *const options)
-{
-    return (UI_SETTINGS_TAB) {
-        .header_gs = header_gs,
-        .ops = &m_EditorOps,
-        .user_data = UI_SettingsEditor_Init(options),
-    };
-}
-
 static bool M_PresetsControl(
     void *const user_data, UI_SETTINGS_PHASE *const phase)
 {
@@ -131,6 +121,16 @@ static float M_PresetsGetContentHeight(void *const user_data)
 static int32_t M_PresetsGetItemCount(void *const user_data)
 {
     return UI_ConfigPresets_GetItemCount(user_data);
+}
+
+UI_SETTINGS_TAB UI_SettingsTab_MakeEditor(
+    const GAME_STRING_ID header_gs, const UI_SETTINGS_OPTION *const options)
+{
+    return (UI_SETTINGS_TAB) {
+        .header_gs = header_gs,
+        .ops = &m_EditorOps,
+        .user_data = UI_SettingsEditor_Init(options),
+    };
 }
 
 static const UI_SETTINGS_TAB_OPS m_PresetsOps = {

--- a/src/trx/game/ui/settings.c
+++ b/src/trx/game/ui/settings.c
@@ -613,26 +613,6 @@ static bool M_LoadMenuColors(JSON_READ_IO *const io)
     JSON_FINISH();
 }
 
-void UI_Settings_LoadFromFile(const char *const path)
-{
-    JSON_VALUE *const root = JSONFile_ReadEx(path, true);
-    JSON_READ_IO *const io = JSON_ReadIO_Create(root, 0, path);
-
-    M_FreeBarThemes();
-    if (!JSON_PUSH(io, "bars") || !M_LoadBarThemes(io) || !JSON_POP(io)) {
-        M_ExitWithJSONError(path, io);
-    }
-
-    if (!JSON_PUSH(io, "ui") || !M_LoadMenuColors(io) || !JSON_POP(io)) {
-        M_ExitWithJSONError(path, io);
-    }
-
-    M_SeedDynamicEnumValues();
-
-    JSON_ReadIO_Destroy(io);
-    JSON_ValueFree(root);
-}
-
 __attribute__((destructor)) static void M_Shutdown(void)
 {
     M_FreeBarThemes();
@@ -672,6 +652,26 @@ static const UI_BAR_THEME *M_FindThemeByName(
         return &group->colors[entry->index].theme;
     }
     return nullptr;
+}
+
+void UI_Settings_LoadFromFile(const char *const path)
+{
+    JSON_VALUE *const root = JSONFile_ReadEx(path, true);
+    JSON_READ_IO *const io = JSON_ReadIO_Create(root, 0, path);
+
+    M_FreeBarThemes();
+    if (!JSON_PUSH(io, "bars") || !M_LoadBarThemes(io) || !JSON_POP(io)) {
+        M_ExitWithJSONError(path, io);
+    }
+
+    if (!JSON_PUSH(io, "ui") || !M_LoadMenuColors(io) || !JSON_POP(io)) {
+        M_ExitWithJSONError(path, io);
+    }
+
+    M_SeedDynamicEnumValues();
+
+    JSON_ReadIO_Destroy(io);
+    JSON_ValueFree(root);
 }
 
 bool UI_Settings_IsCurrentBarLookPS1(void)

--- a/tools/lint/checks/module_static
+++ b/tools/lint/checks/module_static
@@ -9,19 +9,12 @@ from shared.cfuncs import definitions, is_static, name_of
 
 
 def check(path, text):
-    first_public = None
     for line_num, signature in definitions(text):
-        if not is_static(signature):
-            if first_public is None:
-                first_public = line_num
-            continue
-        if first_public is None:
+        name = name_of(signature)
+        if name is None or not name.startswith("M_") or is_static(signature):
             continue
         yield LintWarning(
-            path,
-            f"{name_of(signature) or 'static function'} belongs above the "
-            f"public function on line {first_public}",
-            line=line_num,
+            path, f"{name} is a module function and belongs static", line=line_num
         )
 
 

--- a/tools/lint/checks/static_order
+++ b/tools/lint/checks/static_order
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harness import LintWarning, file_check
+
+STATIC_RE = re.compile(r"^(?:__attribute__\(\(\w+\)\)\s+)?static\b")
+NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def _signature(lines, brace_idx):
+    # Walk back to the start of the paragraph holding the brace, then forward
+    # past any comment lines, which leaves the first line of the signature.
+    start = brace_idx
+    while start > 0 and lines[start - 1].strip():
+        start -= 1
+    while start < brace_idx and lines[start].lstrip().startswith("//"):
+        start += 1
+    if start == brace_idx:
+        return None
+    head = lines[start]
+    if not (head[:1].isalpha() or head.startswith("_")):
+        return None
+    return start + 1, head
+
+
+def _definitions(text):
+    # clang-format gives a top-level definition a signature at column 0 and an
+    # opening brace alone on a line. Initialisers keep their brace on the line
+    # that opens them, so only functions have this shape.
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        if line != "{":
+            continue
+        signature = _signature(lines, i)
+        if signature is not None:
+            yield signature
+
+
+def check(path, text):
+    first_public = None
+    for line_num, head in _definitions(text):
+        if STATIC_RE.match(head) is None:
+            if first_public is None:
+                first_public = line_num
+            continue
+        if first_public is None:
+            continue
+        name = NAME_RE.search(head)
+        yield LintWarning(
+            path,
+            f"{name[1] if name else 'static function'} belongs above the "
+            f"public function on line {first_public}",
+            line=line_num,
+        )
+
+
+file_check(check)

--- a/tools/shared/cfuncs.py
+++ b/tools/shared/cfuncs.py
@@ -1,0 +1,55 @@
+"""Locate top-level function definitions in a clang-formatted C file.
+
+clang-format gives such a definition a signature at column 0 and an opening
+brace alone on a line; initialisers keep their brace on the line that opens
+them, so nothing else in a .c file has that shape.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+ATTRIBUTE_RE = re.compile(r"^__attribute__\(\(\w+\)\)\s+")
+NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def _head(lines: list[str], brace_idx: int) -> int | None:
+    # Walk back to the start of the paragraph holding the brace, then forward
+    # past any comment lines, which leaves the first line of the signature.
+    start = brace_idx
+    while start > 0 and lines[start - 1].strip():
+        start -= 1
+    while start < brace_idx and lines[start].lstrip().startswith("//"):
+        start += 1
+    if start == brace_idx:
+        return None
+    head = lines[start]
+    if not (head[:1].isalpha() or head.startswith("_")):
+        return None
+    # A definition names its return type first. A head that opens with the
+    # name itself is a macro that expands to one, such as M_GF_HANDLER(x).
+    match = NAME_RE.search(ATTRIBUTE_RE.sub("", head))
+    if match is not None and match.start() == 0:
+        return None
+    return start
+
+
+def definitions(text: str) -> Iterator[tuple[int, str]]:
+    """Yield (1-based line number, signature line) for each definition."""
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        if line != "{":
+            continue
+        start = _head(lines, i)
+        if start is not None:
+            yield start + 1, lines[start]
+
+
+def is_static(signature: str) -> bool:
+    return ATTRIBUTE_RE.sub("", signature).startswith("static ")
+
+
+def name_of(signature: str) -> str | None:
+    match = NAME_RE.search(ATTRIBUTE_RE.sub("", signature))
+    return match[1] if match else None


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

We had many, many violations of static functions interleaving public APIs. This rule is now enforced on the lint level.
Additionally, we had a couple of functions that were using `M_` prefix but were undeclared as `static`. This is now likewise fixed and enforced.

This change is mechanical and does not affect players.