### PR TITLE
Bind object properties to the members that keep them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,12 @@ repos:
     language: python
     files: \.c$
 
+  - id: lint-object-property-binding
+    name: Bound object properties have somewhere to land
+    entry: tools/lint/checks/object_property_binding
+    language: python
+    files: \.c$
+
   - id: lint-gameflow-schema
     name: Gameflow files match the schema
     entry: tools/lint/checks/gameflow_schema

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - added internal collision to lifts when they are moving, so that Lara cannot exit through the meshes
 - improved error messages related to bad command invocations
 - changed reflections UV mapping to be more correct
+- changed object properties to take effect as soon as they change, rather than only when the item is first set up
 - changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - changed the `/spawn`, `/kill` and `/tp` console commands to accept a family such as `pickup`, `door` or `enemy` in place of a name, and to offer the families each of them can act on in autocompletion

--- a/src/trx/core/value.h
+++ b/src/trx/core/value.h
@@ -46,29 +46,65 @@ typedef struct {
     };
 } TRX_VALUE;
 
+// C type, TAG, carrier member. The plain types a value may have, listed once
+// for everything that has to resolve one from a C expression. TVT_ENUM and
+// TVT_DYNAMIC_ENUM are absent: they share their storage with S32 and STRING, so
+// they are named by a caller, never resolved from a member. So is TVT_XYZ_16,
+// which rides in the carrier widened rather than as itself; see Value_TypeOf.
+#define VALUE_PLAIN_TYPES(_)                                                   \
+    _(bool, TVT_BOOL, as_bool)                                                 \
+    _(int8_t, TVT_S8, as_int)                                                  \
+    _(uint8_t, TVT_U8, as_int)                                                 \
+    _(int16_t, TVT_S16, as_int)                                                \
+    _(uint16_t, TVT_U16, as_int)                                               \
+    _(int32_t, TVT_S32, as_int)                                                \
+    _(uint32_t, TVT_U32, as_int)                                               \
+    _(float, TVT_FLOAT, as_num)                                                \
+    _(double, TVT_DOUBLE, as_num)                                              \
+    _(XYZ_32, TVT_XYZ_32, as_xyz)                                              \
+    _(RGB_888, TVT_RGB_888, as_rgb)
+
 // The TRX_VALUE_TYPE that addresses a member of a plain C type, resolved from
 // the member itself so a plain member cannot be mistagged. Listing the types
 // rather than accepting anything means a member of a type nobody planned for -
 // a pointer, a 64-bit integer - fails to compile instead of being addressed as
 // something it is not. Enum members resolve to their integer storage type;
 // enum-string mapping is a caller concern, not a member's.
+#define M_VALUE_TYPE_OF(ctype_, tag_, member_)                                 \
+    ctype_:                                                                    \
+    tag_,
 #define Value_TypeOf(member_)                                                  \
     _Generic(                                                                  \
         (member_),                                                             \
-        bool: TVT_BOOL,                                                        \
-        int8_t: TVT_S8,                                                        \
-        uint8_t: TVT_U8,                                                       \
-        int16_t: TVT_S16,                                                      \
-        uint16_t: TVT_U16,                                                     \
-        int32_t: TVT_S32,                                                      \
-        uint32_t: TVT_U32,                                                     \
-        float: TVT_FLOAT,                                                      \
-        double: TVT_DOUBLE,                                                    \
-        XYZ_16: TVT_XYZ_16,                                                    \
-        XYZ_32: TVT_XYZ_32,                                                    \
-        RGB_888: TVT_RGB_888,                                                  \
+        VALUE_PLAIN_TYPES(M_VALUE_TYPE_OF) XYZ_16: TVT_XYZ_16,                 \
         char *: TVT_STRING,                                                    \
         const char *: TVT_STRING)
+
+#define M_VALUE_MAKER(ctype_, tag_, member_)                                   \
+    static inline TRX_VALUE Value_Make_##tag_(const ctype_ value)              \
+    {                                                                          \
+        return (TRX_VALUE) { .type = tag_, .member_ = value };                 \
+    }
+VALUE_PLAIN_TYPES(M_VALUE_MAKER)
+#undef M_VALUE_MAKER
+
+// The TRX_VALUE carrying `value_`, tagged by the C type of the expression
+// itself. The counterpart of Value_TypeOf for a value rather than a member: a
+// declared default states the value and nothing else, and cannot be tagged as
+// something it is not.
+//
+// An enumeration constant carries its own type under C23 rather than int, so it
+// matches nothing in the table; the default branch takes it as the integer it
+// is. A type that is not a number at all still fails to compile, on the
+// conversion into the maker.
+#define M_VALUE_MAKER_OF(ctype_, tag_, member_)                                \
+    ctype_:                                                                    \
+    Value_Make_##tag_,
+#define Value_Of(value_)                                                       \
+    (_Generic(                                                                 \
+        (value_),                                                              \
+         VALUE_PLAIN_TYPES(M_VALUE_MAKER_OF) default: Value_Make_TVT_S32)(     \
+        value_))
 
 // Stable machine-readable name, e.g. "S16", "XYZ_32", "ENUM".
 const char *Value_TypeName(TRX_VALUE_TYPE type);

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -389,6 +389,9 @@ void Item_Initialise(const int16_t item_num)
         }
     }
 
+    // Before the object's own initialiser, so it reads what it declared.
+    ObjectProperty_ApplyToItem(item);
+
     if (obj->initialise_func != nullptr) {
         obj->initialise_func(item_num);
     }

--- a/src/trx/game/objects/creatures/ape.c
+++ b/src/trx/game/objects/creatures/ape.c
@@ -45,17 +45,11 @@ typedef enum {
     M_ANIM_VAULT = 19,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static BITE m_ApeBite = { .pos = { 0, -19, 75 }, .mesh_num = 15 };
-
-static int32_t M_GetAttackDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static bool M_Vault(int16_t item_num, int16_t angle)
 {
@@ -120,6 +114,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const ape = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -225,7 +220,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK:
             if (!item->required_anim_state && (item->touch_bits & M_TOUCH)) {
                 Creature_Effect(item, &m_ApeBite, Spawn_Blood);
-                Lara_TakeDamage(M_GetAttackDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 item->required_anim_state = M_STATE_STOP;
             }
             break;
@@ -248,6 +243,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -266,10 +263,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the ape bite."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the ape bite."));
 }
 
 REGISTER_OBJECT(O_APE, M_Setup)

--- a/src/trx/game/objects/creatures/atlantean.c
+++ b/src/trx/game/objects/creatures/atlantean.c
@@ -56,21 +56,17 @@ typedef enum {
     // clang-format on
 } M_FLAG;
 
+typedef struct {
+    int32_t part_damage;
+    int32_t lunge_damage;
+    int32_t charge_damage;
+    int32_t punch_damage;
+} M_PRIV;
+
 static bool m_EnableExplosions = true;
 static const BITE m_Bite = { .pos = { -27, 98, 0 }, .mesh_num = 10 };
 static const BITE m_Rocket = { .pos = { 51, 213, 0 }, .mesh_num = 14 };
 static const BITE m_Shard = { .pos = { -35, 269, 0 }, .mesh_num = 9 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_InitialiseGround(const int16_t item_num)
 {
@@ -85,6 +81,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -92,9 +89,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points <= 0) {
         Item_Shatter(
             item_num, -1,
-            m_EnableExplosions
-                ? M_GetDamage(item, "part_damage", M_PART_DAMAGE)
-                : -M_GetDamage(item, "part_damage", M_PART_DAMAGE));
+            m_EnableExplosions ? p->part_damage : -p->part_damage);
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
         LOT_DisableBaddieAI(item_num);
         Item_Destroy(item_num);
@@ -252,8 +247,7 @@ static void M_Control(const int16_t item_num)
         if (item->required_anim_state == M_STATE_EMPTY
             && (item->touch_bits & M_TOUCH_BITS) != 0) {
             Creature_Effect(item, &m_Bite, Spawn_Blood);
-            Lara_TakeDamage(
-                M_GetDamage(item, "lunge_damage", M_LUNGE_DAMAGE), true);
+            Lara_TakeDamage(p->lunge_damage, true);
             item->required_anim_state = M_STATE_STOP;
         }
         break;
@@ -262,8 +256,7 @@ static void M_Control(const int16_t item_num)
         if (item->required_anim_state == M_STATE_EMPTY
             && (item->touch_bits & M_TOUCH_BITS) != 0) {
             Creature_Effect(item, &m_Bite, Spawn_Blood);
-            Lara_TakeDamage(
-                M_GetDamage(item, "charge_damage", M_CHARGE_DAMAGE), true);
+            Lara_TakeDamage(p->charge_damage, true);
             item->required_anim_state = M_STATE_RUN;
         }
         break;
@@ -272,8 +265,7 @@ static void M_Control(const int16_t item_num)
         if (item->required_anim_state == M_STATE_EMPTY
             && (item->touch_bits & M_TOUCH_BITS) != 0) {
             Creature_Effect(item, &m_Bite, Spawn_Blood);
-            Lara_TakeDamage(
-                M_GetDamage(item, "punch_damage", M_PUNCH_DAMAGE), true);
+            Lara_TakeDamage(p->punch_damage, true);
             item->required_anim_state = M_STATE_STOP;
         }
         break;
@@ -332,21 +324,22 @@ static void M_Control(const int16_t item_num)
 
 static void M_SetupProperties(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "charge_damage", M_CHARGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, charge_damage, M_CHARGE_DAMAGE,
             "Damage dealt by the atlantean's charge attack."),
-        OBJECT_PROPERTY_INT(
-            "lunge_damage", M_LUNGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the atlantean's lunge attack."),
-        OBJECT_PROPERTY_INT(
-            "punch_damage", M_PUNCH_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, punch_damage, M_PUNCH_DAMAGE,
             "Damage dealt by the atlantean's punch attack."),
-        OBJECT_PROPERTY_INT(
-            "part_damage", M_PART_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, part_damage, M_PART_DAMAGE,
             "Damage dealt by the atlantean's exploding body parts."));
 }
 

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -14,6 +14,7 @@
 typedef struct {
     bool status;
     bool anchored;
+    int32_t anchor_room;
     int32_t anchor_x;
     int32_t anchor_z;
     int32_t death_count;
@@ -24,13 +25,9 @@ static void M_InitialiseAnchor(ITEM *const item)
     M_PRIV *const p = item->priv;
     p->anchored = false;
 
-    TRX_VALUE value = {};
-    int32_t room_num = item->room_num;
-    if (ObjectProperty_GetItemValue(item, "anchor_room", &value)
-        && value.as_int >= 0) {
-        room_num = value.as_int;
-    }
-
+    // The room she is placed in, unless the level names another.
+    const int32_t room_num =
+        p->anchor_room >= 0 ? p->anchor_room : item->room_num;
     if (room_num >= Room_GetCount()) {
         LOG_ERROR("Could not anchor Bacon Lara to room %d", room_num);
         return;
@@ -223,10 +220,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", LARA_MAX_HITPOINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "anchor_room", -1,
+        OBJECT_PROPERTY(
+            M_PRIV, anchor_room, -1,
             "Room whose center Bacon Lara mirrors Lara's movement about. "
             "-1 uses the room she is placed in. Value range: minimum -1."));
 }

--- a/src/trx/game/objects/creatures/baldy.c
+++ b/src/trx/game/objects/creatures/baldy.c
@@ -30,19 +30,13 @@ typedef enum {
     M_ANIM_DEATH = 14,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_BaldyGun = {
     .muzzle = { .pos = { -20, 440, 20 }, .mesh_num = 9 },
 };
-
-static int32_t M_GetShotDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -67,6 +61,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const baldy = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -144,8 +139,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_SHOOT:
             if (!baldy->flags) {
                 info.distance /= 2;
-                Creature_Shoot(
-                    item, &info, &m_BaldyGun, head, M_GetShotDamage(item));
+                Creature_Shoot(item, &info, &m_BaldyGun, head, p->damage);
                 baldy->flags = 1;
             }
             if (baldy->mood == MOOD_ESCAPE) {
@@ -165,6 +159,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
@@ -182,10 +178,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by Baldy's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by Baldy's shot."));
 }
 
 REGISTER_OBJECT(O_BALDY, M_Setup)

--- a/src/trx/game/objects/creatures/bandit_1.c
+++ b/src/trx/game/objects/creatures/bandit_1.c
@@ -40,19 +40,13 @@ typedef enum {
     M_ANIM_DEATH = 14,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Bandit1Gun = {
     .muzzle = { .pos = { .x = -2, .y = 150, .z = 19 }, .mesh_num = 17 },
 };
-
-static int32_t M_GetShootDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -61,6 +55,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -159,8 +154,7 @@ static void M_Control(const int16_t item_num)
             if (info.ahead) {
                 head = info.angle;
             }
-            if (!Creature_Shoot(
-                    item, &info, &m_Bandit1Gun, head, M_GetShootDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Bandit1Gun, head, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
             break;
@@ -170,8 +164,7 @@ static void M_Control(const int16_t item_num)
             if (info.ahead) {
                 head = info.angle;
             }
-            if (!Creature_Shoot(
-                    item, &info, &m_Bandit1Gun, head, M_GetShootDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Bandit1Gun, head, p->damage)) {
                 item->goal_anim_state = M_STATE_WALK;
             }
             if (info.distance < M_WALK_RANGE) {
@@ -196,6 +189,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -213,10 +207,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the bandit's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the bandit's shot."));
 }
 
 REGISTER_OBJECT(O_BANDIT_1, M_Setup)

--- a/src/trx/game/objects/creatures/bandit_2.c
+++ b/src/trx/game/objects/creatures/bandit_2.c
@@ -40,19 +40,13 @@ typedef enum {
     M_ANIM_DEATH = 9,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Bandit2Gun = {
     .muzzle = { .pos = { .x = -1, .y = 230, .z = 9 }, .mesh_num = 17 },
 };
-
-static int32_t M_GetShootDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -61,6 +55,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -175,9 +170,7 @@ static void M_Control(const int16_t item_num)
                 head = info.angle;
             }
             if (creature->flags == 0) {
-                if (!Creature_Shoot(
-                        item, &info, &m_Bandit2Gun, head,
-                        M_GetShootDamage(item))
+                if (!Creature_Shoot(item, &info, &m_Bandit2Gun, head, p->damage)
                     || Random_GetControl() < 0x2000) {
                     item->goal_anim_state = M_STATE_WAIT;
                 }
@@ -191,8 +184,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags != 1) {
                 if (!Creature_Shoot(
-                        item, &info, &m_Bandit2Gun, head,
-                        M_GetShootDamage(item))) {
+                        item, &info, &m_Bandit2Gun, head, p->damage)) {
                     item->goal_anim_state = M_STATE_WALK;
                 }
                 creature->flags = 1;
@@ -208,8 +200,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags != 2) {
                 if (!Creature_Shoot(
-                        item, &info, &m_Bandit2Gun, head,
-                        M_GetShootDamage(item))) {
+                        item, &info, &m_Bandit2Gun, head, p->damage)) {
                     item->goal_anim_state = M_STATE_WALK;
                 }
                 creature->flags = 2;
@@ -236,6 +227,7 @@ static void M_Setup2A(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -253,10 +245,10 @@ static void M_Setup2A(OBJECT *const obj)
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the bandit's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the bandit's shot."));
 }
 
 static void M_Setup2B(OBJECT *const obj)
@@ -265,6 +257,7 @@ static void M_Setup2B(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     const OBJECT *const ref_obj = Object_Get(O_BANDIT_2);
     if (ref_obj->loaded) {
         obj->anim_idx = ref_obj->anim_idx;
@@ -288,10 +281,10 @@ static void M_Setup2B(OBJECT *const obj)
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the bandit's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the bandit's shot."));
 }
 
 REGISTER_OBJECT(O_BANDIT_2, M_Setup2A)

--- a/src/trx/game/objects/creatures/barracuda.c
+++ b/src/trx/game/objects/creatures/barracuda.c
@@ -32,20 +32,14 @@ typedef enum {
     M_ANIM_DEATH = 6,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_BarracudaBite = {
     .pos = { .x = 2, .y = -60, .z = 121 },
     .mesh_num = 7,
 };
-
-static int32_t M_GetBiteDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -54,6 +48,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     if (item->hit_points > 0) {
@@ -109,7 +104,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(M_GetBiteDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_BarracudaBite, Spawn_Blood);
                 creature->flags = 1;
             }
@@ -138,6 +133,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -155,10 +151,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the barracuda bite."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the barracuda bite."));
 }
 
 REGISTER_OBJECT(O_BARRACUDA, M_Setup)

--- a/src/trx/game/objects/creatures/bat.c
+++ b/src/trx/game/objects/creatures/bat.c
@@ -22,20 +22,14 @@ typedef enum {
     M_STATE_DEATH,
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static BITE m_BatBite = {
     .pos = { 0, 16, 45 },
     .mesh_num = 4,
 };
-
-static int32_t M_GetAttackDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_FixEmbeddedPosition(int16_t item_num)
 {
@@ -75,6 +69,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const bat = item->creature_data;
     int16_t angle = 0;
     if (item->hit_points <= 0) {
@@ -112,7 +107,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK:
             if (item->touch_bits) {
                 Creature_Effect(item, &m_BatBite, Spawn_Blood);
-                Lara_TakeDamage(M_GetAttackDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
             } else {
                 item->goal_anim_state = M_STATE_FLY;
                 bat->mood = MOOD_BORED;
@@ -139,6 +134,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -154,10 +151,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the bat attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the bat attack."));
 }
 
 REGISTER_OBJECT(O_BAT, M_Setup)

--- a/src/trx/game/objects/creatures/bear.c
+++ b/src/trx/game/objects/creatures/bear.c
@@ -41,21 +41,17 @@ typedef enum {
     M_STATE_DEATH,
 } M_STATE;
 
+typedef struct {
+    int32_t slam_damage;
+    int32_t charge_damage;
+    int32_t attack_damage;
+    int32_t pat_damage;
+} M_PRIV;
+
 static BITE m_BearHeadBite = {
     .pos = { 0, 96, 335 },
     .mesh_num = 14,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -64,6 +60,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     OBJECT *const obj = Object_Get(item->object_id);
     obj->pivot_length = g_Config.gameplay.fix_bear_ai ? 0 : 500;
 
@@ -97,8 +94,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_DEATH:
             if (bear != nullptr && bear->flags != 0
                 && (item->touch_bits & M_TOUCH) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "slam_damage", M_SLAM_DAMAGE), true);
+                Lara_TakeDamage(p->slam_damage, true);
                 bear->flags = 0;
             }
             break;
@@ -155,8 +151,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_RUN:
             bear->maximum_turn = M_RUN_TURN;
             if (item->touch_bits & M_TOUCH) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "charge_damage", M_CHARGE_DAMAGE), true);
+                Lara_TakeDamage(p->charge_damage, true);
             }
             if (bear->mood == MOOD_BORED || dead_enemy) {
                 item->goal_anim_state = M_STATE_STOP;
@@ -215,16 +210,14 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK_1:
             if (!item->required_anim_state && (item->touch_bits & M_TOUCH)) {
                 Creature_Effect(item, &m_BearHeadBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "attack_damage", M_ATTACK_DAMAGE), true);
+                Lara_TakeDamage(p->attack_damage, true);
                 item->required_anim_state = M_STATE_STOP;
             }
             break;
 
         case M_STATE_ATTACK_2:
             if (!item->required_anim_state && (item->touch_bits & M_TOUCH)) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "pat_damage", M_PAT_DAMAGE), true);
+                Lara_TakeDamage(p->pat_damage, true);
                 item->required_anim_state = M_STATE_REAR;
             }
             break;
@@ -240,6 +233,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -256,19 +251,20 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "charge_damage", M_CHARGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, charge_damage, M_CHARGE_DAMAGE,
             "Damage dealt while the bear charges into Lara."),
-        OBJECT_PROPERTY_INT(
-            "slam_damage", M_SLAM_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, slam_damage, M_SLAM_DAMAGE,
             "Damage dealt if the falling bear slams into Lara."),
-        OBJECT_PROPERTY_INT(
-            "attack_damage", M_ATTACK_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, attack_damage, M_ATTACK_DAMAGE,
             "Damage dealt by the bear bite attack."),
-        OBJECT_PROPERTY_INT(
-            "pat_damage", M_PAT_DAMAGE, "Damage dealt by the bear paw swipe."));
+        OBJECT_PROPERTY(
+            M_PRIV, pat_damage, M_PAT_DAMAGE,
+            "Damage dealt by the bear paw swipe."));
 }
 
 REGISTER_OBJECT(O_BEAR, M_Setup)

--- a/src/trx/game/objects/creatures/big_eel.c
+++ b/src/trx/game/objects/creatures/big_eel.c
@@ -30,6 +30,7 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t damage;
     int32_t pos;
 } M_PRIV;
 
@@ -37,16 +38,6 @@ static const BITE m_BigEelBite = {
     .pos = { .x = 7, .y = 157, .z = 333 },
     .mesh_num = 7,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static bool M_IsTargetable(const ITEM *const item)
 {
@@ -93,7 +84,7 @@ static void M_Control(const int16_t item_num)
             }
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_BigEelBite, Spawn_Blood);
                 item->required_anim_state = M_STATE_STOP;
             }
@@ -118,17 +109,16 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
     obj->is_targetable_func = M_IsTargetable;
     obj->priv_size = sizeof(M_PRIV);
-
     obj->save_hitpoints = true;
     obj->save_flags = true;
     obj->save_anim = true;
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the big eel bite."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the big eel bite."));
 }
 
 REGISTER_OBJECT(O_BIG_EEL, M_Setup)

--- a/src/trx/game/objects/creatures/big_spider.c
+++ b/src/trx/game/objects/creatures/big_spider.c
@@ -26,20 +26,14 @@ typedef enum {
     M_ANIM_DEATH = 2,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_SpiderBite = {
     .pos = { .x = 0, .y = 0, .z = 41 },
     .mesh_num = 1,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -48,6 +42,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t tilt = 0;
@@ -100,7 +95,7 @@ static void M_Control(const int16_t item_num)
 
         case M_STATE_ATTACK_1:
             if (!creature->flags && item->touch_bits != 0) {
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_SpiderBite, Spawn_Blood);
                 creature->flags = 1;
             }
@@ -123,6 +118,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -136,10 +132,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the big spider bite."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the big spider bite."));
 }
 
 REGISTER_OBJECT(O_BIG_SPIDER, M_Setup)

--- a/src/trx/game/objects/creatures/bird.c
+++ b/src/trx/game/objects/creatures/bird.c
@@ -30,6 +30,10 @@ typedef enum {
     M_STATE_EAT,
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_BirdBite = {
     .pos = { .x = 15, .y = 46, .z = 21 },
     .mesh_num = 6,
@@ -38,16 +42,6 @@ static const BITE m_CrowBite = {
     .pos = { .x = 2, .y = 10, .z = 60 },
     .mesh_num = 14,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -71,6 +65,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const bird = item->creature_data;
 
     if (item->hit_points <= 0) {
@@ -142,7 +137,7 @@ static void M_Control(const int16_t item_num)
 
     case M_STATE_ATTACK:
         if (bird->flags == 0 && item->touch_bits != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             if (item->object_id == O_CROW) {
                 Creature_Effect(item, &m_CrowBite, Spawn_Blood);
             } else {
@@ -166,6 +161,7 @@ static bool M_SetupCommon(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->radius = M_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
@@ -178,8 +174,8 @@ static bool M_SetupCommon(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the bird attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the bird attack."));
 
     return true;
 }
@@ -191,7 +187,7 @@ static void M_SetupEagle(OBJECT *const obj)
     }
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_EAGLE_HITPOINTS, "Maximum hit points."));
 }
 
@@ -202,7 +198,7 @@ static void M_SetupCrow(OBJECT *const obj)
     }
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_CROW_HITPOINTS, "Maximum hit points."));
 }
 
@@ -213,7 +209,7 @@ static void M_SetupVulture(OBJECT *const obj)
     }
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_VULTURE_HITPOINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/bird_guardian.c
+++ b/src/trx/game/objects/creatures/bird_guardian.c
@@ -37,6 +37,10 @@ typedef enum {
     M_ANIM_DEATH = 20,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_BirdGuardianBiteL = {
     .pos = { .x = 0, .y = 224, .z = 0, },
     .mesh_num = 19,
@@ -47,16 +51,6 @@ static const BITE m_BirdGuardianBiteR = {
     .mesh_num = 22,
 };
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
-
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -64,6 +58,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -150,13 +145,13 @@ static void M_Control(const int16_t item_num)
             if ((creature->flags & 1) == 0
                 && (item->touch_bits & M_TOUCH_BITS_R) != 0) {
                 Creature_Effect(item, &m_BirdGuardianBiteR, Spawn_Blood);
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 creature->flags |= 1;
             }
             if ((creature->flags & 2) == 0
                 && (item->touch_bits & M_TOUCH_BITS_L) != 0) {
                 Creature_Effect(item, &m_BirdGuardianBiteL, Spawn_Blood);
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 creature->flags |= 2;
             }
             break;
@@ -179,6 +174,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -196,10 +192,11 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 14)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the bird guardian punch."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE,
+            "Damage dealt by the bird guardian punch."));
 }
 
 REGISTER_OBJECT(O_BIRD_GUARDIAN, M_Setup)

--- a/src/trx/game/objects/creatures/centaur.c
+++ b/src/trx/game/objects/creatures/centaur.c
@@ -33,6 +33,11 @@ typedef enum {
     M_ANIM_DEATH = 8,
 } M_ANIM;
 
+typedef struct {
+    int32_t rear_damage;
+    int32_t part_damage;
+} M_PRIV;
+
 static BITE m_CentaurRocket = {
     .pos = { 11, 415, 41 },
     .mesh_num = 13,
@@ -42,17 +47,6 @@ static BITE m_CentaurRear = {
     .mesh_num = 5,
 };
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
-
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -60,6 +54,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const centaur = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -133,8 +128,7 @@ static void M_Control(const int16_t item_num)
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH)) {
                 Creature_Effect(item, &m_CentaurRear, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "rear_damage", M_REAR_DAMAGE), true);
+                Lara_TakeDamage(p->rear_damage, true);
                 item->required_anim_state = M_STATE_STOP;
             }
             break;
@@ -146,8 +140,7 @@ static void M_Control(const int16_t item_num)
 
     if (item->is_finished) {
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
-        Item_Shatter(
-            item_num, -1, M_GetDamage(item, "part_damage", M_PART_DAMAGE));
+        Item_Shatter(item_num, -1, p->part_damage);
         Item_Destroy(item_num);
         Item_SetFinished(item, true);
     }
@@ -158,6 +151,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -177,13 +172,13 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 10)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "rear_damage", M_REAR_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, rear_damage, M_REAR_DAMAGE,
             "Damage dealt by the centaur rear attack."),
-        OBJECT_PROPERTY_INT(
-            "part_damage", M_PART_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, part_damage, M_PART_DAMAGE,
             "Damage dealt by the centaur death explosion."));
 }
 

