### PR TITLE
lara/common: allow for target quadrant correction when moving

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -97,6 +97,7 @@
 - fixed animated textures, such as water surfaces, cycling at half their original speed
 - fixed flares burning red and trailing sparks and bubbles, so they now burn green and cast only their light, as in the original TR4
 - fixed Lara being able to light a flare while crawling; she now refuses, as in the original TR4
+- fixed Lara sidestepping in the wrong direction when turning off floor/crowbar switches
 
 **Lua**
 

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -922,6 +922,13 @@ bool Lara_IsNearItem(const XYZ_32 *const pos, const int32_t distance)
 
 bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
 {
+    return Lara_MovePositionEx(ref_item, vec, 0);
+}
+
+bool Lara_MovePositionEx(
+    const ITEM *const ref_item, const XYZ_32 *const vec,
+    const int16_t extra_y_rot)
+{
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
     const bool walk_to_items = g_Config.gameplay.enable_walk_to_items
         && ref_item->object_id != O_FLARE_ITEM;
@@ -995,7 +1002,7 @@ bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
             const int32_t angle = (DEG_360 - Math_Atan(dx, dz)) % DEG_360;
             const uint32_t src_quadrant = (uint32_t)(angle + DEG_45) / DEG_90;
             const uint32_t dst_quadrant =
-                (uint32_t)(new_rot.y + DEG_45) / DEG_90;
+                (uint32_t)(new_rot.y + DEG_45 + extra_y_rot) / DEG_90;
             const DIRECTION quadrant = (src_quadrant - dst_quadrant) % 4;
 
             Item_SwitchToAnim(lara_item, step_to_anim_num[quadrant], 0);

--- a/src/trx/game/lara/common.h
+++ b/src/trx/game/lara/common.h
@@ -35,6 +35,8 @@ bool Lara_TestBoundsCollide(const ITEM *item, int32_t radius);
 bool Lara_TestPosition(const ITEM *item, const OBJECT_BOUNDS *bounds);
 void Lara_AlignPosition(const ITEM *item, const XYZ_32 *vec);
 bool Lara_MovePosition(const ITEM *item, const XYZ_32 *vec);
+bool Lara_MovePositionEx(
+    const ITEM *item, const XYZ_32 *vec, int16_t extra_y_rot);
 bool Lara_IsNearItem(const XYZ_32 *pos, int32_t distance);
 
 LARA_ANIMATION Lara_AnimToGameID(LARA_TRX_ANIMATION anim);

--- a/src/trx/game/objects/general/floor_switch.c
+++ b/src/trx/game/objects/general/floor_switch.c
@@ -16,7 +16,7 @@ typedef struct {
     XYZ_32 position;
     M_STATE item_goal_state;
     LARA_TRX_ANIMATION lara_animation;
-    bool flip_lara;
+    int16_t lara_y_rot;
     bool requires_crowbar;
 } M_INTERACTION;
 
@@ -34,7 +34,7 @@ static const M_INTERACTION m_InteractFloorOff = {
     .position = { .x = 0, .y = 0, .z = -550 },
     .item_goal_state = M_STATE_ON,
     .lara_animation = LA_LEVERSWITCH_PUSH,
-    .flip_lara = false,
+    .lara_y_rot = 0,
     .requires_crowbar = false,
 };
 
@@ -52,7 +52,7 @@ static const M_INTERACTION m_InteractFloorOn = {
     .position = { .x = 0, .y = 0, .z = 550 },
     .item_goal_state = M_STATE_OFF,
     .lara_animation = LA_LEVERSWITCH_PUSH,
-    .flip_lara = true,
+    .lara_y_rot = -DEG_180,
     .requires_crowbar = false,
 };
 
@@ -70,7 +70,7 @@ static const M_INTERACTION m_InteractCrowbarOff = {
     .position = { .x = -89, .y = 0, .z = -328 },
     .item_goal_state = M_STATE_ON,
     .lara_animation = LA_CROWBAR_USE_ON_FLOOR,
-    .flip_lara = false,
+    .lara_y_rot = 0,
     .requires_crowbar = true,
 };
 
@@ -88,7 +88,7 @@ static const M_INTERACTION m_InteractCrowbarOn = {
     .position = { .x = 89, .y = 0, .z = 328 },
     .item_goal_state = M_STATE_OFF,
     .lara_animation = LA_CROWBAR_USE_ON_FLOOR,
-    .flip_lara = true,
+    .lara_y_rot = -DEG_180,
     .requires_crowbar = true,
 };
 
@@ -129,20 +129,14 @@ static bool M_Interact(ITEM *const item, ITEM *const lara_item)
     const int16_t item_num = Item_GetIndex(item);
     LARA_INFO *const lara = Lara_GetLaraInfo();
 
-    if (interaction->flip_lara) {
-        lara_item->rot.y += DEG_180;
-    }
+    lara_item->rot.y += interaction->lara_y_rot;
 
     bool result = false;
     if (Lara_TestPosition(item, &interaction->bounds)) {
         if (!lara->interact_target.is_moving && interaction->requires_crowbar) {
-            if (interaction->flip_lara) {
-                lara_item->rot.y += DEG_180;
-            }
+            lara_item->rot.y += interaction->lara_y_rot;
             const bool inv_result = M_ShowCrowbarInventory();
-            if (interaction->flip_lara) {
-                lara_item->rot.y += DEG_180;
-            }
+            lara_item->rot.y += interaction->lara_y_rot;
 
             if (!inv_result) {
                 Lara_RefuseInteraction();
@@ -157,7 +151,8 @@ static bool M_Interact(ITEM *const item, ITEM *const lara_item)
             lara->interact_target.is_moving = false;
         }
 
-        if (Lara_MovePosition(item, &interaction->position)) {
+        if (Lara_MovePositionEx(
+                item, &interaction->position, interaction->lara_y_rot)) {
             Item_SwitchToAnim(lara_item, LA(interaction->lara_animation), 0);
             const ANIM *const anim = Item_GetAnim(lara_item);
             lara_item->current_anim_state = anim->current_anim_state;
@@ -173,9 +168,7 @@ static bool M_Interact(ITEM *const item, ITEM *const lara_item)
     }
 
 finish:
-    if (interaction->flip_lara) {
-        lara_item->rot.y += DEG_180;
-    }
+    lara_item->rot.y += interaction->lara_y_rot;
 
     return result;
 }
@@ -239,13 +232,9 @@ int16_t Switch_FindNearbyCrowbarSwitch(void)
         // Proper bounds testing is required for cases where Lara picks the
         // crowbar manually from the inventory, but she is facing the wrong
         // direction.
-        if (interaction->flip_lara) {
-            lara_item->rot.y += DEG_180;
-        }
+        lara_item->rot.y += interaction->lara_y_rot;
         const bool result = Lara_TestPosition(item, &interaction->bounds);
-        if (interaction->flip_lara) {
-            lara_item->rot.y += DEG_180;
-        }
+        lara_item->rot.y += interaction->lara_y_rot;
 
         if (result) {
             return item_num;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara sidestepping in the opposite direction to which she is moving when interacting with flipped floor switches. Her temporary flip is required for correct bounds tests and position moving, but selecting the destination quadrant would then yield the opposite side.

Resolves TRX813.