### PR TITLE
Add main menu flybys to TR4

### DIFF
--- a/data/trx/ship/games/tr4/gameflow.json5
+++ b/data/trx/ship/games/tr4/gameflow.json5
@@ -25,6 +25,9 @@
     "title": {
         "path": "title.tr4",
         "music_track": 104,
+        // title.tr4 numbers its flyby sequences from 1; sequence 0 has no
+        // cameras.
+        "flyby_sequence": 1,
         "sequence": [
             {"type": "play_fmv", "fmv_id": 0},
             {"type": "exit_to_title"},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - changed lift collision to force Lara out of her climbing and vaulting animations if one collides with her (#5899, #5911)
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
 - changed skidoo and quad bike crashes to not kill Lara when she is immune
+- fixed the sun's glare staying on screen in cutscenes once the camera has looked away from it
 - fixed exploding deaths in TR4 showing no flames or explosions
 - fixed Lara's shadow in TR4 being darker than in the original game
 - fixed some console commands being able to target unintended items

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)
 - fixed the camera snapping aggressively to Lara after some flyby sequences (regression from 1.9)
+- fixed flyby sequences set to loop playing only once, then swinging the camera back to Lara
 - fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
 - fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
 - fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.3...develop) - ××××-××-××
+- added the flyby of the title level playing behind the TR4 main menu, as in the original game
 - added TR4 camera mode, which is similar to TR3 but more responsive to Lara's actions such as picking up items
 - added the ability to paste commands in the developer console (with Ctrl+V)
 - added autocompletion to the developer console (with Tab and Shift+Tab to cycle the matches)

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -197,6 +197,10 @@
         "music_track": {
           "type": "integer"
         },
+        "flyby_sequence": {
+          "type": "integer",
+          "description": "Flyby camera sequence of the title level played behind the menu."
+        },
         "inherit_injections": {
           "type": "boolean"
         },

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -1,6 +1,7 @@
 #include <trx/game/camera/flyby_mode.h>
 
 #include <trx/game/camera.h>
+#include <trx/game/game_flow.h>
 #include <trx/game/lara.h>
 #include <trx/game/rooms.h>
 #include <trx/game/viewport.h>
@@ -217,10 +218,23 @@ static void M_TestTriggers(void)
         return;
     }
 
-    // TODO: if current level == 0 (title?), test non-heavy too
     m_TriggerItem.pos = g_Camera.pos.pos;
     m_TriggerItem.room_num = g_Camera.pos.room_num;
-    Room_TestTriggers(&m_TriggerItem);
+
+    // The camera stands in for a heavy object while it tests, so the triggers
+    // it runs do not also reach for a fixed camera.
+    const CAMERA_TYPE camera_type = g_Camera.type;
+    g_Camera.type = CAM_HEAVY;
+
+    // There is no player on the title level to walk onto a pad or a plain
+    // trigger, so the flyby answers for both kinds there.
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    if (level != nullptr && level->type == GFL_TITLE) {
+        Room_TestTriggersEx(&m_TriggerItem, false);
+    }
+    Room_TestTriggersEx(&m_TriggerItem, true);
+
+    g_Camera.type = camera_type;
     m_State.flags.test_triggers = false;
 }
 

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -516,7 +516,7 @@ void Camera_FlybyMode_Update(void)
         m_State.current.camera_idx++;
 
         if (m_State.current.camera_idx > M_GetLastCamera(sequence)) {
-            if (current_camera->flags.loop) {
+            if (first_camera->flags.loop) {
                 m_State.current.camera_idx = sequence->camera_idx;
             } else if (
                 first_camera->flags.snap_to_game

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -9,6 +9,7 @@
 #include <trx/game/const.h>
 #include <trx/game/effects.h>
 #include <trx/game/fx.h>
+#include <trx/game/game/control.h>
 #include <trx/game/gun/misc.h>
 #include <trx/game/gun/smoke.h>
 #include <trx/game/input.h>
@@ -247,15 +248,12 @@ static void M_DrawGunFlash(const LARA_MESH hand_mesh)
 
 static void M_Control(void)
 {
-    Output_ResetDynamicLights();
-    FX_NewFrame();
+    Game_TickBeginFrame();
     Camera_UpdateCutscene();
     M_ControlGun();
-    Item_Control();
-    Effect_Control();
-    Sparks_Control();
+    Game_TickWorld();
     FX_Control();
-    Output_AnimateTextures(1);
+    Game_TickEndFrame();
     Lara_Hair_Control(true);
 }
 

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -219,27 +219,46 @@ GF_COMMAND Game_Control(const bool demo_mode)
         }
     }
 
+    Game_TickBeginFrame();
+    Sound_ResetAmbient();
+    Game_TickWorld();
+
+    Lara_Control();
+    Lara_Hair_Control(false);
+
+    Game_TickPostControl();
+    Game_TickEndFrame();
+    Overlay_Animate(1);
+    Output_LensFlares_Update();
+    return (GF_COMMAND) { .action = GF_NOOP };
+}
+
+void Game_TickBeginFrame(void)
+{
     Output_ResetDynamicLights();
     FX_NewFrame();
+}
 