--- a/src/trx/game/objects/creatures/civilian.c
+++ b/src/trx/game/objects/creatures/civilian.c
@@ -55,21 +55,16 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t punch_1_damage;
+    int32_t punch_2_damage;
+    int32_t punch_3_damage;
+} M_PRIV;
+
 static const BITE m_Bite = {
     .pos = { 0, 0, 0 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -112,6 +107,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -326,8 +322,7 @@ static void M_Control(const int16_t item_num)
         creature->maximum_turn = M_WALK_TURN;
 
         if (creature->flags == 0 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "punch_1_damage", M_PUNCH_1_DAMAGE), true);
+            Lara_TakeDamage(p->punch_1_damage, true);
             Creature_Effect(item, &m_Bite, Spawn_Blood);
             Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
             creature->flags = 1;
@@ -342,8 +337,7 @@ static void M_Control(const int16_t item_num)
         creature->maximum_turn = M_WALK_TURN;
 
         if (creature->flags == 0 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "punch_2_damage", M_PUNCH_2_DAMAGE), true);
+            Lara_TakeDamage(p->punch_2_damage, true);
             Creature_Effect(item, &m_Bite, Spawn_Blood);
             Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
             creature->flags = 1;
@@ -363,8 +357,7 @@ static void M_Control(const int16_t item_num)
         creature->maximum_turn = M_WALK_TURN;
 
         if (creature->flags != 2 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "punch_3_damage", M_PUNCH_3_DAMAGE), true);
+            Lara_TakeDamage(p->punch_3_damage, true);
             Creature_Effect(item, &m_Bite, Spawn_Blood);
             Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
             creature->flags = 2;
@@ -392,6 +385,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
@@ -412,16 +406,16 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "punch_1_damage", M_PUNCH_1_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, punch_1_damage, M_PUNCH_1_DAMAGE,
             "Damage dealt by the civilian's first punch attack."),
-        OBJECT_PROPERTY_INT(
-            "punch_2_damage", M_PUNCH_2_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, punch_2_damage, M_PUNCH_2_DAMAGE,
             "Damage dealt by the civilian's second punch attack."),
-        OBJECT_PROPERTY_INT(
-            "punch_3_damage", M_PUNCH_3_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, punch_3_damage, M_PUNCH_3_DAMAGE,
             "Damage dealt by the civilian's third punch attack."));
 }
 

--- a/src/trx/game/objects/creatures/claw_mutant.c
+++ b/src/trx/game/objects/creatures/claw_mutant.c
@@ -45,6 +45,7 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t damage;
     bool recently_fired;
 } M_PRIV;
 
@@ -60,16 +61,6 @@ static const BITE m_PlasmaEmitter = {
     .pos = { .x = -32, .y = -16, .z = -192 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -344,7 +335,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (creature->flags == 0 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             Creature_Effect(item, &m_ClawLeft, Spawn_Blood);
             Creature_Effect(item, &m_ClawRight, Spawn_Blood);
             creature->flags = 1;
@@ -416,12 +407,12 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE,
             "Damage dealt by the claw mutant melee attack."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "plasma_ball_damage", CLAW_MUTANT_PLASMA_BALL_DAMAGE,
             "Damage dealt by the claw mutant plasma ball."));
 }

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -9,10 +9,10 @@
 #define M_HIT_POINTS      8
 #define M_DAMAGE          80
 #define M_ALERT_RANGE     1.5
-#define M_ATTACK_RANGE    1
-#define M_FORGET_RANGE    3
+#define M_ATTACK_RANGE    1.0
+#define M_FORGET_RANGE    3.0
 #define M_RADIUS          (WALL_L / 10) // = 102
-#define M_SETUP_RADIUS(r) (SQUARE(WALL_L * r))
+#define M_SQ_SECTORS(r)   (SQUARE(WALL_L * (r)))
 // clang-format on
 
 typedef enum {
@@ -29,11 +29,10 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
-    struct {
-        int32_t alert;
-        int32_t attack;
-        int32_t forget;
-    } radius;
+    int32_t damage;
+    float alert_radius;
+    float attack_radius;
+    float forget_radius;
 } M_PRIV;
 
 static BITE m_CobraBite = {
@@ -48,25 +47,6 @@ static void M_Initialise(const int16_t item_num)
     Item_SwitchToAnim(item, M_ANIM_SLEEP, 45);
     item->current_anim_state = M_STATE_SLEEP;
     item->goal_anim_state = M_STATE_SLEEP;
-
-    M_PRIV *const p = item->priv;
-    p->radius.alert = M_SETUP_RADIUS(M_ALERT_RANGE);
-    p->radius.attack = M_SETUP_RADIUS(M_ATTACK_RANGE);
-    p->radius.forget = M_SETUP_RADIUS(M_FORGET_RANGE);
-
-    TRX_VALUE radius_val = {};
-    if (ObjectProperty_GetItemValue(item, "alert_radius", &radius_val)
-        && radius_val.type == TVT_DOUBLE) {
-        p->radius.alert = M_SETUP_RADIUS(radius_val.as_num);
-    }
-    if (ObjectProperty_GetItemValue(item, "attack_radius", &radius_val)
-        && radius_val.type == TVT_DOUBLE) {
-        p->radius.attack = M_SETUP_RADIUS(radius_val.as_num);
-    }
-    if (ObjectProperty_GetItemValue(item, "forget_radius", &radius_val)
-        && radius_val.type == TVT_DOUBLE) {
-        p->radius.forget = M_SETUP_RADIUS(radius_val.as_num);
-    }
 }
 
 static bool M_IsTargetable(const ITEM *const item)
@@ -83,16 +63,6 @@ static bool M_CanTakeDamage(const ITEM *const item)
 static bool M_CanBeProjectileTarget(const ITEM *const item)
 {
     return item->hit_points > 0 && item->is_collidable;
-}
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
 }
 
 static void M_Control(const int16_t item_num)
@@ -143,11 +113,11 @@ static void M_Control(const int16_t item_num)
 
     case M_STATE_ALERT:
         creature->flags = 0;
-        if (info.distance > p->radius.forget) {
+        if (info.distance > M_SQ_SECTORS(p->forget_radius)) {
             item->goal_anim_state = M_STATE_SLEEP;
         } else if (
             lara_item->hit_points > 0
-            && ((info.ahead && info.distance < p->radius.attack)
+            && ((info.ahead && info.distance < M_SQ_SECTORS(p->attack_radius))
                 || item->hit_status || lara_item->speed > 15)) {
             item->goal_anim_state = M_STATE_BITE;
         }
@@ -156,7 +126,7 @@ static void M_Control(const int16_t item_num)
     case M_STATE_BITE:
         if (creature->flags != 1 && (item->touch_bits & 0x2000) != 0) {
             creature->flags = 1;
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             lara->poison.value = 256;
             Creature_Effect(item, &m_CobraBite, Spawn_Blood);
         }
@@ -164,7 +134,8 @@ static void M_Control(const int16_t item_num)
 
     case M_STATE_SLEEP:
         creature->flags = 0;
-        if (info.distance < p->radius.alert && lara_item->hit_points > 0) {
+        if (info.distance < M_SQ_SECTORS(p->alert_radius)
+            && lara_item->hit_points > 0) {
             item->goal_anim_state = M_STATE_WAKING_UP;
         }
         break;
@@ -202,16 +173,18 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the cobra bite."),
-        OBJECT_PROPERTY_DOUBLE(
-            "alert_radius", M_ALERT_RANGE, "Alert radius, in sectors."),
-        OBJECT_PROPERTY_DOUBLE(
-            "attack_radius", M_ATTACK_RANGE, "Attack radius, in sectors."),
-        OBJECT_PROPERTY_DOUBLE(
-            "forget_radius", M_FORGET_RANGE, "Forget radius, in sectors."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the cobra bite."),
+        OBJECT_PROPERTY(
+            M_PRIV, alert_radius, M_ALERT_RANGE, "Alert radius, in sectors."),
+        OBJECT_PROPERTY(
+            M_PRIV, attack_radius, M_ATTACK_RANGE,
+            "Attack radius, in sectors."),
+        OBJECT_PROPERTY(
+            M_PRIV, forget_radius, M_FORGET_RANGE,
+            "Forget radius, in sectors."));
 }
 
 REGISTER_OBJECT(O_COBRA, M_Setup)

--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -44,6 +44,7 @@ typedef struct {
 } M_SHARED_PRIV;
 
 typedef struct {
+    int32_t damage;
     bool attack_lara;
     int32_t scared_timer;
     int32_t carcass_item_num;
@@ -55,16 +56,6 @@ static BITE m_Bite = {
     .pos = { .x = 0, .y = 0, .z = 0 },
     .mesh_num = 2,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static bool M_FindCarcass(ITEM *const item)
 {
@@ -255,7 +246,7 @@ static void M_Control(const int16_t item_num)
         if (!(creature->flags & M_HIT_FLAG)) {
             if ((item->touch_bits & M_TOUCH_BITS) && p->shared->attack_lara) {
                 creature->flags |= M_HIT_FLAG;
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
             } else if (
                 info.distance < M_HIT_RANGE && info.ahead
@@ -303,10 +294,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 2)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the compy attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the compy attack."));
 }
 
 REGISTER_OBJECT(O_COMPY, M_Setup)

--- a/src/trx/game/objects/creatures/cowboy.c
+++ b/src/trx/game/objects/creatures/cowboy.c
@@ -31,6 +31,10 @@ typedef enum {
     M_ANIM_DEATH = 7,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_CowboyGun1 = {
     .muzzle = { .pos = { 1, 200, 41 }, .mesh_num = 5, },
 };
@@ -38,16 +42,6 @@ static const CREATURE_GUN m_CowboyGun1 = {
 static const CREATURE_GUN m_CowboyGun2 = {
     .muzzle = { .pos = { -2, 200, 40 }, .mesh_num = 8, },
 };
-
-static int32_t M_GetShotDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
@@ -66,6 +60,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const cowboy = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -142,13 +137,10 @@ static void M_Control(const int16_t item_num)
 
         case M_STATE_SHOOT:
             if (!cowboy->flags) {
-                Creature_Shoot(
-                    item, &info, &m_CowboyGun1, head, M_GetShotDamage(item));
+                Creature_Shoot(item, &info, &m_CowboyGun1, head, p->damage);
             } else if (cowboy->flags == 6) {
                 if (Creature_CanTargetEnemy(item, &info)) {
-                    Creature_Shoot(
-                        item, &info, &m_CowboyGun2, head,
-                        M_GetShotDamage(item));
+                    Creature_Shoot(item, &info, &m_CowboyGun2, head, p->damage);
                 } else {
                     int16_t effect_num = Creature_Effect(
                         item, &m_CowboyGun2.muzzle, Spawn_GunShot);
@@ -176,6 +168,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
@@ -193,10 +187,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the cowboy's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the cowboy's shot."));
 }
 
 REGISTER_OBJECT(O_COWBOY, M_Setup)

--- a/src/trx/game/objects/creatures/crawler_mutant.c
+++ b/src/trx/game/objects/creatures/crawler_mutant.c
@@ -485,7 +485,7 @@ static void M_SetupCrawler(OBJECT *const obj)
     Object_GetBone(obj, 9)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/crocodile.c
+++ b/src/trx/game/objects/creatures/crocodile.c
@@ -76,15 +76,9 @@ static const HYBRID_INFO m_CrocodileInfo = {
     .water.death_state = M_ALLIGATOR_STATE_DEATH,
 };
 
-static int32_t M_GetDamage(const ITEM *const item, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_UpdateCreatureLOT(const ITEM *const item)
 {
@@ -114,6 +108,7 @@ static void M_ControlCrocodile(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const croc = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -194,8 +189,7 @@ static void M_ControlCrocodile(const int16_t item_num)
         case M_CROCODILE_STATE_ATTACK_1:
             if (item->required_anim_state == M_CROCODILE_STATE_EMPTY) {
                 Creature_Effect(item, &m_CrocodileBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, M_CROCODILE_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->damage, true);
                 item->required_anim_state = M_CROCODILE_STATE_STOP;
             }
             break;
@@ -225,6 +219,7 @@ static void M_ControlAlligator(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const gator = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -286,8 +281,7 @@ static void M_ControlAlligator(const int16_t item_num)
         if (info.bite && item->touch_bits) {
             if (item->required_anim_state == M_ALLIGATOR_STATE_EMPTY) {
                 Creature_Effect(item, &m_CrocodileBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, M_ALLIGATOR_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->damage, true);
                 item->required_anim_state = M_ALLIGATOR_STATE_SWIM;
             }
             if (g_Config.gameplay.fix_alligator_ai) {
@@ -316,6 +310,7 @@ static void M_ControlAlligator(const int16_t item_num)
 
 static void M_SetupBase(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = M_SHADOW_SIZE;
@@ -341,10 +336,10 @@ static void M_SetupCrocodile(OBJECT *const obj)
     obj->smartness = M_CROCODILE_SMARTNESS;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_CROCODILE_HITPOINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_CROCODILE_BITE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_CROCODILE_BITE_DAMAGE,
             "Damage dealt by the crocodile bite."));
 }
 
@@ -361,10 +356,10 @@ static void M_SetupAlligator(OBJECT *const obj)
     obj->lot_setup = LOT_Setup(LOT_SETUP_FLYER);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_ALLIGATOR_HITPOINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_ALLIGATOR_BITE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_ALLIGATOR_BITE_DAMAGE,
             "Damage dealt by the alligator bite."));
 }
 

--- a/src/trx/game/objects/creatures/cultist_1.c
+++ b/src/trx/game/objects/creatures/cultist_1.c
@@ -38,19 +38,13 @@ typedef enum {
     M_ANIM_DEATH = 20,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Cultist1Gun = {
     .muzzle = { .pos = { .x = 3, .y = 331, .z = 56 }, .mesh_num = 10 },
 };
-
-static int32_t M_GetShootDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -73,6 +67,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -200,8 +195,7 @@ static void M_Control(const int16_t item_num)
                 head = info.angle;
             }
             if (creature->flags == 0) {
-                Creature_Shoot(
-                    item, &info, &m_Cultist1Gun, head, M_GetShootDamage(item));
+                Creature_Shoot(item, &info, &m_Cultist1Gun, head, p->damage);
                 creature->flags = 1;
             }
             break;
@@ -212,8 +206,7 @@ static void M_Control(const int16_t item_num)
             }
             if (item->required_anim_state == M_STATE_EMPTY) {
                 if (!Creature_Shoot(
-                        item, &info, &m_Cultist1Gun, head,
-                        M_GetShootDamage(item))) {
+                        item, &info, &m_Cultist1Gun, head, p->damage)) {
                     item->goal_anim_state = M_STATE_RUN;
                 }
                 item->required_anim_state = M_STATE_SHOOT_2;
@@ -232,6 +225,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_SetupCommon(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -249,10 +243,10 @@ static void M_SetupCommon(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the cultist's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the cultist's shot."));
 }
 
 static void M_Setup1(OBJECT *const obj)

--- a/src/trx/game/objects/creatures/cultist_2.c
+++ b/src/trx/game/objects/creatures/cultist_2.c
@@ -235,7 +235,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/cultist_3.c
+++ b/src/trx/game/objects/creatures/cultist_3.c
@@ -37,6 +37,10 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Cultist3LeftGun = {
     .muzzle = { .pos = { .x = -2, .y = 275, .z = 23 }, .mesh_num = 6 },
 };
@@ -44,16 +48,6 @@ static const CREATURE_GUN m_Cultist3LeftGun = {
 static const CREATURE_GUN m_Cultist3RightGun = {
     .muzzle = { .pos = { .x = 2, .y = 275, .z = 23 }, .mesh_num = 10 },
 };
-
-static int32_t M_GetShootDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -71,6 +65,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -218,8 +213,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags == 0) {
                 Creature_Shoot(
-                    item, &info, &m_Cultist3LeftGun, head,
-                    M_GetShootDamage(item));
+                    item, &info, &m_Cultist3LeftGun, head, p->damage);
                 creature->flags = 1;
             }
             break;
@@ -231,8 +225,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags == 0) {
                 Creature_Shoot(
-                    item, &info, &m_Cultist3RightGun, head,
-                    M_GetShootDamage(item));
+                    item, &info, &m_Cultist3RightGun, head, p->damage);
                 creature->flags = 1;
             }
             break;
@@ -242,11 +235,8 @@ static void M_Control(const int16_t item_num)
                 body = info.angle;
             }
             if (creature->flags == 0) {
-                Creature_Shoot(
-                    item, &info, &m_Cultist3LeftGun, 0, M_GetShootDamage(item));
-                Creature_Shoot(
-                    item, &info, &m_Cultist3RightGun, 0,
-                    M_GetShootDamage(item));
+                Creature_Shoot(item, &info, &m_Cultist3LeftGun, 0, p->damage);
+                Creature_Shoot(item, &info, &m_Cultist3RightGun, 0, p->damage);
                 creature->flags = 1;
             }
             break;
@@ -285,6 +275,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -300,10 +291,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the cultist's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the cultist's shot."));
 }
 
 REGISTER_OBJECT(O_CULT_3, M_Setup)

--- a/src/trx/game/objects/creatures/diver.c
+++ b/src/trx/game/objects/creatures/diver.c
@@ -258,7 +258,7 @@ static void M_Setup(OBJECT *const obj)
     }
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/dog.c
+++ b/src/trx/game/objects/creatures/dog.c
@@ -45,21 +45,15 @@ typedef enum {
     M_ANIM_DEATH = 13,
 } M_ANIM;
 
+typedef struct {
+    int32_t bite_damage;
+    int32_t lunge_damage;
+} M_PRIV;
+
 static const BITE m_DogBite = {
     .pos = { .x = 0, .y = 30, .z = 141 },
     .mesh_num = 20,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -68,6 +62,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -161,8 +156,7 @@ static void M_Control(const int16_t item_num)
             if (creature->flags != 1 && info.ahead
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
                 Creature_Effect(item, &m_DogBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 creature->flags = 1;
             }
             if (info.distance > M_ATTACK_1_RANGE
@@ -177,8 +171,7 @@ static void M_Control(const int16_t item_num)
             if (creature->flags != 2
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
                 Creature_Effect(item, &m_DogBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "lunge_damage", M_LUNGE_DAMAGE), true);
+                Lara_TakeDamage(p->lunge_damage, true);
                 creature->flags = 2;
             }
             if (info.distance < M_ATTACK_1_RANGE) {
@@ -193,8 +186,7 @@ static void M_Control(const int16_t item_num)
             if (creature->flags != 3
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
                 Creature_Effect(item, &m_DogBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "lunge_damage", M_LUNGE_DAMAGE), true);
+                Lara_TakeDamage(p->lunge_damage, true);
                 creature->flags = 3;
             }
             if (info.distance < M_ATTACK_1_RANGE) {
@@ -221,6 +213,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -237,12 +230,13 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 19)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the dog bite."),
-        OBJECT_PROPERTY_INT(
-            "lunge_damage", M_LUNGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the dog bite."),
+        OBJECT_PROPERTY(
+            M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the dog's lunge attack."));
 }
 

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -75,23 +75,14 @@ typedef enum {
 typedef struct {
     int16_t dragon_front_item_num;
     M_MODE mode;
+    int32_t touch_damage;
+    int32_t swipe_damage;
 } M_PRIV;
 
 static const BITE m_DragonMouth = {
     .pos = { .x = 35, .y = 171, .z = 1168 },
     .mesh_num = 12,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -418,9 +409,8 @@ static void M_ControlBack(const int16_t item_num)
         const bool is_ahead = info.ahead && info.distance > M_CLOSE_RANGE
             && info.distance < M_STOP_RANGE;
         if (dragon_front_item->touch_bits) {
-            Lara_TakeDamage(
-                M_GetDamage(dragon_front_item, "touch_damage", M_TOUCH_DAMAGE),
-                true);
+            const M_PRIV *const front = dragon_front_item->priv;
+            Lara_TakeDamage(front->touch_damage, true);
         }
 
         switch (dragon_front_item->current_anim_state) {
@@ -523,20 +513,16 @@ static void M_ControlBack(const int16_t item_num)
 
         case M_STATE_SWIPE_LEFT:
             if ((dragon_front_item->touch_bits & M_TOUCH_L) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(
-                        dragon_front_item, "swipe_damage", M_SWIPE_DAMAGE),
-                    true);
+                const M_PRIV *const front = dragon_front_item->priv;
+                Lara_TakeDamage(front->swipe_damage, true);
                 creature->flags = 0;
             }
             break;
 
         case M_STATE_SWIPE_RIGHT:
             if ((dragon_front_item->touch_bits & M_TOUCH_R) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(
-                        dragon_front_item, "swipe_damage", M_SWIPE_DAMAGE),
-                    true);
+                const M_PRIV *const front = dragon_front_item->priv;
+                Lara_TakeDamage(front->swipe_damage, true);
                 creature->flags = 0;
             }
             break;
@@ -564,6 +550,7 @@ static void M_SetupFront(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     SOFT_ASSERT(
         Object_Get(O_DRAGON_BACK)->loaded, "Dragon back object missing");
     obj->initialise_func = M_InitialiseFront;
@@ -582,13 +569,13 @@ static void M_SetupFront(OBJECT *const obj)
     Object_GetBone(obj, 10)->rot.z = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "touch_damage", M_TOUCH_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, touch_damage, M_TOUCH_DAMAGE,
             "Damage dealt while Lara is touching the dragon."),
-        OBJECT_PROPERTY_INT(
-            "swipe_damage", M_SWIPE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, swipe_damage, M_SWIPE_DAMAGE,
             "Damage dealt by the dragon swipe attack."));
 }
 

--- a/src/trx/game/objects/creatures/eel.c
+++ b/src/trx/game/objects/creatures/eel.c
@@ -30,6 +30,7 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t damage;
     int32_t pos;
 } M_PRIV;
 
@@ -37,16 +38,6 @@ static const BITE m_EelBite = {
     .pos = { .x = 7, .y = 157, .z = 333 },
     .mesh_num = 7,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static bool M_IsTargetable(const ITEM *const item)
 {
@@ -99,7 +90,7 @@ static void M_Control(const int16_t item_num)
             }
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_EelBite, Spawn_Blood);
                 item->required_anim_state = M_STATE_STOP;
             }
@@ -129,10 +120,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the eel bite."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the eel bite."));
 }
 
 REGISTER_OBJECT(O_EEL, M_Setup)

--- a/src/trx/game/objects/creatures/hybrid_mutant.c
+++ b/src/trx/game/objects/creatures/hybrid_mutant.c
@@ -40,6 +40,12 @@ typedef enum {
     M_ANIM_DEATH = 18,
 } M_ANIM;
 
+typedef struct {
+    int32_t jump_damage;
+    int32_t slash_damage;
+    int32_t kick_damage;
+} M_PRIV;
+
 static const BITE m_BiteLeft = {
     .pos = { 19, -13, 3 },
     .mesh_num = 7,
@@ -49,17 +55,6 @@ static const BITE m_BiteRight = {
     .mesh_num = 14,
 };
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
-
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -67,6 +62,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t tilt = 0;
     int16_t angle = 0;
@@ -211,8 +207,7 @@ static void M_Control(const int16_t item_num)
         creature->maximum_turn = 0;
 
         if ((item->touch_bits & M_TOUCH_BITS_LEFT) != 0) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "jump_damage", M_JUMP_DAMAGE), true);
+            Lara_TakeDamage(p->jump_damage, true);
             Creature_Effect(item, &m_BiteLeft, Spawn_Blood);
         }
         break;
@@ -228,8 +223,7 @@ static void M_Control(const int16_t item_num)
 
         if (creature->flags == 0
             && (item->touch_bits & M_TOUCH_BITS_LEFT) != 0) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "slash_damage", M_SLASH_DAMAGE), true);
+            Lara_TakeDamage(p->slash_damage, true);
             Creature_Effect(item, &m_BiteLeft, Spawn_Blood);
             creature->flags = 1;
         }
@@ -252,8 +246,7 @@ static void M_Control(const int16_t item_num)
 
         if (creature->flags == 0
             && (item->touch_bits & M_TOUCH_BITS_RIGHT) != 0) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "kick_damage", M_KICK_DAMAGE), true);
+            Lara_TakeDamage(p->kick_damage, true);
             Creature_Effect(item, &m_BiteRight, Spawn_Blood);
             creature->flags = 1;
         }
@@ -282,6 +275,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
 
@@ -299,16 +293,16 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "jump_damage", M_JUMP_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, jump_damage, M_JUMP_DAMAGE,
             "Damage dealt by the hybrid mutant jump attack."),
-        OBJECT_PROPERTY_INT(
-            "slash_damage", M_SLASH_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, slash_damage, M_SLASH_DAMAGE,
             "Damage dealt by the hybrid mutant slash attack."),
-        OBJECT_PROPERTY_INT(
-            "kick_damage", M_KICK_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, kick_damage, M_KICK_DAMAGE,
             "Damage dealt by the hybrid mutant kick attack."));
 }
 

--- a/src/trx/game/objects/creatures/jelly.c
+++ b/src/trx/game/objects/creatures/jelly.c
@@ -18,15 +18,9 @@ typedef enum {
     M_STATE_STOP,
 } M_STATE;
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_Control(const int16_t item_num)
 {
@@ -35,6 +29,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     if (item->hit_points <= 0) {
@@ -65,7 +60,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (item->touch_bits != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
         }
 
         Creature_Head(item, 0);
@@ -80,6 +75,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -94,10 +90,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the jelly sting."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the jelly sting."));
 }
 
 REGISTER_OBJECT(O_JELLY, M_Setup)

--- a/src/trx/game/objects/creatures/larson.c
+++ b/src/trx/game/objects/creatures/larson.c
@@ -31,19 +31,13 @@ typedef enum {
     M_ANIM_DEATH = 15,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_LarsonGun = {
     .muzzle = { .pos = { -60, 170, 0 }, .mesh_num = 14, },
 };
-
-static int32_t M_GetShotDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
@@ -62,6 +56,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const person = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -154,8 +149,7 @@ static void M_Control(const int16_t item_num)
 
         case M_STATE_SHOOT:
             if (!item->required_anim_state) {
-                Creature_Shoot(
-                    item, &info, &m_LarsonGun, head, M_GetShotDamage(item));
+                Creature_Shoot(item, &info, &m_LarsonGun, head, p->damage);
                 item->required_anim_state = M_STATE_AIM;
             }
             if (person->mood == MOOD_ESCAPE) {
@@ -176,6 +170,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
@@ -193,10 +189,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by Larson's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by Larson's shot."));
 }
 
 REGISTER_OBJECT(O_LARSON, M_Setup)

--- a/src/trx/game/objects/creatures/lion.c
+++ b/src/trx/game/objects/creatures/lion.c
@@ -39,21 +39,15 @@ typedef enum {
     M_PUMA_ANIM_DEATH = 4,
 } M_PUMA_ANIM;
 
+typedef struct {
+    int32_t pounce_damage;
+    int32_t bite_damage;
+} M_PRIV;
+
 static BITE m_LionBite = {
     .pos = { -2, -10, 132 },
     .mesh_num = 21,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -62,6 +56,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const lion = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -132,8 +127,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK_1:
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH)) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "pounce_damage", M_POUNCE_DAMAGE), true);
+                Lara_TakeDamage(p->pounce_damage, true);
                 item->required_anim_state = M_STATE_STOP;
             }
             break;
