### PR TITLE
Refactor lifecycle events

### DIFF
--- a/data/trx/ship/games/tr1/scripts/atlantis.lua
+++ b/data/trx/ship/games/tr1/scripts/atlantis.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function()
+trx.events.on_game_start(function()
   trx.objects.bacon_lara.properties.anchor_room = 10
 end)

--- a/data/trx/ship/games/tr2/scripts/floating.lua
+++ b/data/trx/ship/games/tr2/scripts/floating.lua
@@ -1,4 +1,4 @@
-trx.events.after_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.swap_mesh(
     trx.catalog.objects.secret_2_option,
     trx.catalog.objects.secret_3_option,

--- a/data/trx/ship/games/tr2/scripts/level1.lua
+++ b/data/trx/ship/games/tr2/scripts/level1.lua
@@ -1,4 +1,4 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.monk_1)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_2)
 end)

--- a/data/trx/ship/games/tr2/scripts/level3.lua
+++ b/data/trx/ship/games/tr2/scripts/level3.lua
@@ -1,4 +1,4 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.monk_2)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_1)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_2)

--- a/data/trx/ship/games/tr2/scripts/level4.lua
+++ b/data/trx/ship/games/tr2/scripts/level4.lua
@@ -1,4 +1,4 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.monk_2)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_2)
 end)

--- a/data/trx/ship/games/tr2/scripts/monastry.lua
+++ b/data/trx/ship/games/tr2/scripts/monastry.lua
@@ -1,4 +1,4 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.monk_1)
   trx.creatures.add_ally(trx.catalog.objects.monk_2)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_1)

--- a/data/trx/ship/games/tr3/scripts/aldwych.lua
+++ b/data/trx/ship/games/tr3/scripts/aldwych.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.ceiling_spikes.properties.speed = 10
 end)

--- a/data/trx/ship/games/tr3/scripts/antarc.lua
+++ b/data/trx/ship/games/tr3/scripts/antarc.lua
@@ -1,4 +1,4 @@
-trx.events.after_level_state(function()
+trx.events.on_game_start(function()
   for _, room in pairs(trx.rooms) do
     room.damaging = room.underwater
     room.cold = true

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -1,9 +1,6 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   local props = trx.objects.strobe_light.properties
   props.requires_alarm_active = true
-end)
-
-trx.events.before_level_file(function(level)
   trx.creatures.add_ally(trx.catalog.objects.prisoner)
 end)
 

--- a/data/trx/ship/games/tr3/scripts/chunnel.lua
+++ b/data/trx/ship/games/tr3/scripts/chunnel.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.quad_bike.properties.is_heavy = false
 end)

--- a/data/trx/ship/games/tr3/scripts/compound.lua
+++ b/data/trx/ship/games/tr3/scripts/compound.lua
@@ -1,3 +1,3 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.prisoner)
 end)

--- a/data/trx/ship/games/tr3/scripts/crash.lua
+++ b/data/trx/ship/games/tr3/scripts/crash.lua
@@ -1,8 +1,5 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.sthpac_mercenary)
-end)
-
-trx.events.before_item_setup(function(level)
   -- Setup shoals
   trx.items[114].properties.range = { x = 22, y = 6, z = 6 }
 end)

--- a/data/trx/ship/games/tr3/scripts/ganges.lua
+++ b/data/trx/ship/games/tr3/scripts/ganges.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   local props = trx.objects.quad_bike.properties
   props.track_1 = 9
   props.track_2 = 12

--- a/data/trx/ship/games/tr3/scripts/house.lua
+++ b/data/trx/ship/games/tr3/scripts/house.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   -- Setup shoals
   trx.items[55].properties.range = { x = 22, y = 2, z = 10 }
   trx.items[56].properties.range = { x = 18, y = 1, z = 10 }

--- a/data/trx/ship/games/tr3/scripts/jungle.lua
+++ b/data/trx/ship/games/tr3/scripts/jungle.lua
@@ -1,8 +1,5 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.monkey)
-end)
-
-trx.events.before_item_setup(function(level)
   -- Setup shoals
   trx.items[133].properties.range = { x = 10, y = 3, z = 22 }
 end)

--- a/data/trx/ship/games/tr3/scripts/mines.lua
+++ b/data/trx/ship/games/tr3/scripts/mines.lua
@@ -1,8 +1,5 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.rx_worker_3)
-end)
-
-trx.events.after_level_state(function()
   for _, room in pairs(trx.rooms) do
     room.damaging = room.underwater
     room.cold = true

--- a/data/trx/ship/games/tr3/scripts/nevada.lua
+++ b/data/trx/ship/games/tr3/scripts/nevada.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   local props = trx.objects.cobra.properties
   props.alert_radius = 1.25
   props.attack_radius = 0.666667

--- a/data/trx/ship/games/tr3/scripts/rapids.lua
+++ b/data/trx/ship/games/tr3/scripts/rapids.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   -- Setup shoals
   trx.items[15].properties.range = { x = 6, y = 5, z = 10 }
   trx.items[51].properties.range = { x = 18, y = 8, z = 18 }

--- a/data/trx/ship/games/tr3/scripts/shore.lua
+++ b/data/trx/ship/games/tr3/scripts/shore.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   -- Setup shoals
   trx.items[8].properties.range = { x = 14, y = 6, z = 22 }
   trx.items[12].properties.range = { x = 14, y = 6, z = 14 }

--- a/data/trx/ship/games/tr3/scripts/temple.lua
+++ b/data/trx/ship/games/tr3/scripts/temple.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   -- Setup shoals
   trx.items[0].properties.range = { x = 6, y = 3, z = 30 }
   trx.items[19].properties.range = { x = 6, y = 2, z = 18 }

--- a/data/trx/ship/games/tr3/scripts/thames.lua
+++ b/data/trx/ship/games/tr3/scripts/thames.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.propeller_2.properties.damage = 1000
   trx.objects.propeller_3.properties.damage = 1000
 end)

--- a/data/trx/ship/games/tr3/scripts/tinnos.lua
+++ b/data/trx/ship/games/tr3/scripts/tinnos.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   local query = trx.items.query:of_object(trx.catalog.objects.animating_ext_1)
   for _, item in ipairs(query:matches()) do
     item.properties.kill_on_trigger = true

--- a/data/trx/ship/games/tr3/scripts/tower.lua
+++ b/data/trx/ship/games/tr3/scripts/tower.lua
@@ -1,3 +1,3 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.punk_1)
 end)

--- a/data/trx/ship/games/tr3/scripts/zoo.lua
+++ b/data/trx/ship/games/tr3/scripts/zoo.lua
@@ -1,8 +1,5 @@
-trx.events.before_level_file(function(level)
+trx.events.on_game_start(function(level)
   trx.creatures.add_ally(trx.catalog.objects.monkey)
-end)
-
-trx.events.before_item_setup(function(level)
   -- Setup shoals
   trx.items[65].properties.range = { x = 14, y = 6, z = 14 }
   trx.items[70].properties.range = { x = 14, y = 6, z = 14 }

--- a/data/trx/ship/games/tr4/scripts/alexhub.lua
+++ b/data/trx/ship/games/tr4/scripts/alexhub.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[38].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[39].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[40].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/alexhub2.lua
+++ b/data/trx/ship/games/tr4/scripts/alexhub2.lua
@@ -1,10 +1,7 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_14.properties.collidable = false
   trx.objects.animating_15.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false
-end)
-
-trx.events.before_item_setup(function(level)
   trx.items[42].properties.crowbar = true
   trx.items[79].properties.crowbar = true
   trx.items[82].properties.crowbar = true

--- a/data/trx/ship/games/tr4/scripts/ang_race.lua
+++ b/data/trx/ship/games/tr4/scripts/ang_race.lua
@@ -1,9 +1,6 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level, is_save)
   trx.objects.animating_14.properties.collidable = false
   trx.objects.animating_15.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false
-end)
-
-trx.events.on_game_start(function(level, is_save)
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
 end)

--- a/data/trx/ship/games/tr4/scripts/angkor1.lua
+++ b/data/trx/ship/games/tr4/scripts/angkor1.lua
@@ -1,10 +1,7 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level, is_save)
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_14.properties.collidable = false
   trx.objects.animating_15.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false
-end)
-
-trx.events.on_game_start(function(level, is_save)
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
 end)

--- a/data/trx/ship/games/tr4/scripts/bikebit.lua
+++ b/data/trx/ship/games/tr4/scripts/bikebit.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[56].properties.crowbar = true
 end)

--- a/data/trx/ship/games/tr4/scripts/cortyard.lua
+++ b/data/trx/ship/games/tr4/scripts/cortyard.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[1].properties.lift = true
 end)

--- a/data/trx/ship/games/tr4/scripts/csplit1.lua
+++ b/data/trx/ship/games/tr4/scripts/csplit1.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[58].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[92].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[104].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/highstrt.lua
+++ b/data/trx/ship/games/tr4/scripts/highstrt.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_13.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby2.lua
+++ b/data/trx/ship/games/tr4/scripts/joby2.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby4a.lua
+++ b/data/trx/ship/games/tr4/scripts/joby4a.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby4b.lua
+++ b/data/trx/ship/games/tr4/scripts/joby4b.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby4c.lua
+++ b/data/trx/ship/games/tr4/scripts/joby4c.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_13.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby5a.lua
+++ b/data/trx/ship/games/tr4/scripts/joby5a.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_14.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby5b.lua
+++ b/data/trx/ship/games/tr4/scripts/joby5b.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/karnak1.lua
+++ b/data/trx/ship/games/tr4/scripts/karnak1.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[66].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[68].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[82].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/lake.lua
+++ b/data/trx/ship/games/tr4/scripts/lake.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[16].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[33].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[34].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/libend.lua
+++ b/data/trx/ship/games/tr4/scripts/libend.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[13].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/library.lua
+++ b/data/trx/ship/games/tr4/scripts/library.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[12].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[135].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/lowstrt.lua
+++ b/data/trx/ship/games/tr4/scripts/lowstrt.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[45].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 
   trx.objects.animating_13.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/nutrench.lua
