### PR TITLE
lara/flare: hold the flare arm up in TR4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed the sun's glare staying on screen in cutscenes once the camera has looked away from it
 - fixed exploding deaths in TR4 showing no flames or explosions
 - fixed Lara's shadow in TR4 being darker than in the original game
+- fixed Lara's arm swinging while she runs or crouches with a flare in TR4
 - fixed some console commands being able to target unintended items
 - fixed the `/spawn` and `/kill` console commands not reaching army Winston
 - fixed the `/teatime` console command summoning army Winston rather than Winston himself

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -63,6 +63,17 @@ static const LARA_TRX_STATE m_HoldStates[] = {
     // clang-format on
 };
 
+// TR4 also keeps the arm on the flare while running and crouching.
+static const LARA_TRX_STATE m_HoldStatesTR4[] = {
+    // clang-format off
+    LS_RUN,
+    LS_CROUCH_IDLE,
+    LS_CROUCH_TURN_LEFT,
+    LS_CROUCH_TURN_RIGHT,
+    LS_TRX_INVALID, // sentinel
+    // clang-format on
+};
+
 static const LARA_TRX_STATE m_ThrowStates[] = {
     // clang-format off
     LS_FAST_FALL,
@@ -221,7 +232,8 @@ static bool M_CanUseFlareControl(void)
         return anim != LA_CROUCH_PICKUP && anim != LA_CRAWL_PICKUP
             && anim != LA_FAST_PICKUP;
     }
-    return Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates);
+    return Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates)
+        || (g_TRVersion == 4 && Lara_HasState(m_HoldStatesTR4));
 }
 
 static void M_ControlArmless(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The flare holding states carry the TR2 list, so the left arm follows the body animation while Lara runs or crouches and the flare swings with it. TR4 lists running and the three crouch states as holding states as well, which keeps the arm up on the flare.

The extra states apply to TR4 only; TR1 through TR3 are unaffected.

Resolves TRX822.