@@ -142,8 +136,7 @@ static void M_Control(const int16_t item_num)
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH)) {
                 Creature_Effect(item, &m_LionBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 item->required_anim_state = M_STATE_STOP;
             }
             break;
@@ -157,6 +150,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_SetupBase(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -174,11 +168,12 @@ static void M_SetupBase(OBJECT *const obj)
     Object_GetBone(obj, 19)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "pounce_damage", M_POUNCE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, pounce_damage, M_POUNCE_DAMAGE,
             "Damage dealt by the pounce attack."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the bite attack."));
 }
 
 static void M_SetupLion(OBJECT *const obj)
@@ -192,7 +187,7 @@ static void M_SetupLion(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_LION_HIT_POINTS, "Maximum hit points."));
 }
 
@@ -207,7 +202,7 @@ static void M_SetupLioness(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_LIONESS_HIT_POINTS, "Maximum hit points."));
 }
 
@@ -222,7 +217,7 @@ static void M_SetupPuma(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_PUMA_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -55,6 +55,11 @@ typedef enum {
     M_ANIM_SLIDE_2 = 31,
 } M_ANIM;
 
+typedef struct {
+    int32_t bite_damage;
+    int32_t swipe_damage;
+} M_PRIV;
+
 static BITE m_BiteHit = {
     .pos = { .x = 0, .y = -120, .z = 120 },
     .mesh_num = 10,
@@ -67,17 +72,6 @@ static BITE m_GasHit = {
     .pos = { .x = 0, .y = -64, .z = 56 },
     .mesh_num = 9,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_TriggerGas(
     const XYZ_32 pos, const XYZ_32 vel, const int32_t effect_num)
@@ -249,6 +243,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t tilt = 0;
     int16_t angle = 0;
@@ -345,8 +340,7 @@ static void M_Control(const int16_t item_num)
                 neck = info.angle;
             }
             if (creature->flags != 2 && item->touch_bits & M_BITE_TOUCH_BITS) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 Creature_Effect(item, &m_BiteHit, Spawn_Blood);
                 creature->flags = 2;
             }
@@ -419,8 +413,7 @@ static void M_Control(const int16_t item_num)
             }
 
             if (!creature->flags && item->touch_bits & M_SWIPE_TOUCH_BITS) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "swipe_damage", M_SWIPE_DAMAGE), true);
+                Lara_TakeDamage(p->swipe_damage, true);
                 Creature_Effect(item, &m_SwipeHit, Spawn_Blood);
                 creature->flags = 1;
             }
@@ -532,6 +525,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -550,12 +544,13 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 9)->rot.z = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the lizard bite."),
-        OBJECT_PROPERTY_INT(
-            "swipe_damage", M_SWIPE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the lizard bite."),
+        OBJECT_PROPERTY(
+            M_PRIV, swipe_damage, M_SWIPE_DAMAGE,
             "Damage dealt by the lizard swipe attack."));
 }
 

--- a/src/trx/game/objects/creatures/mercenary.c
+++ b/src/trx/game/objects/creatures/mercenary.c
@@ -38,6 +38,10 @@ typedef enum {
     M_STATE_SHOOT_3
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_MercenaryGun = {
     .muzzle = { .pos = { 0, 300, 64 }, .mesh_num = 7 },
     .tr3_enemy_flash = true,
@@ -46,16 +50,6 @@ static const CREATURE_GUN m_MercenaryGun = {
     .tr3_flash_shade = 600,
     .tr3_flash_rot_x = -DEG_90,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -109,6 +103,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t tilt = 0;
     int16_t angle = 0;
@@ -298,8 +293,7 @@ static void M_Control(const int16_t item_num)
         if (creature->flags != 0) {
             creature->flags--;
         } else if (creature->enemy != nullptr) {
-            Creature_Shoot(
-                item, &info, &m_MercenaryGun, torso_y, M_GetDamage(item));
+            Creature_Shoot(item, &info, &m_MercenaryGun, torso_y, p->damage);
             creature->flags = 5;
         }
         break;
@@ -347,6 +341,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -365,10 +360,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the mercenary's shot."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the mercenary's shot."));
 }
 
 REGISTER_OBJECT(O_STHPAC_MERCENARY, M_Setup)

--- a/src/trx/game/objects/creatures/monk.c
+++ b/src/trx/game/objects/creatures/monk.c
@@ -42,21 +42,15 @@ typedef enum {
     M_ANIM_DEATH = 20,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+    int32_t enemy_damage;
+} M_PRIV;
+
 static const BITE m_MonkHit = {
     .pos = { .x = -23, .y = 16, .z = 265 },
     .mesh_num = 14,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -65,6 +59,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -199,8 +194,7 @@ static void M_Control(const int16_t item_num)
             if (creature->enemy == Lara_GetItem()) {
                 if ((creature->flags & 0xF000) == 0
                     && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                    Lara_TakeDamage(
-                        M_GetDamage(item, "damage", M_BIFF_DAMAGE), true);
+                    Lara_TakeDamage(p->damage, true);
                     Sound_Effect(SFX_MONK_CRUNCH, &item->pos, SPM_NORMAL);
                     Creature_Effect(item, &m_MonkHit, Spawn_Blood);
                     creature->flags |= 0x1000;
@@ -212,9 +206,7 @@ static void M_Control(const int16_t item_num)
                 const int32_t dz = ABS(creature->enemy->pos.z - item->pos.z);
                 if (dx < M_HIT_RANGE && dy < M_HIT_RANGE && dz < M_HIT_RANGE) {
                     Item_TakeDamage(
-                        creature->enemy,
-                        M_GetDamage(item, "enemy_damage", M_BIFF_ENEMY_DAMAGE),
-                        IDF_NONE, item);
+                        creature->enemy, p->enemy_damage, IDF_NONE, item);
                     Sound_Effect(SFX_MONK_CRUNCH, &item->pos, SPM_NORMAL);
                     creature->flags |= 0x1000;
                 }
@@ -233,6 +225,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_SetupBase(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -248,12 +241,12 @@ static void M_SetupBase(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_BIFF_DAMAGE, "Damage dealt by melee attacks."),
-        OBJECT_PROPERTY_INT(
-            "enemy_damage", M_BIFF_ENEMY_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_BIFF_DAMAGE, "Damage dealt by melee attacks."),
+        OBJECT_PROPERTY(
+            M_PRIV, enemy_damage, M_BIFF_ENEMY_DAMAGE,
             "Damage dealt by melee attacks against non-player targets."));
 }
 

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -27,6 +27,11 @@
 #define M_F_PICKUP      12
 // clang-format on
 
+typedef struct {
+    int32_t damage;
+    int32_t jump_damage;
+} M_PRIV;
+
 static BITE m_MonkeyBite = {
     .pos = { 10, 10, 11 },
     .mesh_num = 13,
@@ -66,17 +71,6 @@ typedef enum {
     M_ANIM_DOWN_3 = 21,
     M_ANIM_DOWN_4 = 20,
 } M_ANIM;
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Bite(ITEM *const item, ITEM *const enemy, const int32_t dmg)
 {
@@ -191,6 +185,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     ITEM *const lara_item = Lara_GetItem();
@@ -464,9 +459,7 @@ static void M_Control(const int16_t item_num)
             } else {
                 item->rot.y += M_WALK_TURN;
             }
-            M_Bite(
-                item, creature->enemy,
-                M_GetDamage(item, "damage", M_DAMAGE_NORMAL));
+            M_Bite(item, creature->enemy, p->damage);
             break;
 
 #pragma GCC diagnostic push
@@ -483,9 +476,7 @@ static void M_Control(const int16_t item_num)
             } else {
                 item->rot.y += M_WALK_TURN;
             }
-            M_Bite(
-                item, creature->enemy,
-                M_GetDamage(item, "damage", M_DAMAGE_NORMAL));
+            M_Bite(item, creature->enemy, p->damage);
 
             // OG mistake
             // break;
@@ -502,9 +493,7 @@ static void M_Control(const int16_t item_num)
             } else {
                 item->rot.y += M_WALK_TURN;
             }
-            M_Bite(
-                item, creature->enemy,
-                M_GetDamage(item, "jump_damage", M_DAMAGE_JUMP));
+            M_Bite(item, creature->enemy, p->jump_damage);
             break;
 #pragma GCC diagnostic pop
         }
@@ -574,6 +563,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     if (!Object_Get(O_MESH_SWAP_2)->loaded) {
         Shell_ExitSystem("Monkey requires O_MESH_SWAP_2 (pickups)");
     }
@@ -600,12 +590,12 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE_NORMAL, "Damage dealt by bite attacks."),
-        OBJECT_PROPERTY_INT(
-            "jump_damage", M_DAMAGE_JUMP,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE_NORMAL, "Damage dealt by bite attacks."),
+        OBJECT_PROPERTY(
+            M_PRIV, jump_damage, M_DAMAGE_JUMP,
             "Damage dealt by the jumping bite attack."));
 }
 

--- a/src/trx/game/objects/creatures/mouse.c
+++ b/src/trx/game/objects/creatures/mouse.c
@@ -31,20 +31,14 @@ typedef enum {
     M_ANIM_DEATH = 9,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_MouseBite = {
     .pos = { .x = 0, .y = 0, .z = 57 },
     .mesh_num = 2,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_BITE_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -53,6 +47,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -124,7 +119,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK:
             if (item->required_anim_state == M_STATE_NULL
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_MouseBite, Spawn_Blood);
                 item->required_anim_state = M_STATE_STOP;
             }
@@ -145,6 +140,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -161,10 +157,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 3)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_BITE_DAMAGE, "Damage dealt by the bite attack."));
 }
 
 REGISTER_OBJECT(O_MOUSE, M_Setup)

--- a/src/trx/game/objects/creatures/mp_1.c
+++ b/src/trx/game/objects/creatures/mp_1.c
@@ -59,6 +59,13 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t punch_1_damage;
+    int32_t punch_2_damage;
+    int32_t punch_3_damage;
+    int32_t kick_damage;
+} M_PRIV;
+
 static const BITE m_HitBite = {
     .pos = { 247, 10, 11 },
     .mesh_num = 13,
@@ -67,17 +74,6 @@ static const BITE m_KickBite = {
     .pos = { 0, 0, 100 },
     .mesh_num = 6,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -158,6 +154,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -376,9 +373,7 @@ static void M_Control(const int16_t item_num)
         if (enemy == lara_item) {
             if (creature->flags == 0
                 && (item->touch_bits & M_HIT_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_1_damage", M_PUNCH_1_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->punch_1_damage, true);
                 Creature_Effect(item, &m_HitBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -387,10 +382,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy,
-                    M_GetDamage(item, "punch_1_damage", M_PUNCH_1_DAMAGE) / 16,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->punch_1_damage / 16, IDF_NONE, item);
                 Creature_Effect(item, &m_HitBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -408,9 +400,7 @@ static void M_Control(const int16_t item_num)
         if (enemy == lara_item) {
             if (creature->flags == 0
                 && (item->touch_bits & M_HIT_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_2_damage", M_PUNCH_2_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->punch_2_damage, true);
                 Creature_Effect(item, &m_HitBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -419,10 +409,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy,
-                    M_GetDamage(item, "punch_2_damage", M_PUNCH_2_DAMAGE) / 16,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->punch_2_damage / 16, IDF_NONE, item);
                 Creature_Effect(item, &m_HitBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -445,9 +432,7 @@ static void M_Control(const int16_t item_num)
         if (enemy == lara_item) {
             if (creature->flags != 2
                 && (item->touch_bits & M_HIT_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_3_damage", M_PUNCH_3_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->punch_3_damage, true);
                 Creature_Effect(item, &m_HitBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 2;
@@ -456,10 +441,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy,
-                    M_GetDamage(item, "punch_3_damage", M_PUNCH_3_DAMAGE) / 16,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->punch_3_damage / 16, IDF_NONE, item);
                 Creature_Effect(item, &m_HitBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 2;
@@ -478,8 +460,7 @@ static void M_Control(const int16_t item_num)
             if (creature->flags != 1
                 && (item->touch_bits & M_KICK_TOUCH_BITS) != 0
                 && frame_num > 8) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "kick_damage", M_KICK_DAMAGE), true);
+                Lara_TakeDamage(p->kick_damage, true);
                 Creature_Effect(item, &m_KickBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -488,9 +469,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy, M_GetDamage(item, "kick_damage", M_KICK_DAMAGE) / 16,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->kick_damage / 16, IDF_NONE, item);
                 Creature_Effect(item, &m_KickBite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -519,6 +498,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
@@ -539,16 +519,20 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "punch_1_damage", M_PUNCH_1_DAMAGE, "Damage dealt by punch 1."),
-        OBJECT_PROPERTY_INT(
-            "punch_2_damage", M_PUNCH_2_DAMAGE, "Damage dealt by punch 2."),
-        OBJECT_PROPERTY_INT(
-            "punch_3_damage", M_PUNCH_3_DAMAGE, "Damage dealt by punch 3."),
-        OBJECT_PROPERTY_INT(
-            "kick_damage", M_KICK_DAMAGE, "Damage dealt by the kick attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, punch_1_damage, M_PUNCH_1_DAMAGE,
+            "Damage dealt by punch 1."),
+        OBJECT_PROPERTY(
+            M_PRIV, punch_2_damage, M_PUNCH_2_DAMAGE,
+            "Damage dealt by punch 2."),
+        OBJECT_PROPERTY(
+            M_PRIV, punch_3_damage, M_PUNCH_3_DAMAGE,
+            "Damage dealt by punch 3."),
+        OBJECT_PROPERTY(
+            M_PRIV, kick_damage, M_KICK_DAMAGE,
+            "Damage dealt by the kick attack."));
 }
 
 REGISTER_OBJECT(O_MP_1, M_Setup)

--- a/src/trx/game/objects/creatures/mp_2.c
+++ b/src/trx/game/objects/creatures/mp_2.c
@@ -61,6 +61,10 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Gun = {
     .muzzle = { .pos = { 0, 160, 40 }, .mesh_num = 13 },
     .tr3_enemy_flash = true,
@@ -70,19 +74,10 @@ static const CREATURE_GUN m_Gun = {
     .tr3_flash_rot_x = -DEG_90,
 };
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
-
 static void M_FireFinalShot(
     ITEM *const item, int16_t *const head, int16_t *const torso_y)
 {
+    const M_PRIV *const p = item->priv;
     if (!Item_TestFrameEqual(item, 1)) {
         return;
     }
@@ -95,7 +90,7 @@ static void M_FireFinalShot(
 
     *head = info.angle;
     *torso_y = info.angle;
-    Creature_Shoot(item, &info, &m_Gun, info.angle, M_GetDamage(item));
+    Creature_Shoot(item, &info, &m_Gun, info.angle, p->damage);
     Sound_Effect(SFX_LONDON_SWAT_FIRE, &item->pos, SPM_NORMAL);
 }
 
@@ -152,6 +147,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -326,8 +322,7 @@ static void M_Control(const int16_t item_num)
 
         if (anim_idx == M_ANIM_AIM_1
             || (anim_idx == M_ANIM_SHOOT_1 && frame_idx == 10)) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->required_anim_state = M_STATE_WAIT;
             }
         } else if (
@@ -356,8 +351,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
         } else if (
@@ -376,8 +370,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0 || frame_idx == 11) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
         } else if (
@@ -396,8 +389,7 @@ static void M_Control(const int16_t item_num)
 
         if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 16)
             || (anim_idx == M_ANIM_AIM_4B && frame_idx == 6)) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->required_anim_state = M_STATE_WALK;
             }
         } else if (
@@ -424,8 +416,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 16
-            && !Creature_Shoot(
-                item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            && !Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
             item->goal_anim_state = M_STATE_WALK;
         }
 
@@ -470,7 +461,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0
-            && (!Creature_Shoot(item, &info, &m_Gun, torso_y, M_GetDamage(item))
+            && (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)
                 || (Random_GetControl() & 7) == 0)) {
             item->goal_anim_state = M_STATE_DUCKED;
         }
@@ -504,6 +495,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
 
@@ -521,9 +513,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by gun shots."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by gun shots."));
 }
 
 REGISTER_OBJECT(O_MP_2, M_Setup)

--- a/src/trx/game/objects/creatures/mummy.c
+++ b/src/trx/game/objects/creatures/mummy.c
@@ -86,7 +86,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 2)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -348,7 +348,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 2)->rot.z = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/patrol_dog.c
+++ b/src/trx/game/objects/creatures/patrol_dog.c
@@ -27,6 +27,11 @@
 #define M_AWARE_RANGE          SQUARE(3 * WALL_L) // = 0x900000
 // clang-format on
 
+typedef struct {
+    int32_t lunge_damage;
+    int32_t bite_damage;
+} M_PRIV;
+
 static BITE m_DogBite = {
     .pos = { .x = 0, .y = 0, .z = 100 },
     .mesh_num = 3,
@@ -63,17 +68,6 @@ static M_ANIM m_DeathAnims[4] = {
     M_ANIM_DEATH_1,
 };
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
-
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -88,6 +82,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t angle = 0;
     int16_t head = 0;
@@ -272,8 +267,7 @@ static void M_Control(const int16_t item_num)
             if (info.bite && item->touch_bits & M_LUNGE_TOUCH_BITS && frame >= 4
                 && frame <= 14) {
                 Creature_Effect(item, &m_DogBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "lunge_damage", M_LUNGE_DAMAGE), true);
+                Lara_TakeDamage(p->lunge_damage, true);
             }
             item->goal_anim_state = M_STATE_RUN;
             break;
@@ -288,8 +282,7 @@ static void M_Control(const int16_t item_num)
                 && ((frame >= 9 && frame <= 12)
                     || (frame >= 22 && frame <= 25))) {
                 Creature_Effect(item, &m_DogBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
             }
             break;
         }
@@ -307,6 +300,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -325,13 +319,14 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 2)->rot.x = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "lunge_damage", M_LUNGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the lunge attack."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the bite attack."));
 }
 
 REGISTER_OBJECT(O_PATROL_DOG, M_Setup)

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -37,6 +37,10 @@ typedef enum {
     M_ANIM_DEATH = 12,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_PierreGun1 = {
     .muzzle = { .pos = { 60, 200, 0 }, .mesh_num = 11, },
 };
@@ -44,16 +48,6 @@ static const CREATURE_GUN m_PierreGun2 = {
     .muzzle = { .pos = { -57, 200, 0 }, .mesh_num = 14, },
 };
 static int16_t m_PierreItemNum = NO_ITEM;
-
-static int32_t M_GetShotDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_SHOT_DAMAGE;
-}
 
 static bool M_CanDropItems(const ITEM *const item)
 {
@@ -73,6 +67,7 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (g_Config.gameplay.change_pierre_spawn) {
         if (m_PierreItemNum == NO_ITEM) {
@@ -205,12 +200,8 @@ static void M_Control(const int16_t item_num)
 
         case M_STATE_SHOOT:
             if (!item->required_anim_state) {
-                Creature_Shoot(
-                    item, &info, &m_PierreGun1, head,
-                    M_GetShotDamage(item) / 2);
-                Creature_Shoot(
-                    item, &info, &m_PierreGun2, head,
-                    M_GetShotDamage(item) / 2);
+                Creature_Shoot(item, &info, &m_PierreGun1, head, p->damage / 2);
+                Creature_Shoot(item, &info, &m_PierreGun2, head, p->damage / 2);
                 item->required_anim_state = M_STATE_AIM;
             }
             if (pierre->mood == MOOD_ESCAPE
@@ -262,6 +253,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
@@ -284,9 +276,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_SHOT_DAMAGE, "Damage dealt by shots."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_SHOT_DAMAGE, "Damage dealt by shots."));
 }
 
 REGISTER_OBJECT(O_PIERRE, M_Setup)

--- a/src/trx/game/objects/creatures/prisoner.c
+++ b/src/trx/game/objects/creatures/prisoner.c
@@ -53,21 +53,16 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t punch_1_damage;
+    int32_t punch_2_damage;
+    int32_t punch_3_damage;
+} M_PRIV;
+
 static const BITE m_Bite = {
     .pos = { 10, 10, 11 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -152,6 +147,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -384,9 +380,7 @@ static void M_Control(const int16_t item_num)
         if (enemy == lara_item) {
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_1_damage", M_PUNCH_1_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->punch_1_damage, true);
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -395,10 +389,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy,
-                    M_GetDamage(item, "punch_1_damage", M_PUNCH_1_DAMAGE) / 2,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->punch_1_damage / 2, IDF_NONE, item);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
@@ -416,9 +407,7 @@ static void M_Control(const int16_t item_num)
         if (enemy == lara_item) {
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_2_damage", M_PUNCH_2_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->punch_2_damage, true);
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -427,10 +416,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy,
-                    M_GetDamage(item, "punch_2_damage", M_PUNCH_2_DAMAGE) / 2,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->punch_2_damage / 2, IDF_NONE, item);
                 creature->flags = 1;
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
@@ -453,9 +439,7 @@ static void M_Control(const int16_t item_num)
         if (enemy == lara_item) {
             if (creature->flags != 2
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_3_damage", M_PUNCH_3_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->punch_3_damage, true);
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 2;
@@ -464,10 +448,7 @@ static void M_Control(const int16_t item_num)
             if (ABS(enemy->pos.x - item->pos.x) < STEP_L
                 && ABS(enemy->pos.y - item->pos.y) <= STEP_L
                 && ABS(enemy->pos.z - item->pos.z) < STEP_L) {
-                Item_TakeDamage(
-                    enemy,
-                    M_GetDamage(item, "punch_3_damage", M_PUNCH_3_DAMAGE) / 2,
-                    IDF_NONE, item);
+                Item_TakeDamage(enemy, p->punch_3_damage / 2, IDF_NONE, item);
                 Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 creature->flags = 2;
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
@@ -496,6 +477,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
@@ -516,14 +498,17 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "punch_1_damage", M_PUNCH_1_DAMAGE, "Damage dealt by punch 1."),
-        OBJECT_PROPERTY_INT(
-            "punch_2_damage", M_PUNCH_2_DAMAGE, "Damage dealt by punch 2."),
-        OBJECT_PROPERTY_INT(
-            "punch_3_damage", M_PUNCH_3_DAMAGE, "Damage dealt by punch 3."));
+        OBJECT_PROPERTY(
+            M_PRIV, punch_1_damage, M_PUNCH_1_DAMAGE,
+            "Damage dealt by punch 1."),
+        OBJECT_PROPERTY(
+            M_PRIV, punch_2_damage, M_PUNCH_2_DAMAGE,
+            "Damage dealt by punch 2."),
+        OBJECT_PROPERTY(
+            M_PRIV, punch_3_damage, M_PUNCH_3_DAMAGE,
+            "Damage dealt by punch 3."));
 }
 
 REGISTER_OBJECT(O_PRISONER, M_Setup)

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -64,6 +64,8 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t hit_damage;
+    int32_t swipe_damage;
     struct {
         bool initialised;
         bool on_fire;
@@ -75,17 +77,6 @@ static const BITE m_Bite = {
     .pos = { 16, 48, 320 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -514,7 +505,7 @@ static void M_Control(const int16_t item_num)
 
         creature->maximum_turn = M_WALK_TURN;
         if (creature->flags == 0 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            M_HitLara(item, M_GetDamage(item, "hit_damage", M_HIT_DAMAGE));
+            M_HitLara(item, p->hit_damage);
             creature->flags = 1;
         }
 
@@ -533,7 +524,7 @@ static void M_Control(const int16_t item_num)
 
         creature->maximum_turn = M_WALK_TURN;
         if (creature->flags != 2 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            M_HitLara(item, M_GetDamage(item, "swipe_damage", M_SWIPE_DAMAGE));
+            M_HitLara(item, p->swipe_damage);
             creature->flags = 2;
         }
         break;
@@ -582,12 +573,13 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "hit_damage", M_HIT_DAMAGE, "Damage dealt by punches 1 and 2."),
-        OBJECT_PROPERTY_INT(
-            "swipe_damage", M_SWIPE_DAMAGE, "Damage dealt by punch 3."));
+        OBJECT_PROPERTY(
+            M_PRIV, hit_damage, M_HIT_DAMAGE,
+            "Damage dealt by punches 1 and 2."),
+        OBJECT_PROPERTY(
+            M_PRIV, swipe_damage, M_SWIPE_DAMAGE, "Damage dealt by punch 3."));
 }
 
 REGISTER_OBJECT(O_PUNK_1, M_Setup)

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -42,21 +42,16 @@ typedef enum {
     M_ANIM_DEATH = 9,
 } M_ANIM;
 