+++ b/data/trx/ship/games/tr4/scripts/nutrench.lua
@@ -1,3 +1,3 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/palaces.lua
+++ b/data/trx/ship/games/tr4/scripts/palaces.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[63].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[104].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/palaces2.lua
+++ b/data/trx/ship/games/tr4/scripts/palaces2.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.objects.animating_16.properties.collidable = false
   trx.items[26].properties.crowbar = true
   trx.items[123].properties.crowbar = true

--- a/data/trx/ship/games/tr4/scripts/semer.lua
+++ b/data/trx/ship/games/tr4/scripts/semer.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[47].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[235].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[236].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/semer2.lua
+++ b/data/trx/ship/games/tr4/scripts/semer2.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[52].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[59].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[60].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/settomb1.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb1.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[3].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[4].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[87].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/settomb2.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb2.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[3].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[135].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 

--- a/data/trx/ship/games/tr4/scripts/train.lua
+++ b/data/trx/ship/games/tr4/scripts/train.lua
@@ -1,4 +1,4 @@
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   trx.items[4].properties.crowbar = true
   trx.items[57].properties.crowbar = true
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added a `damage` property to the `O_POWER_SAW` object
 - improved error messages related to bad command invocations
 - changed reflections UV mapping to be more correct
+- changed the Lua level events to a single `on_game_start`, which every kind of level fires, with `on_title_start` for the title screen; refer to migration notes
 - changed object properties to take effect as soon as they change, rather than only when the item is first set up
 - changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -228,14 +228,37 @@ order: 3
 22. **Update game flows that anchor Bacon Lara**
    The `setup_bacon_lara` sequence event was removed. The anchor room is an
    `anchor_room` object property now, which a level editor can set on the object
-   or on a single item, and a script can set in `before_item_setup`:
+   or on a single item, and a script can set in `on_game_start`:
    ```lua
-   trx.events.before_item_setup(function()
+   trx.events.on_game_start(function()
      trx.objects.bacon_lara.properties.anchor_room = 10
    end)
    ```
    The property is optional: at its default of -1, the room Bacon Lara is placed
    in is the anchor. Refer to the Atlantis level in the default game flow.
+
+23. **Update scripts that use the level lifecycle events**
+   `before_level_file`, `after_level_file`, `before_item_setup`,
+   `after_item_setup` and `after_level_state` were removed. `on_game_start` is
+   the one moment a level script gets before play: the level file is loaded, its
+   items are set up, any savegame state has been applied, and nothing has been
+   drawn yet. A handler moves across as it stands:
+   ```lua
+   trx.events.on_game_start(function(level_num, is_save)
+     trx.creatures.add_ally(trx.catalog.objects.monkey)
+     trx.items[65].properties.range = { x = 14, y = 6, z = 14 }
+   end)
+   ```
+   An object property no longer has to be written before its item is
+   initialised, which is what the earlier moments were for. `on_game_start`
+   fires for cutscene and demo levels too, and the title screen has
+   `on_title_start`.
+
+24. **Update scripts that raise an item's maximum hit points**
+   Writing `max_hit_points` carries the item's current hit points with it, by
+   the difference: an item that has taken no damage comes out at full health,
+   and one that is already hurt stays hurt by as much. It no longer needs a
+   companion write to `hit_points`.
 
 ### Version 1.8 to 1.9
 

