### PR TITLE
Fix crash when a replay file is missing

### DIFF
--- a/src/trx/core/completion.c
+++ b/src/trx/core/completion.c
@@ -13,20 +13,25 @@ void Completion_Init(COMPLETION *const c)
 
 void Completion_Clear(COMPLETION *const c)
 {
+    c->start = 0;
+    c->end = 0;
+    if (c->suggestions == nullptr) {
+        return;
+    }
     for (int32_t i = 0; i < c->suggestions->count; i++) {
         SUGGESTION *const s = Vector_Get(c->suggestions, i);
         Memory_Free(s->text);
     }
     Vector_Clear(c->suggestions);
-    c->start = 0;
-    c->end = 0;
 }
 
 void Completion_Free(COMPLETION *const c)
 {
     Completion_Clear(c);
-    Vector_Free(c->suggestions);
-    c->suggestions = nullptr;
+    if (c->suggestions != nullptr) {
+        Vector_Free(c->suggestions);
+        c->suggestions = nullptr;
+    }
 }
 
 void Completion_Add(COMPLETION *const c, const char *const text)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Pointing `--test-replay` at a file that is not there ended in a segfault instead of a clean error: terminating shuts down the console, which had not been started yet, so its prompt walked a null suggestions vector. Clearing or freeing a completion that was never initialised now leaves that vector alone.

This change is internal and does not affect players.