### PR TITLE
demo: start the demo cycle over on a mod switch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@
 - fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
 - fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
 - fixed the title screen starting on the wrong item after switching mods, such as the home photo in place of the passport (regression from 1.5)
+- fixed the demos not starting from the first one after switching mods (regression from 1.5)
 - fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)
 - fixed quick saves bypassing the save crystals mode
 - fixed the game displaying a GUI error dialog when it fails to start in headless mode

--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -72,6 +72,12 @@ static void M_RestoreConfig(M_PRIV *const p)
     Config_Update();
 }
 
+void Demo_Shutdown(void)
+{
+    m_Priv = (M_PRIV) {};
+    m_LastDemoNum = 0;
+}
+
 void Demo_LoadData(VFILE *const file, const size_t size)
 {
     M_PRIV *const p = &m_Priv;

--- a/src/trx/game/demo.h
+++ b/src/trx/game/demo.h
@@ -3,6 +3,10 @@
 #include <trx/core/virtual_file.h>
 #include <trx/game/game_flow/types.h>
 
+// Forgets which demo comes next, and the level data behind the last one.
+// Switching mods restarts the shell in place, so neither can be carried over.
+void Demo_Shutdown(void);
+
 void Demo_LoadData(VFILE *file, size_t size);
 uint32_t *Demo_GetData(void);
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -9,6 +9,7 @@
 #include <trx/game/catalog/manager.h>
 #include <trx/game/clock.h>
 #include <trx/game/console.h>
+#include <trx/game/demo.h>
 #include <trx/game/events.h>
 #include <trx/game/fmv.h>
 #include <trx/game/game.h>
@@ -178,6 +179,7 @@ static void M_ShutdownModules(void)
     Console_Shutdown();
     Savegame_Shutdown();
     Gym_Shutdown();
+    Demo_Shutdown();
 
     GF_Shutdown();
     LUA_Shutdown();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The counter that picks the next demo, and the demo data behind the last one, sat in statics that a mod switch does not clear, since it restarts the shell in place. Drop both on shutdown.

Resolves TRX829