--- a/docs/trx/lua/GETTING_STARTED.md
+++ b/docs/trx/lua/GETTING_STARTED.md
@@ -32,7 +32,7 @@ Create a file `data/scripts/level1.lua` folder in your project and put the
 following content:
 
 ```lua
-trx.events.after_level_state(function(level)
+trx.events.on_game_start(function(level)
   trx.log.info("hello from level 1!")
 end)
 ```

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3135,118 +3135,7 @@
       "path": "creatures.add_ally_target"
     },
     {
-      "description": "Happens prior to loading the level file.",
-      "examples": [
-        "trx.events.before_level_file(function(level_num)\n  -- handle pre-file-load setup\nend)"
-      ],
-      "params": [
-        {
-          "name": "callback",
-          "params": [
-            {
-              "description": "Number of the level the event fired for.",
-              "name": "level_num",
-              "type": "integer"
-            }
-          ],
-          "type": "function"
-        }
-      ],
-      "path": "events.before_level_file",
-      "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
-      }
-    },
-    {
-      "description": "Happens after the level finishes loading, prior to loading information from a savegame.",
-      "params": [
-        {
-          "name": "callback",
-          "params": [
-            {
-              "description": "Number of the level the event fired for.",
-              "name": "level_num",
-              "type": "integer"
-            }
-          ],
-          "type": "function"
-        }
-      ],
-      "path": "events.after_level_file",
-      "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
-      }
-    },
-    {
-      "description": "Happens after level items exist, before they are initialized. Use this to set object or item properties that item initialization reads.",
-      "params": [
-        {
-          "name": "callback",
-          "params": [
-            {
-              "description": "Number of the level the event fired for.",
-              "name": "level_num",
-              "type": "integer"
-            }
-          ],
-          "type": "function"
-        }
-      ],
-      "path": "events.before_item_setup",
-      "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
-      }
-    },
-    {
-      "description": "Happens after level items exist, after they are initialized.",
-      "params": [
-        {
-          "name": "callback",
-          "params": [
-            {
-              "description": "Number of the level the event fired for.",
-              "name": "level_num",
-              "type": "integer"
-            }
-          ],
-          "type": "function"
-        }
-      ],
-      "path": "events.after_item_setup",
-      "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
-      }
-    },
-    {
-      "description": "Happens after the level finishes loading, after loading information from a savegame. If the game is started normally, this duplicates `after_level_file`.",
-      "examples": [
-        "trx.events.after_level_state(function(level_num)\n  -- handle post-savegame state restore\nend)"
-      ],
-      "params": [
-        {
-          "name": "callback",
-          "params": [
-            {
-              "description": "Number of the level the event fired for.",
-              "name": "level_num",
-              "type": "integer"
-            }
-          ],
-          "type": "function"
-        }
-      ],
-      "path": "events.after_level_state",
-      "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
-      }
-    },
-    {
-      "description": "Happens after the level finishes loading and the game is about to start. Unlike `after_level_file` and `after_level_state`, this waits for the fade-to-black / cross-fade effects to finish, so it is the place to play sound effects and run game logic.",
+      "description": "    Happens as a level starts running, before its first frame is drawn. By then\n    the level file is loaded, its items are set up and any savegame state has\n    been applied, so this is where a script sets object properties, declares\n    allies, changes room state and plays sound effects. Every kind of level\n    fires it: a played level, a cutscene and the attract demo alike. The title\n    screen has `on_title_start` instead.\n  ",
       "params": [
         {
           "name": "callback",
@@ -3266,6 +3155,23 @@
         }
       ],
       "path": "events.on_game_start",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "    Happens when the title screen's scene starts playing behind the menu, once\n    its level is loaded and its items are set up. The handler takes no\n    arguments. `on_game_start` does not fire for the title level.\n  ",
+      "examples": [
+        "trx.events.on_title_start(function()\n  trx.log.info(\"the menu is up\")\nend)"
+      ],
+      "params": [
+        {
+          "name": "callback",
+          "type": "function"
+        }
+      ],
+      "path": "events.on_title_start",
       "returns": {
         "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
         "type": "integer"

--- a/docs/trx/lua/examples/README.md
+++ b/docs/trx/lua/examples/README.md
@@ -13,7 +13,7 @@ section](../../OBJECTS.md) as a reference for original values.
 
 ```lua
 -- Adjust HP of certain enemies
-trx.events.before_item_setup(function(level)
+trx.events.on_game_start(function(level)
   -- Randomize bats HP
   for _, item in pairs(trx.items) do
     if item.object_id == trx.catalog.objects.bat then

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -18,72 +18,14 @@ A handler attached from a level script is detached automatically when the level 
 
 ### Functions
 
-- [lua]`trx.events.before_level_file(callback)`  
-  Happens prior to loading the level file.
-
-  Parameters:
-  - **`callback`** (function).
-    Called with:
-    - **`level_num`** (integer). Number of the level the event fired for.
-
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
-
-  Example:
-  ```lua
-  trx.events.before_level_file(function(level_num)
-    -- handle pre-file-load setup
-  end)
-  ```
-
-- [lua]`trx.events.after_level_file(callback)`  
-  Happens after the level finishes loading, prior to loading information from a savegame.
-
-  Parameters:
-  - **`callback`** (function).
-    Called with:
-    - **`level_num`** (integer). Number of the level the event fired for.
-
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
-
-- [lua]`trx.events.before_item_setup(callback)`  
-  Happens after level items exist, before they are initialized. Use this to set object or item properties that item initialization reads.
-
-  Parameters:
-  - **`callback`** (function).
-    Called with:
-    - **`level_num`** (integer). Number of the level the event fired for.
-
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
-
-- [lua]`trx.events.after_item_setup(callback)`  
-  Happens after level items exist, after they are initialized.
-
-  Parameters:
-  - **`callback`** (function).
-    Called with:
-    - **`level_num`** (integer). Number of the level the event fired for.
-
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
-
-- [lua]`trx.events.after_level_state(callback)`  
-  Happens after the level finishes loading, after loading information from a savegame. If the game is started normally, this duplicates `after_level_file`.
-
-  Parameters:
-  - **`callback`** (function).
-    Called with:
-    - **`level_num`** (integer). Number of the level the event fired for.
-
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
-
-  Example:
-  ```lua
-  trx.events.after_level_state(function(level_num)
-    -- handle post-savegame state restore
-  end)
-  ```
-
 - [lua]`trx.events.on_game_start(callback)`  
-  Happens after the level finishes loading and the game is about to start. Unlike `after_level_file` and `after_level_state`, this waits for the fade-to-black / cross-fade effects to finish, so it is the place to play sound effects and run game logic.
+      Happens as a level starts running, before its first frame is drawn. By then
+      the level file is loaded, its items are set up and any savegame state has
+      been applied, so this is where a script sets object properties, declares
+      allies, changes room state and plays sound effects. Every kind of level
+      fires it: a played level, a cutscene and the attract demo alike. The title
+      screen has `on_title_start` instead.
+
 
   Parameters:
   - **`callback`** (function).
@@ -92,6 +34,24 @@ A handler attached from a level script is detached automatically when the level 
     - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh.
 
   Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+- [lua]`trx.events.on_title_start(callback)`  
+      Happens when the title screen's scene starts playing behind the menu, once
+      its level is loaded and its items are set up. The handler takes no
+      arguments. `on_game_start` does not fire for the title level.
+
+
+  Parameters:
+  - **`callback`** (function).
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+  Example:
+  ```lua
+  trx.events.on_title_start(function()
+    trx.log.info("the menu is up")
+  end)
+  ```
 
 - [lua]`trx.events.on_pickup(callback)`  
   Happens just after Lara picks up an item.

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -30,85 +30,15 @@ local LISTENER_ID = {
   description = "Listener id. Pass it to `trx.events.detach` to stop listening.",
 }
 
--- The five level-lifecycle events share a signature; only the moment differs.
-local function level_hook(event_type, description, examples)
-  return {
-    description = description,
-    params = {
-      {
-        name = "callback",
-        type = "function",
-        params = {
-          {
-            name = "level_num",
-            type = "integer",
-            description = "Number of the level the event fired for.",
-          },
-        },
-      },
-    },
-    returns = LISTENER_ID,
-    examples = examples,
-    impl = hook(event_type),
-  }
-end
-
-api.define(
-  "events.before_level_file",
-  level_hook(
-    types.BEFORE_LEVEL_FILE,
-    "Happens prior to loading the level file.",
-    {
-      [[trx.events.before_level_file(function(level_num)
-  -- handle pre-file-load setup
-end)]],
-    }
-  )
-)
-
-api.define(
-  "events.after_level_file",
-  level_hook(
-    types.AFTER_LEVEL_FILE,
-    "Happens after the level finishes loading, prior to loading information from a savegame."
-  )
-)
-
-api.define(
-  "events.before_item_setup",
-  level_hook(
-    types.BEFORE_ITEM_SETUP,
-    "Happens after level items exist, before they are initialized. Use this to set object or "
-      .. "item properties that item initialization reads."
-  )
-)
-
-api.define(
-  "events.after_item_setup",
-  level_hook(
-    types.AFTER_ITEM_SETUP,
-    "Happens after level items exist, after they are initialized."
-  )
-)
-
-api.define(
-  "events.after_level_state",
-  level_hook(
-    types.AFTER_LEVEL_STATE,
-    "Happens after the level finishes loading, after loading information from a savegame. If the "
-      .. "game is started normally, this duplicates `after_level_file`.",
-    {
-      [[trx.events.after_level_state(function(level_num)
-  -- handle post-savegame state restore
-end)]],
-    }
-  )
-)
-
 api.define("events.on_game_start", {
-  description = "Happens after the level finishes loading and the game is about to start. Unlike "
-    .. "`after_level_file` and `after_level_state`, this waits for the fade-to-black / cross-fade "
-    .. "effects to finish, so it is the place to play sound effects and run game logic.",
+  description = [[
+    Happens as a level starts running, before its first frame is drawn. By then
+    the level file is loaded, its items are set up and any savegame state has
+    been applied, so this is where a script sets object properties, declares
+    allies, changes room state and plays sound effects. Every kind of level
+    fires it: a played level, a cutscene and the attract demo alike. The title
+    screen has `on_title_start` instead.
+  ]],
   params = {
     {
       name = "callback",
@@ -129,6 +59,22 @@ api.define("events.on_game_start", {
   },
   returns = LISTENER_ID,
   impl = hook(types.GAME_START),
+})
+
+api.define("events.on_title_start", {
+  description = [[
+    Happens when the title screen's scene starts playing behind the menu, once
+    its level is loaded and its items are set up. The handler takes no
+    arguments. `on_game_start` does not fire for the title level.
+  ]],
+  params = { { name = "callback", type = "function" } },
+  returns = LISTENER_ID,
+  examples = {
+    [[trx.events.on_title_start(function()
+  trx.log.info("the menu is up")
+end)]],
+  },
+  impl = hook(types.TITLE_START),
 })
 
 api.define("events.on_pickup", {

--- a/src/tests/unit/lua/events.lua
+++ b/src/tests/unit/lua/events.lua
@@ -39,22 +39,13 @@ test("the control events pass no arguments", function()
   assert(seen == 0, "before_control handed the handler an argument")
 end)
 
-test("the level events pass the level number", function()
-  local events = {
-    "before_level_file",
-    "after_level_file",
-    "before_item_setup",
-    "after_item_setup",
-    "after_level_state",
-  }
-  for _, name in ipairs(events) do
-    local seen = nil
-    trx.events[name](function(level_num)
-      seen = level_num
-    end)
-    fake.fire(name, 7)
-    assert(seen == 7, name .. " did not receive the level number")
-  end
+test("on_title_start passes no arguments", function()
+  local seen = "unset"
+  trx.events.on_title_start(function(...)
+    seen = select("#", ...)
+  end)
+  fake.fire("on_title_start")
+  assert(seen == 0, "on_title_start handed the handler an argument")
 end)
 
 test("on_pickup passes the item number", function()

--- a/src/tests/unit/test_lua_events.c
+++ b/src/tests/unit/test_lua_events.c
@@ -48,19 +48,8 @@ static int M_FakeFire(lua_State *const L)
               .value = { .b = lua_toboolean(L, 3) } },
         };
         LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
-    } else if (strcmp(name, "before_level_file") == 0) {
-        LUA_FireEventInt32(
-            LUA_EVENT_BEFORE_LEVEL_FILE, luaL_checkinteger(L, 2));
-    } else if (strcmp(name, "after_level_file") == 0) {
-        LUA_FireEventInt32(LUA_EVENT_AFTER_LEVEL_FILE, luaL_checkinteger(L, 2));
-    } else if (strcmp(name, "before_item_setup") == 0) {
-        LUA_FireEventInt32(
-            LUA_EVENT_BEFORE_ITEM_SETUP, luaL_checkinteger(L, 2));
-    } else if (strcmp(name, "after_item_setup") == 0) {
-        LUA_FireEventInt32(LUA_EVENT_AFTER_ITEM_SETUP, luaL_checkinteger(L, 2));
-    } else if (strcmp(name, "after_level_state") == 0) {
-        LUA_FireEventInt32(
-            LUA_EVENT_AFTER_LEVEL_STATE, luaL_checkinteger(L, 2));
+    } else if (strcmp(name, "on_title_start") == 0) {
+        LUA_FireEvent(LUA_EVENT_TITLE_START);
     } else if (strcmp(name, "on_flip_effect") == 0) {
         // The seam floor_data.c and the animation-command paths fire through.
         // The result - whether a script took the effect - is handed back, so

--- a/src/trx/game/enum.c
+++ b/src/trx/game/enum.c
@@ -124,12 +124,8 @@ static __attribute__((constructor)) void M_Init(void)
     ENUM_MAP(ITEM_TRIGGER_KIND, ITEM_TRIGGER_ANTI, "antitrigger");
 
     // LUA_EVENT_NUMBER_OF is a sentinel, not an event.
-    ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_BEFORE_LEVEL_FILE, "before_level_file");
-    ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_AFTER_LEVEL_FILE, "after_level_file");
-    ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_BEFORE_ITEM_SETUP, "before_item_setup");
-    ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_AFTER_ITEM_SETUP, "after_item_setup");
-    ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_AFTER_LEVEL_STATE, "after_level_state");
     ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_GAME_START, "game_start");
+    ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_TITLE_START, "title_start");
     ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_PICKUP, "pickup");
     ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_BEFORE_CONTROL, "before_control");
     ENUM_MAP(LUA_EVENT_TYPE, LUA_EVENT_AFTER_CONTROL, "after_control");

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -264,8 +264,6 @@ GF_COMMAND GF_InterpretSequence(
         }
     }
 
-    LUA_RunLevelScript(level);
-
     // load the level
     const GF_SEQUENCE *const sequence = &level->sequence;
     for (int32_t i = 0; i < sequence->length; i++) {

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -142,8 +142,6 @@ M_GF_HANDLER(M_HandlePlayLevel)
         Music_Stop();
     }
 
-    LUA_FireEventInt32(LUA_EVENT_AFTER_LEVEL_FILE, level->num);
-
     // post load
     switch (seq_ctx) {
     case GFSC_SAVED: {
@@ -170,8 +168,6 @@ M_GF_HANDLER(M_HandlePlayLevel)
         break;
     }
     GF_DisableObjectsIfNeeded();
-
-    LUA_FireEventInt32(LUA_EVENT_AFTER_LEVEL_STATE, level->num);
 
     g_Passport.ask_for_save =
         g_Config.gameplay.save_crystal_mode == SAVE_CRYSTAL_SAVE

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -17,6 +17,7 @@
 #include <trx/game/inventory_ring/priv.h>
 #include <trx/game/inventory_ring/vars.h>
 #include <trx/game/lara.h>
+#include <trx/game/lua/events.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
 #include <trx/game/option.h>
@@ -986,6 +987,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
             lara_item->mesh_bits = 0;
         }
         FlybyMode_Activate(g_GameFlow.title_flyby_sequence, false);
+        LUA_FireEvent(LUA_EVENT_TITLE_START);
     }
 
     Interpolation_Remember();

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -308,10 +308,10 @@ void Item_Initialise(const int16_t item_num)
     item->rot.z = 0;
     item->speed = 0;
     item->fall_speed = 0;
-    TRX_VALUE max_hit_points = {};
-    ObjectProperty_GetItemValue(item, "max_hit_points", &max_hit_points);
-    item->hit_points = max_hit_points.as_int;
-    item->max_hit_points = max_hit_points.as_int;
+    // Both are written by the max_hit_points property, once the item is far
+    // enough along to hold it.
+    item->hit_points = 0;
+    item->max_hit_points = 0;
     item->timer = 0;
     item->mesh_bits = 0xFFFFFFFF;
     item->touch_bits = 0;
@@ -375,12 +375,6 @@ void Item_Initialise(const int16_t item_num)
         Room_GetWorldSector(room, item->pos.x, item->pos.z);
     item->floor = sector->floor.height;
 
-    // TODO: remove GF check once demo config reset is run before level load
-    if (Game_IsBonusFlagSet(GBF_NGPLUS)
-        && GF_GetCurrentLevel()->type != GFL_DEMO) {
-        item->hit_points *= 2;
-    }
-
     if (obj->priv_size != 0) {
         if (item->priv != nullptr) {
             memset(item->priv, 0, obj->priv_size);
@@ -391,6 +385,12 @@ void Item_Initialise(const int16_t item_num)
 
     // Before the object's own initialiser, so it reads what it declared.
     ObjectProperty_ApplyToItem(item);
+
+    // TODO: remove GF check once demo config reset is run before level load
+    if (Game_IsBonusFlagSet(GBF_NGPLUS)
+        && GF_GetCurrentLevel()->type != GFL_DEMO) {
+        item->hit_points *= 2;
+    }
 
     if (obj->initialise_func != nullptr) {
         obj->initialise_func(item_num);

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <trx/core/handle.h>
+#include <trx/core/utils.h>
 #include <trx/game/anims.h>
 #include <trx/game/items/types.h>
+#include <trx/game/objects/property.h>
 
 void Item_Reset(void);
 void Item_InitialiseItems(int32_t num_items);
@@ -34,6 +36,24 @@ int16_t Item_CreateLevelItem(void);
 int16_t Item_Spawn(const ITEM *item, OBJECT_ID obj_id);
 
 void Item_Initialise(int16_t item_num);
+
+// The starting hit points an object gives its items, declared once for every
+// object that has any. Moving the ceiling carries the current hit points with
+// it, so a level states the maximum alone and an item that has already been
+// hurt stays hurt by as much.
+static inline void Item_Property_SetMaxHitPoints(
+    ITEM *item, const TRX_VALUE *value)
+{
+    item->hit_points += value->as_int - item->max_hit_points;
+    item->max_hit_points = value->as_int;
+    CLAMP(item->hit_points, 0, item->max_hit_points);
+}
+
+#define ITEM_PROPERTY_MAX_HIT_POINTS(value_)                                   \
+    OBJECT_PROPERTY_ITEM(                                                      \
+        max_hit_points, value_, nullptr, Item_Property_SetMaxHitPoints,        \
+        "Maximum hit points.")
+
 void Item_Control(void);
 
 // Begin fading a body out, if the rules call for bodies to fade at all.

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -88,7 +88,10 @@ bool Level_Initialise(
 
     Level_Unload();
 
-    LUA_FireEventInt32(LUA_EVENT_BEFORE_LEVEL_FILE, level->num);
+    // After the unload, so what the outgoing level torn down reaches the script
+    // that set it up, and here rather than in the sequencer, so a level loaded
+    // by any other path - the title screen among them - still runs its own.
+    LUA_RunLevelScript(level);
 
     Level_Pipeline_Load(level);
 

--- a/src/trx/game/level/finalize/gameplay_objects.c
+++ b/src/trx/game/level/finalize/gameplay_objects.c
@@ -162,7 +162,6 @@ void Level_Finalize_LoadObjectsAndItems(LEVEL_CONTEXT *const ctx)
     M_PrepareTR4Items(ctx);
 
     Inject_ApplyProperties();
-    LUA_FireEventInt32(LUA_EVENT_BEFORE_ITEM_SETUP, GF_GetCurrentLevel()->num);
 
     const int32_t item_count = Item_GetLevelCount();
     for (int32_t i = 0; i < item_count; i++) {

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -205,16 +205,10 @@ static const char *M_SetPos(void *const self, const TRX_VALUE *const in)
 static const char *M_SetHitPoints(void *const self, const TRX_VALUE *const in)
 {
     ITEM *const item = self;
-    item->hit_points = in->as_int;
-    if (item->hit_points > item->max_hit_points) {
-        ObjectProperty_SetItemValueRaw(
-            item, "max_hit_points",
-            (TRX_VALUE) {
-                .type = TVT_S32,
-                .as_int = item->hit_points,
-            });
-        item->max_hit_points = item->hit_points;
+    if (in->as_int > item->max_hit_points) {
+        ObjectProperty_SetItemValueRaw(item, "max_hit_points", *in);
     }
+    item->hit_points = in->as_int;
     return nullptr;
 }
 

--- a/src/trx/game/lua/events.h
+++ b/src/trx/game/lua/events.h
@@ -6,12 +6,8 @@
 // Event types for Lua listeners. Named in ENUM_MAP (see trx/game/enum.c), which
 // is what the hooks in src/lua/api/events.lua reflect.
 typedef enum {
-    LUA_EVENT_BEFORE_LEVEL_FILE,
-    LUA_EVENT_AFTER_LEVEL_FILE,
-    LUA_EVENT_BEFORE_ITEM_SETUP,
-    LUA_EVENT_AFTER_ITEM_SETUP,
-    LUA_EVENT_AFTER_LEVEL_STATE,
     LUA_EVENT_GAME_START,
+    LUA_EVENT_TITLE_START,
     LUA_EVENT_PICKUP,
     LUA_EVENT_BEFORE_CONTROL,
     LUA_EVENT_AFTER_CONTROL,

--- a/src/trx/game/objects/creatures/ape.c
+++ b/src/trx/game/objects/creatures/ape.c
@@ -262,9 +262,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the ape bite."));
 }

--- a/src/trx/game/objects/creatures/atlantean.c
+++ b/src/trx/game/objects/creatures/atlantean.c
@@ -326,9 +326,7 @@ static void M_SetupProperties(OBJECT *const obj)
 {
     obj->priv_size = sizeof(M_PRIV);
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, charge_damage, M_CHARGE_DAMAGE,
             "Damage dealt by the atlantean's charge attack."),

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -1,6 +1,5 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
-#include <trx/core/log.h>
 #include <trx/game/creature.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
@@ -20,23 +19,29 @@ typedef struct {
     int32_t death_count;
 } M_PRIV;
 
-static void M_InitialiseAnchor(ITEM *const item)
+static const char *M_CheckAnchorRoom(const TRX_VALUE *const in)
+{
+    // -1 leaves her in the room she is placed in, which is not known yet.
+    return in->as_int >= Room_GetCount() ? "no such room to anchor to"
+                                         : nullptr;
+}
+
+// She mirrors Lara about the centre of a room, which is worked out as the room
+// is named rather than each time she moves.
+static void M_SetAnchorRoom(ITEM *const item, const TRX_VALUE *const in)
 {
     M_PRIV *const p = item->priv;
-    p->anchored = false;
-
+    p->anchor_room = in->as_int;
     // The room she is placed in, unless the level names another.
-    const int32_t room_num =
-        p->anchor_room >= 0 ? p->anchor_room : item->room_num;
-    if (room_num >= Room_GetCount()) {
-        LOG_ERROR("Could not anchor Bacon Lara to room %d", room_num);
+    const int32_t room_num = in->as_int >= 0 ? in->as_int : item->room_num;
+    p->anchored = room_num < Room_GetCount();
+    if (!p->anchored) {
         return;
     }
 
     const ROOM *const room = Room_Get(room_num);
     p->anchor_x = room->pos.x + room->size.x * (WALL_L >> 1);
     p->anchor_z = room->pos.z + room->size.z * (WALL_L >> 1);
-    p->anchored = true;
 }
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
@@ -62,7 +67,6 @@ static void M_Initialise(const int16_t item_num)
     bacon_obj->anim_idx = lara_obj->anim_idx;
     bacon_obj->frame_base = lara_obj->frame_base;
     p->status = false;
-    M_InitialiseAnchor(item);
 }
 
 static void M_SyncToLara(ITEM *const item, const ITEM *const lara_item)
@@ -219,11 +223,9 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", LARA_MAX_HITPOINTS, "Maximum hit points."),
-        OBJECT_PROPERTY(
-            M_PRIV, anchor_room, -1,
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(LARA_MAX_HITPOINTS),
+        OBJECT_PROPERTY_SETTER(
+            M_PRIV, anchor_room, -1, M_CheckAnchorRoom, M_SetAnchorRoom,
             "Room whose center Bacon Lara mirrors Lara's movement about. "
             "-1 uses the room she is placed in. Value range: minimum -1."));
 }

--- a/src/trx/game/objects/creatures/baldy.c
+++ b/src/trx/game/objects/creatures/baldy.c
@@ -177,9 +177,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 0)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by Baldy's shot."));
 }

--- a/src/trx/game/objects/creatures/bandit_1.c
+++ b/src/trx/game/objects/creatures/bandit_1.c
@@ -206,9 +206,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the bandit's shot."));
 }

--- a/src/trx/game/objects/creatures/bandit_2.c
+++ b/src/trx/game/objects/creatures/bandit_2.c
@@ -244,9 +244,7 @@ static void M_Setup2A(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the bandit's shot."));
 }
@@ -280,9 +278,7 @@ static void M_Setup2B(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the bandit's shot."));
 }

--- a/src/trx/game/objects/creatures/barracuda.c
+++ b/src/trx/game/objects/creatures/barracuda.c
@@ -150,9 +150,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the barracuda bite."));
 }

--- a/src/trx/game/objects/creatures/bat.c
+++ b/src/trx/game/objects/creatures/bat.c
@@ -150,9 +150,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     obj->save_flags = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the bat attack."));
 }

--- a/src/trx/game/objects/creatures/bear.c
+++ b/src/trx/game/objects/creatures/bear.c
@@ -250,9 +250,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, charge_damage, M_CHARGE_DAMAGE,
             "Damage dealt while the bear charges into Lara."),

--- a/src/trx/game/objects/creatures/big_eel.c
+++ b/src/trx/game/objects/creatures/big_eel.c
@@ -114,9 +114,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
 
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the big eel bite."));
 }

--- a/src/trx/game/objects/creatures/big_spider.c
+++ b/src/trx/game/objects/creatures/big_spider.c
@@ -131,9 +131,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the big spider bite."));
 }

--- a/src/trx/game/objects/creatures/bird.c
+++ b/src/trx/game/objects/creatures/bird.c
@@ -185,10 +185,7 @@ static void M_SetupEagle(OBJECT *const obj)
     if (!M_SetupCommon(obj)) {
         return;
     }
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_EAGLE_HITPOINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_EAGLE_HITPOINTS));
 }
 
 static void M_SetupCrow(OBJECT *const obj)
@@ -196,10 +193,7 @@ static void M_SetupCrow(OBJECT *const obj)
     if (!M_SetupCommon(obj)) {
         return;
     }
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_CROW_HITPOINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_CROW_HITPOINTS));
 }
 
 static void M_SetupVulture(OBJECT *const obj)
@@ -207,10 +201,7 @@ static void M_SetupVulture(OBJECT *const obj)
     if (!M_SetupCommon(obj)) {
         return;
     }
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_VULTURE_HITPOINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_VULTURE_HITPOINTS));
 }
 
 REGISTER_OBJECT(O_EAGLE, M_SetupEagle)

--- a/src/trx/game/objects/creatures/bird_guardian.c
+++ b/src/trx/game/objects/creatures/bird_guardian.c
@@ -191,9 +191,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 14)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE,
             "Damage dealt by the bird guardian punch."));

--- a/src/trx/game/objects/creatures/centaur.c
+++ b/src/trx/game/objects/creatures/centaur.c
@@ -171,9 +171,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 10)->rot.x = true;
     Object_GetBone(obj, 10)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, rear_damage, M_REAR_DAMAGE,
             "Damage dealt by the centaur rear attack."),

--- a/src/trx/game/objects/creatures/civilian.c
+++ b/src/trx/game/objects/creatures/civilian.c
@@ -405,9 +405,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, punch_1_damage, M_PUNCH_1_DAMAGE,
             "Damage dealt by the civilian's first punch attack."),

--- a/src/trx/game/objects/creatures/claw_mutant.c
+++ b/src/trx/game/objects/creatures/claw_mutant.c
@@ -406,9 +406,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.z = true;
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE,
             "Damage dealt by the claw mutant melee attack."),

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -172,9 +172,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the cobra bite."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -293,9 +293,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 1)->rot.y = true;
     Object_GetBone(obj, 2)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the compy attack."));
 }

--- a/src/trx/game/objects/creatures/cowboy.c
+++ b/src/trx/game/objects/creatures/cowboy.c
@@ -186,9 +186,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 0)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the cowboy's shot."));
 }

--- a/src/trx/game/objects/creatures/crawler_mutant.c
+++ b/src/trx/game/objects/creatures/crawler_mutant.c
@@ -483,10 +483,7 @@ static void M_SetupCrawler(OBJECT *const obj)
     Object_GetBone(obj, 8)->rot.x = true;
     Object_GetBone(obj, 8)->rot.z = true;
     Object_GetBone(obj, 9)->rot.y = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 static void M_SetupDying(OBJECT *const obj)

--- a/src/trx/game/objects/creatures/crocodile.c
+++ b/src/trx/game/objects/creatures/crocodile.c
@@ -335,9 +335,7 @@ static void M_SetupCrocodile(OBJECT *const obj)
     obj->radius = M_CROCODILE_RADIUS;
     obj->smartness = M_CROCODILE_SMARTNESS;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_CROCODILE_HITPOINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_CROCODILE_HITPOINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_CROCODILE_BITE_DAMAGE,
             "Damage dealt by the crocodile bite."));
@@ -355,9 +353,7 @@ static void M_SetupAlligator(OBJECT *const obj)
     obj->smartness = M_ALLIGATOR_SMARTNESS;
     obj->lot_setup = LOT_Setup(LOT_SETUP_FLYER);
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_ALLIGATOR_HITPOINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_ALLIGATOR_HITPOINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_ALLIGATOR_BITE_DAMAGE,
             "Damage dealt by the alligator bite."));

--- a/src/trx/game/objects/creatures/cultist_1.c
+++ b/src/trx/game/objects/creatures/cultist_1.c
@@ -242,9 +242,7 @@ static void M_SetupCommon(OBJECT *const obj)
 
     Object_GetBone(obj, 0)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the cultist's shot."));
 }

--- a/src/trx/game/objects/creatures/cultist_2.c
+++ b/src/trx/game/objects/creatures/cultist_2.c
@@ -233,10 +233,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_CULT_2, M_Setup)

--- a/src/trx/game/objects/creatures/cultist_3.c
+++ b/src/trx/game/objects/creatures/cultist_3.c
@@ -290,9 +290,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the cultist's shot."));
 }

--- a/src/trx/game/objects/creatures/diver.c
+++ b/src/trx/game/objects/creatures/diver.c
@@ -256,10 +256,7 @@ static void M_Setup(OBJECT *const obj)
         Object_GetBone(obj, 10)->rot.y = true;
         Object_GetBone(obj, 14)->rot.z = true;
     }
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_DIVER, M_Setup)

--- a/src/trx/game/objects/creatures/dog.c
+++ b/src/trx/game/objects/creatures/dog.c
@@ -229,9 +229,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 19)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, bite_damage, M_BITE_DAMAGE,
             "Damage dealt by the dog bite."),

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -568,9 +568,7 @@ static void M_SetupFront(OBJECT *const obj)
 
     Object_GetBone(obj, 10)->rot.z = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, touch_damage, M_TOUCH_DAMAGE,
             "Damage dealt while Lara is touching the dragon."),

--- a/src/trx/game/objects/creatures/eel.c
+++ b/src/trx/game/objects/creatures/eel.c
@@ -119,9 +119,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the eel bite."));
 }

--- a/src/trx/game/objects/creatures/hybrid_mutant.c
+++ b/src/trx/game/objects/creatures/hybrid_mutant.c
@@ -292,9 +292,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.z = true;
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, jump_damage, M_JUMP_DAMAGE,
             "Damage dealt by the hybrid mutant jump attack."),

--- a/src/trx/game/objects/creatures/jelly.c
+++ b/src/trx/game/objects/creatures/jelly.c
@@ -89,9 +89,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the jelly sting."));
 }

--- a/src/trx/game/objects/creatures/larson.c
+++ b/src/trx/game/objects/creatures/larson.c
@@ -188,9 +188,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by Larson's shot."));
 }

--- a/src/trx/game/objects/creatures/lion.c
+++ b/src/trx/game/objects/creatures/lion.c
@@ -185,10 +185,7 @@ static void M_SetupLion(OBJECT *const obj)
 
     obj->smartness = 0x7FFF;
 
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_LION_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_LION_HIT_POINTS));
 }
 
 static void M_SetupLioness(OBJECT *const obj)
@@ -200,10 +197,7 @@ static void M_SetupLioness(OBJECT *const obj)
 
     obj->smartness = 0x2000;
 
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_LIONESS_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_LIONESS_HIT_POINTS));
 }
 
 static void M_SetupPuma(OBJECT *const obj)
@@ -215,10 +209,7 @@ static void M_SetupPuma(OBJECT *const obj)
 
     obj->smartness = 0x2000;
 
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_PUMA_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_PUMA_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_LION, M_SetupLion)

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -543,9 +543,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 1)->rot.z = true;
     Object_GetBone(obj, 9)->rot.z = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, bite_damage, M_BITE_DAMAGE,
             "Damage dealt by the lizard bite."),

--- a/src/trx/game/objects/creatures/mercenary.c
+++ b/src/trx/game/objects/creatures/mercenary.c
@@ -359,9 +359,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the mercenary's shot."));
 }

--- a/src/trx/game/objects/creatures/monk.c
+++ b/src/trx/game/objects/creatures/monk.c
@@ -240,9 +240,7 @@ static void M_SetupBase(OBJECT *const obj)
 
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_BIFF_DAMAGE, "Damage dealt by melee attacks."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -589,9 +589,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.x = true;
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE_NORMAL, "Damage dealt by bite attacks."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/creatures/mouse.c
+++ b/src/trx/game/objects/creatures/mouse.c
@@ -156,9 +156,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 3)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_BITE_DAMAGE, "Damage dealt by the bite attack."));
 }

--- a/src/trx/game/objects/creatures/mp_1.c
+++ b/src/trx/game/objects/creatures/mp_1.c
@@ -518,9 +518,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, punch_1_damage, M_PUNCH_1_DAMAGE,
             "Damage dealt by punch 1."),

--- a/src/trx/game/objects/creatures/mp_2.c
+++ b/src/trx/game/objects/creatures/mp_2.c
@@ -512,9 +512,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by gun shots."));
 }

--- a/src/trx/game/objects/creatures/mummy.c
+++ b/src/trx/game/objects/creatures/mummy.c
@@ -84,10 +84,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
 
     Object_GetBone(obj, 2)->rot.y = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_MUMMY, M_Setup)

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -354,10 +354,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 2)->rot.x = true;
     Object_GetBone(obj, 2)->rot.z = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_NATLA, M_Setup)

--- a/src/trx/game/objects/creatures/patrol_dog.c
+++ b/src/trx/game/objects/creatures/patrol_dog.c
@@ -318,9 +318,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 2)->rot.y = true;
     Object_GetBone(obj, 2)->rot.x = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the lunge attack."),

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -275,9 +275,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_SHOT_DAMAGE, "Damage dealt by shots."));
 }

--- a/src/trx/game/objects/creatures/prisoner.c
+++ b/src/trx/game/objects/creatures/prisoner.c
@@ -497,9 +497,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, punch_1_damage, M_PUNCH_1_DAMAGE,
             "Damage dealt by punch 1."),

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -572,9 +572,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, hit_damage, M_HIT_DAMAGE,
             "Damage dealt by punches 1 and 2."),

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -340,9 +340,7 @@ static void M_Setup(OBJECT *const obj)
         Object_GetBone(obj, 25)->rot.y = true;
     }
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, lunge_damage, M_LUNGE_DAMAGE,
             "Damage dealt by the lunge attack."),

--- a/src/trx/game/objects/creatures/rat.c
+++ b/src/trx/game/objects/creatures/rat.c
@@ -243,9 +243,7 @@ static void M_SetupBase(OBJECT *const obj)
 
     Object_GetBone(obj, 1)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_RAT_HITPOINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_RAT_HITPOINTS),
         OBJECT_PROPERTY(
             M_PRIV, bite_damage, M_RAT_BITE_DAMAGE,
             "Damage dealt by the bite attack."),

--- a/src/trx/game/objects/creatures/rx_worker_1.c
+++ b/src/trx/game/objects/creatures/rx_worker_1.c
@@ -489,9 +489,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."));
 }
 

--- a/src/trx/game/objects/creatures/rx_worker_2.c
+++ b/src/trx/game/objects/creatures/rx_worker_2.c
@@ -360,9 +360,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."));
 }
 

--- a/src/trx/game/objects/creatures/rx_worker_3.c
+++ b/src/trx/game/objects/creatures/rx_worker_3.c
@@ -538,10 +538,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.x = true;
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 7)->rot.y = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_RX_WORKER_3, M_Setup)

--- a/src/trx/game/objects/creatures/security_guard.c
+++ b/src/trx/game/objects/creatures/security_guard.c
@@ -491,9 +491,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."),
         OBJECT_PROPERTY(
             M_PRIV, final_shot_damage, M_FINAL_SHOT_DAMAGE,

--- a/src/trx/game/objects/creatures/shark.c
+++ b/src/trx/game/objects/creatures/shark.c
@@ -172,9 +172,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 9)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by bite attacks."));
 }

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -523,9 +523,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 25)->rot.x = true;
     Object_GetBone(obj, 25)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, pincer_damage, M_PINCER_DAMAGE,
             "Damage dealt by the pincer attack."),

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -234,9 +234,7 @@ static void M_Setup(OBJECT *const obj)
             O_SKATEBOARD);
     }
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, stop_shot_damage, M_STOP_SHOT_DAMAGE,
             "Damage dealt by shots while stopped."),

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -304,7 +304,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_STORED("max_hit_points", 1, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(1),
         OBJECT_PROPERTY(
             M_PRIV, shot_damage, M_LARA_DAMAGE,
             "Damage dealt by shots when Lara is not mounted."),

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -937,9 +937,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY_STORED(
             "knockback_damage", SOPHIA_KNOCKBACK_DAMAGE,
             "Damage dealt by the knockback shockwave."),

--- a/src/trx/game/objects/creatures/spider.c
+++ b/src/trx/game/objects/creatures/spider.c
@@ -167,9 +167,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
 
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by bite attacks."));
 }

--- a/src/trx/game/objects/creatures/swat.c
+++ b/src/trx/game/objects/creatures/swat.c
@@ -384,9 +384,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 7)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(M_PRIV, damage, M_DAMAGE, "Damage dealt by shots."),
         OBJECT_PROPERTY(
             M_PRIV, final_shot_damage, M_FINAL_SHOT_DAMAGE,

--- a/src/trx/game/objects/creatures/tiger.c
+++ b/src/trx/game/objects/creatures/tiger.c
@@ -202,9 +202,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 21)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by bite attacks."));
 }

--- a/src/trx/game/objects/creatures/tony.c
+++ b/src/trx/game/objects/creatures/tony.c
@@ -643,9 +643,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY_STORED(
             "fire_ball_damage", TONY_FIRE_BALL_DAMAGE,
             "Damage dealt by direct fire ball hits."));

--- a/src/trx/game/objects/creatures/torso.c
+++ b/src/trx/game/objects/creatures/torso.c
@@ -254,9 +254,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 1)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, touch_damage, M_TOUCH_DAMAGE,
             "Damage dealt by body contact."),

--- a/src/trx/game/objects/creatures/trex.c
+++ b/src/trx/game/objects/creatures/trex.c
@@ -199,9 +199,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 10)->rot.y = true;
     Object_GetBone(obj, 11)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, touch_damage, M_TOUCH_DAMAGE,
             "Damage dealt by body contact."),

--- a/src/trx/game/objects/creatures/trex_alpha.c
+++ b/src/trx/game/objects/creatures/trex_alpha.c
@@ -404,9 +404,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 20)->rot.y = true;
     Object_GetBone(obj, 22)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, touch_damage, M_TOUCH_DAMAGE,
             "Damage dealt by body contact."),

--- a/src/trx/game/objects/creatures/tribe_axeman.c
+++ b/src/trx/game/objects/creatures/tribe_axeman.c
@@ -364,9 +364,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, attack_2_damage, M_ATTACK_2_DAMAGE,
             "Damage dealt by attack 2."),

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -1460,9 +1460,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 7)->rot.y = true;
     Object_GetBone(obj, 7)->rot.x = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, head_beam_damage, M_HEAD_BEAM_DAMAGE,
             "Damage dealt by the head electric beam."));

--- a/src/trx/game/objects/creatures/tribe_pipeman.c
+++ b/src/trx/game/objects/creatures/tribe_pipeman.c
@@ -380,9 +380,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 13)->rot.y = true;
     Object_GetBone(obj, 13)->rot.x = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_BIFF_DAMAGE, "Damage dealt by melee attacks."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/creatures/wasp_mutant.c
+++ b/src/trx/game/objects/creatures/wasp_mutant.c
@@ -299,9 +299,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by the sting attack."));
 }

--- a/src/trx/game/objects/creatures/willard.c
+++ b/src/trx/game/objects/creatures/willard.c
@@ -966,9 +966,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, touch_damage, M_TOUCH_DAMAGE,
             "Damage dealt by body contact."),

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -116,9 +116,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED("max_hit_points", 1, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(1));
 }
 
 REGISTER_OBJECT(O_WINSTON, M_Setup)

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -263,10 +263,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_hitpoints = true;
     obj->save_flags = true;
     obj->save_anim = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS));
 }
 
 REGISTER_OBJECT(O_WINSTON_ARMY, M_Setup)

--- a/src/trx/game/objects/creatures/wolf.c
+++ b/src/trx/game/objects/creatures/wolf.c
@@ -233,9 +233,7 @@ static void M_Setup(OBJECT *const obj)
 
     Object_GetBone(obj, 2)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, pounce_damage, M_POUNCE_DAMAGE,
             "Damage dealt by the pounce attack."),

--- a/src/trx/game/objects/creatures/worker_1.c
+++ b/src/trx/game/objects/creatures/worker_1.c
@@ -224,9 +224,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 4)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by gun shots."));
 }

--- a/src/trx/game/objects/creatures/worker_2.c
+++ b/src/trx/game/objects/creatures/worker_2.c
@@ -248,9 +248,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 4)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DAMAGE, "Damage dealt by gun shots."));
 }

--- a/src/trx/game/objects/creatures/worker_3.c
+++ b/src/trx/game/objects/creatures/worker_3.c
@@ -312,9 +312,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 4)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, hit_damage, M_HIT_DAMAGE, "Damage dealt by punch attacks."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/creatures/xian_knight.c
+++ b/src/trx/game/objects/creatures/xian_knight.c
@@ -270,9 +270,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 16)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, damage, M_HACK_DAMAGE, "Damage dealt by sword slashes."));
 }

--- a/src/trx/game/objects/creatures/xian_spearman.c
+++ b/src/trx/game/objects/creatures/xian_spearman.c
@@ -426,9 +426,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 12)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, hit_1_damage, M_HIT_1_DAMAGE, "Damage dealt by attack 1."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/creatures/yeti.c
+++ b/src/trx/game/objects/creatures/yeti.c
@@ -328,9 +328,7 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 14)->rot.y = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", M_HIT_POINTS, "Maximum hit points."),
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(M_HIT_POINTS),
         OBJECT_PROPERTY(
             M_PRIV, punch_damage, M_PUNCH_DAMAGE, "Damage dealt by attack 1."),
         OBJECT_PROPERTY(

--- a/src/trx/game/objects/general/ai_node.c
+++ b/src/trx/game/objects/general/ai_node.c
@@ -3,9 +3,7 @@
 static void M_Setup(OBJECT *const obj)
 {
     obj->draw_func = nullptr;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED("max_hit_points", 0, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(0));
 }
 
 REGISTER_OBJECT(O_AI_AMBUSH, M_Setup)

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -247,9 +247,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = 128;
     obj->radius = 102;
     obj->intelligent = false;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED("max_hit_points", 8, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(8));
 }
 
 REGISTER_OBJECT(O_ASSAULT_TARGET, M_Setup)

--- a/src/trx/game/objects/general/cutscene_player.c
+++ b/src/trx/game/objects/general/cutscene_player.c
@@ -50,9 +50,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->control_func = M_Control;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED("max_hit_points", 1, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(1));
 }
 
 REGISTER_OBJECT(O_PLAYER_1, M_Setup)

--- a/src/trx/game/objects/general/pulley_switch.c
+++ b/src/trx/game/objects/general/pulley_switch.c
@@ -18,7 +18,7 @@ typedef struct {
     bool is_locked;
     bool is_single_use;
     int32_t required_pulls;
-    int32_t remaining_pulls;
+    int32_t pulls_done;
 } M_PRIV;
 
 static const OBJECT_BOUNDS m_Bounds = {
@@ -34,12 +34,19 @@ static const OBJECT_BOUNDS m_Bounds = {
 
 static const XYZ_32 m_Position = { .x = 0, .y = 0, .z = -148 };
 
+// What is left to pull. A requirement raised mid-pull asks for the difference;
+// one lowered past what has already been done leaves nothing to do.
+static int32_t M_RemainingPulls(const M_PRIV *const p)
+{
+    return MAX(0, p->required_pulls - p->pulls_done);
+}
+
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     JSON_SHOULD(JSON_READ(io, "is_on", &p->is_on));
     JSON_SHOULD(JSON_READ(io, "is_locked", &p->is_locked));
-    JSON_SHOULD(JSON_READ(io, "remaining_pulls", &p->remaining_pulls));
+    JSON_SHOULD(JSON_READ(io, "pulls_done", &p->pulls_done));
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
@@ -47,7 +54,7 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     const M_PRIV *const p = item->priv;
     JSONW_WRITE(io, "is_on", p->is_on);
     JSONW_WRITE(io, "is_locked", p->is_locked);
-    JSONW_WRITE(io, "remaining_pulls", p->remaining_pulls);
+    JSONW_WRITE(io, "pulls_done", p->pulls_done);
 }
 
 // Fewer pulls than the minimum would leave the pulley unusable.
@@ -62,7 +69,6 @@ static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    p->remaining_pulls = p->required_pulls;
 
     // The visibility initialisation flag is temporarily used to indicate that
     // the pulley cannot be operated until later events take place.
@@ -77,7 +83,7 @@ static void M_ControlWithLara(ITEM *const item)
 {
     ITEM *const lara_item = Lara_GetItem();
     M_PRIV *const p = item->priv;
-    if (g_Input.action && p->remaining_pulls != 0) {
+    if (g_Input.action && M_RemainingPulls(p) != 0) {
         lara_item->goal_anim_state = LS(LS_PULLEY);
     } else {
         lara_item->goal_anim_state = LS(LS_STOP);
@@ -98,7 +104,7 @@ static void M_ControlWithLara(ITEM *const item)
         return;
     }
 
-    if (p->remaining_pulls == 0 || p->is_locked) {
+    if (M_RemainingPulls(p) == 0 || p->is_locked) {
         return;
     }
 
@@ -106,14 +112,15 @@ static void M_ControlWithLara(ITEM *const item)
         return;
     }
 
-    p->remaining_pulls--;
-    if (p->remaining_pulls == 0) {
+    p->pulls_done++;
+    if (M_RemainingPulls(p) == 0) {
         if (p->is_single_use) {
             item->trigger.spent = true;
         } else {
             // Potentially multiple pulls to activate, but one to deactivate.
+            // Turning it back off takes a single pull.
             p->is_on = !p->is_on;
-            p->remaining_pulls = p->is_on ? M_MIN_PULLS : p->required_pulls;
+            p->pulls_done = p->is_on ? p->required_pulls - M_MIN_PULLS : 0;
         }
         Item_SetFinished(item, true);
     }

--- a/src/trx/game/objects/general/scion3.c
+++ b/src/trx/game/objects/general/scion3.c
@@ -80,9 +80,7 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
     obj->save_hitpoints = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED("max_hit_points", 5, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(5));
 }
 
 REGISTER_OBJECT(O_SCION_ITEM_3, M_Setup)

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -18,6 +18,7 @@ struct OBJECT_PROPERTY_ENTRY {
     size_t field_offset;
     TRX_VALUE_TYPE field_type;
     size_t field_size;
+    bool on_item;
     const char *(*check)(const TRX_VALUE *value);
     void (*set)(ITEM *item, const TRX_VALUE *value);
 };
@@ -101,19 +102,21 @@ static void M_WriteLiveValue(
     if (item == nullptr || (decl->set == nullptr && decl->field_size == 0)) {
         return;
     }
-    // A member, and a setter standing in for one, both live in the priv the
-    // level has not allocated yet; that copy is written as the item is
-    // initialised. A setter with no member of its own keeps its value
-    // elsewhere, so it runs either way.
-    if (decl->field_size != 0 && item->priv == nullptr) {
+    // A member of the object's priv, and a setter standing in for one, both
+    // live in what the level has not allocated yet; that copy is written as the
+    // item is initialised. A member of the item itself is there from the start,
+    // and a setter with no member of its own keeps its value elsewhere, so both
+    // run either way.
+    if (decl->field_size != 0 && !decl->on_item && item->priv == nullptr) {
         return;
     }
 
     if (decl->set != nullptr) {
         decl->set(item, value);
     } else {
+        void *const base = decl->on_item ? (void *)item : item->priv;
         Value_WritePtr(
-            decl->field_type, (char *)item->priv + decl->field_offset, value);
+            decl->field_type, (char *)base + decl->field_offset, value);
     }
 }
 
@@ -221,6 +224,7 @@ void ObjectProperty_ApplyDeclarations(
         entry->field_offset = declaration->field_offset;
         entry->field_type = declaration->field_type;
         entry->field_size = declaration->field_size;
+        entry->on_item = declaration->on_item;
         entry->check = declaration->check;
         entry->set = declaration->set;
         // A bound property is the view of its member: it carries the member's

--- a/src/trx/game/objects/property.h
+++ b/src/trx/game/objects/property.h
@@ -28,6 +28,9 @@ typedef struct {
     size_t field_offset;
     TRX_VALUE_TYPE field_type;
     size_t field_size;
+    // Whether the member belongs to the item itself rather than to the priv
+    // struct its object declares.
+    bool on_item;
     // Whether the property will take the value at all. It is asked without an
     // item, so it runs wherever a value is stated - including before the level
     // has items to write it to. Returns nullptr once the value is accepted, or
@@ -86,6 +89,22 @@ typedef OBJECT_PROPERTY_SET ITEM_PROPERTY_SET;
         .field_offset = offsetof(struct_, member_),                            \
         .field_type = Value_TypeOf(((struct_ *)nullptr)->member_),             \
         .field_size = sizeof(((struct_ *)nullptr)->member_),                   \
+        .check = check_,                                                       \
+        .set = set_,                                                           \
+    }
+
+// A property an item carries in a member of its own rather than in what its
+// object keeps privately: one the engine reads for every object, whatever it
+// is. `set_` may be nullptr.
+#define OBJECT_PROPERTY_ITEM(member_, value_, check_, set_, description_)      \
+    {                                                                          \
+        .name = #member_,                                                      \
+        .description = description_,                                           \
+        .value = Value_Of(value_),                                             \
+        .field_offset = offsetof(ITEM, member_),                               \
+        .field_type = Value_TypeOf(((ITEM *)nullptr)->member_),                \
+        .field_size = sizeof(((ITEM *)nullptr)->member_),                      \
+        .on_item = true,                                                       \
         .check = check_,                                                       \
         .set = set_,                                                           \
     }

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -19,10 +19,7 @@ static void M_SetupLara(OBJECT *const obj)
     obj->save_hitpoints = true;
     obj->save_flags = true;
     obj->save_anim = true;
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", LARA_MAX_HITPOINTS, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(LARA_MAX_HITPOINTS));
     ObjectProperty_SetObjectValueRaw(
         obj, "max_hit_points",
         (TRX_VALUE) {

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -330,10 +330,7 @@ static void M_SetupCommon(OBJECT *const obj)
 static void M_SetupAlarm(OBJECT *const obj)
 {
     M_SetupCommon(obj);
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(m_DefaultBeamCount));
 }
 
 static void M_SetupDeadly(OBJECT *const obj)
@@ -344,17 +341,13 @@ static void M_SetupDeadly(OBJECT *const obj)
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when Lara crosses the security laser."),
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
+        ITEM_PROPERTY_MAX_HIT_POINTS(m_DefaultBeamCount));
 }
 
 static void M_SetupKiller(OBJECT *const obj)
 {
     M_SetupCommon(obj);
-    OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
+    OBJECT_PROPERTIES(obj, ITEM_PROPERTY_MAX_HIT_POINTS(m_DefaultBeamCount));
 }
 
 REGISTER_OBJECT(O_SECURITY_LASER_ALARM, M_SetupAlarm)

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -244,7 +244,7 @@ static void M_Setup(OBJECT *const obj)
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when the sentry gun hits Lara."),
-        OBJECT_PROPERTY_STORED("max_hit_points", 100, "Maximum hit points."));
+        ITEM_PROPERTY_MAX_HIT_POINTS(100));
 }
 
 REGISTER_OBJECT(O_SENTRY_GUN, M_Setup)

--- a/src/trx/game/objects/vehicles/skidoo_armed.c
+++ b/src/trx/game/objects/vehicles/skidoo_armed.c
@@ -47,9 +47,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     OBJECT_PROPERTIES(
-        obj,
-        OBJECT_PROPERTY_STORED(
-            "max_hit_points", SKIDOO_DRIVER_HITPOINTS, "Maximum hit points."));
+        obj, ITEM_PROPERTY_MAX_HIT_POINTS(SKIDOO_DRIVER_HITPOINTS));
 }
 
 void SkidooArmed_Push(

--- a/src/trx/game/phase/phase_cutscene.c
+++ b/src/trx/game/phase/phase_cutscene.c
@@ -42,6 +42,13 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     }
     Game_SetIsPlaying(true);
     Lara_SetControllable(false);
+    // The same event a played level fires: whatever the level is, this is the
+    // moment it starts running.
+    const LUA_EVENT_ARG args[] = {
+        { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = p->args.level_num } },
+        { .type = LUA_EVENT_ARG_BOOL, .value = { .b = false } },
+    };
+    LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
     return (PHASE_CONTROL) {};
 }
 

--- a/src/trx/game/phase/phase_demo.c
+++ b/src/trx/game/phase/phase_demo.c
@@ -6,6 +6,7 @@
 #include <trx/game/game.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/inventory_ring.h>
+#include <trx/game/lua/events.h>
 #include <trx/game/output/overlay.h>
 #include <trx/game/shell.h>
 
@@ -41,6 +42,14 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
 
     p->state = STATE_RUN;
     Game_SetIsPlaying(true);
+
+    // The same event a played level fires: whatever the level is, this is the
+    // moment it starts running.
+    const LUA_EVENT_ARG args[] = {
+        { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = p->level_num } },
+        { .type = LUA_EVENT_ARG_BOOL, .value = { .b = false } },
+    };
+    LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
 
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -558,14 +558,17 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t read_index)
     }
 
     if (obj->save_hitpoints) {
-        M_MUST(JSON_READ(io, "hitpoints", &item->hit_points));
-        M_MUST(JSON_READ(io, "max_hitpoints", &item->max_hit_points));
+        int16_t hit_points = 0;
+        int16_t max_hit_points = 0;
+        M_MUST(JSON_READ(io, "hitpoints", &hit_points));
+        M_MUST(JSON_READ(io, "max_hitpoints", &max_hit_points));
         ObjectProperty_SetItemValueRaw(
             item, "max_hit_points",
             (TRX_VALUE) {
                 .type = TVT_S32,
-                .as_int = item->max_hit_points,
+                .as_int = max_hit_points,
             });
+        item->hit_points = hit_points;
     }
     M_MUST(ObjectProperty_ReadItemOverrides(io, item));
 

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -338,7 +338,6 @@ void Stats_CalculateMaxStats(void)
             Rules_Reset();
 
             LUA_RunLevelScript(level);
-            LUA_FireEventInt32(LUA_EVENT_BEFORE_LEVEL_FILE, level->num);
 
             Inject_InitLevel(level, INJECTION_MODE_STATS);
             if (loader->probe(loader, file, LEVEL_FORMAT_PROBE_STATS)) {
@@ -351,7 +350,6 @@ void Stats_CalculateMaxStats(void)
                 }
 
                 Inject_ApplyProperties();
-                LUA_FireEventInt32(LUA_EVENT_BEFORE_ITEM_SETUP, level->num);
 
                 const int32_t item_count = Item_GetLevelCount();
                 for (int32_t item_num = 0; item_num < item_count; item_num++) {
@@ -364,8 +362,6 @@ void Stats_CalculateMaxStats(void)
                         room->item_num = item_num;
                     }
                 }
-
-                LUA_FireEventInt32(LUA_EVENT_AFTER_ITEM_SETUP, level->num);
 
                 Carrier_InitialiseLevel(level);
                 Stats_ScanLevel(level);

--- a/tools/lint/gen/object_docs
+++ b/tools/lint/gen/object_docs
@@ -527,7 +527,7 @@ def read_struct_members(source: str) -> dict[str, dict[str, str]]:
     cannot see past.
     """
     structs: dict[str, dict[str, str]] = {}
-    for match in re.finditer(r"typedef struct \{", source):
+    for match in re.finditer(r"typedef struct(?:\s+\w+)?\s*\{", source):
         depth, index = 1, match.end()
         members: dict[str, str] = {}
         line_start = index
@@ -569,6 +569,15 @@ def infer_stored_type(value_expr: str, constants: dict[str, str]) -> str:
     return "INT"
 
 
+# Named declarations that stand for a whole property. The tuple is what the
+# macro fills in: the member it binds, the type of that member, and the
+# description it carries.
+NAMED_DECLARATIONS = {
+    "ITEM_PROPERTY_MAX_HIT_POINTS": (
+        "max_hit_points", "ITEM", "Maximum hit points."),
+}
+
+
 def iter_object_property_declarations(
     source: str,
     structs: dict[str, dict[str, str]],
@@ -576,19 +585,38 @@ def iter_object_property_declarations(
 ) -> list[PropertyInfo]:
     declarations: list[PropertyInfo] = []
     pattern = re.compile(
-        r"\bOBJECT_PROPERTY"
-        r"(?P<variant>_STORED_SETTER|_STORED|_SETTER|_CHECKED)?\(",
+        r"\b(?:OBJECT_PROPERTY"
+        r"(?P<variant>_STORED_SETTER|_STORED|_SETTER|_CHECKED|_ITEM)?"
+        r"|(?P<named>" + "|".join(NAMED_DECLARATIONS) + r"))\(",
         re.MULTILINE,
     )
     # How many hooks sit between the default and the description.
-    HOOK_COUNTS = {"_CHECKED": 1, "_SETTER": 2, "_STORED_SETTER": 2}
+    HOOK_COUNTS = {"_CHECKED": 1, "_SETTER": 2, "_STORED_SETTER": 2, "_ITEM": 2}
     for match, args in iter_balanced_calls(source, pattern):
+        named = match.group("named")
+        if named is not None:
+            name, struct, description = NAMED_DECLARATIONS[named]
+            declarations.append(
+                PropertyInfo(
+                    internal_name=name,
+                    macro_type=MEMBER_TYPES.get(
+                        structs.get(struct, {}).get(name), "INT"),
+                    value_expr=" ".join(args.split()),
+                    description=description,
+                    constants={},
+                )
+            )
+            continue
         variant = match.group("variant") or ""
         parts = [" ".join(part.split()) for part in split_args(args)]
         stored = variant.startswith("_STORED")
         hooks = HOOK_COUNTS.get(variant, 0)
         if hooks:
             parts = parts[: -hooks - 1] + parts[-1:]
+        # An item-bound property names a member of ITEM rather than of a priv
+        # struct, so the struct is not written out.
+        if variant == "_ITEM":
+            parts = ["ITEM"] + parts
         if stored:
             if len(parts) != 3:
                 continue


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR collapses the five events a level script could listen for as its level loaded:

- `before_level_file`
- `after_level_file`
- `before_item_setup`
- `after_item_setup`
- `after_level_state`

into `on_game_start`, plus a new `on_title_start` for the title screen.

They existed because the engine read what a script set at different points of the load: properties before the items were initialised, allies before anything targeted, room state after the savegame. Property writes now land whenever they are made, so one moment covers all of it.

- 56 shipped scripts move across with only the name changed. `after_item_setup` needed none – it never fired during play.
- Cutscene and demo levels now fire `on_game_start` too.
- The title level's script used to stop working after the first game, because `GF_RunTitle` never ran it. It now runs from the level load itself.
- The old names are removed rather than aliased. A handler runs later than it used to, and breaking loudly beats doing nothing quietly. Migration notes cover the move.
- `max_hit_points` was the last property that had to be set before its item existed. Raising it now carries the creature's current hit points, so it works on a living enemy.

#### Testing

- [x] Start TR3 Antarctica fresh
  The RX worker fights for Lara; underwater rooms damage and every room is cold.
- [x] Start TR4 Karnak and pick up the four plinth items
  They still use the low-plinth animation.
- [x] Start TR1 Atlantis and let Bacon Lara mirror Lara
  She pivots about room 10, as before.
- [x] Save mid-level in each, reload
  Same behaviour after the reload.
- [x] Play a level, quit to the title, start another
  The title screen still loads and its menu works.
- [x] Watch the TR2 cutscene before the Wreck
  Lara changes into the diving suit at the right frame.
- [ ] `/set` an enemy's `max_hit_points` after wounding it
  Its current hit points rise by the same amount, not to full.
- [x] Operate a TR4 pulley switch, saving and reloading mid-sequence
  The pulls already done still count.
- [x] Start a level with NG+ enabled
  Enemies still have double hit points.
- [x] Start Floating Islands
  3D secret meshes match 2D sprites
- [x] Start Floating Islands, save, reload
  3D secret meshes match 2D sprites