+typedef struct {
+    int32_t lunge_damage;
+    int32_t charge_damage;
+    int32_t bite_damage;
+} M_PRIV;
+
 static BITE m_RaptorBite = {
     .pos = { 0, 66, 318 },
     .mesh_num = 22,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_CalculateTarget(const ITEM *const item)
 {
@@ -103,19 +98,20 @@ static void M_CalculateTarget(const ITEM *const item)
 
 static void M_Attack(ITEM *const item, const AI_INFO *const info)
 {
+    const M_PRIV *const p = item->priv;
     int32_t damage = 0;
     int16_t next_state = M_STATE_EMPTY;
     switch (item->current_anim_state) {
     case M_STATE_ATTACK_1:
-        damage = M_GetDamage(item, "lunge_damage", M_LUNGE_DAMAGE);
+        damage = p->lunge_damage;
         next_state = M_STATE_STOP;
         break;
     case M_STATE_ATTACK_2:
-        damage = M_GetDamage(item, "charge_damage", M_CHARGE_DAMAGE);
+        damage = p->charge_damage;
         next_state = M_STATE_RUN;
         break;
     case M_STATE_ATTACK_3:
-        damage = M_GetDamage(item, "bite_damage", M_BITE_DAMAGE);
+        damage = p->bite_damage;
         next_state = M_STATE_STOP;
         break;
     default:
@@ -321,6 +317,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -343,16 +341,17 @@ static void M_Setup(OBJECT *const obj)
     }
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "lunge_damage", M_LUNGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the lunge attack."),
-        OBJECT_PROPERTY_INT(
-            "charge_damage", M_CHARGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, charge_damage, M_CHARGE_DAMAGE,
             "Damage dealt by the charge attack."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the bite attack."));
 }
 
 REGISTER_OBJECT(O_RAPTOR, M_Setup)

--- a/src/trx/game/objects/creatures/rat.c
+++ b/src/trx/game/objects/creatures/rat.c
@@ -39,6 +39,11 @@ typedef enum {
     M_VOLE_STATE_DEATH = 3,
 } M_VOLE_STATE;
 
+typedef struct {
+    int32_t bite_damage;
+    int32_t charge_damage;
+} M_PRIV;
+
 static BITE m_RatBite = { .pos = { 0, -11, 108 }, .mesh_num = 3 };
 
 static const HYBRID_INFO m_RatInfo = {
@@ -51,17 +56,6 @@ static const HYBRID_INFO m_RatInfo = {
     .water.death_anim = M_VOLE_DIE_ANIM,
     .water.death_state = M_VOLE_STATE_DEATH,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
@@ -77,6 +71,7 @@ static void M_ControlRat(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const rat = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -124,8 +119,7 @@ static void M_ControlRat(const int16_t item_num)
             if (item->required_anim_state == M_RAT_STATE_EMPTY && info.ahead
                 && (item->touch_bits & M_RAT_TOUCH)) {
                 Creature_Effect(item, &m_RatBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_RAT_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 item->required_anim_state = M_RAT_STATE_STOP;
             }
             break;
@@ -134,9 +128,7 @@ static void M_ControlRat(const int16_t item_num)
             if (item->required_anim_state == M_RAT_STATE_EMPTY && info.ahead
                 && (item->touch_bits & M_RAT_TOUCH)) {
                 Creature_Effect(item, &m_RatBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "charge_damage", M_RAT_CHARGE_DAMAGE),
-                    true);
+                Lara_TakeDamage(p->charge_damage, true);
                 item->required_anim_state = M_RAT_STATE_RUN;
             }
             break;
@@ -164,6 +156,7 @@ static void M_ControlVole(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     int16_t head = 0;
     int16_t angle = 0;
 
@@ -202,8 +195,7 @@ static void M_ControlVole(const int16_t item_num)
             if (item->required_anim_state == M_VOLE_STATE_EMPTY && info.ahead
                 && (item->touch_bits & M_RAT_TOUCH)) {
                 Creature_Effect(item, &m_RatBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_RAT_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 item->required_anim_state = M_VOLE_STATE_SWIM;
             }
             item->goal_anim_state = M_VOLE_STATE_EMPTY;
@@ -234,6 +226,7 @@ static void M_ControlVole(const int16_t item_num)
 
 static void M_SetupBase(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
@@ -251,13 +244,13 @@ static void M_SetupBase(OBJECT *const obj)
     Object_GetBone(obj, 1)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_RAT_HITPOINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_RAT_BITE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_RAT_BITE_DAMAGE,
             "Damage dealt by the bite attack."),
-        OBJECT_PROPERTY_INT(
-            "charge_damage", M_RAT_CHARGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, charge_damage, M_RAT_CHARGE_DAMAGE,
             "Damage dealt by the charge attack."));
 }
 

--- a/src/trx/game/objects/creatures/rx_worker_1.c
+++ b/src/trx/game/objects/creatures/rx_worker_1.c
@@ -58,6 +58,10 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Gun = {
     .muzzle = { .pos = { 0, 160, 40 }, .mesh_num = 13 },
     .tr3_enemy_flash = true,
@@ -67,19 +71,10 @@ static const CREATURE_GUN m_Gun = {
     .tr3_flash_rot_x = -DEG_90,
 };
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
-
 static void M_FireFinalShot(
     ITEM *const item, int16_t *const head, int16_t *const torso_y)
 {
+    const M_PRIV *const p = item->priv;
     if (!Item_TestFrameEqual(item, 47)) {
         return;
     }
@@ -92,7 +87,7 @@ static void M_FireFinalShot(
 
     *head = info.angle;
     *torso_y = info.angle;
-    Creature_Shoot(item, &info, &m_Gun, info.angle, M_GetDamage(item) * 3);
+    Creature_Shoot(item, &info, &m_Gun, info.angle, p->damage * 3);
     Sound_Effect(SFX_LONDON_SWAT_FIRE, &item->pos, SPM_NORMAL);
 }
 
@@ -121,6 +116,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -299,8 +295,7 @@ static void M_Control(const int16_t item_num)
 
         if (anim_idx == M_ANIM_SHOOT_1
             || (anim_idx == M_ANIM_AIM_1 && frame_idx == 10)) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->required_anim_state = M_STATE_WAIT;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -327,8 +322,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -345,8 +339,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0 || frame_idx == 11) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -363,8 +356,7 @@ static void M_Control(const int16_t item_num)
 
         if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 16)
             || (anim_idx == M_ANIM_AIM_4B && frame_idx == 6)) {
-            if (!Creature_Shoot(
-                    item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
                 item->required_anim_state = M_STATE_WALK;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -389,8 +381,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 16
-            && !Creature_Shoot(
-                item, &info, &m_Gun, torso_y, M_GetDamage(item))) {
+            && !Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)) {
             item->goal_anim_state = M_STATE_WALK;
         }
 
@@ -435,7 +426,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0) {
-            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, M_GetDamage(item))
+            if (!Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage)
                 || (Random_GetControl() & 7) == 0) {
                 item->goal_anim_state = M_STATE_DUCKED;
             }
@@ -481,6 +472,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
 
@@ -498,9 +490,9 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by shots."));
+        OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."));
 }
 
 REGISTER_OBJECT(O_RX_WORKER_1, M_Setup)

--- a/src/trx/game/objects/creatures/rx_worker_2.c
+++ b/src/trx/game/objects/creatures/rx_worker_2.c
@@ -39,6 +39,10 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Gun = {
     .muzzle = { .pos = { 0, 400, 64 }, .mesh_num = 7 },
     .tr3_enemy_flash = true,
@@ -47,16 +51,6 @@ static const CREATURE_GUN m_Gun = {
     .tr3_flash_shade = 600,
     .tr3_flash_rot_x = -DEG_90,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -91,6 +85,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t tilt = 0;
     int16_t angle = 0;
@@ -294,7 +289,7 @@ static void M_Control(const int16_t item_num)
         if (creature->flags != 0) {
             creature->flags--;
         } else {
-            Creature_Shoot(item, &info, &m_Gun, torso_y, M_GetDamage(item));
+            Creature_Shoot(item, &info, &m_Gun, torso_y, p->damage);
             creature->flags = 5;
         }
         break;
@@ -347,6 +342,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
@@ -365,9 +361,9 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by shots."));
+        OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."));
 }
 
 REGISTER_OBJECT(O_RX_WORKER_2, M_Setup)

--- a/src/trx/game/objects/creatures/rx_worker_3.c
+++ b/src/trx/game/objects/creatures/rx_worker_3.c
@@ -540,7 +540,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/security_guard.c
+++ b/src/trx/game/objects/creatures/security_guard.c
@@ -60,6 +60,11 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t final_shot_damage;
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_GuardGun = {
     .muzzle = { .pos = { 0, 160, 40 }, .mesh_num = 13 },
     .tr3_enemy_flash = true,
@@ -69,20 +74,10 @@ static const CREATURE_GUN m_GuardGun = {
     .tr3_flash_rot_x = -DEG_90,
 };
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
-
 static void M_FireFinalShot(
     ITEM *const item, int16_t *const head, int16_t *const torso_y)
 {
+    const M_PRIV *const p = item->priv;
     const int16_t frame_idx = Item_GetRelativeFrame(item);
     if (frame_idx != 3 && frame_idx != 28) {
         return;
@@ -97,9 +92,7 @@ static void M_FireFinalShot(
 
     *head = info.angle;
     *torso_y = info.angle;
-    Creature_Shoot(
-        item, &info, &m_GuardGun, info.angle,
-        M_GetDamage(item, "final_shot_damage", M_FINAL_SHOT_DAMAGE));
+    Creature_Shoot(item, &info, &m_GuardGun, info.angle, p->final_shot_damage);
     Sound_Effect(SFX_SECURITY_GUARD_FIRE, &item->pos, SPM_NORMAL);
 }
 
@@ -128,6 +121,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -309,9 +303,7 @@ static void M_Control(const int16_t item_num)
 
         if (anim_idx == M_ANIM_AIM_1
             || (anim_idx == M_ANIM_SHOOT_1 && frame_idx == 10)) {
-            if (!Creature_Shoot(
-                    item, &info, &m_GuardGun, torso_y,
-                    M_GetDamage(item, "damage", M_DAMAGE))) {
+            if (!Creature_Shoot(item, &info, &m_GuardGun, torso_y, p->damage)) {
                 item->required_anim_state = M_STATE_WAIT;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -338,9 +330,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0) {
-            if (!Creature_Shoot(
-                    item, &info, &m_GuardGun, torso_y,
-                    M_GetDamage(item, "damage", M_DAMAGE))) {
+            if (!Creature_Shoot(item, &info, &m_GuardGun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -357,9 +347,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 0 || frame_idx == 11) {
-            if (!Creature_Shoot(
-                    item, &info, &m_GuardGun, torso_y,
-                    M_GetDamage(item, "damage", M_DAMAGE))) {
+            if (!Creature_Shoot(item, &info, &m_GuardGun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WAIT;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -376,9 +364,7 @@ static void M_Control(const int16_t item_num)
 
         if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 16)
             || (anim_idx == M_ANIM_AIM_4B && frame_idx == 6)) {
-            if (!Creature_Shoot(
-                    item, &info, &m_GuardGun, torso_y,
-                    M_GetDamage(item, "damage", M_DAMAGE))) {
+            if (!Creature_Shoot(item, &info, &m_GuardGun, torso_y, p->damage)) {
                 item->goal_anim_state = M_STATE_WALK;
             }
         } else if (M_ShouldDuck(item, near_cover)) {
@@ -403,9 +389,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (frame_idx == 16
-            && !Creature_Shoot(
-                item, &info, &m_GuardGun, torso_y,
-                M_GetDamage(item, "damage", M_DAMAGE))) {
+            && !Creature_Shoot(item, &info, &m_GuardGun, torso_y, p->damage)) {
             item->goal_anim_state = M_STATE_WALK;
         }
 
@@ -453,9 +437,7 @@ static void M_Control(const int16_t item_num)
             break;
         }
 
-        if (!Creature_Shoot(
-                item, &info, &m_GuardGun, torso_y,
-                M_GetDamage(item, "damage", M_DAMAGE))
+        if (!Creature_Shoot(item, &info, &m_GuardGun, torso_y, p->damage)
             || (Random_GetControl() & 7) == 0) {
             item->goal_anim_state = M_STATE_DUCKED;
         }
@@ -492,6 +474,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -509,11 +492,11 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by shots."),
-        OBJECT_PROPERTY_INT(
-            "final_shot_damage", M_FINAL_SHOT_DAMAGE,
+        OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."),
+        OBJECT_PROPERTY(
+            M_PRIV, final_shot_damage, M_FINAL_SHOT_DAMAGE,
             "Damage dealt by the death-state final shot."));
 }
 

--- a/src/trx/game/objects/creatures/shark.c
+++ b/src/trx/game/objects/creatures/shark.c
@@ -38,20 +38,14 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_SharkBite = {
     .pos = { .x = 17, .y = -22, .z = 344 },
     .mesh_num = 12,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -60,6 +54,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     const ITEM *const lara_item = Lara_GetItem();
@@ -129,7 +124,7 @@ static void M_Control(const int16_t item_num)
 
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_SharkBite, Spawn_Blood);
                 creature->flags = 1;
             }
@@ -158,6 +153,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Creature_Collision;
@@ -177,10 +173,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 9)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by bite attacks."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by bite attacks."));
 }
 
 REGISTER_OBJECT(O_SHARK, M_Setup)

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -44,6 +44,8 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t pincer_damage;
+    int32_t chopper_damage;
     int32_t effect_mesh;
 } M_PRIV;
 
@@ -55,17 +57,6 @@ static BITE m_LeftBlade = {
     .pos = { 0, 0, 920 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static bool M_ShouldSpawnBlood(const ITEM *const item)
 {
@@ -425,9 +416,7 @@ static void M_Control(const int16_t item_num)
                 head_y = info.angle;
             }
             creature->maximum_turn = M_WALK_TURN;
-            M_Damage(
-                item, creature,
-                M_GetDamage(item, "pincer_damage", M_PINCER_DAMAGE));
+            M_Damage(item, creature, p->pincer_damage);
             break;
 
         case M_STATE_KILL: {
@@ -450,9 +439,7 @@ static void M_Control(const int16_t item_num)
                 torso_x = info.x_angle;
             }
             creature->maximum_turn = M_WALK_TURN;
-            M_Damage(
-                item, creature,
-                M_GetDamage(item, "chopper_damage", M_CHOPPER_DAMAGE));
+            M_Damage(item, creature, p->chopper_damage);
             break;
 
         case M_STATE_WALK_BACK:
@@ -537,13 +524,13 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 25)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "pincer_damage", M_PINCER_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, pincer_damage, M_PINCER_DAMAGE,
             "Damage dealt by the pincer attack."),
-        OBJECT_PROPERTY_INT(
-            "chopper_damage", M_CHOPPER_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, chopper_damage, M_CHOPPER_DAMAGE,
             "Damage dealt by the chopper attack."));
 }
 

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -39,6 +39,8 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t stop_shot_damage;
+    int32_t skate_shot_damage;
     int16_t skateboard_item_num;
     bool speech_started;
 } M_PRIV;
@@ -61,17 +63,6 @@ static const CREATURE_GUN m_KidGun1 = {
 static const CREATURE_GUN m_KidGun2 = {
     .muzzle = { .pos = { 0, 150, 37 }, .mesh_num = 4 },
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -181,9 +172,8 @@ static void M_Control(const int16_t item_num)
             if (!kid->flags && Creature_CanTargetEnemy(item, &info)) {
                 const int32_t damage =
                     item->current_anim_state == M_STATE_SHOOT_1
-                    ? M_GetDamage(item, "stop_shot_damage", M_STOP_SHOT_DAMAGE)
-                    : M_GetDamage(
-                          item, "skate_shot_damage", M_SKATE_SHOT_DAMAGE);
+                    ? p->stop_shot_damage
+                    : p->skate_shot_damage;
                 Creature_Shoot(item, &info, &m_KidGun1, head, damage);
 
                 Creature_Shoot(item, &info, &m_KidGun2, head, damage);
@@ -245,13 +235,13 @@ static void M_Setup(OBJECT *const obj)
     }
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "stop_shot_damage", M_STOP_SHOT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, stop_shot_damage, M_STOP_SHOT_DAMAGE,
             "Damage dealt by shots while stopped."),
-        OBJECT_PROPERTY_INT(
-            "skate_shot_damage", M_SKATE_SHOT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, skate_shot_damage, M_SKATE_SHOT_DAMAGE,
             "Damage dealt by shots while skating."));
 }
 

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -35,18 +35,9 @@ typedef enum {
 
 typedef struct {
     int16_t skidoo_item_num;
+    int32_t shot_damage;
+    int32_t mounted_shot_damage;
 } M_PRIV;
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_KillDriver(ITEM *const driver_item, const ITEM *const skidoo_item)
 {
@@ -161,9 +152,10 @@ static int16_t M_ControlAlive(ITEM *const driver_item, ITEM *const skidoo_item)
         const ITEM *const lara_item = Lara_GetItem();
         if (driver_data->flags == 0 && ABS(info.angle) < M_TARGET_ANGLE
             && lara_item->hit_points > 0) {
+            const M_PRIV *const p = driver_item->priv;
             const int32_t damage = Lara_Vehicle_IsMounted()
-                ? M_GetDamage(driver_item, "mounted_shot_damage", M_SHOT_DAMAGE)
-                : M_GetDamage(driver_item, "shot_damage", M_LARA_DAMAGE);
+                ? p->mounted_shot_damage
+                : p->shot_damage;
 
             const bool left_targetable = Creature_Shoot(
                 skidoo_item, &info,
@@ -312,12 +304,12 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 1, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "shot_damage", M_LARA_DAMAGE,
+        obj, OBJECT_PROPERTY_STORED("max_hit_points", 1, "Maximum hit points."),
+        OBJECT_PROPERTY(
+            M_PRIV, shot_damage, M_LARA_DAMAGE,
             "Damage dealt by shots when Lara is not mounted."),
-        OBJECT_PROPERTY_INT(
-            "mounted_shot_damage", M_SHOT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, mounted_shot_damage, M_SHOT_DAMAGE,
             "Damage dealt by shots when Lara is mounted."));
 }
 

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -938,24 +938,24 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "knockback_damage", SOPHIA_KNOCKBACK_DAMAGE,
             "Damage dealt by the knockback shockwave."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "laser_bolt_damage", SOPHIA_LASER_BOLT_DAMAGE,
             "Damage dealt by regular laser bolt direct hits."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "big_laser_bolt_damage", SOPHIA_BIG_LASER_BOLT_DAMAGE,
             "Damage dealt by the big laser bolt direct hit."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "laser_bolt_splash_damage", SOPHIA_LASER_BOLT_SPLASH_DAMAGE,
             "Maximum splash damage dealt by regular laser bolts."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "big_laser_bolt_splash_damage", SOPHIA_BIG_LASER_BOLT_SPLASH_DAMAGE,
             "Maximum splash damage dealt by the big laser bolt."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "plasma_ball_damage", SOPHIA_PLASMA_BALL_DAMAGE,
             "Damage dealt by plasma ball direct hits."));
 }

--- a/src/trx/game/objects/creatures/spider.c
+++ b/src/trx/game/objects/creatures/spider.c
@@ -33,20 +33,14 @@ typedef enum {
     M_ANIM_LEAP = 2,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_SpiderBite = {
     .pos = { .x = 0, .y = 0, .z = 41 },
     .mesh_num = 1,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Leap(const int16_t item_num, const int16_t angle)
 {
@@ -74,6 +68,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t angle = 0;
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     if (item->hit_points > 0) {
@@ -131,7 +126,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK_3:
             if (creature->flags == 0 && item->touch_bits != 0) {
                 Creature_Effect(item, &m_SpiderBite, Spawn_Blood);
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 creature->flags = 1;
             }
             break;
@@ -157,6 +152,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -172,10 +168,10 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by bite attacks."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by bite attacks."));
 }
 
 REGISTER_OBJECT(O_SPIDER, M_Setup)

--- a/src/trx/game/objects/creatures/swat.c
+++ b/src/trx/game/objects/creatures/swat.c
@@ -44,6 +44,11 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t final_shot_damage;
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_SwatGun = {
     .muzzle = { .pos = { 0, 300, 64 }, .mesh_num = 7 },
     .tr3_enemy_flash = true,
@@ -60,17 +65,6 @@ static const CREATURE_GUN m_SwatGun = {
         .width = 2.0f,
     },
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -91,6 +85,7 @@ static void M_TriggerLaser(const ITEM *const item)
 static void M_FireFinalShot(
     ITEM *const item, int16_t *const head, int16_t *const torso_y)
 {
+    const M_PRIV *const p = item->priv;
     const int16_t frame_idx = Item_GetRelativeFrame(item);
     if (frame_idx <= 44 || frame_idx >= 52 || (item->frame_num & 3) != 0) {
         return;
@@ -105,9 +100,7 @@ static void M_FireFinalShot(
 
     *head = info.angle;
     *torso_y = info.angle;
-    Creature_Shoot(
-        item, &info, &m_SwatGun, info.angle,
-        M_GetDamage(item, "final_shot_damage", M_FINAL_SHOT_DAMAGE));
+    Creature_Shoot(item, &info, &m_SwatGun, info.angle, p->final_shot_damage);
     const SAMPLE_TRX_ID fire_sfx = item->object_id == O_SWAT_3
         ? SFX_AMERICAN_SWAT_FIRE
         : SFX_LONDON_SWAT_FIRE;
@@ -121,6 +114,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
@@ -345,9 +339,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (creature->flags == 0) {
-            Creature_Shoot(
-                item, &info, &m_SwatGun, torso_y,
-                M_GetDamage(item, "damage", M_DAMAGE));
+            Creature_Shoot(item, &info, &m_SwatGun, torso_y, p->damage);
             creature->flags = 5;
         } else {
             creature->flags--;
@@ -374,6 +366,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->collision_func = Creature_Collision;
     obj->control_func = M_Control;
@@ -392,11 +385,11 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by shots."),
-        OBJECT_PROPERTY_INT(
-            "final_shot_damage", M_FINAL_SHOT_DAMAGE,
+        OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."),
+        OBJECT_PROPERTY(
+            M_PRIV, final_shot_damage, M_FINAL_SHOT_DAMAGE,
             "Damage dealt by the death-state final shot."));
 }
 

--- a/src/trx/game/objects/creatures/tiger.c
+++ b/src/trx/game/objects/creatures/tiger.c
@@ -37,20 +37,14 @@ typedef enum {
     M_ANIM_DEATH = 11,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_TigerBite = {
     .pos = { .x = 19, .y = -13, .z = 3 },
     .mesh_num = 26,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -59,6 +53,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -166,7 +161,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_ATTACK_3:
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(M_GetDamage(item), true);
+                Lara_TakeDamage(p->damage, true);
                 Creature_Effect(item, &m_TigerBite, Spawn_Blood);
                 creature->flags = 1;
             }
@@ -191,6 +186,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -207,10 +203,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 21)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by bite attacks."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by bite attacks."));
 }
 
 REGISTER_OBJECT(O_TIGER, M_Setup)

--- a/src/trx/game/objects/creatures/tony.c
+++ b/src/trx/game/objects/creatures/tony.c
@@ -644,9 +644,9 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "fire_ball_damage", TONY_FIRE_BALL_DAMAGE,
             "Damage dealt by direct fire ball hits."));
 }

--- a/src/trx/game/objects/creatures/torso.c
+++ b/src/trx/game/objects/creatures/torso.c
@@ -53,16 +53,11 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
+typedef struct {
+    int32_t touch_damage;
+    int32_t attack_damage;
+    int32_t part_damage;
+} M_PRIV;
 
 static void M_KillLara(ITEM *const item)
 {
@@ -78,6 +73,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const torso = item->creature_data;
     int16_t head = 0;
     ITEM *const lara_item = Lara_GetItem();
@@ -103,8 +99,7 @@ static void M_Control(const int16_t item_num)
             - item->rot.y;
 
         if (item->touch_bits) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "touch_damage", M_TOUCH_DAMAGE), true);
+            Lara_TakeDamage(p->touch_damage, true);
         }
 
         switch (item->current_anim_state) {
@@ -125,9 +120,7 @@ static void M_Control(const int16_t item_num)
                 item->goal_anim_state = M_STATE_TURN_L;
             } else if (info.distance >= M_ATTACK_RANGE) {
                 item->goal_anim_state = M_STATE_FORWARD;
-            } else if (
-                lara_item->hit_points
-                > M_GetDamage(item, "attack_damage", M_ATTACK_DAMAGE)) {
+            } else if (lara_item->hit_points > p->attack_damage) {
                 if (Random_GetControl() < 0x4000) {
                     item->goal_anim_state = M_STATE_ATTACK_1;
                 } else {
@@ -188,16 +181,14 @@ static void M_Control(const int16_t item_num)
 
         case M_STATE_ATTACK_1:
             if (!torso->flags && (item->touch_bits & M_TOUCH_RIGHT)) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "attack_damage", M_ATTACK_DAMAGE), true);
+                Lara_TakeDamage(p->attack_damage, true);
                 torso->flags = 1;
             }
             break;
 
         case M_STATE_ATTACK_2:
             if (!torso->flags && (item->touch_bits & M_TOUCH)) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "attack_damage", M_ATTACK_DAMAGE), true);
+                Lara_TakeDamage(p->attack_damage, true);
                 torso->flags = 1;
             }
             break;
@@ -233,8 +224,7 @@ static void M_Control(const int16_t item_num)
 
     if (item->is_finished) {
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
-        Item_Shatter(
-            item_num, -1, M_GetDamage(item, "part_damage", M_PART_DAMAGE));
+        Item_Shatter(item_num, -1, p->part_damage);
         Room_TestTriggers(item);
 
         Item_Destroy(item_num);
@@ -247,6 +237,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -263,14 +255,16 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 1)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "touch_damage", M_TOUCH_DAMAGE, "Damage dealt by body contact."),
-        OBJECT_PROPERTY_INT(
-            "attack_damage", M_ATTACK_DAMAGE, "Damage dealt by swipe attacks."),
-        OBJECT_PROPERTY_INT(
-            "part_damage", M_PART_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, touch_damage, M_TOUCH_DAMAGE,
+            "Damage dealt by body contact."),
+        OBJECT_PROPERTY(
+            M_PRIV, attack_damage, M_ATTACK_DAMAGE,
+            "Damage dealt by swipe attacks."),
+        OBJECT_PROPERTY(
+            M_PRIV, part_damage, M_PART_DAMAGE,
             "Damage dealt by the death explosion."));
 }
 

--- a/src/trx/game/objects/creatures/trex.c
+++ b/src/trx/game/objects/creatures/trex.c
@@ -43,20 +43,16 @@ typedef enum {
     M_STATE_KILL,
 } M_STATE;
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
+typedef struct {
+    int32_t bite_damage;
+    int32_t trample_damage;
+    int32_t touch_damage;
+} M_PRIV;
 
 static void M_KillLara(ITEM *const item)
 {
-    Lara_TakeDamage(M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+    const M_PRIV *const p = item->priv;
+    Lara_TakeDamage(p->bite_damage, true);
     Creature_SpecialKill(item, M_ANIM_KILL, M_STATE_KILL, LS_EXTRA_TREX_KILL);
     Lara_Skin_SwapAllExtra(LS_EXTRA_TREX_KILL);
 }
@@ -79,6 +75,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -101,11 +98,9 @@ static void M_Control(const int16_t item_num)
 
     if (item->touch_bits != 0) {
         if (item->current_anim_state == M_STATE_RUN) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "trample_damage", M_TRAMPLE_DAMAGE), false);
+            Lara_TakeDamage(p->trample_damage, false);
         } else {
-            Lara_TakeDamage(
-                M_GetDamage(item, "touch_damage", M_TOUCH_DAMAGE), false);
+            Lara_TakeDamage(p->touch_damage, false);
         }
     }
 
@@ -182,6 +177,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     if (g_TRVersion == 1) {
         obj->initialise_func = Creature_Initialise;
     }
@@ -204,15 +200,17 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 11)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "touch_damage", M_TOUCH_DAMAGE, "Damage dealt by body contact."),
-        OBJECT_PROPERTY_INT(
-            "trample_damage", M_TRAMPLE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, touch_damage, M_TOUCH_DAMAGE,
+            "Damage dealt by body contact."),
+        OBJECT_PROPERTY(
+            M_PRIV, trample_damage, M_TRAMPLE_DAMAGE,
             "Damage dealt while trampling."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the bite attack."));
 }
 
 REGISTER_OBJECT(O_TREX, M_Setup)

--- a/src/trx/game/objects/creatures/trex_alpha.c
+++ b/src/trx/game/objects/creatures/trex_alpha.c
@@ -57,6 +57,10 @@ typedef enum {
 } M_STATE;
 
 typedef struct {
+    int32_t bite_damage;
+    int32_t raptor_damage;
+    int32_t trample_damage;
+    int32_t touch_damage;
     int32_t aggression_timer;
     int32_t distraction_count;
 } M_PRIV;
