### PR TITLE
shadows: match TR4 shadow opacity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
 - changed skidoo and quad bike crashes to not kill Lara when she is immune
 - fixed exploding deaths in TR4 showing no flames or explosions
+- fixed Lara's shadow in TR4 being darker than in the original game
 - fixed some console commands being able to target unintended items
 - fixed the `/spawn` and `/kill` console commands not reaching army Winston
 - fixed the `/teatime` console command summoning army Winston rather than Winston himself

--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -4,6 +4,7 @@
 #include <trx/core/memory.h>
 #include <trx/game/output.h>
 #include <trx/game/output/mesh_batcher/mesh_builder.h>
+#include <trx/version.h>
 
 typedef struct {
     MESH_BATCHER *batcher;
@@ -17,7 +18,7 @@ static OUTPUT_MESH *M_GenerateShadow(
     MESH_BUILDER *const builder, const int32_t fidelity)
 {
     const int32_t y = -5;
-    const RGBA_8888 color = { 0, 0, 0, 128 };
+    const RGBA_8888 color = { 0, 0, 0, g_TRVersion == 4 ? 0x4F : 128 };
     const OUTPUT_MESH_VERTEX center = {
         .pos = { 0.0f, (float)y, 0.0f, 0.0f },
         .normal = { 0.0f, 0.0f, 0.0f },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The shadow blob is drawn at 128 alpha, whereas TR4 uses 0x4F.
Does not affect the injected sprite.

Resolves TRX616.