### PR TITLE
Check the Lua API docs in CI

### DIFF
--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -73,6 +73,19 @@ jobs:
             just trx-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.trx_dir }}" --no-zip
           fi
 
+      # The dump needs a binary to query, so it rides along with the Linux build
+      # rather than paying for one of its own. The engine boots SDL before it
+      # prints the API, hence the dummy video driver and libGL. Release builds
+      # skip it: a stale dump is not a reason to stop a release.
+      - name: Check the Lua API docs
+        if: ${{ inputs.platform == 'linux' && inputs.target == 'debug' }}
+        env:
+          SDL_VIDEODRIVER: dummy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1
+          just lua-api-check
+
       - name: Upload artifacts (combined)
         uses: actions/upload-artifact@v4
         with:

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -130,7 +130,7 @@
     },
     {
       "bulk": true,
-      "count": 795,
+      "count": 798,
       "description": "Every object TRX has a name for.",
       "examples": [
         "if item.object_id == trx.catalog.objects.WOLF then ... end"
@@ -865,6 +865,9 @@
         "SWINGING_AXE",
         "SWITCH_TYPE_AIRLOCK",
         "SWITCH_TYPE_BUTTON",
+        "SWITCH_TYPE_CROWBAR",
+        "SWITCH_TYPE_FLOOR",
+        "SWITCH_TYPE_JUMP",
         "SWITCH_TYPE_NORMAL",
         "SWITCH_TYPE_SMALL",
         "SWITCH_TYPE_UW",

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -37,7 +37,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
     - `trx.catalog.Context.ITEM_ACTIONS` = `5`  
         Item actions, which the flip effects trigger.
 
-- [lua]`trx.catalog.objects` - 795 names
+- [lua]`trx.catalog.objects` - 798 names
 
     Every object TRX has a name for.
 
@@ -233,7 +233,8 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
     `SPIKES`, `SPIKE_WALL`, `SPINNING_BLADE`, `SPLASH_1`, `SPLASH_2`,
     `SPRINGBOARD`, `STEAM_EMITTER`, `STHPAC_MERCENARY`, `STOPWATCH_OPTION`,
     `STROBE_LIGHT`, `SWAT_1`, `SWAT_2`, `SWAT_3`, `SWINGING_AXE`,
-    `SWITCH_TYPE_AIRLOCK`, `SWITCH_TYPE_BUTTON`, `SWITCH_TYPE_NORMAL`,
+    `SWITCH_TYPE_AIRLOCK`, `SWITCH_TYPE_BUTTON`, `SWITCH_TYPE_CROWBAR`,
+    `SWITCH_TYPE_FLOOR`, `SWITCH_TYPE_JUMP`, `SWITCH_TYPE_NORMAL`,
     `SWITCH_TYPE_SMALL`, `SWITCH_TYPE_UW`, `SWITCH_TYPE_WHEEL`, `TEETH_TRAP`,
     `TEXT_BOX`, `THORS_HANDLE`, `THORS_HEAD`, `TIGER`, `TONY`, `TONY_FIRE_BALL`,
     `TORSO`, `TRAIN`, `TRAPDOOR_TYPE_1`, `TRAPDOOR_TYPE_2`, `TRAPDOOR_TYPE_3`,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The committed Lua API dump goes stale whenever the engine gains a name and nobody reruns `just lua-api-dump`, and so far only a reviewer noticing has caught it. `just lua-api-check` now runs in CI, on the Linux build job that has a binary to query already.

- The check is a step in the Linux build job, so it needs no build of its own. It runs for pull request builds and prereleases; release builds skip it, since a stale dump is no reason to stop a release.
- The engine boots SDL before it prints the API, so the step runs with the dummy video driver and installs libGL.
- The first commit regenerates the object catalog docs, which had gone stale on develop.

This change is internal and does not affect players.