@@ -65,17 +69,6 @@ static BITE m_Bite = {
     .pos = { .x = 0, .y = 32, .z = 64 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -93,7 +86,8 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
 
 static void M_KillLara(ITEM *const item)
 {
-    Lara_TakeDamage(M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+    const M_PRIV *const p = item->priv;
+    Lara_TakeDamage(p->bite_damage, true);
     Creature_SpecialKill(item, M_ANIM_KILL, M_STATE_KILL, LS_EXTRA_TREX_KILL);
     Lara_Skin_SwapAllExtra(LS_EXTRA_TREX_KILL);
 }
@@ -178,14 +172,13 @@ static bool M_CanAttack(const ITEM *const item, const ITEM *const target)
 
 static void M_Attack(ITEM *const item, ITEM *const target)
 {
+    const M_PRIV *const p = item->priv;
     if (target == Lara_GetItem()) {
         Creature_Effect(item, &m_Bite, Spawn_Blood);
         M_KillLara(item);
     } else if (target->object_id == O_RAPTOR) {
         Creature_Effect(item, &m_Bite, Spawn_Blood);
-        Item_TakeDamage(
-            target, M_GetDamage(item, "raptor_damage", M_RAPTOR_DAMAGE),
-            IDF_NONE, item);
+        Item_TakeDamage(target, p->raptor_damage, IDF_NONE, item);
     } else if (target->object_id == O_FLARE_ITEM) {
         target->hit_points = M_FLARE_SEEN;
     }
@@ -230,11 +223,9 @@ static void M_Control(const int16_t item_num)
 
     if (item->touch_bits != 0) {
         if (item->current_anim_state == M_STATE_RUN) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "trample_damage", M_TRAMPLE_DAMAGE), false);
+            Lara_TakeDamage(p->trample_damage, false);
         } else {
-            Lara_TakeDamage(
-                M_GetDamage(item, "touch_damage", M_TOUCH_DAMAGE), false);
+            Lara_TakeDamage(p->touch_damage, false);
         }
     }
 
@@ -414,17 +405,19 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 22)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "touch_damage", M_TOUCH_DAMAGE, "Damage dealt by body contact."),
-        OBJECT_PROPERTY_INT(
-            "trample_damage", M_TRAMPLE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, touch_damage, M_TOUCH_DAMAGE,
+            "Damage dealt by body contact."),
+        OBJECT_PROPERTY(
+            M_PRIV, trample_damage, M_TRAMPLE_DAMAGE,
             "Damage dealt while trampling."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."),
-        OBJECT_PROPERTY_INT(
-            "raptor_damage", M_RAPTOR_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the bite attack."),
+        OBJECT_PROPERTY(
+            M_PRIV, raptor_damage, M_RAPTOR_DAMAGE,
             "Damage dealt to raptors by the bite attack."));
 }
 

--- a/src/trx/game/objects/creatures/tribe_axeman.c
+++ b/src/trx/game/objects/creatures/tribe_axeman.c
@@ -29,6 +29,12 @@
 // clang-format on
 
 typedef struct {
+    int32_t attack_2_damage;
+    int32_t attack_3_damage;
+    int32_t attack_4_damage;
+    int32_t attack_5_damage;
+    int32_t attack_6_damage;
+    int32_t enemy_damage;
     bool wants_wait_2;
 } M_PRIV;
 
@@ -79,34 +85,24 @@ static M_HIT_FRAME m_HitFrames[13] = {
     { .start_frame = 15, .end_frame = 19 },
 };
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
-
 static int32_t M_GetAttackDamage(const ITEM *const item)
 {
+    const M_PRIV *const p = item->priv;
     switch (item->current_anim_state) {
     case M_STATE_ATTACK_2:
-        return M_GetDamage(item, "attack_2_damage", M_ATTACK_2_DAMAGE);
+        return p->attack_2_damage;
 
     case M_STATE_ATTACK_3:
-        return M_GetDamage(item, "attack_3_damage", M_ATTACK_3_DAMAGE);
+        return p->attack_3_damage;
 
     case M_STATE_ATTACK_4:
-        return M_GetDamage(item, "attack_4_damage", M_ATTACK_4_DAMAGE);
+        return p->attack_4_damage;
 
     case M_STATE_ATTACK_5:
-        return M_GetDamage(item, "attack_5_damage", M_ATTACK_5_DAMAGE);
+        return p->attack_5_damage;
 
     case M_STATE_ATTACK_6:
-        return M_GetDamage(item, "attack_6_damage", M_ATTACK_6_DAMAGE);
+        return p->attack_6_damage;
 
     default:
         return 0;
@@ -289,9 +285,7 @@ static void M_Control(const int16_t item_num)
                 if (Item_IsNearby(enemy, item, M_HIT_RANGE)) {
                     if (creature->flags >= hit_frame->start_frame
                         && creature->flags <= hit_frame->end_frame) {
-                        Item_TakeDamage(
-                            enemy, M_GetDamage(item, "enemy_damage", 2),
-                            IDF_NONE, item);
+                        Item_TakeDamage(enemy, p->enemy_damage, IDF_NONE, item);
                         Creature_Effect(item, &m_AxeHit, Spawn_Blood);
                         Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                     }
@@ -371,20 +365,25 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "attack_2_damage", M_ATTACK_2_DAMAGE, "Damage dealt by attack 2."),
-        OBJECT_PROPERTY_INT(
-            "attack_3_damage", M_ATTACK_3_DAMAGE, "Damage dealt by attack 3."),
-        OBJECT_PROPERTY_INT(
-            "attack_4_damage", M_ATTACK_4_DAMAGE, "Damage dealt by attack 4."),
-        OBJECT_PROPERTY_INT(
-            "attack_5_damage", M_ATTACK_5_DAMAGE, "Damage dealt by attack 5."),
-        OBJECT_PROPERTY_INT(
-            "attack_6_damage", M_ATTACK_6_DAMAGE, "Damage dealt by attack 6."),
-        OBJECT_PROPERTY_INT(
-            "enemy_damage", 2, "Damage dealt to non-player targets."));
+        OBJECT_PROPERTY(
+            M_PRIV, attack_2_damage, M_ATTACK_2_DAMAGE,
+            "Damage dealt by attack 2."),
+        OBJECT_PROPERTY(
+            M_PRIV, attack_3_damage, M_ATTACK_3_DAMAGE,
+            "Damage dealt by attack 3."),
+        OBJECT_PROPERTY(
+            M_PRIV, attack_4_damage, M_ATTACK_4_DAMAGE,
+            "Damage dealt by attack 4."),
+        OBJECT_PROPERTY(
+            M_PRIV, attack_5_damage, M_ATTACK_5_DAMAGE,
+            "Damage dealt by attack 5."),
+        OBJECT_PROPERTY(
+            M_PRIV, attack_6_damage, M_ATTACK_6_DAMAGE,
+            "Damage dealt by attack 6."),
+        OBJECT_PROPERTY(
+            M_PRIV, enemy_damage, 2, "Damage dealt to non-player targets."));
 }
 
 REGISTER_OBJECT(O_TRIBE_AXEMAN, M_Setup)

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -62,6 +62,7 @@ typedef struct {
 } M_LIZARD_SUMMON_COORDS;
 
 typedef struct {
+    int32_t head_beam_damage;
     uint8_t dead;
     int16_t attack_count;
     int16_t death_count;
@@ -106,17 +107,6 @@ static int32_t m_DeathDist[5] = {};
 static int32_t m_DeathHeights[5] = {};
 
 static M_SHARED_PRIV m_SharedPriv = {};
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static int16_t M_FindLizard(const int16_t room_num)
 {
@@ -546,9 +536,7 @@ static void M_TriggerElectricBeam(
             && M_LaraOnLOS(src, &target)
             && !g_Config.debug.enable_invulnerability
             && lara_info->water_status != LWS_CHEAT) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "head_beam_damage", M_HEAD_BEAM_DAMAGE),
-                true);
+            Lara_TakeDamage(p->head_beam_damage, true);
             if (lara_item->hit_points <= 0) {
                 lara_info->electric = 1;
             }
@@ -1473,10 +1461,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.x = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "head_beam_damage", M_HEAD_BEAM_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, head_beam_damage, M_HEAD_BEAM_DAMAGE,
             "Damage dealt by the head electric beam."));
 }
 

--- a/src/trx/game/objects/creatures/tribe_pipeman.c
+++ b/src/trx/game/objects/creatures/tribe_pipeman.c
@@ -44,6 +44,11 @@ typedef enum {
     M_STATE_WAIT_2
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+    int32_t enemy_damage;
+} M_PRIV;
+
 static BITE m_BiffHit = {
     .pos = { .x = 0, .y = 0, .z = -200 },
     .mesh_num = 13,
@@ -52,17 +57,6 @@ static BITE m_ShootHit = {
     .pos = { .x = 8, .y = 40, .z = -248 },
     .mesh_num = 13,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_SpawnDart(ITEM *const item)
 {
@@ -124,6 +118,7 @@ static void M_Control(const int16_t item_num)
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t angle = 0;
     int16_t tilt = 0;
@@ -293,18 +288,14 @@ static void M_Control(const int16_t item_num)
             if (enemy == lara_item) {
                 if (!(creature->flags & 0xF000)
                     && item->touch_bits & M_TOUCH_BITS) {
-                    Lara_TakeDamage(
-                        M_GetDamage(item, "damage", M_BIFF_DAMAGE), true);
+                    Lara_TakeDamage(p->damage, true);
                     creature->flags |= 0x1000;
                     Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                     Creature_Effect(item, &m_BiffHit, Spawn_Blood);
                 }
             } else if (!(creature->flags & 0xF000) && enemy != nullptr) {
                 if (Item_IsNearby(enemy, item, M_HIT_RANGE)) {
-                    Item_TakeDamage(
-                        enemy,
-                        M_GetDamage(item, "enemy_damage", M_BIFF_ENEMY_DAMAGE),
-                        IDF_NONE, item);
+                    Item_TakeDamage(enemy, p->enemy_damage, IDF_NONE, item);
                     creature->flags |= 0x1000;
                     Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                 }
@@ -370,6 +361,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -389,12 +381,12 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.x = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_BIFF_DAMAGE, "Damage dealt by melee attacks."),
-        OBJECT_PROPERTY_INT(
-            "enemy_damage", M_BIFF_ENEMY_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_BIFF_DAMAGE, "Damage dealt by melee attacks."),
+        OBJECT_PROPERTY(
+            M_PRIV, enemy_damage, M_BIFF_ENEMY_DAMAGE,
             "Damage dealt to non-player targets."));
 }
 

--- a/src/trx/game/objects/creatures/wasp_mutant.c
+++ b/src/trx/game/objects/creatures/wasp_mutant.c
@@ -40,6 +40,7 @@ typedef enum {
 } M_ANIM;
 
 typedef struct {
+    int32_t damage;
     int16_t light;
 } M_PRIV;
 
@@ -47,16 +48,6 @@ static const BITE m_Sting = {
     .pos = {},
     .mesh_num = 12,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -183,6 +174,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
     int16_t angle = 0;
 
@@ -248,7 +240,7 @@ static void M_Control(const int16_t item_num)
         }
 
         if (creature->flags == 0 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             Creature_Effect(item, &m_Sting, Spawn_Blood);
             creature->flags = 1;
         }
@@ -308,10 +300,10 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DAMAGE, "Damage dealt by the sting attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by the sting attack."));
 }
 
 REGISTER_OBJECT(O_WASP_MUTANT, M_Setup)

--- a/src/trx/game/objects/creatures/willard.c
+++ b/src/trx/game/objects/creatures/willard.c
@@ -73,6 +73,9 @@ typedef struct {
 } M_AI_POINT;
 
 typedef struct {
+    int32_t touch_damage;
+    int32_t lunge_damage;
+    int32_t bite_damage;
     bool puzzle_ready;
     uint8_t ring_count;
     int16_t explode_count;
@@ -103,17 +106,6 @@ static const int32_t m_DHeights1[5] = { -7680, -4224, -768, 2688, 6144 };
 static const int32_t m_DHeights2[5] = { -1536, -1152, -768, -384, 0 };
 static int32_t m_DeathDist[5] = {};
 static int32_t m_DeathHeights[5] = {};
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_ResetPriv(M_PRIV *const p)
 {
@@ -659,8 +651,7 @@ static void M_Control(const int16_t item_num)
         Creature_AIInfo(item, &info);
 
         if (item->touch_bits) {
-            Lara_TakeDamage(
-                M_GetDamage(item, "touch_damage", M_TOUCH_DAMAGE), false);
+            Lara_TakeDamage(p->touch_damage, false);
         }
 
         const int32_t index = p->lara_ai_path - p->closest_ai_path;
@@ -720,8 +711,7 @@ static void M_Control(const int16_t item_num)
             creature->maximum_turn = M_ATTACK_TURN;
 
             if (!creature->flags && item->touch_bits & M_TOUCH_BITS) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "lunge_damage", M_LUNGE_DAMAGE), true);
+                Lara_TakeDamage(p->lunge_damage, true);
                 Creature_Effect(item, &m_BiteLeft, Spawn_Blood);
                 Creature_Effect(item, &m_BiteRight, Spawn_Blood);
                 creature->flags = 1;
@@ -748,8 +738,7 @@ static void M_Control(const int16_t item_num)
         case M_STATE_WALK_ATTACK_1:
         case M_STATE_WALK_ATTACK_2:
             if (!creature->flags && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 Creature_Effect(item, &m_BiteLeft, Spawn_Blood);
                 Creature_Effect(item, &m_BiteRight, Spawn_Blood);
                 creature->flags = 1;
@@ -972,16 +961,18 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "touch_damage", M_TOUCH_DAMAGE, "Damage dealt by body contact."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by bite attacks."),
-        OBJECT_PROPERTY_INT(
-            "lunge_damage", M_LUNGE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, touch_damage, M_TOUCH_DAMAGE,
+            "Damage dealt by body contact."),
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by bite attacks."),
+        OBJECT_PROPERTY(
+            M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the lunge attack."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "plasma_ball_damage", WILLARD_PLASMA_BALL_DAMAGE,
             "Damage dealt by direct plasma ball hits."));
 }

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -117,7 +117,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 1, "Maximum hit points."));
+        obj,
+        OBJECT_PROPERTY_STORED("max_hit_points", 1, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_WINSTON, M_Setup)

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -265,7 +265,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/creatures/wolf.c
+++ b/src/trx/game/objects/creatures/wolf.c
@@ -46,18 +46,12 @@ typedef enum {
     M_ANIM_DEATH = 20,
 } M_ANIM;
 
+typedef struct {
+    int32_t pounce_damage;
+    int32_t bite_damage;
+} M_PRIV;
+
 static BITE m_WolfJawBite = { .pos = { 0, -14, 174 }, .mesh_num = 6 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -72,6 +66,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const wolf = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -192,8 +187,7 @@ static void M_Control(const int16_t item_num)
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH)) {
                 Creature_Effect(item, &m_WolfJawBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "pounce_damage", M_POUNCE_DAMAGE), true);
+                Lara_TakeDamage(p->pounce_damage, true);
                 item->required_anim_state = M_STATE_RUN;
             }
             item->goal_anim_state = M_STATE_RUN;
@@ -203,8 +197,7 @@ static void M_Control(const int16_t item_num)
             if (item->required_anim_state == M_STATE_EMPTY
                 && (item->touch_bits & M_TOUCH) && info.ahead) {
                 Creature_Effect(item, &m_WolfJawBite, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "bite_damage", M_BITE_DAMAGE), true);
+                Lara_TakeDamage(p->bite_damage, true);
                 item->required_anim_state = M_STATE_CROUCH;
             }
             break;
@@ -221,6 +214,8 @@ static void M_Setup(OBJECT *const obj)
     if (!obj->loaded) {
         return;
     }
+
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
@@ -239,13 +234,14 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 2)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "pounce_damage", M_POUNCE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, pounce_damage, M_POUNCE_DAMAGE,
             "Damage dealt by the pounce attack."),
-        OBJECT_PROPERTY_INT(
-            "bite_damage", M_BITE_DAMAGE, "Damage dealt by the bite attack."));
+        OBJECT_PROPERTY(
+            M_PRIV, bite_damage, M_BITE_DAMAGE,
+            "Damage dealt by the bite attack."));
 }
 
 REGISTER_OBJECT(O_WOLF, M_Setup)

--- a/src/trx/game/objects/creatures/worker_1.c
+++ b/src/trx/game/objects/creatures/worker_1.c
@@ -33,22 +33,16 @@ typedef enum {
     M_ANIM_DEATH = 18,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Worker1Gun = {
     .muzzle = {
         .pos = { .x = 0, .y = 281, .z = 40 },
         .mesh_num = 9,
     },
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -57,6 +51,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -174,8 +169,7 @@ static void M_Control(const int16_t item_num)
                 head = info.angle;
             }
             if (creature->flags == 0) {
-                Creature_Shoot(
-                    item, &info, &m_Worker1Gun, head, M_GetDamage(item));
+                Creature_Shoot(item, &info, &m_Worker1Gun, head, p->damage);
                 creature->flags = 1;
             }
             if (item->goal_anim_state != M_STATE_STOP
@@ -191,8 +185,7 @@ static void M_Control(const int16_t item_num)
                 head = info.angle;
             }
             if (creature->flags == 0) {
-                Creature_Shoot(
-                    item, &info, &m_Worker1Gun, head, M_GetDamage(item));
+                Creature_Shoot(item, &info, &m_Worker1Gun, head, p->damage);
                 creature->flags = 1;
             }
             break;
@@ -214,6 +207,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -231,9 +225,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by gun shots."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by gun shots."));
 }
 
 REGISTER_OBJECT(O_WORKER_1, M_Setup)

--- a/src/trx/game/objects/creatures/worker_2.c
+++ b/src/trx/game/objects/creatures/worker_2.c
@@ -34,6 +34,10 @@ typedef enum {
     M_ANIM_DEATH = 19,
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const CREATURE_GUN m_Worker2Gun = {
     .muzzle = {
         .pos = { .x = 0, .y = 308, .z = 32 },
@@ -41,25 +45,16 @@ static const CREATURE_GUN m_Worker2Gun = {
     },
 };
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DAMAGE;
-}
-
 static void M_ShootAtLara(
     ITEM *const item, CREATURE *const creature, const AI_INFO *const info,
     const int16_t head)
 {
+    const M_PRIV *const p = item->priv;
     if (item->object_id == O_WORKER_2) {
         if (creature->flags != 0) {
             creature->flags--;
         } else {
-            Creature_Shoot(item, info, &m_Worker2Gun, head, M_GetDamage(item));
+            Creature_Shoot(item, info, &m_Worker2Gun, head, p->damage);
             creature->flags = 5;
         }
     } else {
@@ -236,6 +231,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -253,9 +249,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT("damage", M_DAMAGE, "Damage dealt by gun shots."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DAMAGE, "Damage dealt by gun shots."));
 }
 
 REGISTER_OBJECT(O_WORKER_2, M_Setup)

--- a/src/trx/game/objects/creatures/worker_3.c
+++ b/src/trx/game/objects/creatures/worker_3.c
@@ -54,21 +54,15 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t hit_damage;
+    int32_t swipe_damage;
+} M_PRIV;
+
 static const BITE m_Worker3Hit = {
     .pos = { .x = 247, .y = 10, .z = 11 },
     .mesh_num = 10,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -77,6 +71,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t tilt = 0;
@@ -217,8 +212,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "hit_damage", M_HIT_DAMAGE), true);
+                Lara_TakeDamage(p->hit_damage, true);
                 Creature_Effect(item, &m_Worker3Hit, Spawn_Blood);
                 Sound_Effect(SFX_ENEMY_HIT_2, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -231,8 +225,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "hit_damage", M_HIT_DAMAGE), true);
+                Lara_TakeDamage(p->hit_damage, true);
                 Creature_Effect(item, &m_Worker3Hit, Spawn_Blood);
                 Sound_Effect(SFX_ENEMY_HIT_1, &item->pos, SPM_NORMAL);
                 creature->flags = 1;
@@ -249,8 +242,7 @@ static void M_Control(const int16_t item_num)
             }
             if (creature->flags != 2
                 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(
-                    M_GetDamage(item, "swipe_damage", M_SWIPE_DAMAGE), true);
+                Lara_TakeDamage(p->swipe_damage, true);
                 Creature_Effect(item, &m_Worker3Hit, Spawn_Blood);
                 Sound_Effect(SFX_ENEMY_HIT_1, &item->pos, SPM_NORMAL);
                 creature->flags = 2;
@@ -302,6 +294,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -320,12 +313,12 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 4)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "hit_damage", M_HIT_DAMAGE, "Damage dealt by punch attacks."),
-        OBJECT_PROPERTY_INT(
-            "swipe_damage", M_SWIPE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, hit_damage, M_HIT_DAMAGE, "Damage dealt by punch attacks."),
+        OBJECT_PROPERTY(
+            M_PRIV, swipe_damage, M_SWIPE_DAMAGE,
             "Damage dealt by the swipe attack."));
 }
 

--- a/src/trx/game/objects/creatures/xian_knight.c
+++ b/src/trx/game/objects/creatures/xian_knight.c
@@ -40,20 +40,14 @@ typedef enum {
     M_STATE_DEATH,
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_XianKnightSword = {
     .pos = { .x = 0, .y = 37, .z = 550 },
     .mesh_num = 15,
 };
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_HACK_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -87,6 +81,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -230,7 +225,7 @@ static void M_Control(const int16_t item_num)
             head = info.angle;
         }
         if (creature->flags == 0 && (item->touch_bits & M_TOUCH_BITS) != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             Creature_Effect(item, &m_XianKnightSword, Spawn_Blood);
             creature->flags = 1;
         }
@@ -252,6 +247,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     SOFT_ASSERT(
         Object_Get(O_XIAN_KNIGHT_STATUE)->loaded,
         "Xian swordsman statue object missing");
@@ -275,10 +271,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 16)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_HACK_DAMAGE, "Damage dealt by sword slashes."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_HACK_DAMAGE, "Damage dealt by sword slashes."));
 }
 
 REGISTER_OBJECT(O_XIAN_KNIGHT, M_Setup)

--- a/src/trx/game/objects/creatures/xian_spearman.c
+++ b/src/trx/game/objects/creatures/xian_spearman.c
@@ -65,6 +65,13 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t hit_1_damage;
+    int32_t hit_2_damage;
+    int32_t hit_5_damage;
+    int32_t hit_6_damage;
+} M_PRIV;
+
 static const BITE m_XianSpearmanLeftSpear = {
     .pos = { .x = 0, .y = 0, .z = 920 },
     .mesh_num = 11,
@@ -74,17 +81,6 @@ static const BITE m_XianSpearmanRightSpear = {
     .pos = { .x = 0, .y = 0, .z = 920 },
     .mesh_num = 18,
 };
-
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
 
 static void M_DoDamage(
     const ITEM *const item, CREATURE *const creature, const int32_t damage)
@@ -125,6 +121,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -331,8 +328,7 @@ static void M_Control(const int16_t item_num)
         break;
 
     case M_STATE_HIT_1:
-        M_DoDamage(
-            item, creature, M_GetDamage(item, "hit_1_damage", M_HIT_1_DAMAGE));
+        M_DoDamage(item, creature, p->hit_1_damage);
         break;
 
     case M_STATE_HIT_2:
@@ -341,8 +337,7 @@ static void M_Control(const int16_t item_num)
         if (info.ahead) {
             head = info.angle;
         }
-        M_DoDamage(
-            item, creature, M_GetDamage(item, "hit_2_damage", M_HIT_2_DAMAGE));
+        M_DoDamage(item, creature, p->hit_2_damage);
         if (info.ahead && info.distance < M_ATTACK_1_RANGE) {
             const int32_t random = Random_GetControl();
             if (random < 0x4000) {
@@ -359,8 +354,7 @@ static void M_Control(const int16_t item_num)
         if (info.ahead) {
             head = info.angle;
         }
-        M_DoDamage(
-            item, creature, M_GetDamage(item, "hit_5_damage", M_HIT_5_DAMAGE));
+        M_DoDamage(item, creature, p->hit_5_damage);
         if (info.ahead && info.distance < M_ATTACK_1_RANGE) {
             item->goal_anim_state = M_STATE_STOP;
         } else {
@@ -372,8 +366,7 @@ static void M_Control(const int16_t item_num)
         if (info.ahead) {
             head = info.angle;
         }
-        M_DoDamage(
-            item, creature, M_GetDamage(item, "hit_6_damage", M_HIT_6_DAMAGE));
+        M_DoDamage(item, creature, p->hit_6_damage);
         if (info.ahead && info.distance < M_ATTACK_1_RANGE) {
             const int32_t random = Random_GetControl();
             if (random < 0x4000) {
@@ -410,6 +403,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     SOFT_ASSERT(
         Object_Get(O_XIAN_SPEARMAN_STATUE)->loaded,
         "Xian spearman statue object missing");
@@ -433,16 +427,17 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 12)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "hit_1_damage", M_HIT_1_DAMAGE, "Damage dealt by attack 1."),
-        OBJECT_PROPERTY_INT(
-            "hit_2_damage", M_HIT_2_DAMAGE, "Damage dealt by attacks 2 to 4."),
-        OBJECT_PROPERTY_INT(
-            "hit_5_damage", M_HIT_5_DAMAGE, "Damage dealt by attack 5."),
-        OBJECT_PROPERTY_INT(
-            "hit_6_damage", M_HIT_6_DAMAGE, "Damage dealt by attack 6."));
+        OBJECT_PROPERTY(
+            M_PRIV, hit_1_damage, M_HIT_1_DAMAGE, "Damage dealt by attack 1."),
+        OBJECT_PROPERTY(
+            M_PRIV, hit_2_damage, M_HIT_2_DAMAGE,
+            "Damage dealt by attacks 2 to 4."),
+        OBJECT_PROPERTY(
+            M_PRIV, hit_5_damage, M_HIT_5_DAMAGE, "Damage dealt by attack 5."),
+        OBJECT_PROPERTY(
+            M_PRIV, hit_6_damage, M_HIT_6_DAMAGE, "Damage dealt by attack 6."));
 }
 
 REGISTER_OBJECT(O_XIAN_SPEARMAN, M_Setup)

--- a/src/trx/game/objects/creatures/yeti.c
+++ b/src/trx/game/objects/creatures/yeti.c
@@ -59,6 +59,12 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t punch_damage;
+    int32_t thump_damage;
+    int32_t charge_damage;
+} M_PRIV;
+
 static const BITE m_YetiBiteL = {
     .pos = { .x = 12, .y = 101, .z = 19 },
     .mesh_num = 13,
@@ -69,17 +75,6 @@ static const BITE m_YetiBiteR = {
     .mesh_num = 10,
 };
 
-static int32_t M_GetDamage(
-    const ITEM *const item, const char *const key, const int32_t default_value)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, key, &damage)) {
-        return damage.as_int;
-    }
-
-    return default_value;
-}
-
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -87,6 +82,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
@@ -221,8 +217,7 @@ static void M_Control(const int16_t item_num)
             if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS_R) != 0) {
                 Creature_Effect(item, &m_YetiBiteR, Spawn_Blood);
-                Lara_TakeDamage(
-                    M_GetDamage(item, "punch_damage", M_PUNCH_DAMAGE), true);
+                Lara_TakeDamage(p->punch_damage, true);
                 creature->flags = 1;
                 break;
             }
@@ -241,8 +236,7 @@ static void M_Control(const int16_t item_num)
                 if ((item->touch_bits & M_TOUCH_BITS_R) != 0) {
                     Creature_Effect(item, &m_YetiBiteR, Spawn_Blood);
                 }
-                Lara_TakeDamage(
-                    M_GetDamage(item, "thump_damage", M_THUMP_DAMAGE), true);
+                Lara_TakeDamage(p->thump_damage, true);
                 creature->flags = 1;
             }
             break;
@@ -259,8 +253,7 @@ static void M_Control(const int16_t item_num)
                 if ((item->touch_bits & M_TOUCH_BITS_R) != 0) {
                     Creature_Effect(item, &m_YetiBiteR, Spawn_Blood);
                 }
-                Lara_TakeDamage(
-                    M_GetDamage(item, "charge_damage", M_CHARGE_DAMAGE), true);
+                Lara_TakeDamage(p->charge_damage, true);
                 creature->flags = 1;
             }
             break;
