### PR TITLE
gun: restart the target cycle when it runs out

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed Bacon Lara dying prematurely in some geometry setups
 - fixed jittery interpolation on Bacon Lara when falling from great heights
 - fixed the detonator box returning to its original position after loading a save (OG bug)
+- fixed Lara's arms dropping for a moment when she changes target and there is nothing else to switch to
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -24,6 +24,7 @@
 
 static ITEM *m_TargetList[LOT_SLOT_COUNT] = {};
 static ITEM *m_LastTargetList[LOT_SLOT_COUNT] = {};
+static ITEM *m_BestTarget = nullptr;
 static int16_t m_TargetCount = 0;
 
 static bool M_TargetListContains(const ITEM *const item, const int16_t count)
@@ -604,6 +605,7 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
     }
 
     m_TargetCount = ctx.num_targets;
+    m_BestTarget = ctx.best_target;
 
     if ((g_Config.gameplay.target_mode == TARGET_LOCK_MODE_FULL
          || g_Config.gameplay.target_mode == TARGET_LOCK_MODE_SEMI)
@@ -662,6 +664,13 @@ void Gun_ChangeTarget(const WEAPON_INFO *const weapon)
             lara->target = m_TargetList[new_target];
             break;
         }
+    }
+
+    // Every target in range has been through the cycle already: start it over
+    // rather than leaving Lara with none, which would unlock her arms.
+    if (lara->target == nullptr) {
+        lara->target = m_BestTarget;
+        m_LastTargetList[0] = nullptr;
     }
 
     if (lara->target != m_LastTargetList[0]) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Changing target cleared Lara's target and picked the first candidate not yet in the history list. With a single enemy in range, or at the point the cycle wraps, there is no such candidate and she was left with no target for a frame, dropping her arms. Fall back to the best target, as TR4 does.

Resolves TRX801.