### PR TITLE
Fix lethal falls, hit reporting and declared strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,13 @@ repos:
     additional_dependencies:
       - pyjson5
 
+  - id: lint-lua-module-order
+    name: Lua module order numbers are unique
+    entry: tools/lint/checks/lua_module_order
+    language: python
+    pass_filenames: false
+    files: ^src/lua/api/.*\.lua$
+
   - id: gen-sort-imports
     name: Sort C includes
     entry: tools/lint/gen/sort_imports

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3940,7 +3940,7 @@
       "path": "lara.clear_equipment"
     },
     {
-      "description": "Declares game string keys and the text behind them.\n\nA key belongs with the script that shows it, so a command carries its own\nwording. What is declared here is the fallback: the strings files and their\ntranslations are read over it, and a declaration shows only for a key they have\nnothing for.",
+      "description": "Declares game string keys and the text behind them.\n\nA key belongs with the script that shows it, so a command carries its own\nwording. What is declared here is a fallback, and it takes only for a key\nnothing else holds: the strings files, their translations, and any earlier\ndeclaration keep the text they already carry.",
       "examples": [
         "trx.locale.declare({\n  [\"console/cmd/heal/help\"] = \"Heals Lara back to full health.\",\n  [\"console/cmd/heal/success\"] = \"Healed Lara back to full health\",\n})"
       ],

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -4694,59 +4694,59 @@
     {
       "description": "Argument checking for the whole of `trx`.",
       "name": "api",
-      "order": 20,
+      "order": 26,
       "title": "API registry"
     },
     {
       "description": "A small, declarative argument parser for console commands, in the shape of\nPython's argparse.\n\nA parser both reads a command's arguments and offers completions for them,\nfrom one declaration. Every command written with `trx.console.register` has\none; a command shapes it through the `args` function it hands over, and `run`\nthen receives a table of parsed values. A command that shapes nothing takes no\narguments, and is told so when given one.\n\nEvery parser answers `-h` and `--help` on its own, printing what it accepts.\n\nHow a positional reads a token is its `matcher`, one of:\n\n- `type` - coerce to `\"integer\"`, `\"number\"`, `\"string\"` or `\"boolean\"`.\n- `choices` - the allowed set: a list of values or a `function(parsed)`\n  returning one. The token must match one; the set is shown in errors and\n  completes.\n- `match` - a `function(token, parsed)` returning `value, ok`, for a shape of its own.\n\nThese do not combine on one positional; a value that is a number *or* a name is\ntwo matchers, declared with `any_of`. Separately, `suggest` offers completions\nwithout restricting or being shown in errors - for a free value with a long\nlist behind it, like a setting name.\n\nA parser has these methods, each returning the parser so calls chain:\n\n- `positional(name, opts)` - a positional with one matcher (`opts.type`,\n  `opts.choices` or `opts.match`). `opts.optional` lets it be left out;\n  `opts.greedy` reads the rest of the line as one token, so a value with spaces\n  in it still arrives whole; `opts.suggest` completes it; `opts.help` describes\n  it.\n- `any_of(name, alternatives, opts)` - a positional whose value is the first of\n  several matchers to take the token. Each alternative is a matcher table,\n  `{ type = ... }` or `{ choices = ... }`. Same `opts` as `positional`.\n- `rest(name, opts)` - the rest of the line from here on, verbatim as one\n  string, or nil when an optional one is absent. Always the last argument;\n  `opts.suggest` completes it.\n- `flag(name, opts)` - a boolean that may sit anywhere. `opts.short` and\n  `opts.long` are the spellings, e.g. `\"-f\"` and `\"--force\"`; `opts.help`\n  describes it.\n- `parse(args)` - reads the argument string, returning a table of values, or\n  `nil` and a structured error the console layer turns into localized text. A\n  value carried by a `{ key, value }` choice comes back as its `value`;\n  `-h`/`--help` comes back as `{ help = true }`.\n- `complete(text, caret)` - the candidate completions for the token the caret\n  sits in, and the byte offsets `start, end` of the run they replace (reaching\n  to the end of the line for a greedy argument).\n- `usage()` - a short description of what the command accepts.\n\nA choice is either a bare string, where the key and value are the same, or a\n`{ key, value }` pair, where `key` is matched and shown and `value` is what\n`parse` gives back. Matching is forgiving, through `trx.strings.fuzzy_match`.",
       "name": "argparse",
-      "order": 23
+      "order": 18
     },
     {
       "description": "Module for controlling the Assault Course and Quad Bike timers in gym levels.",
       "name": "assault",
-      "order": 14,
+      "order": 13,
       "title": "Assault course"
     },
     {
       "description": "Module for inspecting the active camera state.",
       "name": "camera",
-      "order": 16
+      "order": 10
     },
     {
       "description": "The names TRX knows things by.\n\nEach catalog is an enum of every object, sample, music track, Lara state, Lara animation or item action the engine has a name for. The names are the C ones with their prefix taken off - `O_WOLF` is `trx.catalog.objects.WOLF` - and a catalog answers to a name in any case, so `trx.catalog.objects.wolf` is the same constant.\n\nThe ids in a catalog are TRX's own, and they are the same in all four games. The number a builder reads off Tomb Editor is not: that is the slot the game's own files use. `to_slot` and `from_slot` convert between the two.",
       "name": "catalog",
-      "order": 13
+      "order": 6
     },
     {
       "description": "Module for reading and changing engine settings.\n\nThese are the player's settings, not the level's. `set` writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants `override` instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.",
       "name": "config",
-      "order": 8
+      "order": 19
     },
     {
       "description": "Module for interacting with the developer console.\n\n`trx.console.log` writes to the console overlay in-game, where `trx.log` writes only to the terminal and the log file.",
       "name": "console",
-      "order": 5
+      "order": 17
     },
     {
       "description": "Module for controlling certain creature behavior.",
       "name": "creatures",
-      "order": 12
+      "order": 9
     },
     {
       "description": "Lua scripts can listen for game events by attaching a handler to one of the hooks below. Attaching returns a listener id, which `trx.events.detach` takes.\n\nA handler attached from a level script is detached automatically when the level ends; one attached from a global script lives for the whole session.",
       "name": "events",
-      "order": 2
+      "order": 1
     },
     {
       "description": "Module for the game flow: which levels there are, and which one is being played.",
       "name": "game",
-      "order": 11
+      "order": 8
     },
     {
       "description": "Module for controlling all moveables.",
       "name": "items",
-      "order": 4
+      "order": 2
     },
     {
       "description": "Module for reading and nudging Lara's own state.\n\nHer position, room and hit points are not here: she is an item like any other and they live on it, as `trx.lara.item`.",
@@ -4756,75 +4756,75 @@
     {
       "description": "The text the player reads, in the player's own language.",
       "name": "locale",
-      "order": 18
+      "order": 16
     },
     {
       "description": "Logs a message to the terminal and to `TRX.log` in the installation directory. Each call records the Lua script's filename, function name and line number.",
       "name": "log",
-      "order": 1,
+      "order": 22,
       "title": "Logging"
     },
     {
       "description": "Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the same state as every other script.",
       "name": "lua",
-      "order": 22
+      "order": 25
     },
     {
       "description": "Fixed-point trigonometry, matching the engine's own tables.\n\nTRX angles are 16-bit units where 65536 is a full turn, not radians. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would.",
       "name": "math",
-      "order": 17
+      "order": 23
     },
     {
       "description": "The mods the game was built with, and which one is loaded.",
       "name": "mod",
-      "order": 23
+      "order": 21
     },
     {
       "description": "Module for playing and controlling the soundtrack.",
       "name": "music",
-      "order": 6
+      "order": 15
     },
     {
       "description": "Module for the object definitions a level is built from.\n\nAn object is the pattern every item of that type is cut from: a wolf's radius, not this wolf's. Per-item state lives on the item - see `trx.items`.",
       "name": "objects",
-      "order": 15,
+      "order": 5,
       "title": "Object"
     },
     {
       "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; you narrow one down and then read\nthe result.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nFour ways to narrow, which mix freely:\n\n- Chain methods read left to right and combine with AND:\n  `q:spawnable():by_name(\"wolf\")`. Each domain adds its own - see\n  `trx.objects.query` and `trx.items.query` for the ones it has.\n- The operators `&`, `|` and `~` are AND, OR and NOT over whole queries, for\n  what a chain cannot say: `q:pickup() | q:inventory_item()`, `~q:animation()`.\n  Both sides of `&`/`|` must come from the same domain.\n- `by_name(name)` ranks rather than filters: it matches the way a player types\n  a name, forgivingly, and orders what survives the rest of the query best\n  first. Some of a domain's filters are also searchable groups - `pickup` is\n  one - so their name matches every member. Only a domain that has names offers\n  `by_name`, `names` and `best`.\n- `where(predicate)` narrows by a test of your own, called with the id and the\n  handle, for what a domain does not name: `q:where(function(id, item) return\n  item.timer > 0 end)`.\n\nRead a query with a terminal:\n\n- `ids()` - the matching ids, a list. For objects these are object ids; for\n  items, their numbers.\n- `matches()` - the matching handles: `trx.objects.Object`s or\n  `trx.items.Item`s.\n- `first()` - the first matching handle, or `nil`.\n- `count()` - how many match.\n- `names()` - every name the matches answer to, for offering completions. The\n  group names any match belongs to come first.\n- `best()` - the ids tied for the best `by_name` score: one for a name only one\n  thing answers to, the whole group for a group name.\n",
       "name": "query",
-      "order": 16,
+      "order": 7,
       "title": "Query"
     },
     {
       "description": "Module for inspecting and altering the rooms of the current level.",
       "name": "rooms",
-      "order": 10
+      "order": 4
     },
     {
       "description": "Module for the numbers the engine plays by.\n\nThese are the game's rules: a mechanic that no single item owns. An object's own numbers live on\nthe object, as `trx.objects.<name>.properties`, and the player's own choices live in `trx.config`.\n\nA rule lasts as long as the playthrough: it is saved with the game and restored with it, and a\nnew game starts from the defaults. A level script states what its level wants, and states it\nagain on every entry, so a level that wants the defaults back asks for them.",
       "name": "rules",
-      "order": 25
+      "order": 11
     },
     {
       "description": "The save slots, and starting or reading a saved game.",
       "name": "savegame",
-      "order": 24
+      "order": 20
     },
     {
       "description": "Module for playing sound effects.",
       "name": "sound",
-      "order": 7
+      "order": 14
     },
     {
       "description": "Utilities for working with strings.\n\nNot to be confused with `trx.locale`, which is the text a player reads: this module is about manipulating strings, that one is about which string the player gets.",
       "name": "strings",
-      "order": 19
+      "order": 24
     },
     {
       "description": "The runtime weather effect the current level shows.",
       "name": "weather",
-      "order": 21
+      "order": 12
     }
   ],
   "namespaces": [

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -1,6 +1,6 @@
 ---
 title: API registry
-order: 20
+order: 26
 ---
 
 <!--

--- a/docs/trx/lua/reference/ARGPARSE.md
+++ b/docs/trx/lua/reference/ARGPARSE.md
@@ -1,6 +1,6 @@
 ---
 title: Argparse
-order: 23
+order: 18
 ---
 
 <!--

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -1,6 +1,6 @@
 ---
 title: Assault course
-order: 14
+order: 13
 ---
 
 <!--

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -1,6 +1,6 @@
 ---
 title: Camera
-order: 16
+order: 10
 ---
 
 <!--

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -1,6 +1,6 @@
 ---
 title: Catalog
-order: 13
+order: 6
 ---
 
 <!--

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -1,6 +1,6 @@
 ---
 title: Config
-order: 8
+order: 19
 ---
 
 <!--

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -1,6 +1,6 @@
 ---
 title: Console
-order: 5
+order: 17
 ---
 
 <!--

--- a/docs/trx/lua/reference/CREATURES.md
+++ b/docs/trx/lua/reference/CREATURES.md
@@ -1,6 +1,6 @@
 ---
 title: Creatures
-order: 12
+order: 9
 ---
 
 <!--

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -1,6 +1,6 @@
 ---
 title: Events
-order: 2
+order: 1
 ---
 
 <!--

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -1,6 +1,6 @@
 ---
 title: Game
-order: 11
+order: 8
 ---
 
 <!--

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -1,6 +1,6 @@
 ---
 title: Items
-order: 4
+order: 2
 ---
 
 <!--

--- a/docs/trx/lua/reference/LOCALE.md
+++ b/docs/trx/lua/reference/LOCALE.md
@@ -20,9 +20,9 @@ The text the player reads, in the player's own language.
   Declares game string keys and the text behind them.
 
   A key belongs with the script that shows it, so a command carries its own
-  wording. What is declared here is the fallback: the strings files and their
-  translations are read over it, and a declaration shows only for a key they have
-  nothing for.
+  wording. What is declared here is a fallback, and it takes only for a key
+  nothing else holds: the strings files, their translations, and any earlier
+  declaration keep the text they already carry.
 
   Parameters:
   - **`strings`** (table). Keys to their English text.

--- a/docs/trx/lua/reference/LOCALE.md
+++ b/docs/trx/lua/reference/LOCALE.md
@@ -1,6 +1,6 @@
 ---
 title: Locale
-order: 18
+order: 16
 ---
 
 <!--

--- a/docs/trx/lua/reference/LOG.md
+++ b/docs/trx/lua/reference/LOG.md
@@ -1,6 +1,6 @@
 ---
 title: Logging
-order: 1
+order: 22
 ---
 
 <!--

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -1,6 +1,6 @@
 ---
 title: Lua
-order: 22
+order: 25
 ---
 
 <!--

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -1,6 +1,6 @@
 ---
 title: Math
-order: 17
+order: 23
 ---
 
 <!--

--- a/docs/trx/lua/reference/MOD.md
+++ b/docs/trx/lua/reference/MOD.md
@@ -1,6 +1,6 @@
 ---
 title: Mod
-order: 23
+order: 21
 ---
 
 <!--

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -1,6 +1,6 @@
 ---
 title: Music
-order: 6
+order: 15
 ---
 
 <!--

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -1,6 +1,6 @@
 ---
 title: Object
-order: 15
+order: 5
 ---
 
 <!--

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -1,6 +1,6 @@
 ---
 title: Query
-order: 16
+order: 7
 ---
 
 <!--

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -1,6 +1,6 @@
 ---
 title: Rooms
-order: 10
+order: 4
 ---
 
 <!--

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -1,6 +1,6 @@
 ---
 title: Rules
-order: 25
+order: 11
 ---
 
 <!--

--- a/docs/trx/lua/reference/SAVEGAME.md
+++ b/docs/trx/lua/reference/SAVEGAME.md
@@ -1,6 +1,6 @@
 ---
 title: Savegame
-order: 24
+order: 20
 ---
 
 <!--

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -1,6 +1,6 @@
 ---
 title: Sound
-order: 7
+order: 14
 ---
 
 <!--

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -1,6 +1,6 @@
 ---
 title: Strings
-order: 19
+order: 24
 ---
 
 <!--

--- a/docs/trx/lua/reference/WEATHER.md
+++ b/docs/trx/lua/reference/WEATHER.md
@@ -1,6 +1,6 @@
 ---
 title: Weather
-order: 21
+order: 12
 ---
 
 <!--

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -1181,7 +1181,7 @@ end
 -- run is what a script can use: strict mode, and the question of whether it is
 -- on. The rest declared the surface and is gone by the time any script runs.
 api.module("api", {
-  order = 20,
+  order = 26,
   title = "API registry",
   description = "Argument checking for the whole of `trx`.",
 })

--- a/src/lua/api/argparse.lua
+++ b/src/lua/api/argparse.lua
@@ -3,7 +3,7 @@ local api = trx.api
 require("trx.locale")
 
 api.module("argparse", {
-  order = 23,
+  order = 18,
   description = [[
 A small, declarative argument parser for console commands, in the shape of
 Python's argparse.

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -2,7 +2,7 @@ local raw = trxc.assault
 local api = trx.api
 
 api.module("assault", {
-  order = 14,
+  order = 13,
   title = "Assault course",
   description = "Module for controlling the Assault Course and Quad Bike timers in gym levels.",
 })

--- a/src/lua/api/camera.lua
+++ b/src/lua/api/camera.lua
@@ -2,7 +2,7 @@ local raw = trxc.camera
 local api = trx.api
 
 api.module("camera", {
-  order = 16,
+  order = 10,
   description = "Module for inspecting the active camera state.",
 })
 

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -2,7 +2,7 @@ local raw = trxc.catalog
 local api = trx.api
 
 api.module("catalog", {
-  order = 13,
+  order = 6,
   description = "The names TRX knows things by.\n\n"
     .. "Each catalog is an enum of every object, sample, music track, Lara state, Lara animation "
     .. "or item action the engine has a name for. The names are the C ones with their prefix "

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -4,7 +4,7 @@ local api = trx.api
 require("trx.locale")
 
 api.module("config", {
-  order = 8,
+  order = 19,
   description = "Module for reading and changing engine settings.\n\n"
     .. "These are the player's settings, not the level's. `set` writes to them and keeps the "
     .. "change: it is remembered across saves and relaunches, exactly as if the player had made "

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -8,7 +8,7 @@ require("trx.locale")
 local LogLevel = trx.log.LogLevel
 
 api.module("console", {
-  order = 5,
+  order = 17,
   description = "Module for interacting with the developer console.\n\n"
     .. "`trx.console.log` writes to the console overlay in-game, where `trx.log` writes only to "
     .. "the terminal and the log file.",

--- a/src/lua/api/creatures.lua
+++ b/src/lua/api/creatures.lua
@@ -2,7 +2,7 @@ local raw = trxc.creatures
 local api = trx.api
 
 api.module("creatures", {
-  order = 12,
+  order = 9,
   description = "Module for controlling certain creature behavior.",
 })
 

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -10,7 +10,7 @@ for _, constant in ipairs(trxc.enum.values("LUA_EVENT_TYPE")) do
 end
 
 api.module("events", {
-  order = 2,
+  order = 1,
   description = "Lua scripts can listen for game events by attaching a handler to one of the hooks "
     .. "below. Attaching returns a listener id, which `trx.events.detach` takes.\n\n"
     .. "A handler attached from a level script is detached automatically when the level ends; one "

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -2,7 +2,7 @@ local raw = trxc.game
 local api = trx.api
 
 api.module("game", {
-  order = 11,
+  order = 8,
   description = "Module for the game flow: which levels there are, and which one is being played.",
 })
 

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -4,7 +4,7 @@ local api = trx.api
 require("trx.query")
 
 api.module("items", {
-  order = 4,
+  order = 2,
   description = "Module for controlling all moveables.",
 })
 

--- a/src/lua/api/locale.lua
+++ b/src/lua/api/locale.lua
@@ -13,9 +13,9 @@ api.define("locale.declare", {
 Declares game string keys and the text behind them.
 
 A key belongs with the script that shows it, so a command carries its own
-wording. What is declared here is the fallback: the strings files and their
-translations are read over it, and a declaration shows only for a key they have
-nothing for.]],
+wording. What is declared here is a fallback, and it takes only for a key
+nothing else holds: the strings files, their translations, and any earlier
+declaration keep the text they already carry.]],
   params = {
     {
       name = "strings",

--- a/src/lua/api/locale.lua
+++ b/src/lua/api/locale.lua
@@ -4,7 +4,7 @@ local api = trx.api
 require("trx.log")
 
 api.module("locale", {
-  order = 18,
+  order = 16,
   description = "The text the player reads, in the player's own language.",
 })
 

--- a/src/lua/api/log.lua
+++ b/src/lua/api/log.lua
@@ -2,7 +2,7 @@ local raw = trxc.log
 local api = trx.api
 
 api.module("log", {
-  order = 1,
+  order = 22,
   title = "Logging",
   description = "Logs a message to the terminal and to `TRX.log` in the installation directory. "
     .. "Each call records the Lua script's filename, function name and line number.",

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -2,7 +2,7 @@ local raw = trxc.lua
 local api = trx.api
 
 api.module("lua", {
-  order = 22,
+  order = 25,
   description = "Evaluating Lua at runtime: a string of code, or a file on disk. "
     .. "Both run in the same state as every other script.",
 })

--- a/src/lua/api/math.lua
+++ b/src/lua/api/math.lua
@@ -2,7 +2,7 @@ local raw = trxc.math
 local api = trx.api
 
 api.module("math", {
-  order = 17,
+  order = 23,
   description = "Fixed-point trigonometry, matching the engine's own tables.\n\n"
     .. "TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these rather "
     .. "than Lua's `math` library guarantees a script places things exactly where the engine "

--- a/src/lua/api/mod.lua
+++ b/src/lua/api/mod.lua
@@ -2,7 +2,7 @@ local raw = trxc.mod
 local api = trx.api
 
 api.module("mod", {
-  order = 23,
+  order = 21,
   description = "The mods the game was built with, and which one is loaded.",
 })
 

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -2,7 +2,7 @@ local raw = trxc.music
 local api = trx.api
 
 api.module("music", {
-  order = 6,
+  order = 15,
   description = "Module for playing and controlling the soundtrack.",
 })
 

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -6,7 +6,7 @@ require("trx.catalog")
 require("trx.query")
 
 api.module("objects", {
-  order = 15,
+  order = 5,
   title = "Object",
   description = "Module for the object definitions a level is built from.\n\n"
     .. "An object is the pattern every item of that type is cut from: a wolf's radius, not this "

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -1,7 +1,7 @@
 local api = trx.api
 
 api.module("query", {
-  order = 16,
+  order = 7,
   title = "Query",
   description = [[
 A composable filter over a domain of things - the objects a level is built

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -82,7 +82,7 @@ local ROOM_LISTENER_ID = {
 }
 
 api.module("rooms", {
-  order = 10,
+  order = 4,
   description = "Module for inspecting and altering the rooms of the current level.",
 })
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -2,7 +2,7 @@ local raw = trxc.rules
 local api = trx.api
 
 api.module("rules", {
-  order = 25,
+  order = 11,
   description = [[Module for the numbers the engine plays by.
 
 These are the game's rules: a mechanic that no single item owns. An object's own numbers live on

--- a/src/lua/api/savegame.lua
+++ b/src/lua/api/savegame.lua
@@ -2,7 +2,7 @@ local raw = trxc.savegame
 local api = trx.api
 
 api.module("savegame", {
-  order = 24,
+  order = 20,
   description = "The save slots, and starting or reading a saved game.",
 })
 

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -2,7 +2,7 @@ local raw = trxc.sound
 local api = trx.api
 
 api.module("sound", {
-  order = 7,
+  order = 14,
   description = "Module for playing sound effects.",
 })
 

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -2,7 +2,7 @@ local raw = trxc.strings
 local api = trx.api
 
 api.module("strings", {
-  order = 19,
+  order = 24,
   description = "Utilities for working with strings.\n\n"
     .. "Not to be confused with `trx.locale`, which is the text a player reads: this module is "
     .. "about manipulating strings, that one is about which string the player gets.",

--- a/src/lua/api/weather.lua
+++ b/src/lua/api/weather.lua
@@ -2,7 +2,7 @@ local raw = trxc.weather
 local api = trx.api
 
 api.module("weather", {
-  order = 21,
+  order = 12,
   description = "The runtime weather effect the current level shows.",
 })
 

--- a/src/tests/unit/fake_engine_locale.c
+++ b/src/tests/unit/fake_engine_locale.c
@@ -65,3 +65,8 @@ const char *GameString_Get(const char *const key)
     }
     return nullptr;
 }
+
+bool GameString_IsKnown(const char *const key)
+{
+    return GameString_Get(key) != nullptr;
+}

--- a/src/tests/unit/lua/locale.lua
+++ b/src/tests/unit/lua/locale.lua
@@ -16,12 +16,17 @@ test("a declared key reads back the text declared for it", function()
   assert(trx.locale.format("test/declared_formatted", 7) == "Declared 7")
 end)
 
-test("declaring a key again replaces the text behind it", function()
-  -- A mod ships its own wording for a key the base game declares, and what the
-  -- player reads is the mod's.
+test("declaring a key again leaves the text behind it alone", function()
   trx.locale.declare({ ["test/redeclared"] = "First" })
   trx.locale.declare({ ["test/redeclared"] = "Second" })
-  assert(trx.locale.get("test/redeclared") == "Second")
+  assert(trx.locale.get("test/redeclared") == "First")
+end)
+
+test("declaring a key the strings files have keeps their text", function()
+  -- A level script runs after its translations are applied, so a declaration
+  -- that took the key would put English over what the player reads.
+  trx.locale.declare({ ["test/plain"] = "Declared text" })
+  assert(trx.locale.get("test/plain") == "Plain text")
 end)
 
 test("declare takes strings and nothing else", function()

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -167,12 +167,17 @@ void Item_TakeDamage(
         Stats_AddKill();
     }
 
-    const LUA_EVENT_ARG args[] = {
-        { .type = LUA_EVENT_ARG_INT32,
-          .value = { .i32 = Item_GetIndex(item) } },
-        { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = damage } },
-    };
-    LUA_FireEventEx(LUA_EVENT_HIT, args, 2);
+    // A kill deals an item whatever it has left, which is nothing once it is
+    // already down, and Lara's death paths leave her below zero. Neither is a
+    // hit worth reporting.
+    if (damage > 0) {
+        const LUA_EVENT_ARG args[] = {
+            { .type = LUA_EVENT_ARG_INT32,
+              .value = { .i32 = Item_GetIndex(item) } },
+            { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = damage } },
+        };
+        LUA_FireEventEx(LUA_EVENT_HIT, args, 2);
+    }
     if (died) {
         LUA_FireEventInt32(LUA_EVENT_KILL, Item_GetIndex(item));
     }

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -717,12 +717,14 @@ LANDED_STATE Lara_Col_LandedBad(ITEM *const item)
         return LANDED_OK;
     }
 
-    if (land_speed <= DAMAGE_LENGTH) {
+    if (g_Config.debug.enable_invulnerability) {
+        return LANDED_OK;
+    } else if (land_speed <= DAMAGE_LENGTH) {
         Lara_TakeDamage(
             LARA_MAX_HITPOINTS * SQUARE(land_speed) / SQUARE(DAMAGE_LENGTH),
             false);
     } else {
-        Lara_TakeDamage(item->hit_points, false);
+        Lara_Kill();
     }
 
     // #675: Original bug to keep. Correct operator would be <=

--- a/src/trx/game/lua/capi/locale.c
+++ b/src/trx/game/lua/capi/locale.c
@@ -27,7 +27,14 @@ static int M_L_LocaleGet(lua_State *const L)
 // trxc.locale.declare(key, text)
 static int M_L_LocaleDeclare(lua_State *const L)
 {
-    GameString_Define(luaL_checkstring(L, 1), luaL_checkstring(L, 2));
+    // A declaration is a fallback, and the strings files run before the level
+    // scripts do: taking a key the table already holds would put English over
+    // the player's own language.
+    const char *const key = luaL_checkstring(L, 1);
+    const char *const text = luaL_checkstring(L, 2);
+    if (!GameString_IsKnown(key)) {
+        GameString_Define(key, text);
+    }
     return 0;
 }
 

--- a/tools/lint/checks/lua_module_order
+++ b/tools/lint/checks/lua_module_order
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harness import LintWarning, repo_check
+from shared.paths import SRC_DIR
+
+# api.module("name", { order = N, ... }) - the order the module takes in the
+# generated reference. Two modules sharing one leave their pages in whatever
+# order the sort happens to settle on.
+MODULE_RE = re.compile(
+    r"""api\.module\(\s*"([^"]+)"\s*,\s*\{[^}]*?\border\s*=\s*(\d+)""",
+    re.DOTALL,
+)
+
+
+def check():
+    api_dir = SRC_DIR / "lua/api"
+    seen: dict[int, tuple[Path, str]] = {}
+    for path in sorted(api_dir.glob("*.lua")):
+        text = path.read_text(encoding="utf-8")
+        for match in MODULE_RE.finditer(text):
+            name, order = match.group(1), int(match.group(2))
+            line = text.count("\n", 0, match.start()) + 1
+            if order in seen:
+                other_path, other_name = seen[order]
+                yield LintWarning(
+                    path,
+                    f"module '{name}' takes order {order}, "
+                    f"which '{other_name}' already has "
+                    f"({other_path.relative_to(SRC_DIR.parent)})",
+                    line=line,
+                )
+                continue
+            seen[order] = (path, name)
+
+
+repo_check(check)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Routing the instant deaths onto the damage path left two of them reporting the wrong thing, and `trx.locale.declare()` turned out to overwrite the translations it is meant to sit under. None of this reached a release, so there is no changelog entry.

- A fall past the fatal threshold dealt Lara her remaining hit points, and the damage path clamps at zero, so the check that reads the death off a negative value saw her as alive and she stood up. It goes through `Lara_Kill()` now, and honors immunity again.
- `trx.events.on_hit` reported a hit of zero, which is what a kill deals an item that is already down, and one of minus one for Lara, whose death paths leave her below zero. Bacon Lara reported a hit every tick she lay in the pit. Only real damage reports now.
- `trx.locale.declare()` took a key the strings files already carry. A level script runs after the strings for that level are applied, so a declaration could put English over what the player reads; a known key is left alone.
- The `order` a Lua module carries is its reference page's front matter, which the docs site sorts on, and two pairs of modules shared a number. Every module is renumbered into one run, reading from what a script reaches for first to what it reaches for last, and a lint check keeps the numbers apart.

This change is internal and does not affect players.