@@ -317,6 +310,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
@@ -335,14 +329,15 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 14)->rot.y = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
-        OBJECT_PROPERTY_INT(
-            "punch_damage", M_PUNCH_DAMAGE, "Damage dealt by attack 1."),
-        OBJECT_PROPERTY_INT(
-            "thump_damage", M_THUMP_DAMAGE, "Damage dealt by attack 2."),
-        OBJECT_PROPERTY_INT(
-            "charge_damage", M_CHARGE_DAMAGE, "Damage dealt by attack 3."));
+        OBJECT_PROPERTY(
+            M_PRIV, punch_damage, M_PUNCH_DAMAGE, "Damage dealt by attack 1."),
+        OBJECT_PROPERTY(
+            M_PRIV, thump_damage, M_THUMP_DAMAGE, "Damage dealt by attack 2."),
+        OBJECT_PROPERTY(
+            M_PRIV, charge_damage, M_CHARGE_DAMAGE,
+            "Damage dealt by attack 3."));
 }
 
 REGISTER_OBJECT(O_YETI, M_Setup)

--- a/src/trx/game/objects/general/ai_node.c
+++ b/src/trx/game/objects/general/ai_node.c
@@ -4,7 +4,8 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->draw_func = nullptr;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 0, "Maximum hit points."));
+        obj,
+        OBJECT_PROPERTY_STORED("max_hit_points", 0, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_AI_AMBUSH, M_Setup)

--- a/src/trx/game/objects/general/animating.c
+++ b/src/trx/game/objects/general/animating.c
@@ -5,18 +5,6 @@ typedef struct {
     bool collidable;
 } M_PRIV;
 
-static void M_Initialise(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    p->collidable = true;
-
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "collidable", &value)) {
-        p->collidable = value.as_bool;
-    }
-}
-
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -44,7 +32,6 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->save_flags = true;
@@ -52,8 +39,8 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
-            "collidable", true,
+        OBJECT_PROPERTY(
+            M_PRIV, collidable, true,
             "Whether or not Lara can collide with the animating."));
 }
 

--- a/src/trx/game/objects/general/animating_ext.c
+++ b/src/trx/game/objects/general/animating_ext.c
@@ -8,15 +8,9 @@ typedef enum {
     // clang-format on
 } M_STATE;
 
-static bool M_KillOnTrigger(const ITEM *const item)
-{
-    TRX_VALUE value = {};
-    if (!ObjectProperty_GetItemValue(item, "kill_on_trigger", &value)) {
-        return false;
-    }
-
-    return value.as_bool;
-}
+typedef struct {
+    bool kill_on_trigger;
+} M_PRIV;
 
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
@@ -32,8 +26,9 @@ static void M_Collision(
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
-    if (M_KillOnTrigger(item) && !Item_IsTriggerActive(item)) {
+    if (p->kill_on_trigger && !Item_IsTriggerActive(item)) {
         Item_Destroy(item_num);
         return;
     }
@@ -67,10 +62,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+    obj->priv_size = sizeof(M_PRIV);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
-            "kill_on_trigger", false,
+        OBJECT_PROPERTY(
+            M_PRIV, kill_on_trigger, false,
             "Kill the item immediately while its trigger is inactive."));
 }
 

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -248,7 +248,8 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = 102;
     obj->intelligent = false;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 8, "Maximum hit points."));
+        obj,
+        OBJECT_PROPERTY_STORED("max_hit_points", 8, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_ASSAULT_TARGET, M_Setup)

--- a/src/trx/game/objects/general/big_bowl.c
+++ b/src/trx/game/objects/general/big_bowl.c
@@ -18,32 +18,34 @@ typedef enum {
 
 typedef struct {
     int32_t pour_time;
-    int32_t flip_time;
     int32_t flip_slot;
 } M_PRIV;
 
-static void M_Initialise(const int16_t item_num)
+// The pour is stated in seconds and counted in frames, and the bowl tips over
+// a little before it finishes.
+static int32_t M_FlipTime(const M_PRIV *const p)
 {
-    ITEM *const item = Item_Get(item_num);
+    return (p->pour_time - M_FLIP_TIME_OFFSET) * LOGIC_FPS;
+}
+
+static const char *M_SetPourTime(ITEM *const item, const TRX_VALUE *const in)
+{
+    if (in->as_int < M_MIN_POUR_TIME) {
+        return "pour time is below what the bowl can animate";
+    }
     M_PRIV *const p = item->priv;
-    p->pour_time = M_DEFAULT_POUR_TIME;
-    p->flip_slot = M_DEFAULT_FLIP_SLOT;
+    p->pour_time = in->as_int;
+    return nullptr;
+}
 
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "pour_time", &value)
-        && value.as_int > 0) {
-        p->pour_time = value.as_int;
+static const char *M_SetFlipSlot(ITEM *const item, const TRX_VALUE *const in)
+{
+    if (in->as_int >= MAX_FLIP_MAPS) {
+        return "no such flip map";
     }
-    if (ObjectProperty_GetItemValue(item, "flip_slot", &value)
-        && value.as_int < MAX_FLIP_MAPS) {
-        p->flip_slot = value.as_int;
-    }
-
-    CLAMPL(p->pour_time, M_MIN_POUR_TIME);
-    CLAMPL(p->flip_slot, -1);
-    p->flip_time = p->pour_time - M_FLIP_TIME_OFFSET;
-    p->pour_time *= LOGIC_FPS;
-    p->flip_time *= LOGIC_FPS;
+    M_PRIV *const p = item->priv;
+    p->flip_slot = MAX(-1, in->as_int);
+    return nullptr;
 }
 
 static void M_CreateHotLiquid(const ITEM *const bowl_item)
@@ -66,7 +68,7 @@ static void M_CreateHotLiquid(const ITEM *const bowl_item)
 static bool M_ShouldFlipMap(const ITEM *const item)
 {
     const M_PRIV *const p = item->priv;
-    return p->flip_slot >= 0 && item->timer == p->flip_time
+    return p->flip_slot >= 0 && item->timer == M_FlipTime(p)
         && !Room_GetFlipStatus();
 }
 
@@ -93,26 +95,25 @@ static void M_Control(const int16_t item_num)
 
     Item_Animate(item);
 
-    if (item->is_finished && item->timer >= p->pour_time) {
+    if (item->is_finished && item->timer >= p->pour_time * LOGIC_FPS) {
         Item_RemoveSimulated(item_num);
     }
 }
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->save_flags = true;
     obj->save_anim = true;
     obj->priv_size = sizeof(M_PRIV);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "pour_time", M_DEFAULT_POUR_TIME,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, pour_time, M_DEFAULT_POUR_TIME, M_SetPourTime,
             "The amount of time hot liquid is poured from the bowl, in "
             "seconds."),
-        OBJECT_PROPERTY_INT(
-            "flip_slot", M_DEFAULT_FLIP_SLOT,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, flip_slot, M_DEFAULT_FLIP_SLOT, M_SetFlipSlot,
             "The flip map slot to alter once liquid has finished pouring. -1 = "
             "no flipmap is performed. Value range: minimum -1; maximum 10."));
 }

--- a/src/trx/game/objects/general/cabin.c
+++ b/src/trx/game/objects/general/cabin.c
@@ -16,19 +16,14 @@ typedef struct {
     int32_t flip_slot;
 } M_PRIV;
 
-static void M_Initialise(const int16_t item_num)
+static const char *M_SetFlipSlot(ITEM *const item, const TRX_VALUE *const in)
 {
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    p->flip_slot = M_DEFAULT_FLIP_SLOT;
-
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "flip_slot", &value)
-        && value.as_int < MAX_FLIP_MAPS) {
-        p->flip_slot = value.as_int;
+    if (in->as_int >= MAX_FLIP_MAPS) {
+        return "no such flip map";
     }
-
-    CLAMPL(p->flip_slot, -1);
+    M_PRIV *const p = item->priv;
+    p->flip_slot = MAX(-1, in->as_int);
+    return nullptr;
 }
 
 static bool M_ShouldFlipMap(const ITEM *const item)
@@ -77,7 +72,6 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Object_Collision;
@@ -86,8 +80,8 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "flip_slot", M_DEFAULT_FLIP_SLOT,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, flip_slot, M_DEFAULT_FLIP_SLOT, M_SetFlipSlot,
             "The flip map slot to alter once the cabin has landed. -1 = "
             "no flipmap is performed. Value range: minimum -1; maximum 10."));
 }

--- a/src/trx/game/objects/general/cutscene_player.c
+++ b/src/trx/game/objects/general/cutscene_player.c
@@ -51,7 +51,8 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->control_func = M_Control;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 1, "Maximum hit points."));
+        obj,
+        OBJECT_PROPERTY_STORED("max_hit_points", 1, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_PLAYER_1, M_Setup)

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -303,11 +303,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
-            "crowbar", false,
+        OBJECT_PROPERTY(
+            M_PRIV, crowbar, false,
             "Whether the door must be pried open with the crowbar."),
-        OBJECT_PROPERTY_BOOL(
-            "lift", false,
+        OBJECT_PROPERTY(
+            M_PRIV, lift, false,
             "Whether the door rises vertically while activated instead of "
             "playing its open animation."));
 }
@@ -317,15 +317,6 @@ void Door_Initialise(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
 
-    p->crowbar = false;
-    p->lift = false;
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "crowbar", &value)) {
-        p->crowbar = value.as_bool;
-    }
-    if (ObjectProperty_GetItemValue(item, "lift", &value)) {
-        p->lift = value.as_bool;
-    }
     p->lift_count = 0;
     p->lift_base_y = item->pos.y;
 

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -402,7 +402,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_DOUBLE(
+        OBJECT_PROPERTY_STORED(
             "burn_time", M_DEFAULT_FLARE_TIME,
             "How long the flare burns for, in seconds."));
 

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -40,8 +40,8 @@ typedef enum {
 
 typedef struct {
     int32_t start_height;
+    int32_t wait_timer;
     int32_t wait_time;
-    int32_t max_wait_time;
     int32_t travel_distance;
     int32_t speed;
     bool is_moving;
@@ -72,7 +72,7 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     JSON_SHOULD(JSON_READ(io, "start_height", &p->start_height));
-    JSON_SHOULD(JSON_READ(io, "wait_time", &p->wait_time));
+    JSON_SHOULD(JSON_READ(io, "wait_time", &p->wait_timer));
     JSON_SHOULD(JSON_READ(io, "is_moving", &p->is_moving));
     for (int32_t i = 0; i < M_NUM_SECTORS; i++) {
         const char *const key = String_FormatStatic("linked_%d", i);
@@ -89,7 +89,7 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
 {
     const M_PRIV *const p = item->priv;
     JSONW_WRITE(io, "start_height", p->start_height);
-    JSONW_WRITE(io, "wait_time", p->wait_time);
+    JSONW_WRITE(io, "wait_time", p->wait_timer);
     JSONW_WRITE(io, "is_moving", p->is_moving);
     for (int32_t i = 0; i < M_NUM_SECTORS; i++) {
         const char *const key = String_FormatStatic("linked_%d", i);
@@ -282,33 +282,23 @@ static void M_SetupInternalWall(ITEM *const item)
     p->wall_bounds.max.y -= STEP_L / 2;
 }
 
+static const char *M_SetSpeed(ITEM *const item, const TRX_VALUE *const in)
+{
+    if (in->as_int > M_MAXIMUM_SPEED) {
+        return "speed is above what the lift can travel at";
+    }
+    M_PRIV *const p = item->priv;
+    p->speed = in->as_int;
+    return nullptr;
+}
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     p->start_height = item->pos.y;
-    p->wait_time = 0;
-    p->max_wait_time = M_DEFAULT_WAIT_TIME;
-    p->travel_distance = M_DEFAULT_TRAVEL_DIST;
-    p->speed = M_DEFAULT_SPEED;
+    p->wait_timer = 0;
     p->is_moving = false;
-
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "wait_time", &value)
-        && value.as_int > 0) {
-        p->max_wait_time = value.as_int;
-    }
-    if (ObjectProperty_GetItemValue(item, "travel_distance", &value)
-        && value.as_int > 0) {
-        p->travel_distance = value.as_int;
-    }
-    if (ObjectProperty_GetItemValue(item, "speed", &value)
-        && value.as_int > 0) {
-        p->speed = value.as_int;
-    }
-    p->max_wait_time *= LOGIC_FPS;
-    p->travel_distance *= STEP_L;
-    CLAMPG(p->speed, M_MAXIMUM_SPEED);
 
     VECTOR *const positions = Vector_Create(sizeof(XYZ_32));
     M_GetSectorPositions(item, positions);
@@ -533,19 +523,19 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     const int32_t bottom = p->start_height;
-    const int32_t top = bottom + p->travel_distance;
+    const int32_t top = bottom + p->travel_distance * STEP_L;
     const int32_t target = Item_IsTriggerActive(item) ? top : bottom;
 
     if (item->pos.y == target) {
         item->goal_anim_state = M_STATE_DOOR_OPEN;
-        p->wait_time = 0;
+        p->wait_timer = 0;
         if (p->is_moving) {
             M_ShiftStackableItems(item, true);
         }
         p->is_moving = false;
-    } else if (p->wait_time < p->max_wait_time) {
+    } else if (p->wait_timer < p->wait_time * LOGIC_FPS) {
         item->goal_anim_state = M_STATE_DOOR_OPEN;
-        p->wait_time++;
+        p->wait_timer++;
         // Prevent Lara from interacting with blocks about to move.
         M_ShiftStackableItems(item, false);
     } else {
@@ -625,16 +615,16 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "wait_time", M_DEFAULT_WAIT_TIME,
+        OBJECT_PROPERTY(
+            M_PRIV, wait_time, M_DEFAULT_WAIT_TIME,
             "The time to wait before the lift begins moving, in seconds. Value "
             "range: minimum 1."),
-        OBJECT_PROPERTY_INT(
-            "travel_distance", M_DEFAULT_TRAVEL_DIST,
+        OBJECT_PROPERTY(
+            M_PRIV, travel_distance, M_DEFAULT_TRAVEL_DIST,
             "The vertical distance the lift will travel, in clicks. Value "
             "range: minimum 1."),
-        OBJECT_PROPERTY_INT(
-            "speed", M_DEFAULT_SPEED,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, speed, M_DEFAULT_SPEED, M_SetSpeed,
             "The speed at which the lift moves, in world units. Value range: "
             "minimum 1; maximum 64."));
 }

--- a/src/trx/game/objects/general/lights/strobe_light.c
+++ b/src/trx/game/objects/general/lights/strobe_light.c
@@ -27,17 +27,6 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "alarm_active", p->alarm_active);
 }
 
-static void M_Initialise(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    TRX_VALUE requires_alarm_active = {};
-    if (ObjectProperty_GetItemValue(
-            item, "requires_alarm_active", &requires_alarm_active)) {
-        p->requires_alarm_active = requires_alarm_active.as_bool;
-    }
-}
-
 static void M_TriggerAlertLight(
     const XYZ_32 pos, const RGB_888 color, const int16_t angle,
     const int16_t room_num)
@@ -116,14 +105,13 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     obj->priv_load_func = M_LoadPriv;
     obj->priv_save_func = M_SavePriv;
-    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->event_func = M_HandleEvent;
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
-            "requires_alarm_active", false,
+        OBJECT_PROPERTY(
+            M_PRIV, requires_alarm_active, false,
             "Require an alert event before the light activates."));
 }
 

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -108,13 +108,16 @@ static void M_Initialise(int16_t item_num)
     if (item->is_visible) {
         Item_AddSimulated(item_num);
     }
+}
 
-    p->pickup_mode = PICKUP_MODE_NORMAL;
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "pickup_mode", &value)
-        && value.as_int >= 0 && value.as_int < PICKUP_MODE_NUMBER_OF) {
-        p->pickup_mode = value.as_int;
+static const char *M_SetPickupMode(ITEM *const item, const TRX_VALUE *const in)
+{
+    if (in->as_int < 0 || in->as_int >= PICKUP_MODE_NUMBER_OF) {
+        return "no such pickup mode";
     }
+    M_PRIV *const p = item->priv;
+    p->pickup_mode = in->as_int;
+    return nullptr;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
@@ -665,8 +668,8 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "pickup_mode", 0,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, pickup_mode, PICKUP_MODE_NORMAL, M_SetPickupMode,
             "Pickup animation mode - 0: normal; 1: low pedestal; 2: high "
             "pedestal."));
 }

--- a/src/trx/game/objects/general/pulley_switch.c
+++ b/src/trx/game/objects/general/pulley_switch.c
@@ -50,20 +50,19 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "remaining_pulls", p->remaining_pulls);
 }
 
+// Fewer pulls than the minimum would leave the pulley unusable.
+static const char *M_SetRequiredPulls(
+    ITEM *const item, const TRX_VALUE *const in)
+{
+    M_PRIV *const p = item->priv;
+    p->required_pulls = MAX(M_MIN_PULLS, in->as_int);
+    return nullptr;
+}
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "required_pulls", &value)) {
-        p->required_pulls = value.as_int;
-    }
-    if (ObjectProperty_GetItemValue(item, "is_single_use", &value)) {
-        p->is_single_use = value.as_bool;
-    }
-
-    p->required_pulls = MAX(M_MIN_PULLS, p->required_pulls);
     p->remaining_pulls = p->required_pulls;
 
     // The visibility initialisation flag is temporarily used to indicate that
@@ -194,12 +193,12 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "required_pulls", M_MIN_PULLS,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, required_pulls, M_MIN_PULLS, M_SetRequiredPulls,
             "The number of pulls required before activating the trigger under "
             "the pulley. Value range: minimum 1"),
-        OBJECT_PROPERTY_BOOL(
-            "is_single_use", false,
+        OBJECT_PROPERTY(
+            M_PRIV, is_single_use, false,
             "Whether or not the pulley can only be used once."));
 }
 

--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -27,6 +27,10 @@
 #define M_MESH_TR3_SAVE 1
 
 typedef struct {
+    int32_t mesh_index;
+    int32_t heal_amount;
+    RGB_888 glow_color;
+    bool bob;
     bool initialised;
     bool counted_for_stats;
     bool used_for_save;
@@ -104,12 +108,8 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 // would otherwise keep the default mesh_bits and draw all of its tints at once.
 static void M_ApplyMesh(ITEM *const item)
 {
-    TRX_VALUE value = {};
-    int32_t mesh_index = -1;
-    if (ObjectProperty_GetItemValue(item, "mesh_index", &value)) {
-        mesh_index = value.as_int;
-    }
-    item->mesh_bits = SaveCrystal_GetMeshBits(item->object_id, mesh_index);
+    const M_PRIV *const p = item->priv;
+    item->mesh_bits = SaveCrystal_GetMeshBits(item->object_id, p->mesh_index);
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -174,12 +174,8 @@ static RGB_888 M_GetModeGlow(void)
 
 static void M_AddGlow(const ITEM *const item, const int32_t intensity)
 {
-    TRX_VALUE value = {};
-    if (!ObjectProperty_GetItemValue(item, "glow_color", &value)) {
-        return;
-    }
-
-    RGB_888 color = value.as_rgb;
+    const M_PRIV *const p = item->priv;
+    RGB_888 color = p->glow_color;
     if (color.r == 0 && color.g == 0 && color.b == 0) {
         color = M_GetModeGlow();
     }
@@ -201,11 +197,7 @@ static void M_AddGlow(const ITEM *const item, const int32_t intensity)
 static void M_Animate(ITEM *const item)
 {
     M_PRIV *const p = item->priv;
-
-    TRX_VALUE value = {};
-    const bool bob =
-        ObjectProperty_GetItemValue(item, "bob", &value) && value.as_bool;
-    if (!bob) {
+    if (!p->bob) {
         Item_Animate(item);
         M_AddGlow(item, 0xFF);
         return;
@@ -238,14 +230,9 @@ static bool M_TestProximity(const ITEM *const item, const ITEM *const lara_item)
 
 static void M_Heal(ITEM *const lara_item, const ITEM *const item)
 {
-    TRX_VALUE value = {};
-    int32_t heal_amount = LARA_MAX_HITPOINTS / 2;
-    if (ObjectProperty_GetItemValue(item, "heal_amount", &value)) {
-        heal_amount = value.as_int;
-    }
-
+    const M_PRIV *const p = item->priv;
     Lara_Poison_Cure();
-    lara_item->hit_points += heal_amount;
+    lara_item->hit_points += p->heal_amount;
     CLAMPG(lara_item->hit_points, LARA_MAX_HITPOINTS);
 
     // PS1: SFX_SAVE_CRYSTAL, PC: SFX_MENU_MEDI
@@ -348,19 +335,19 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
-            "bob", g_TRVersion == 3,
+        OBJECT_PROPERTY(
+            M_PRIV, bob, (bool)(g_TRVersion == 3),
             "Whether the crystal hovers and bobs in place."),
-        OBJECT_PROPERTY_RGB(
-            "glow_color", 0, 0, 0,
+        OBJECT_PROPERTY(
+            M_PRIV, glow_color, ((RGB_888) { 0, 0, 0 }),
             "Color of the light the crystal casts. Black picks one from the "
             "save crystal mode."),
-        OBJECT_PROPERTY_INT(
-            "mesh_index", -1,
+        OBJECT_PROPERTY(
+            M_PRIV, mesh_index, -1,
             "Mesh the crystal is drawn with. -1 picks one from the save "
             "crystal mode."),
-        OBJECT_PROPERTY_INT(
-            "heal_amount", LARA_MAX_HITPOINTS / 2,
+        OBJECT_PROPERTY(
+            M_PRIV, heal_amount, LARA_MAX_HITPOINTS / 2,
             "Health restored by a healing crystal."));
 
     const SAVE_CRYSTAL_MODE mode = g_Config.gameplay.save_crystal_mode;

--- a/src/trx/game/objects/general/scion3.c
+++ b/src/trx/game/objects/general/scion3.c
@@ -81,7 +81,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_hitpoints = true;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 5, "Maximum hit points."));
+        obj,
+        OBJECT_PROPERTY_STORED("max_hit_points", 5, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_SCION_ITEM_3, M_Setup)

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -47,6 +47,7 @@ typedef struct {
 typedef struct {
     M_FISH fish[M_FISH_PER_SHOAL + 1];
     M_LEADER leader;
+    XYZ_32 range;
     bool use_room_lighting;
     int32_t piranha_hit_wait;
     int16_t carcass_item_num;
@@ -677,27 +678,10 @@ static void M_Initialise(const int16_t item_num)
     p->anchor.pos = item->pos;
     p->anchor.room_num = item->room_num;
 
-    TRX_VALUE range_val = {};
-    if (ObjectProperty_GetItemValue(item, "range", &range_val)) {
-        p->leader.range = range_val.as_xyz;
-    } else {
-        p->leader.range = M_DEFAULT_RANGE;
-    }
-
-    p->leader.range.x = MAX(1, p->leader.range.x) * STEP_L;
-    p->leader.range.y = MAX(1, p->leader.range.y) * STEP_L;
-    p->leader.range.z = MAX(1, p->leader.range.z) * STEP_L;
-
-    TRX_VALUE sprite_val = {};
-    if (ObjectProperty_GetItemValue(item, "sprite_offset", &sprite_val)) {
-        p->sprite_offset = sprite_val.as_int;
-    }
-
-    TRX_VALUE use_room_lighting_val = {};
-    if (ObjectProperty_GetItemValue(
-            item, "use_room_lighting", &use_room_lighting_val)) {
-        p->use_room_lighting = use_room_lighting_val.as_bool;
-    }
+    // The range is stated in quarter tiles and swum in world units.
+    p->leader.range.x = MAX(1, p->range.x) * STEP_L;
+    p->leader.range.y = MAX(1, p->range.y) * STEP_L;
+    p->leader.range.z = MAX(1, p->range.z) * STEP_L;
 }
 
 static void M_SetupCommon(OBJECT *const obj)
@@ -718,10 +702,10 @@ static void M_SetupCommon(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_XYZ(
-            "range", M_DEFAULT_RANGE, "Swim range, in quarter tiles."),
-        OBJECT_PROPERTY_BOOL(
-            "use_room_lighting", (g_TRVersion < 3),
+        OBJECT_PROPERTY(
+            M_PRIV, range, (M_DEFAULT_RANGE), "Swim range, in quarter tiles."),
+        OBJECT_PROPERTY(
+            M_PRIV, use_room_lighting, (bool)(g_TRVersion < 3),
             "Whether the shoal uses the surrounding room lighting."));
 }
 
@@ -730,8 +714,9 @@ static void M_SetupTropicalFish(OBJECT *const obj)
     M_SetupCommon(obj);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "sprite_offset", 0, "Texture offset in `O_TROPICAL_FISH_GFX`."));
+        OBJECT_PROPERTY(
+            M_PRIV, sprite_offset, 0,
+            "Texture offset in `O_TROPICAL_FISH_GFX`."));
 }
 
 static void M_SetupPiranhas(OBJECT *const obj)

--- a/src/trx/game/objects/general/trapdoor.c
+++ b/src/trx/game/objects/general/trapdoor.c
@@ -185,12 +185,6 @@ static void M_Initialise(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
 
-    p->auto_open = true;
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "auto_open", &value)) {
-        p->auto_open = value.as_bool;
-    }
-
     VECTOR *const positions = Vector_Create(sizeof(XYZ_32));
     M_GetSectorPositions(item, positions);
     Walkable_AllocateNodes(item, positions->count);
@@ -328,8 +322,8 @@ static void M_SetupBase(OBJECT *const obj)
     obj->add_walkable_func = M_AddWalkable;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
-            "auto_open", true,
+        OBJECT_PROPERTY(
+            M_PRIV, auto_open, true,
             "Whether the trapdoor opens automatically when triggered."));
 }
 

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -14,6 +14,11 @@ struct OBJECT_PROPERTY_ENTRY {
     const char *name;
     const char *description;
     TRX_VALUE value;
+    // How an item's live copy is reached; see OBJECT_PROPERTY_DECL.
+    size_t field_offset;
+    TRX_VALUE_TYPE field_type;
+    size_t field_size;
+    const char *(*set)(ITEM *item, const TRX_VALUE *value);
 };
 
 // Object properties are numeric: the declaration macros produce only S32, BOOL,
@@ -63,6 +68,48 @@ static const OBJECT_PROPERTY_ENTRY *M_GetObjectEntry(
     return M_GetEntry(&obj->properties, name);
 }
 
+// Writes an item's live copy of a property: the member the object declared, or
+// the setter standing in for one. A property with neither keeps no copy.
+static void M_WriteLiveValue(
+    ITEM *const item, const OBJECT_PROPERTY_ENTRY *const decl,
+    const TRX_VALUE *const value)
+{
+    if (item == nullptr || (decl->set == nullptr && decl->field_size == 0)) {
+        return;
+    }
+    // An item whose priv the level has not allocated yet keeps nothing: its
+    // copy is written as it is initialised.
+    if (item->priv == nullptr) {
+        return;
+    }
+
+    const char *const err = decl->set != nullptr
+        ? decl->set(item, value)
+        : Value_WritePtr(
+              decl->field_type, (char *)item->priv + decl->field_offset, value);
+    if (err != nullptr) {
+        LOG_ERROR("%s: %s", decl->name, err);
+    }
+}
+
+// Every item of an object holds its own copy of what the object declared, so a
+// change to the object's value reaches the items that have not overridden it.
+static void M_WriteLiveValueToItems(
+    const OBJECT *const obj, const OBJECT_PROPERTY_ENTRY *const decl)
+{
+    if (decl->set == nullptr && decl->field_size == 0) {
+        return;
+    }
+    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
+        ITEM *const item = Item_Get(i);
+        if (Object_TryGet(item->object_id) != obj
+            || M_GetEntry(&item->properties, decl->name) != nullptr) {
+            continue;
+        }
+        M_WriteLiveValue(item, decl, &decl->value);
+    }
+}
+
 static OBJECT_PROPERTY_ENTRY *M_AddEntry(
     OBJECT_PROPERTY_SET *const properties, const char *const name,
     const char *const description, const TRX_VALUE *const value)