-    Sound_ResetAmbient();
+void Game_TickWorld(void)
+{
     Item_Control();
     Effect_Control();
     Sparks_Control();
+}
 
-    Lara_Control();
+void Game_TickPostControl(void)
+{
     FX_Control();
-    Lara_Hair_Control(false);
-
     FlybyMode_PostControl();
     Camera_Update();
     ItemAction_RunActive();
     Sound_UpdateEffects();
-    Overlay_Animate(1);
+}
+
+void Game_TickEndFrame(void)
+{
     Output_AnimateTextures(1);
     Output_Sky_Update();
-    Output_LensFlares_Update();
-    return (GF_COMMAND) { .action = GF_NOOP };
 }
 
 void Game_ProcessInput(void)

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -229,7 +229,6 @@ GF_COMMAND Game_Control(const bool demo_mode)
     Game_TickPostControl();
     Game_TickEndFrame();
     Overlay_Animate(1);
-    Output_LensFlares_Update();
     return (GF_COMMAND) { .action = GF_NOOP };
 }
 
@@ -259,6 +258,7 @@ void Game_TickEndFrame(void)
 {
     Output_AnimateTextures(1);
     Output_Sky_Update();
+    Output_LensFlares_Update();
 }
 
 void Game_ProcessInput(void)

--- a/src/trx/game/game/control.h
+++ b/src/trx/game/game/control.h
@@ -7,4 +7,14 @@ void Game_End(void);
 
 GF_COMMAND Game_Control(bool demo_mode);
 
+// The steps of a simulation tick that gameplay, cutscenes and the live title
+// scene share, in the order they run. Each caller drives its own player and
+// HUD around them. Cutscenes update their camera and Lara's gun between the
+// frame start and the world step, because the gun flash adds a dynamic light,
+// and so run no post-control step, keeping their own FX_Control call.
+void Game_TickBeginFrame(void);
+void Game_TickWorld(void);
+void Game_TickPostControl(void);
+void Game_TickEndFrame(void);
+
 void Game_ProcessInput(void);

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -927,12 +927,15 @@ static bool M_LoadDemos(const M_CONTEXT *const ctx)
 
 static bool M_LoadTitleLevel(const M_CONTEXT *const ctx)
 {
+    ctx->gf->title_flyby_sequence = -1;
     if (!JSON_OPTIONAL(JSON_PUSH(ctx->io, "title"))) {
         return true;
     }
     ctx->gf->title_level = Memory_Alloc(sizeof(GF_LEVEL));
     JSON_MUST(
         M_LoadLevel(ctx, ctx->gf->title_level, 0, (void *)(intptr_t)GFL_TITLE));
+    JSON_OPTIONAL(
+        JSON_READ(ctx->io, "flyby_sequence", &ctx->gf->title_flyby_sequence));
     JSON_MUST(JSON_POP(ctx->io));
     JSON_FINISH();
 }

