### PR TITLE
creature: fix crash when an ally loses its target

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed long messages in the developer console running past the right edge of the screen by 1 character
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed a crash when drawing an animating object that has no frame data (#5869)
+- fixed a crash in custom levels when an armed enemy turned ally shoots the last remaining enemy (#5973)
 - fixed the glow around gun and flare flashes lagging behind them (#5920)
 - fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)
 - fixed Lara attempting to climb ladders from inside lifts (#5890)

--- a/src/trx/game/creature/shooting.c
+++ b/src/trx/game/creature/shooting.c
@@ -92,6 +92,11 @@ bool Creature_Shoot(
     const ITEM *const lara_item = Lara_GetItem();
     const CREATURE *const creature = item->creature_data;
     ITEM *const target_item = creature->enemy;
+    if (target_item == nullptr) {
+        // Allies lose their target once the last hostile is gone; callers
+        // treat a false return as a cue to stop shooting.
+        return false;
+    }
 
     if (g_TRVersion == 3) {
         M_TriggerTR3GunShell(item, gun);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Creature_Shoot` read `creature->enemy` and passed it to `M_CalcShootVectors` and `Gun_SmashItems` without checking it. Allies pick their target from the LOT baddie slots, and `M_GetBaddieTarget` leaves the field null once the last hostile is gone, so an armed ally that was mid-shot dereferenced it. Monks never hit this because they are melee.

Return false instead, which callers already treat as a cue to stop shooting.

Resolves #5973 / TRX811