@@ -97,6 +144,7 @@ static void M_ApplyObjectValue(
         return;
     }
     entry->value = *value;
+    M_WriteLiveValueToItems(obj, entry);
 }
 
 static void M_ApplyItemValue(
@@ -108,6 +156,7 @@ static void M_ApplyItemValue(
         return;
     }
     M_AddEntry(&item->properties, name, object_entry->description, value);
+    M_WriteLiveValue(item, object_entry, value);
 }
 
 void ObjectProperty_ResetObject(OBJECT *const obj)
@@ -126,10 +175,42 @@ void ObjectProperty_ApplyDeclarations(
 {
     for (size_t i = 0; i < count; i++) {
         const OBJECT_PROPERTY_DECL *const declaration = &declarations[i];
-        M_AddEntry(
+        OBJECT_PROPERTY_ENTRY *const entry = M_AddEntry(
             &obj->properties, declaration->name, declaration->description,
             &declaration->value);
-        M_ApplyObjectValue(obj, declaration->name, &declaration->value);
+        entry->field_offset = declaration->field_offset;
+        entry->field_type = declaration->field_type;
+        entry->field_size = declaration->field_size;
+        entry->set = declaration->set;
+        // A bound property is the view of its member: it carries the member's
+        // type, so what the member cannot hold is turned away at the write
+        // rather than dropped silently on the way to it. A default of another
+        // numeric type - an integer written for a double member - is converted
+        // once, here.
+        TRX_VALUE value = entry->value;
+        if (entry->field_size != 0 && entry->field_type != value.type) {
+            const bool converted =
+                Value_Coerce(entry->field_type, &entry->value, &value);
+            ASSERT(converted);
+        }
+        M_ApplyObjectValue(obj, declaration->name, &value);
+    }
+}
+
+void ObjectProperty_ApplyToItem(ITEM *const item)
+{
+    const OBJECT *const obj =
+        item == nullptr ? nullptr : Object_TryGet(item->object_id);
+    if (obj == nullptr) {
+        return;
+    }
+
+    for (int32_t i = 0; i < obj->properties.count; i++) {
+        const OBJECT_PROPERTY_ENTRY *const decl = &obj->properties.entries[i];
+        const OBJECT_PROPERTY_ENTRY *const own =
+            M_GetEntry(&item->properties, decl->name);
+        M_WriteLiveValue(
+            item, decl, own != nullptr ? &own->value : &decl->value);
     }
 }
 

--- a/src/trx/game/objects/property.h
+++ b/src/trx/game/objects/property.h
@@ -20,6 +20,19 @@ typedef struct OBJECT OBJECT;
 typedef struct {
     const char *name, *description;
     TRX_VALUE value;
+    // Where an item keeps its live copy: a member of the object's priv struct,
+    // addressed as `field_type`. The engine writes it as the item is
+    // initialised and on every later change, so object code reads the member
+    // and never the store. A zero `field_size` means the property has no member
+    // of its own.
+    size_t field_offset;
+    TRX_VALUE_TYPE field_type;
+    size_t field_size;
+    // Escape hatch for a value that needs validating, or that the object keeps
+    // in a shape the store cannot address - a range converted to engine units,
+    // a bitfield. Runs in place of the member write, at the same moments.
+    // Returns nullptr on success, or why the value was refused.
+    const char *(*set)(ITEM *item, const TRX_VALUE *value);
 } OBJECT_PROPERTY_DECL;
 
 typedef struct OBJECT_PROPERTY_ENTRY OBJECT_PROPERTY_ENTRY;
@@ -30,48 +43,63 @@ typedef struct {
 
 typedef OBJECT_PROPERTY_SET ITEM_PROPERTY_SET;
 
-#define OBJECT_PROPERTY_INT(name_, value_, description_)                       \
+// A property an item carries in the named member of the object's priv struct.
+// It is named after the member, and takes its type, width, offset and the type
+// of its default from the member and the value themselves, so no two of them
+// can disagree.
+#define OBJECT_PROPERTY(struct_, member_, value_, description_)                \
     {                                                                          \
-        .name = name_, .description = description_, .value = {                 \
-            .type = TVT_S32,                                                   \
-            .as_int = value_                                                   \
-        }                                                                      \
-    }
-#define OBJECT_PROPERTY_BOOL(name_, value_, description_)                      \
-    {                                                                          \
-        .name = name_, .description = description_, .value = {                 \
-            .type = TVT_BOOL,                                                  \
-            .as_bool = value_                                                  \
-        }                                                                      \
-    }
-#define OBJECT_PROPERTY_XYZ(name_, value_, description_)                       \
-    {                                                                          \
-        .name = name_, .description = description_, .value = {                 \
-            .type = TVT_XYZ_32,                                                \
-            .as_xyz = value_                                                   \
-        }                                                                      \
+        .name = #member_,                                                      \
+        .description = description_,                                           \
+        .value = Value_Of(value_),                                             \
+        .field_offset = offsetof(struct_, member_),                            \
+        .field_type = Value_TypeOf(((struct_ *)nullptr)->member_),             \
+        .field_size = sizeof(((struct_ *)nullptr)->member_),                   \
     }
 
-#define OBJECT_PROPERTY_RGB(name_, r_, g_, b_, description_)                   \
+// A bound property whose write needs validating, or whose member the store
+// cannot address on its own.
+#define OBJECT_PROPERTY_SET(struct_, member_, value_, set_, description_)      \
     {                                                                          \
-        .name = name_, .description = description_, .value = {                 \
-            .type = TVT_RGB_888,                                               \
-            .as_rgb = { .r = r_, .g = g_, .b = b_ }                            \
-        }                                                                      \
+        .name = #member_,                                                      \
+        .description = description_,                                           \
+        .value = Value_Of(value_),                                             \
+        .field_offset = offsetof(struct_, member_),                            \
+        .field_type = Value_TypeOf(((struct_ *)nullptr)->member_),             \
+        .field_size = sizeof(((struct_ *)nullptr)->member_),                   \
+        .set = set_,                                                           \
     }
 
-#define OBJECT_PROPERTY_DOUBLE(name_, value_, description_)                    \
+// A property the store alone keeps, read back through ObjectProperty_Get*Value:
+// an object-level setting a script tunes, with no item to carry it.
+#define OBJECT_PROPERTY_STORED(name_, value_, description_)                    \
     {                                                                          \
-        .name = name_, .description = description_, .value = {                 \
-            .type = TVT_DOUBLE,                                                \
-            .as_num = value_                                                   \
-        }                                                                      \
+        .name = name_,                                                         \
+        .description = description_,                                           \
+        .value = Value_Of(value_),                                             \
+    }
+
+// A property the object keeps somewhere the store cannot address on its own -
+// a value converted to engine units, one member of several. `set_` stands in
+// for the member write and runs at the same moments.
+#define OBJECT_PROPERTY_STORED_SET(name_, value_, set_, description_)          \
+    {                                                                          \
+        .name = name_,                                                         \
+        .description = description_,                                           \
+        .value = Value_Of(value_),                                             \
+        .set = set_,                                                           \
     }
 
 void ObjectProperty_ResetObject(OBJECT *obj);
 void ObjectProperty_ResetItem(ITEM *item);
 void ObjectProperty_ApplyDeclarations(
     OBJECT *obj, const OBJECT_PROPERTY_DECL *declarations, size_t count);
+
+// Writes every bound property into the item's priv struct. Called as an item is
+// initialised, before the object's own initialiser runs, so the object can read
+// what it declared. A later change to a property writes the member again, which
+// is why object code never has to look a property up.
+void ObjectProperty_ApplyToItem(ITEM *item);
 
 bool ObjectProperty_GetObjectValue(
     const OBJECT *obj, const char *name, TRX_VALUE *out_value);

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -21,7 +21,7 @@ static void M_SetupLara(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", LARA_MAX_HITPOINTS, "Maximum hit points."));
     ObjectProperty_SetObjectValueRaw(
         obj, "max_hit_points",
@@ -75,7 +75,8 @@ void Object_SetupAllObjects(void)
 
         // TODO: this is poor design
         OBJECT_PROPERTIES(
-            obj, OBJECT_PROPERTY_INT("ocb", 0, "Object configuration value."));
+            obj,
+            OBJECT_PROPERTY_STORED("ocb", 0, "Object configuration value."));
     }
 
     Lara_Hair_Initialise();

--- a/src/trx/game/objects/traps/blade.c
+++ b/src/trx/game/objects/traps/blade.c
@@ -23,6 +23,10 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static void M_Initialise(const int16_t item_num)
 {
     const OBJECT *const obj = Object_Get(O_BLADE);
@@ -46,19 +50,10 @@ static void M_Stop(ITEM *const item)
     item->goal_anim_state = M_STATE_STOP;
 }
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (Item_IsTriggerActive(item)
         && item->current_anim_state == M_STATE_STOP) {
@@ -69,7 +64,7 @@ static void M_Control(const int16_t item_num)
 
     if ((item->touch_bits & M_TOUCH_BITS) != 0
         && item->current_anim_state == M_STATE_CUT) {
-        Lara_TakeDamage(M_GetDamage(item), true);
+        Lara_TakeDamage(p->damage, true);
 
         const ITEM *const lara_item = Lara_GetItem();
         Spawn_BloodBath(
@@ -82,6 +77,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
@@ -89,8 +85,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the blade trap."));
 }
 

--- a/src/trx/game/objects/traps/damocles_sword.c
+++ b/src/trx/game/objects/traps/damocles_sword.c
@@ -10,15 +10,9 @@
 #define M_ACTIVATE_DIST ((WALL_L * 3) / 2)
 #define M_DEFAULT_DAMAGE 100
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_Reset(ITEM *const item)
 {
@@ -90,6 +84,7 @@ static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     if (!Lara_TestBoundsCollide(item, coll->radius)) {
         return;
     }
@@ -97,7 +92,7 @@ static void M_Collision(
         Lara_Col_ItemPush(item, coll, false, true);
     }
     if (item->gravity) {
-        Lara_TakeDamage(M_GetDamage(item), false);
+        Lara_TakeDamage(p->damage, false);
         int32_t x = lara_item->pos.x + (Random_GetControl() - 0x4000) / 256;
         int32_t z = lara_item->pos.z + (Random_GetControl() - 0x4000) / 256;
         int32_t y = lara_item->pos.y - Random_GetControl() / 44;
@@ -108,6 +103,7 @@ static void M_Collision(
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
@@ -117,8 +113,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when Lara is struck by the falling Damocles sword."));
 }
 

--- a/src/trx/game/objects/traps/dart.c
+++ b/src/trx/game/objects/traps/dart.c
@@ -16,34 +16,16 @@
 #define M_PITCH (DEG_45 / 2)
 
 typedef struct {
+    int32_t damage;
+    bool poison;
     bool pending_kill;
 } M_PRIV;
 
-static bool M_IsPoison(const ITEM *const item)
-{
-    TRX_VALUE poison = {};
-    if (ObjectProperty_GetItemValue(item, "poison", &poison)) {
-        return poison.as_bool;
-    }
-
-    return item->object_id == O_POISON_DART;
-}
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_IsPoison(item) ? M_DEFAULT_POISON_DAMAGE : M_DEFAULT_DAMAGE;
-}
-
 static void M_DamageLara(const ITEM *const item)
 {
-    const bool is_poison = M_IsPoison(item);
-    Lara_TakeDamage(M_GetDamage(item), true);
-    if (is_poison) {
+    const M_PRIV *const p = item->priv;
+    Lara_TakeDamage(p->damage, true);
+    if (p->poison) {
         LARA_INFO *const lara = Lara_GetLaraInfo();
         lara->poison.value += M_POISON_AMOUNT;
     }
@@ -159,15 +141,17 @@ static bool M_DrawPoisonDart(const ITEM *const item)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT("damage", M_DEFAULT_DAMAGE, "Damage dealt on hit."),
-        OBJECT_PROPERTY_BOOL(
-            "poison", false,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE, "Damage dealt on hit."),
+        OBJECT_PROPERTY(
+            M_PRIV, poison, false,
             "Apply poison buildup in addition to hit damage."));
 }
 
@@ -181,10 +165,11 @@ static void M_SetupPoisonDart(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_POISON_DAMAGE, "Damage dealt on hit."),
-        OBJECT_PROPERTY_BOOL(
-            "poison", true, "Apply poison buildup in addition to hit damage."));
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_POISON_DAMAGE, "Damage dealt on hit."),
+        OBJECT_PROPERTY(
+            M_PRIV, poison, true,
+            "Apply poison buildup in addition to hit damage."));
 }
 
 REGISTER_OBJECT(O_DART, M_Setup)

--- a/src/trx/game/objects/traps/falling_ceiling.c
+++ b/src/trx/game/objects/traps/falling_ceiling.c
@@ -5,26 +5,21 @@
 
 #define M_DEFAULT_DAMAGE 300
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (item->current_anim_state == TRAP_SET) {
         item->goal_anim_state = TRAP_ACTIVATE;
         item->gravity = true;
     } else if (
         item->current_anim_state == TRAP_ACTIVATE && item->touch_bits != 0) {
-        Lara_TakeDamage(M_GetDamage(item), true);
+        Lara_TakeDamage(p->damage, true);
     }
 
     Item_Animate(item);
@@ -52,6 +47,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Trap_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
@@ -60,8 +56,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the falling ceiling."));
 }
 

--- a/src/trx/game/objects/traps/flame_emitter.c
+++ b/src/trx/game/objects/traps/flame_emitter.c
@@ -13,6 +13,7 @@
 
 typedef struct {
     int16_t effect_num;
+    double interval;
 } M_PRIV;
 
 typedef void (*FLAME_INIT_FUNC)(EFFECT *const effect, const ITEM *const item);
@@ -68,14 +69,21 @@ static void M_Initialise(const int16_t item_num)
     p->effect_num = NO_EFFECT;
 }
 
+// An interval of nothing would burst every frame.
+static const char *M_SetInterval(ITEM *const item, const TRX_VALUE *const in)
+{
+    if (in->as_num <= 0.0) {
+        return "interval must be longer than nothing";
+    }
+    M_PRIV *const p = item->priv;
+    p->interval = in->as_num;
+    return nullptr;
+}
+
 static int32_t M_GetSideDuration(const ITEM *const item)
 {
-    TRX_VALUE value = {};
-    if (!ObjectProperty_GetItemValue(item, "interval", &value)
-        || value.type != TVT_DOUBLE || value.as_num <= 0.0) {
-        return M_DEFAULT_SIDE_INTERVAL * LOGIC_FPS;
-    }
-    return value.as_num * LOGIC_FPS;
+    const M_PRIV *const p = item->priv;
+    return p->interval * LOGIC_FPS;
 }
 
 static void M_ControlCommon(
@@ -184,8 +192,8 @@ static void M_SetupSide(OBJECT *const obj)
     M_SetupCommon(obj, M_ControlSide);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_DOUBLE(
-            "interval", M_DEFAULT_SIDE_INTERVAL,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, interval, M_DEFAULT_SIDE_INTERVAL, M_SetInterval,
             "Interval between flame bursts, in seconds."));
 }
 

--- a/src/trx/game/objects/traps/generic_trap.c
+++ b/src/trx/game/objects/traps/generic_trap.c
@@ -26,34 +26,30 @@ typedef struct {
     bool push_lara;
 } M_PRIV;
 
-static void M_Initialise(const int16_t item_num)
+// Each of these holds its value to what the trap can use, so a change made
+// while the level runs is held to it too.
+static const char *M_SetTouchMask(ITEM *const item, const TRX_VALUE *const in)
 {
-    const ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    p->touch_mask = M_DEFAULT_TOUCH;
-    p->damage = M_DEFAULT_DAMAGE;
-    p->blood_intensity = M_DEFAULT_BLOOD;
-    p->push_lara = M_DEFAULT_PUSH;
+    // A negative mask means every mesh, which is the whole of the field.
+    p->touch_mask = in->as_int < 0 ? INT32_MAX : in->as_int;
+    return nullptr;
+}
 
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "touch_mask", &value)) {
-        p->touch_mask = value.as_int;
-    }
-    if (ObjectProperty_GetItemValue(item, "damage", &value)) {
-        p->damage = value.as_int;
-    }
-    if (ObjectProperty_GetItemValue(item, "blood_intensity", &value)) {
-        p->blood_intensity = value.as_int;
-    }
-    if (ObjectProperty_GetItemValue(item, "push_lara", &value)) {
-        p->push_lara = value.as_bool;
-    }
+static const char *M_SetDamage(ITEM *const item, const TRX_VALUE *const in)
+{
+    M_PRIV *const p = item->priv;
+    p->damage = MAX(0, in->as_int);
+    return nullptr;
+}
 
-    if (p->touch_mask < 0) {
-        p->touch_mask = INT32_MAX;
-    }
-    CLAMPL(p->damage, 0);
+static const char *M_SetBloodIntensity(
+    ITEM *const item, const TRX_VALUE *const in)
+{
+    M_PRIV *const p = item->priv;
+    p->blood_intensity = in->as_int;
     CLAMP(p->blood_intensity, 0, M_MAX_BLOOD);
+    return nullptr;
 }
 
 static void M_Collision(
@@ -123,7 +119,6 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
-    obj->initialise_func = M_Initialise;
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
 
@@ -134,19 +129,19 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "touch_mask", M_DEFAULT_TOUCH,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, touch_mask, M_DEFAULT_TOUCH, M_SetTouchMask,
             "A bitmask of damaging mesh numbers. The default value indicates "
             "all meshes are damaging."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, damage, M_DEFAULT_DAMAGE, M_SetDamage,
             "Damage dealt when Lara touches the trap."),
-        OBJECT_PROPERTY_INT(
-            "blood_intensity", M_DEFAULT_BLOOD,
+        OBJECT_PROPERTY_SET(
+            M_PRIV, blood_intensity, M_DEFAULT_BLOOD, M_SetBloodIntensity,
             "The intensity of blood to spawn when Lara is damaged. Value "
             "range: minimum 0; maximum 10."),
-        OBJECT_PROPERTY_BOOL(
-            "push_lara", true,
+        OBJECT_PROPERTY(
+            M_PRIV, push_lara, true,
             "Whether or not Lara should be pushed when colliding with the "
             "trap."));
 }

--- a/src/trx/game/objects/traps/hook.c
+++ b/src/trx/game/objects/traps/hook.c
@@ -8,19 +8,14 @@
 
 #define M_DEFAULT_DAMAGE 50
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (!Item_IsTriggerActive(item) && Item_TestFrameEqual(item, -1)) {
         Item_SwitchToAnim(item, 0, 0);
@@ -32,7 +27,7 @@ static void M_Control(const int16_t item_num)
     item->enable_interpolation = true;
     if (item->touch_bits != 0) {
         const ITEM *const lara_item = Lara_GetItem();
-        Lara_TakeDamage(M_GetDamage(item), true);
+        Lara_TakeDamage(p->damage, true);
         Spawn_BloodBath(
             lara_item->pos.x, lara_item->pos.y - WALL_L / 2, lara_item->pos.z,
             lara_item->speed, lara_item->rot.y, lara_item->room_num, 3);
@@ -50,6 +45,7 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->handle_save_func = M_HandleSave;
@@ -57,8 +53,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the hook."));
 }
 

--- a/src/trx/game/objects/traps/icicle.c
+++ b/src/trx/game/objects/traps/icicle.c
@@ -16,25 +16,20 @@ typedef enum {
     // clang-format on
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static void M_Reset(ITEM *const item)
 {
     item->mesh_bits = 0xFFFFFFFF;
     Trap_Reset(item);
 }
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     switch (item->current_anim_state) {
     case ICICLE_BREAK:
@@ -47,7 +42,7 @@ static void M_Control(const int16_t item_num)
             item->fall_speed = 50;
         }
         if (item->touch_bits != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
         }
         break;
 
@@ -81,6 +76,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Trap_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
@@ -89,8 +85,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when Lara is struck by the falling icicle."));
 }
 

--- a/src/trx/game/objects/traps/killer_statue.c
+++ b/src/trx/game/objects/traps/killer_statue.c
@@ -23,15 +23,9 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -44,6 +38,7 @@ static void M_Initialise(const int16_t item_num)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (Item_IsTriggerActive(item)
         && item->current_anim_state == M_STATE_STOP) {
@@ -54,7 +49,7 @@ static void M_Control(const int16_t item_num)
 
     if ((item->touch_bits & M_TOUCH_BITS) != 0
         && item->current_anim_state == M_STATE_CUT) {
-        Lara_TakeDamage(M_GetDamage(item), true);
+        Lara_TakeDamage(p->damage, true);
 
         const ITEM *const lara_item = Lara_GetItem();
         Spawn_Blood(
@@ -71,6 +66,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
@@ -78,8 +74,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is struck by the killer statue."));
 }
 

--- a/src/trx/game/objects/traps/lava_wedge.c
+++ b/src/trx/game/objects/traps/lava_wedge.c
@@ -12,24 +12,6 @@ typedef struct {
     int32_t speed;
 } M_PRIV;
 
-static int32_t M_GetSpeed(const ITEM *const item)
-{
-    TRX_VALUE speed = {};
-    if (ObjectProperty_GetItemValue(item, "speed", &speed)) {
-        return speed.as_int;
-    }
-
-    return M_DEFAULT_SPEED;
-}
-
-static void M_Initialise(const int16_t item_num)
-{
-    Trap_Initialise(item_num);
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    p->speed = M_GetSpeed(item);
-}
-
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -96,7 +78,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
+    obj->initialise_func = Trap_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->priv_size = sizeof(M_PRIV);
@@ -105,8 +87,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "speed", M_DEFAULT_SPEED,
+        OBJECT_PROPERTY(
+            M_PRIV, speed, M_DEFAULT_SPEED,
             "Offset applied each frame while the lava wedge advances."));
 }
 

--- a/src/trx/game/objects/traps/lightning_emitter.c
+++ b/src/trx/game/objects/traps/lightning_emitter.c
@@ -14,6 +14,7 @@
 #define M_SHOOTS 2
 
 typedef struct {
+    int32_t damage;
     bool active;
     int32_t count;
     bool zapped;
@@ -25,16 +26,6 @@ typedef struct {
     XYZ_32 wibble[M_STEPS];
     XYZ_32 shoot[M_SHOOTS][M_STEPS];
 } M_PRIV;
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -100,7 +91,7 @@ static void M_Control(const int16_t item_num)
             p->target.y = lara_item->pos.y;
             p->target.z = lara_item->pos.z;
 
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
 
             p->zapped = true;
         } else if (p->no_target) {
@@ -300,8 +291,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when Lara is struck by the lightning emitter."));
 }
 

--- a/src/trx/game/objects/traps/pendulum.c
+++ b/src/trx/game/objects/traps/pendulum.c
@@ -22,6 +22,7 @@
 // clang-format on
 
 typedef struct {
+    int32_t damage;
     bool initialised;
     bool on_fire;
     int16_t effect_num;
@@ -177,17 +178,6 @@ static void M_KillFireEffect(ITEM *const item)
     }
 }
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return item->object_id == O_SWINGING_AXE ? M_DEFAULT_AXE_DAMAGE
-                                             : M_DEFAULT_PENDULUM_DAMAGE;
-}
-
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -225,7 +215,7 @@ static void M_Control(const int16_t item_num)
     }
 
     if (working && item->touch_bits != 0) {
-        Lara_TakeDamage(M_GetDamage(item), true);
+        Lara_TakeDamage(p->damage, true);
 
         if (p->on_fire) {
             Lara_CatchFire();
@@ -284,8 +274,8 @@ static void M_SetupAxe(OBJECT *const obj)
     obj->collision_func = Object_Collision_Trap;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_AXE_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_AXE_DAMAGE,
             "Damage dealt while Lara is touching the swinging axe."));
 }
 
@@ -295,8 +285,8 @@ static void M_SetupPendulum(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_PENDULUM_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_PENDULUM_DAMAGE,
             "Damage dealt while Lara is touching the pendulum."));
 }
 

--- a/src/trx/game/objects/traps/propeller.c
+++ b/src/trx/game/objects/traps/propeller.c
@@ -17,6 +17,10 @@ typedef enum {
     // clang-format on
 } M_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -31,14 +35,15 @@ static void M_Collision(
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = Propeller_Control;
     obj->collision_func = M_Collision;
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the propeller."));
 }
 
@@ -51,26 +56,17 @@ static void M_SpawnBlood(const ITEM *const item, const int32_t count)
         item->rot.y + DEG_90, lara_item->room_num, count);
 }
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
 void Propeller_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (Item_IsTriggerActive(item) && !item->trigger.spent) {
         item->goal_anim_state = M_STATE_ON;
 
         if ((item->touch_bits & 6) != 0) {
             const ITEM *const lara_item = Lara_GetItem();
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             if (lara_item->hit_points <= 0) {
                 M_SpawnBlood(item, 5);
             }

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -15,6 +15,10 @@
 #define M_SHAKE_RANGE (WALL_L * 10) // = 10240
 #define M_CLEARANCE_UNIT (STEP_L * 3) // = 768
 
+typedef struct {
+    int32_t air_damage;
+} M_PRIV;
+
 static void M_Roll(ITEM *const item)
 {
     item->gravity = false;
@@ -41,16 +45,6 @@ static void M_Roll(ITEM *const item)
             g_Camera.bounce = 40 * (dist - M_SHAKE_RANGE) / M_SHAKE_RANGE;
         }
     }
-}
-
-static int32_t M_GetAirDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "air_damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_AIR_DAMAGE;
 }
 
 static bool M_TestStop(const ITEM *const item)
@@ -185,6 +179,7 @@ static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
     if (!Item_IsInPlay(item)) {
@@ -205,7 +200,7 @@ static void M_Collision(
         if (coll->enable_baddie_push) {
             Lara_Col_ItemPush(item, coll, coll->enable_hit, true);
         }
-        Lara_TakeDamage(M_GetAirDamage(item), false);
+        Lara_TakeDamage(p->air_damage, false);
 
         // TODO: handle overflows
         const int32_t dx = lara_item->pos.x - item->pos.x;
@@ -254,6 +249,7 @@ static void M_Collision(
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = Trap_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
@@ -263,8 +259,8 @@ static void M_Setup(OBJECT *const obj)
     obj->load_floor = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "air_damage", M_DEFAULT_AIR_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, air_damage, M_DEFAULT_AIR_DAMAGE,
             "Damage dealt when Lara is clipped by a moving boulder without "
             "being crushed."));
 }