--- a/src/trx/game/game_flow/types.h
+++ b/src/trx/game/game_flow/types.h
@@ -200,6 +200,8 @@ typedef struct {
     // global settings
     struct {
         char *main_menu_background_path;
+        // Flyby camera sequence played behind the title menu, or -1.
+        int32_t title_flyby_sequence;
         bool enable_tr2_item_drops;
         bool convert_dropped_guns;
         GF_AMBIENT_DATA ambient_tracks;

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -4,7 +4,9 @@
 #include <trx/core/memory.h>
 #include <trx/game/camera.h>
 #include <trx/game/console.h>
+#include <trx/game/flyby_mode.h>
 #include <trx/game/game.h>
+#include <trx/game/game/control.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/gun.h>
@@ -405,6 +407,23 @@ static void M_SnapshotFrameState(INV_RING *const ring)
     M_SnapshotRingState(ring);
     for (int32_t i = 0; i < ring->number_of_objects; i++) {
         M_SnapshotItemState(ring->list[i]);
+    }
+}
+
+// A minimal simulation tick keeping the title level alive behind the menu:
+// the world and the flyby camera - no Lara, no player input, no HUD.
+static void M_SimTick(void)
+{
+    Interpolation_Remember();
+    Game_TickBeginFrame();
+    Sound_ResetAmbient();
+    Game_TickWorld();
+    Game_TickPostControl();
+    Game_TickEndFrame();
+
+    // Per the OG DoTitle, the flyby loops for as long as the menu is up.
+    if (!FlybyMode_IsActive() && g_GameFlow.title_flyby_sequence >= 0) {
+        FlybyMode_Activate(g_GameFlow.title_flyby_sequence, false);
     }
 }
 
@@ -896,9 +915,13 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
 
     INV_RING *const ring = Memory_Alloc(sizeof(INV_RING));
     ring->mode = mode;
-    ring->background_style = mode == INV_TITLE_MODE
-        ? BK_IMAGE
-        : g_Config.ui.inventory_background_style;
+    // The title level runs live behind the menu when the gameflow names a
+    // flyby sequence for it, so there is no background image to show.
+    ring->live_scene =
+        mode == INV_TITLE_MODE && g_GameFlow.title_flyby_sequence >= 0;
+    ring->background_style = mode != INV_TITLE_MODE
+        ? g_Config.ui.inventory_background_style
+        : (ring->live_scene ? BK_NONE : BK_IMAGE);
     // main_menu_background_path is the title screen's background image;
     // there is no separate configurable image for in-game inventory modes,
     // so BK_IMAGE outside of INV_TITLE_MODE falls back to no image rather
@@ -955,6 +978,16 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     }
 
     g_Inv_Mode = mode;
+
+    if (ring->live_scene) {
+        // The OG title hides Lara during the flyby.
+        ITEM *const lara_item = Lara_GetItem();
+        if (lara_item != nullptr) {
+            lara_item->mesh_bits = 0;
+        }
+        FlybyMode_Activate(g_GameFlow.title_flyby_sequence, false);
+    }
+
     Interpolation_Remember();
 
     if (mode == INV_TITLE_MODE) {
@@ -984,6 +1017,9 @@ void InvRing_Close(INV_RING *const ring)
         Music_Stop();
         Sound_StopAll();
     }
