### PR TITLE
gym: let the title selection follow the mod

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fixed flyby sequences set to loop playing only once, then swinging the camera back to Lara
 - fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
 - fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
+- fixed the title screen starting on the wrong item after switching mods, such as the home photo in place of the passport (regression from 1.5)
 - fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)
 - fixed quick saves bypassing the save crystals mode
 - fixed the game displaying a GUI error dialog when it fails to start in headless mode

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -42,9 +42,12 @@ typedef struct {
     } quad_course;
 } M_PRIV;
 
-static M_PRIV m_Priv = {
-    .is_inventory_open_enabled = -1,
-};
+#define M_PRIV_INITIAL                                                         \
+    {                                                                          \
+        .is_inventory_open_enabled = -1,                                       \
+    }
+
+static M_PRIV m_Priv = M_PRIV_INITIAL;
 
 static int32_t M_CountAssaultTargets(void)
 {
@@ -210,6 +213,11 @@ static void M_Racetrack_Finish(void)
     p->quad_course.timer_active = false;
 }
 
+void Gym_Shutdown(void)
+{
+    m_Priv = (M_PRIV)M_PRIV_INITIAL;
+}
+
 void Gym_SetInventoryOpenEnabled(const bool enabled)
 {
     M_PRIV *const p = &m_Priv;
@@ -218,9 +226,11 @@ void Gym_SetInventoryOpenEnabled(const bool enabled)
 
 bool Gym_IsInventoryOpenEnabled(void)
 {
-    M_PRIV *const p = &m_Priv;
+    const M_PRIV *const p = &m_Priv;
+    // Until the game says otherwise, the answer follows the engine version,
+    // which changes under us when the player switches mods.
     if (p->is_inventory_open_enabled == -1) {
-        p->is_inventory_open_enabled = g_TRVersion >= 2;
+        return g_TRVersion >= 2;
     }
     return p->is_inventory_open_enabled;
 }

--- a/src/trx/game/gym.h
+++ b/src/trx/game/gym.h
@@ -14,6 +14,10 @@ typedef enum {
     GYM_TRACK_NUMBER_OF
 } GYM_TRACK_TYPE;
 
+// Drops the state gathered over a play session. The gym holds nothing that
+// should outlive it, and switching mods restarts the shell in place.
+void Gym_Shutdown(void);
+
 void Gym_SetInventoryOpenEnabled(bool enabled);
 bool Gym_IsInventoryOpenEnabled(void);
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -17,6 +17,7 @@
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/game_strings/manager.h>
 #include <trx/game/gun.h>
+#include <trx/game/gym.h>
 #include <trx/game/input.h>
 #include <trx/game/input/backends/touch.h>
 #include <trx/game/inventory_ring.h>
@@ -176,6 +177,7 @@ static void M_ShutdownModules(void)
 
     Console_Shutdown();
     Savegame_Shutdown();
+    Gym_Shutdown();
 
     GF_Shutdown();
     LUA_Shutdown();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Whether the title ring opens on the home photo or the passport follows the engine version, but the answer was resolved once and stored, and a mod switch restarts the shell in place. Read it live instead, and drop the gym's session state on shutdown.

Resolves TRX830