--- a/src/trx/game/objects/traps/rotating_laser.c
+++ b/src/trx/game/objects/traps/rotating_laser.c
@@ -13,22 +13,13 @@
 #define M_DEFAULT_DAMAGE 25
 
 typedef struct {
+    int32_t damage;
     XYZ_32 origin;
     XYZ_32 target;
     int16_t direction;
     int16_t velocity;
     int16_t reverse_timer;
 } M_PRIV;
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -136,7 +127,7 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const lara_item = Lara_GetItem();
     if (Item_TestBoundsCollide(item, lara_item, 64)) {
-        Lara_TakeDamage(M_GetDamage(item), false);
+        Lara_TakeDamage(p->damage, false);
         Spawn_BloodBathD(
             lara_item->pos.x, item->pos.y - (Random_GetControl() & 0xFF) - 32,
             lara_item->pos.z, (Random_GetControl() & 0x7F) + 128,
@@ -160,8 +151,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the rotating laser."));
 }
 

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -11,18 +11,12 @@
 
 #define M_DEFAULT_DAMAGE 10
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static uint8_t m_LaserShades[32] = {};
 static const int16_t m_DefaultBeamCount = 1;
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
 
 static bool M_IsTargetable(const ITEM *const item)
 {
@@ -218,6 +212,7 @@ static void M_Initialise(const int16_t item_num)
 
 static void M_DamageLara(const ITEM *const item, const int32_t beam_y)
 {
+    const M_PRIV *const p = item->priv;
     if (item->object_id == O_SECURITY_LASER_ALARM) {
         return;
     }
@@ -226,7 +221,7 @@ static void M_DamageLara(const ITEM *const item, const int32_t beam_y)
     if (item->object_id == O_SECURITY_LASER_KILLER) {
         Lara_TakeDamage(lara_item->hit_points, false);
     } else {
-        Lara_TakeDamage(M_GetDamage(item), false);
+        Lara_TakeDamage(p->damage, false);
     }
 
     Spawn_BloodBath(
@@ -321,6 +316,7 @@ static bool M_DrawLaser(const ITEM *const item)
 
 static void M_SetupCommon(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->draw_func = M_DrawLaser;
@@ -336,7 +332,7 @@ static void M_SetupAlarm(OBJECT *const obj)
     M_SetupCommon(obj);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
 }
 
@@ -345,10 +341,10 @@ static void M_SetupDeadly(OBJECT *const obj)
     M_SetupCommon(obj);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when Lara crosses the security laser."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
 }
 
@@ -357,7 +353,7 @@ static void M_SetupKiller(OBJECT *const obj)
     M_SetupCommon(obj);
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -22,21 +22,12 @@ typedef enum {
 } M_MUZZLE;
 
 typedef struct {
+    int32_t damage;
     int16_t active_muzzle;
     int16_t muzzle_flash_timer;
     bool is_alerted;
     bool has_fired;
 } M_PRIV;
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -165,11 +156,11 @@ static void M_Control(const int16_t item_num)
             if (p->active_muzzle == M_MUZZLE_RIGHT) {
                 Creature_Shoot(
                     item, &info, &m_FireLeft, creature->joint_rotation[0],
-                    M_GetDamage(item));
+                    p->damage);
             } else {
                 Creature_Shoot(
                     item, &info, &m_FireRight, creature->joint_rotation[0],
-                    M_GetDamage(item));
+                    p->damage);
             }
 
             p->muzzle_flash_timer = 10;
@@ -250,10 +241,10 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 1)->rot.x = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when the sentry gun hits Lara."),
-        OBJECT_PROPERTY_INT("max_hit_points", 100, "Maximum hit points."));
+        OBJECT_PROPERTY_STORED("max_hit_points", 100, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_SENTRY_GUN, M_Setup)

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -11,18 +11,9 @@
 #define M_DEFAULT_SPEED 5
 
 typedef struct {
+    int32_t damage;
     int32_t speed;
 } M_PRIV;
-
-static int32_t M_GetSpeed(const ITEM *const item)
-{
-    TRX_VALUE speed = {};
-    if (ObjectProperty_GetItemValue(item, "speed", &speed)) {
-        return speed.as_int;
-    }
-
-    return M_DEFAULT_SPEED;
-}
 
 static bool M_Trigger(ITEM *const item, const ITEM_TRIGGER *const trigger)
 {
@@ -37,14 +28,6 @@ static bool M_Trigger(ITEM *const item, const ITEM_TRIGGER *const trigger)
 
     item->timer = 0;
     return true;
-}
-
-static void M_Initialise(const int16_t item_num)
-{
-    Trap_Initialise(item_num);
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    p->speed = M_GetSpeed(item);
 }
 
 static void M_Move(const int16_t item_num)
@@ -64,19 +47,10 @@ static void M_Move(const int16_t item_num)
     }
 }
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
 static void M_HitLara(ITEM *const item)
 {
-    Lara_TakeDamage(M_GetDamage(item), true);
+    const M_PRIV *const p = item->priv;
+    Lara_TakeDamage(p->damage, true);
 
     const ITEM *const lara_item = Lara_GetItem();
     Spawn_BloodBath(
@@ -108,7 +82,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
+    obj->initialise_func = Trap_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->priv_size = sizeof(M_PRIV);
@@ -117,11 +91,11 @@ static void M_Setup(OBJECT *const obj)
     obj->trigger_func = M_Trigger;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "speed", M_DEFAULT_SPEED,
+        OBJECT_PROPERTY(
+            M_PRIV, speed, M_DEFAULT_SPEED,
             "Offset applied each frame while the ceiling spikes descend."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the ceiling spikes."));
 }
 

--- a/src/trx/game/objects/traps/spike_wall.c
+++ b/src/trx/game/objects/traps/spike_wall.c
@@ -13,36 +13,9 @@
 #define M_DEFAULT_SPEED 16
 
 typedef struct {
+    int32_t damage;
     int32_t speed;
 } M_PRIV;
-
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
-static int32_t M_GetSpeed(const ITEM *const item)
-{
-    TRX_VALUE speed = {};
-    if (ObjectProperty_GetItemValue(item, "speed", &speed)) {
-        return speed.as_int;
-    }
-
-    return M_DEFAULT_SPEED;
-}
-
-static void M_Initialise(const int16_t item_num)
-{
-    Trap_Initialise(item_num);
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    p->speed = M_GetSpeed(item);
-}
 
 static void M_Move(const int16_t item_num)
 {
@@ -66,7 +39,8 @@ static void M_Move(const int16_t item_num)
 
 static void M_HitLara(ITEM *const item)
 {
-    Lara_TakeDamage(M_GetDamage(item), true);
+    const M_PRIV *const p = item->priv;
+    Lara_TakeDamage(p->damage, true);
 
     const ITEM *const lara_item = Lara_GetItem();
     Spawn_BloodBath(
@@ -94,7 +68,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
+    obj->initialise_func = Trap_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->priv_size = sizeof(M_PRIV);
@@ -102,11 +76,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "speed", M_DEFAULT_SPEED,
+        OBJECT_PROPERTY(
+            M_PRIV, speed, M_DEFAULT_SPEED,
             "Offset applied each frame while the spike wall advances."),
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the spike wall."));
 }
 

--- a/src/trx/game/objects/traps/spikes.c
+++ b/src/trx/game/objects/traps/spikes.c
@@ -9,20 +9,15 @@
 #define M_FALL_SPEED_LIMIT (g_TRVersion == 1 ? 0 : GRAVITY)
 #define M_DEFAULT_DAMAGE 15
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
+typedef struct {
+    int32_t damage;
+} M_PRIV;
 
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     if (lara_item->hit_points < 0) {
         return;
     }
@@ -45,7 +40,7 @@ static void M_Collision(
         return;
     }
 
-    Lara_TakeDamage(M_GetDamage(item), false);
+    Lara_TakeDamage(p->damage, false);
     for (int32_t i = 0; i < blood_spawn_count; i++) {
         const XYZ_32 pos = {
             .x = lara_item->pos.x + (Random_GetControl() - 0x4000) / 256,
@@ -77,6 +72,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
 
@@ -85,8 +81,8 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when Lara hits the spikes without dying instantly."));
 }
 

--- a/src/trx/game/objects/traps/spinning_blade.c
+++ b/src/trx/game/objects/traps/spinning_blade.c
@@ -26,6 +26,10 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -34,19 +38,10 @@ static void M_Initialise(const int16_t item_num)
     item->current_anim_state = M_STATE_STOP;
 }
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     bool flip = false;
 
     if (item->current_anim_state == M_STATE_SPIN) {
@@ -63,7 +58,7 @@ static void M_Control(const int16_t item_num)
 
         flip = true;
         if (item->touch_bits != 0) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
 
             const ITEM *const lara_item = Lara_GetItem();
             Spawn_BloodBath(
@@ -96,6 +91,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
@@ -104,8 +100,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the spinning blade."));
 }
 

--- a/src/trx/game/objects/traps/teeth_trap.c
+++ b/src/trx/game/objects/traps/teeth_trap.c
@@ -11,6 +11,10 @@ typedef enum {
     TEETH_TRAP_STATE_NASTY = 1,
 } TEETH_TRAP_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static const BITE m_Teeth[M_NUM_TEETH] = {
     // clang-format off
     { .pos = { .x = -23, .y = 0,   .z = -1718 }, .mesh_num = 0 },
@@ -22,16 +26,6 @@ static const BITE m_Teeth[M_NUM_TEETH] = {
     // clang-format on
 };
 
-static int32_t M_GetDamage(const ITEM *const item)
-{
-    TRX_VALUE damage = {};
-    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
-        return damage.as_int;
-    }
-
-    return M_DEFAULT_DAMAGE;
-}
-
 static void M_Bite(ITEM *const item, const BITE *const bite)
 {
     XYZ_32 pos = bite->pos;
@@ -42,12 +36,13 @@ static void M_Bite(ITEM *const item, const BITE *const bite)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (Item_IsTriggerActive(item)) {
         item->goal_anim_state = TEETH_TRAP_STATE_NASTY;
         if (item->touch_bits != 0
             && item->current_anim_state == TEETH_TRAP_STATE_NASTY) {
-            Lara_TakeDamage(M_GetDamage(item), true);
+            Lara_TakeDamage(p->damage, true);
             for (int32_t i = 0; i < M_NUM_TEETH; i++) {
                 M_Bite(item, &m_Teeth[i]);
             }
@@ -61,14 +56,15 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->priv_size = sizeof(M_PRIV);
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
-            "damage", M_DEFAULT_DAMAGE,
+        OBJECT_PROPERTY(
+            M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is caught in the teeth trap."));
 }
 

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -855,7 +855,7 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
+        OBJECT_PROPERTY_STORED(
             "is_heavy", true,
             "Whether or not this vehicle can activate heavy triggers."));
 }

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -1165,7 +1165,7 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
+        OBJECT_PROPERTY_STORED(
             "is_heavy", true,
             "Whether or not this vehicle can activate heavy triggers."));
 }

--- a/src/trx/game/objects/vehicles/mine_cart.c
+++ b/src/trx/game/objects/vehicles/mine_cart.c
@@ -871,14 +871,14 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_1", Music_ToGameID(MX_MINE_CART_THEME),
             "Random music track pool, slot 1. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_4", -1, "Random music track pool, slot 4. -1 = disabled."));
 }
 

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -225,11 +225,6 @@ static void M_Initialise(const int16_t item_num)
     }
 
     item->extra_rotations = p->extra_rotation;
-
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "test_static_collision", &value)) {
-        p->test_static_collision = value.as_bool;
-    }
 }
 
 static int32_t M_GetOnQuadBike(
@@ -1349,19 +1344,19 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_1", -1, "Random music track pool, slot 1. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
-        OBJECT_PROPERTY_BOOL(
+        OBJECT_PROPERTY_STORED(
             "is_heavy", true,
             "Whether or not this vehicle can activate heavy triggers."),
-        OBJECT_PROPERTY_BOOL(
-            "test_static_collision", false,
+        OBJECT_PROPERTY(
+            M_PRIV, test_static_collision, false,
             "Whether or not this vehicle can collide with static meshes."));
 }
 

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -1072,16 +1072,16 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_1", Music_ToGameID(MX_RIB_THEME),
             "Random music track pool, slot 1. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
-        OBJECT_PROPERTY_BOOL(
+        OBJECT_PROPERTY_STORED(
             "is_heavy", true,
             "Whether or not this vehicle can activate heavy triggers."));
 }

--- a/src/trx/game/objects/vehicles/skidoo_armed.c
+++ b/src/trx/game/objects/vehicles/skidoo_armed.c
@@ -48,7 +48,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "max_hit_points", SKIDOO_DRIVER_HITPOINTS, "Maximum hit points."));
 }
 

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -169,11 +169,6 @@ void Skidoo_Initialise(const int16_t item_num)
     skidoo_data->momentum_angle = item->rot.y;
     skidoo_data->track_mesh = 0;
     skidoo_data->pitch = 0;
-
-    TRX_VALUE value = {};
-    if (ObjectProperty_GetItemValue(item, "test_static_collision", &value)) {
-        skidoo_data->test_static_collision = value.as_bool;
-    }
 }
 
 int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -44,32 +44,32 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_1", Music_ToGameID(MX_SKIDOO_THEME),
             "Random music track pool, slot 1. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "battle_track_1", Music_ToGameID(MX_BATTLE_THEME),
             "Random battle music track pool, slot 1. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "battle_track_2", -1,
             "Random battle music track pool, slot 2. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "battle_track_3", -1,
             "Random battle music track pool, slot 3. -1 = disabled."),
-        OBJECT_PROPERTY_INT(
+        OBJECT_PROPERTY_STORED(
             "battle_track_4", -1,
             "Random battle music track pool, slot 4. -1 = disabled."),
-        OBJECT_PROPERTY_BOOL(
+        OBJECT_PROPERTY_STORED(
             "is_heavy", true,
             "Whether or not this vehicle can activate heavy triggers."),
-        OBJECT_PROPERTY_BOOL(
-            "test_static_collision", false,
+        OBJECT_PROPERTY(
+            SKIDOO_INFO, test_static_collision, false,
             "Whether or not this vehicle can collide with static meshes."));
 }
 

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -880,7 +880,7 @@ static void M_Setup(OBJECT *const obj)
 
     OBJECT_PROPERTIES(
         obj,
-        OBJECT_PROPERTY_BOOL(
+        OBJECT_PROPERTY_STORED(
             "is_heavy", true,
             "Whether or not this vehicle can activate heavy triggers."));
 }

--- a/tools/lint/checks/object_property_binding
+++ b/tools/lint/checks/object_property_binding
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harness import LintWarning, file_check
+
+BOUND_RE = re.compile(r"\bOBJECT_PROPERTY(?:_SET)?\(\s*(?P<struct>\w+),")
+CALL_RE = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
+
+
+def function_bodies(text):
+    """Every function in the file, by name, with the line it starts on."""
+    bodies = {}
+    for match in re.finditer(r"\b([A-Za-z_]\w*)\s*\([^;{}]*\)\s*\{", text):
+        depth, index = 1, match.end()
+        while depth and index < len(text):
+            depth += (text[index] == "{") - (text[index] == "}")
+            index += 1
+        line = text.count("\n", 0, match.start()) + 1
+        bodies[match.group(1)] = (text[match.end() : index - 1], line)
+    return bodies
+
+
+def sizes_priv(name, bodies, seen=None):
+    """Whether the function, or anything it calls, sizes the object's priv."""
+    if seen is None:
+        seen = set()
+    if name in seen or name not in bodies:
+        return False
+    seen.add(name)
+    body, _ = bodies[name]
+    if "priv_size" in body:
+        return True
+    return any(sizes_priv(callee, bodies, seen) for callee in CALL_RE.findall(body))
+
+
+def check(path, text):
+    bodies = function_bodies(text)
+    for name, (body, line) in bodies.items():
+        bound = BOUND_RE.search(body)
+        if bound is None or sizes_priv(name, bodies):
+            continue
+        # Without priv, an item has nowhere to keep the value: the engine
+        # writes nothing and the member reads as zero, silently.
+        yield LintWarning(
+            path,
+            f"{name} binds a property to {bound.group('struct')} but never sets "
+            f"obj->priv_size",
+            line=line,
+        )
+
+
+file_check(check)

--- a/tools/lint/gen/object_docs
+++ b/tools/lint/gen/object_docs
@@ -282,11 +282,13 @@ class RegisteredPropertyCatalog:
         result: dict[str, PropertyMap] = {}
         object_categories: dict[str, str] = {}
         global_constants = read_global_constants()
+        global_structs = read_global_structs()
         for path, category in read_source_files():
             source = strip_comments(path.read_text())
             source = expand_pickup_includes(source)
             constants = global_constants | read_local_constants(source)
             function_bodies = read_function_bodies(source)
+            structs = global_structs | read_struct_members(source)
             registrations: list[tuple[str, list[PropertyInfo]]] = []
 
             func_to_objects: dict[str, list[str]] = {}
@@ -301,7 +303,7 @@ class RegisteredPropertyCatalog:
                 if func_name not in function_bodies:
                     continue
                 declarations = collect_object_property_declarations(
-                    func_name, function_bodies
+                    func_name, function_bodies, structs, constants
                 )
                 for object_id in object_ids:
                     registrations.append((object_id, declarations))
@@ -341,7 +343,47 @@ def read_local_constants(source: str) -> dict[str, str]:
     )
     for name, value in const_pattern.findall(source):
         constants[name] = value.strip()
+
+    constants.update(read_enum_constants(source))
     return constants
+
+
+def read_enum_constants(source: str) -> dict[str, str]:
+    """Enumerators and the numbers they stand for.
+
+    A property bound to an enum member states its default as an enumerator, so
+    the docs have to resolve one the way the compiler does: counting up from the
+    last stated value.
+    """
+    constants: dict[str, str] = {}
+    enum_re = re.compile(r"enum\s*\{(?P<body>[^{}]*)\}", re.MULTILINE)
+    for match in enum_re.finditer(source):
+        next_value = 0
+        for entry in match.group("body").split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            name, _, value = (part.strip() for part in entry.partition("="))
+            if not re.fullmatch(r"[A-Za-z_]\w*", name):
+                continue
+            if value:
+                try:
+                    next_value = int(value, 0)
+                except ValueError:
+                    # A value this cannot read leaves the run of implicit ones
+                    # after it unknowable, so the enum is left alone.
+                    break
+            constants[name] = str(next_value)
+            next_value += 1
+    return constants
+
+
+def read_global_structs() -> dict[str, dict[str, str]]:
+    """Struct members from the headers, for a priv struct an object shares."""
+    structs: dict[str, dict[str, str]] = {}
+    for path in HEADER_SOURCE.rglob("*.h"):
+        structs.update(read_struct_members(strip_comments(path.read_text())))
+    return structs
 
 
 def read_global_constants() -> dict[str, str]:
@@ -457,29 +499,124 @@ def iter_macro_calls(source: str, macro_name: str) -> list[str]:
     return [args for _, args in iter_balanced_calls(source, pattern)]
 
 
-def iter_object_property_declarations(source: str) -> list[PropertyInfo]:
+# C member type -> the type name the docs and the Tomb Editor catalogs use.
+# An enum member rides in its integer storage, as it did when the declaration
+# named its own type.
+MEMBER_TYPES = {
+    "bool": "BOOL",
+    "int8_t": "INT",
+    "uint8_t": "INT",
+    "int16_t": "INT",
+    "uint16_t": "INT",
+    "int32_t": "INT",
+    "uint32_t": "INT",
+    "float": "FLOAT",
+    "double": "DOUBLE",
+    "XYZ_32": "XYZ",
+    "RGB_888": "RGB",
+}
+
+MEMBER_RE = re.compile(r"^\s*(?P<type>[A-Za-z_]\w*)\s+(?P<name>\w+)\s*;")
+
+
+def read_struct_members(source: str) -> dict[str, dict[str, str]]:
+    """struct name -> member name -> the C type of that member.
+
+    Only the members the struct itself declares: one nested a level down is not
+    addressable as a property, and the braces around it are what a plain regex
+    cannot see past.
+    """
+    structs: dict[str, dict[str, str]] = {}
+    for match in re.finditer(r"typedef struct \{", source):
+        depth, index = 1, match.end()
+        members: dict[str, str] = {}
+        line_start = index
+        while depth and index < len(source):
+            char = source[index]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            elif char == "\n":
+                if depth == 1:
+                    member = MEMBER_RE.match(source[line_start:index])
+                    if member:
+                        members[member.group("name")] = member.group("type")
+                line_start = index + 1
+            index += 1
+        name = re.match(r"\s*(\w+)\s*;", source[index:])
+        if name:
+            structs[name.group(1)] = members
+    return structs
+
+
+def infer_stored_type(value_expr: str, constants: dict[str, str]) -> str:
+    """The type a stored property carries, read off the value it declares.
+
+    A stored property has no member to take its type from, so the value states
+    it - the same way the compiler reads it through Value_Of. The value may be
+    written as a constant, so resolve one before looking.
+    """
+    expr = resolve_identifiers(value_expr, constants, 1).strip()
+    if expr.startswith("(bool)") or expr in ("true", "false"):
+        return "BOOL"
+    if "XYZ_32" in expr:
+        return "XYZ"
+    if "RGB_888" in expr:
+        return "RGB"
+    if re.search(r"\d\.\d", expr):
+        return "DOUBLE"
+    return "INT"
+
+
+def iter_object_property_declarations(
+    source: str,
+    structs: dict[str, dict[str, str]],
+    constants: dict[str, str],
+) -> list[PropertyInfo]:
     declarations: list[PropertyInfo] = []
     pattern = re.compile(
-        r"\bOBJECT_PROPERTY_(INT|FLOAT|DOUBLE|BOOL|XYZ|RGB)\(",
+        r"\bOBJECT_PROPERTY(?P<variant>_STORED_SET|_STORED|_SET)?\(",
         re.MULTILINE,
     )
     for match, args in iter_balanced_calls(source, pattern):
-        macro_type = match.group(1)
-        parts = split_args(args)
-        # RGB takes its channels as separate arguments.
-        if macro_type == "RGB" and len(parts) == 5:
-            parts = [parts[0], ", ".join(parts[1:4]), parts[4]]
-        if len(parts) == 3:
+        variant = match.group("variant") or ""
+        parts = [" ".join(part.split()) for part in split_args(args)]
+        stored = variant.startswith("_STORED")
+        # A setter sits between the default and the description.
+        if variant.endswith("_SET"):
+            parts = parts[:-2] + parts[-1:]
+        if stored:
+            if len(parts) != 3:
+                continue
             internal_name, value, description = parts
             internal_name = parse_c_string(internal_name)
-            declaration = PropertyInfo(
+            macro_type = infer_stored_type(value, constants)
+        else:
+            if len(parts) != 4:
+                continue
+            struct_name, internal_name, value, description = parts
+            member_type = structs.get(struct_name, {}).get(internal_name)
+            # An unknown member type means the two have drifted apart, which
+            # the compiler catches; the docs report what they can read.
+            macro_type = MEMBER_TYPES.get(member_type, "INT")
+        # An RGB default reads as its channels, not as the literal carrying
+        # them.
+        if macro_type == "RGB":
+            channels = re.search(r"\{(?P<channels>[^{}]*)\}", value)
+            if channels:
+                value = ", ".join(
+                    part.strip() for part in channels.group("channels").split(",")
+                )
+        declarations.append(
+            PropertyInfo(
                 internal_name=internal_name,
                 macro_type=macro_type,
-                value_expr=" ".join(value.split()),
+                value_expr=value,
                 description=parse_c_string(description),
                 constants={},
             )
-            declarations.append(declaration)
+        )
     return declarations
 
 
@@ -533,6 +670,8 @@ def read_function_bodies(source: str) -> dict[str, str]:
 def collect_object_property_declarations(
     func_name: str,
     function_bodies: dict[str, str],
+    structs: dict[str, dict[str, str]],
+    constants: dict[str, str],
     visited: set[str] | None = None,
 ) -> list[PropertyInfo]:
     if visited is None:
@@ -550,7 +689,9 @@ def collect_object_property_declarations(
         if len(props_parts) < 2:
             continue
         decl_text = "{" + ", ".join(props_parts[1:]) + "}"
-        declarations.extend(iter_object_property_declarations(decl_text))
+        declarations.extend(
+            iter_object_property_declarations(decl_text, structs, constants)
+        )
 
     call_pattern = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
     for match in call_pattern.finditer(body):
@@ -558,7 +699,7 @@ def collect_object_property_declarations(
         if callee in function_bodies:
             declarations.extend(
                 collect_object_property_declarations(
-                    callee, function_bodies, visited
+                    callee, function_bodies, structs, constants, visited
                 )
             )
 
@@ -636,6 +777,25 @@ class MusicToGameIDTransformer(ast.NodeTransformer):
         return ast.copy_location(ast.Constant(value=value), node)
 
 
+def strip_redundant_parens(expr: str) -> str:
+    """Drop the parens a resolved constant leaves around a compound literal.
+
+    Only literals: everything else may need the parens it was written with, and
+    a value that resolves to a number is left for the evaluator to fold.
+    """
+    expr = expr.strip()
+    while "{" in expr and expr.startswith("((") and expr.endswith("))"):
+        depth = 0
+        for index, char in enumerate(expr):
+            depth += (char == "(") - (char == ")")
+            if depth == 0:
+                break
+        if index != len(expr) - 1:
+            break
+        expr = expr[1:-1].strip()
+    return expr
+
+
 def evaluate_expression(
     expr: str,
     constants: dict[str, str],
@@ -643,6 +803,8 @@ def evaluate_expression(
     music_catalog: dict[str, str],
 ) -> str:
     expr = convert_ternary(resolve_identifiers(expr, constants, game_version))
+    expr = expr.replace("(bool)", "")
+    expr = strip_redundant_parens(expr)
     try:
         tree = ast.parse(expr, mode="eval")
     except SyntaxError:
@@ -1012,7 +1174,8 @@ class XmlExporter:
 
         if prop_type == "XYZ":
             match = re.fullmatch(
-                r"\(\(\s*XYZ_32\s*\)\s*\{\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\}\s*\)",
+                r"\(*\(\s*XYZ_32\s*\)\s*"
+                r"\{\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\}\s*\)*",
                 value,
             )
             if match:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Properties like `damage` and `collidable` lived in a table, looked up by name. Objects used them in two different ways: some looked the value up where they needed it, others copied it into their own struct when the item was created. The second way set the rule for everyone, because it meant a property changed later was quietly ignored. Nothing said so anywhere.

A property now points at the field that holds it:

```c
OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by the ape bite.")
```

The engine fills that field in when the item is created, and again whenever the property changes. The object just reads `p->damage`.

- Changing a property mid-level now works. Before, it did nothing.
- The lookup goes away. Every creature carried the same eight-line `M_GetDamage()`, and initialisers had blocks that copied properties into place - 316 declarations across 126 files.
- Clamps and conversions moved into the property's setter, so they still apply when a value changes later: the lift's speed, the bowl's pour time, the pulley's pull count, the flip slots, the trap masks.
- Values keep the units they are written in. The cobra's `alert_radius` stays in sectors and is squared where it is compared, instead of being stored already converted.
- A few properties have no field to point at and stay in the table: hit points, which the item manager reads for every object; the vehicle settings whose names are built at runtime; and object-level values with no item behind them.
- New lint check: an object that binds a property but never sets `priv_size` has nowhere to put it, and the field reads as zero all level. It caught one, in `bird.c`.

Players see no difference. `docs/trx/OBJECTS.md` and the Tomb Editor catalogs come out of the generator unchanged, so no default and no type moved.