+    if (ring->live_scene) {
+        FlybyMode_Deactivate();
+    }
 
     if (g_Config.input.enable_buffering_inventory) {
         g_OldInputDB = (INPUT_STATE) {};
@@ -995,6 +1031,9 @@ void InvRing_Close(INV_RING *const ring)
 
 GF_COMMAND InvRing_Control(INV_RING *const ring)
 {
+    if (ring->live_scene) {
+        M_SimTick();
+    }
     InvRing_AdjustMusicVolume(ring);
     m_ActiveRing = ring;
     INVENTORY_ITEM **const prev_list = ring->list;

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -4,6 +4,7 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/game.h>
+#include <trx/game/game/draw.h>
 #include <trx/game/input.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/inventory_ring.h>
@@ -298,10 +299,18 @@ void InvRing_Draw(INV_RING *const ring)
     draw_ring.camera.pos.z = draw_radius + M_CAMERA_2_RING;
 
     if (ring->mode == INV_TITLE_MODE) {
-        if (ring->background_path != nullptr) {
-            Output_Overlay_DrawImageBilinear(ring->background_path);
+        if (ring->live_scene) {
+            // The inventory lighting mode is meant for the ring items; the
+            // level behind them renders with its own in-game lighting.
+            Output_SetInventoryLightingMode(false);
+            Game_Draw(false);
+            Output_SetInventoryLightingMode(true);
+        } else {
+            if (ring->background_path != nullptr) {
+                Output_Overlay_DrawImageBilinear(ring->background_path);
+            }
+            Interpolation_Interpolate();
         }
-        Interpolation_Interpolate();
     } else {
         const float opacity = g_Config.ui.inventory_fade_effects
             ? Fader_GetCurrentValue(&ring->back_fader)

--- a/src/trx/game/inventory_ring/types.h
+++ b/src/trx/game/inventory_ring/types.h
@@ -133,6 +133,8 @@ typedef struct {
 
     BACKGROUND_TYPE background_style;
     const char *background_path;
+    // The title level keeps running behind the menu, with its flyby camera.
+    bool live_scene;
     struct {
         XYZ_16 rot;
         int32_t selection;

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -177,6 +177,174 @@ static int32_t M_DecodeSplit(int32_t height)
     return height << 8;
 }
 
+// Anything other than the player trips triggers as a heavy object.
+static bool M_IsHeavy(const ITEM *const item)
+{
+    return item->object_id != O_LARA;
+}
+
+static bool M_TestSectorTrigger(
+    const ITEM *const item, const SECTOR *const sector, const bool is_heavy)
+{
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (!is_heavy) {
+        if (sector->is_death_sector && M_TestLava(item)) {
+            Lara_TouchDeathSector(Level_GetDeathTile());
+        }
+
+        const LADDER_DIRECTION direction = 1 << Math_GetDirection(item->rot.y);
+        lara_info->climb_status = (sector->ladder & direction) == direction;
+    }
+
+    const TRIGGER *const trigger = sector->trigger;
+    if (trigger == nullptr || !trigger->enabled) {
+        return false;
+    }
+
+    if (g_Camera.type != CAM_HEAVY) {
+        Camera_RefreshFromTrigger(trigger);
+    }
+
+    TRIGGER_STATUS status = {
+        .is_heavy = is_heavy,
+        .heavy_mask = trigger->mask,
+        .camera_item = nullptr,
+        .switch_off = false,
+        .flip_map = false,
+        .flip_status = Room_GetFlipStatus(),
+        .flip_available = false,
+        .new_effect = -1,
+    };
+
+    if (is_heavy) {
+        switch (trigger->type) {
+        case TT_HEAVY:
+        case TT_HEAVY_ANTITRIGGER:
+            break;
+        case TT_HEAVY_SWITCH:
+            const int32_t item_mask = item->trigger.mask;
+            if (item_mask == 0) {
+                return false;
+            }
+            if (item_mask != status.heavy_mask) {
+                return false;
+            }
+            break;
+        default:
+            return false;
+        }
+    } else {
+        switch (trigger->type) {
+        case TT_PAD:
+        case TT_ANTIPAD:
+            if (!Gym_TrackManager_OnPadContact(GYM_TRACK_ASSAULT, false)) {
+                return false;
+            }
+            // A pad answers to the player standing on it, whoever asked.
+            const ITEM *const lara_item = Lara_GetItem();
+            if (lara_item->pos.y != lara_item->floor) {
+                return false;
+            }
+            if (item->object_id == O_LARA
+                && !Gym_TrackManager_OnPadContact(GYM_TRACK_ASSAULT, true)) {
+                return false;
+            }
+            break;
+
+        case TT_SWITCH: {
+            const bool switch_result =
+                Switch_Trigger(trigger->item_index, trigger->timer);
+            ITEM *const switch_item = Item_Get(trigger->item_index);
+            const bool intelligent =
+                Object_Get(switch_item->object_id)->intelligent;
+            if (!intelligent && g_TRVersion >= 3 && trigger->one_shot) {
+                switch_item->trigger.switch_spent = true;
+            }
+            if (!switch_result) {
+                return false;
+            }
+            status.switch_off = !intelligent
+                && switch_item->current_anim_state == SWITCH_STATE_OFF;
+            break;
+        }
+
+        case TT_KEY: {
+            if (!Keyhole_Trigger(trigger->item_index)) {
+                return false;
+            }
+            break;
+        }
+
+        case TT_PICKUP: {
+            if (!Pickup_Trigger(trigger->item_index)) {
+                return false;
+            }
+            break;
+        }
+
+        case TT_HEAVY:
+        case TT_DUMMY:
+        case TT_HEAVY_SWITCH:
+        case TT_HEAVY_ANTITRIGGER:
+            return false;
+
+        case TT_COMBAT:
+            if (lara_info->gun_status != LGS_READY) {
+                return false;
+            }
+            break;
+
+        case TT_MONKEY:
+            if (!Lara_HasState(m_MonkeyStates)) {
+                return false;
+            }
+            break;
+
+        case TT_CROUCH:
+            if (!Lara_HasState(m_CrouchStates)) {
+                return false;
+            }
+            break;
+
+        case TT_CLIMB:
+            if (!Lara_HasState(m_ClimbStates)) {
+                return false;
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    for (const TRIGGER_CMD *cmd = trigger->command; cmd != nullptr;
+         cmd = cmd->next_cmd) {
+        if (m_Handlers[cmd->type] != nullptr) {
+            m_Handlers[cmd->type](trigger, cmd, &status);
+        }
+    }
+
+    if (status.camera_item != nullptr
+        && (g_Camera.type == CAM_FIXED || g_Camera.type == CAM_HEAVY)) {
+        g_Camera.item = status.camera_item;
+    }
+
+    if (status.flip_map) {
+        Room_FlipMap();
+    }
+
+    if (status.new_effect != -1
+        && (status.flip_map || !status.flip_available)) {
+        if (!ItemAction_Intercept(
+                status.new_effect, trigger->timer, Item_GetIndex(item))) {
+            Room_SetFlipEffect(status.new_effect);
+            Room_SetFlipTimer(0);
+        }
+    }
+
+    return true;
+}
+
 void Room_ParseFloorData(
     const int16_t *floor_data, const int32_t floor_data_size)
 {
@@ -350,11 +518,16 @@ void Room_RegisterTriggerHandler(
 
 bool Room_TestTriggers(const ITEM *const item)
 {
+    return Room_TestTriggersEx(item, M_IsHeavy(item));
+}
+
+bool Room_TestTriggersEx(const ITEM *const item, const bool is_heavy)
+{
     int16_t room_num = item->room_num;
     const SECTOR *sector = Room_GetSector(
         (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
 
-    bool result = Room_TestSectorTrigger(item, sector);
+    bool result = M_TestSectorTrigger(item, sector, is_heavy);
     if (item->object_id != O_TORSO) {
         return result;
     }
@@ -373,7 +546,7 @@ bool Room_TestTriggers(const ITEM *const item)
                     item->pos.z + dz * WALL_L,
                 },
                 &room_num);
-            result |= Room_TestSectorTrigger(item, sector);
+            result |= M_TestSectorTrigger(item, sector, is_heavy);
         }
     }
 
@@ -382,162 +555,7 @@ bool Room_TestTriggers(const ITEM *const item)
 
 bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 {
-    LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    const bool is_heavy = item->object_id != O_LARA;
-    if (!is_heavy) {
-        if (sector->is_death_sector && M_TestLava(item)) {
-            Lara_TouchDeathSector(Level_GetDeathTile());
-        }
-
-        const LADDER_DIRECTION direction = 1 << Math_GetDirection(item->rot.y);
-        lara_info->climb_status = (sector->ladder & direction) == direction;
-    }
-
-    const TRIGGER *const trigger = sector->trigger;
-    if (trigger == nullptr || !trigger->enabled) {
-        return false;
-    }
-
-    if (g_Camera.type != CAM_HEAVY) {
-        Camera_RefreshFromTrigger(trigger);
-    }
-
-    TRIGGER_STATUS status = {
-        .is_heavy = is_heavy,
-        .heavy_mask = trigger->mask,
-        .camera_item = nullptr,
-        .switch_off = false,
-        .flip_map = false,
-        .flip_status = Room_GetFlipStatus(),
-        .flip_available = false,
-        .new_effect = -1,
-    };
-
-    if (is_heavy) {
-        switch (trigger->type) {
-        case TT_HEAVY:
-        case TT_HEAVY_ANTITRIGGER:
-            break;
-        case TT_HEAVY_SWITCH:
-            const int32_t item_mask = item->trigger.mask;
-            if (item_mask == 0) {
-                return false;
-            }
-            if (item_mask != status.heavy_mask) {
-                return false;
-            }
-            break;
-        default:
-            return false;
-        }
-    } else {
-        switch (trigger->type) {
-        case TT_PAD:
-        case TT_ANTIPAD:
-            if (!Gym_TrackManager_OnPadContact(GYM_TRACK_ASSAULT, false)) {
-                return false;
-            }
-            if (item->pos.y != item->floor) {
-                return false;
-            }
-            if (item->object_id == O_LARA
-                && !Gym_TrackManager_OnPadContact(GYM_TRACK_ASSAULT, true)) {
-                return false;
-            }
-            break;
-
-        case TT_SWITCH: {
-            const bool switch_result =
-                Switch_Trigger(trigger->item_index, trigger->timer);
-            ITEM *const switch_item = Item_Get(trigger->item_index);
-            const bool intelligent =
-                Object_Get(switch_item->object_id)->intelligent;
-            if (!intelligent && g_TRVersion >= 3 && trigger->one_shot) {
-                switch_item->trigger.switch_spent = true;
-            }
-            if (!switch_result) {
-                return false;
-            }
-            status.switch_off = !intelligent
-                && switch_item->current_anim_state == SWITCH_STATE_OFF;
-            break;
-        }
-
-        case TT_KEY: {
-            if (!Keyhole_Trigger(trigger->item_index)) {
-                return false;
-            }
-            break;
-        }
-
-        case TT_PICKUP: {
-            if (!Pickup_Trigger(trigger->item_index)) {
-                return false;
-            }
-            break;
-        }
-
-        case TT_HEAVY:
-        case TT_DUMMY:
-        case TT_HEAVY_SWITCH:
-        case TT_HEAVY_ANTITRIGGER:
-            return false;
-
-        case TT_COMBAT:
-            if (lara_info->gun_status != LGS_READY) {
-                return false;
-            }
-            break;
-
-        case TT_MONKEY:
-            if (!Lara_HasState(m_MonkeyStates)) {
-                return false;
-            }
-            break;
-
-        case TT_CROUCH:
-            if (!Lara_HasState(m_CrouchStates)) {
-                return false;
-            }
-            break;
-
-        case TT_CLIMB:
-            if (!Lara_HasState(m_ClimbStates)) {
-                return false;
-            }
-            break;
-
-        default:
-            break;
-        }
-    }
-
-    for (const TRIGGER_CMD *cmd = trigger->command; cmd != nullptr;
-         cmd = cmd->next_cmd) {
-        if (m_Handlers[cmd->type] != nullptr) {
-            m_Handlers[cmd->type](trigger, cmd, &status);
-        }
-    }
-
-    if (status.camera_item != nullptr
-        && (g_Camera.type == CAM_FIXED || g_Camera.type == CAM_HEAVY)) {
-        g_Camera.item = status.camera_item;
-    }
-
-    if (status.flip_map) {
-        Room_FlipMap();
-    }
-
-    if (status.new_effect != -1
-        && (status.flip_map || !status.flip_available)) {
-        if (!ItemAction_Intercept(
-                status.new_effect, trigger->timer, Item_GetIndex(item))) {
-            Room_SetFlipEffect(status.new_effect);
-            Room_SetFlipTimer(0);
-        }
-    }
-
-    return true;
+    return M_TestSectorTrigger(item, sector, M_IsHeavy(item));
 }
 
 bool Room_IsAntiTrigger(const TRIGGER_TYPE type)

--- a/src/trx/game/rooms/floor_data.h
+++ b/src/trx/game/rooms/floor_data.h
@@ -16,6 +16,10 @@ void Room_RegisterTriggerHandler(
         TRIGGER_STATUS *status));
 bool Room_TestTriggers(const ITEM *item);
 bool Room_TestSectorTrigger(const ITEM *item, const SECTOR *sector);
+// As Room_TestTriggers, with the heaviness stated rather than derived from the
+// item. The flyby camera needs it: on the title level it tests the same point
+// both ways.
+bool Room_TestTriggersEx(const ITEM *item, bool is_heavy);
 bool Room_IsAntiTrigger(TRIGGER_TYPE type);
 
 #define REGISTER_TRIGGER_HANDLER(cmd_type, handle_func)                        \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds flyby control to the main screen in TR4, collapsing a few shared tick routines into the game API.

The camera behaves a bit weird after completing its cycle, but this should be tackled separately.