### PR TITLE
fx/water: keep ripples off submerged ceilings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
 - fixed Lara not getting killed by lifts if standing on top of one and the ceiling space becomes too low
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
+- fixed Lara leaving ripples on ceilings that lie below the waterline (regression from 1.1)
 - fixed shoals of fish and piranhas jumping back to their starting spot when loading a save
 - fixed rain and snow starting over when a save is loaded (#5901)
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -527,12 +527,23 @@ void FX_Water_Splash(const ITEM *const item)
     FX_Water_SetupSplash(&setup);
 }
 
-void FX_Water_WadeSplash(
-    const ITEM *const item, const int32_t water_height, const int32_t depth)
+void FX_Water_WadeSplash(const ITEM *const item, const int32_t depth)
 {
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos, &room_num);
     if (!M_IsRoomUnderwater(room_num)) {
+        return;
+    }
+
+    // Lara swimming below a submerged ceiling has no surface to break, so she
+    // leaves nothing behind on it.
+    const int32_t water_height = Room_GetWaterHeightEx(
+        item->pos, item->room_num,
+        (ROOM_WATER_HEIGHT_ARGS) {
+            .fix_tilts = true,
+            .require_air_above = true,
+        });
+    if (water_height == NO_HEIGHT) {
         return;
     }
 

--- a/src/trx/game/fx/water.h
+++ b/src/trx/game/fx/water.h
@@ -73,7 +73,7 @@ FX_WATER_RIPPLE *FX_Water_SetupRipple(
     int32_t x, int32_t y, int32_t z, int32_t size, bool is_still);
 void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *setup);
 void FX_Water_Splash(const ITEM *item);
-void FX_Water_WadeSplash(const ITEM *item, int32_t water_height, int32_t depth);
+void FX_Water_WadeSplash(const ITEM *item, int32_t depth);
 
 void FX_Water_TriggerUnderwaterBlood(XYZ_32 pos, int32_t size);
 void FX_Water_TriggerUnderwaterBloodD(XYZ_32 pos, int32_t size);

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -373,7 +373,7 @@ static void M_UpdateEnvironment(void)
     lara_info->water_surface_dist = -water_height_diff;
 
     if (g_TRVersion >= 3) {
-        FX_Water_WadeSplash(item, water_height, water_depth);
+        FX_Water_WadeSplash(item, water_depth);
     } else if (
         g_Config.gameplay.enable_wading
         && lara_info->water_status != LWS_CHEAT) {

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -919,8 +919,8 @@ bool UPV_Control(void)
     item->floor = Room_GetHeight(sector, item->pos);
 
     if (p->flags.control && !p->flags.dead) {
-        const int32_t water_height =
-            Room_GetWaterHeightEx(item->pos, room_num, false);
+        const int32_t water_height = Room_GetWaterHeightEx(
+            item->pos, room_num, (ROOM_WATER_HEIGHT_ARGS) {});
 
         if (water_height != NO_HEIGHT
             && !Room_Get(item->room_num)->flags.underwater) {

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -470,11 +470,12 @@ int32_t Room_GetCeilingEx(
 
 int32_t Room_GetWaterHeight(const XYZ_32 pos, const int16_t room_num)
 {
-    return Room_GetWaterHeightEx(pos, room_num, true);
+    return Room_GetWaterHeightEx(
+        pos, room_num, (ROOM_WATER_HEIGHT_ARGS) { .fix_tilts = true });
 }
 
 int32_t Room_GetWaterHeightEx(
-    const XYZ_32 pos, int16_t room_num, const bool fix_tilts)
+    const XYZ_32 pos, int16_t room_num, const ROOM_WATER_HEIGHT_ARGS args)
 {
     const int32_t x = pos.x;
     const int32_t y = pos.y;
@@ -516,23 +517,27 @@ int32_t Room_GetWaterHeightEx(
                && !M_IsPortalSolid(sector->ceiling, x, z)) {
             room = Room_Get(sector->portal_room.sky);
             if (!room->flags.underwater && !room->flags.swamp) {
-                if (fix_tilts) {
-                    break;
-                } else {
-                    return room->min_floor;
-                }
+                return args.fix_tilts
+                    ? M_GetSurfaceHeight(sector->ceiling, x, z, true)
+                    : room->min_floor;
             }
             sector = Room_GetWorldSector(room, x, z);
         }
-        return fix_tilts ? M_GetSurfaceHeight(sector->ceiling, x, z, true)
-                         : room->max_ceiling;
+
+        // Nothing but solid ceiling above the water here.
+        if (args.require_air_above) {
+            return NO_HEIGHT;
+        }
+        return args.fix_tilts ? M_GetSurfaceHeight(sector->ceiling, x, z, true)
+                              : room->max_ceiling;
     } else {
         while (sector->portal_room.pit != NO_ROOM
                && !M_IsPortalSolid(sector->floor, x, z)) {
             room = Room_Get(sector->portal_room.pit);
             if (room->flags.underwater || room->flags.swamp) {
-                return fix_tilts ? M_GetSurfaceHeight(sector->floor, x, z, true)
-                                 : room->max_ceiling;
+                return args.fix_tilts
+                    ? M_GetSurfaceHeight(sector->floor, x, z, true)
+                    : room->max_ceiling;
             }
             sector = Room_GetWorldSector(room, x, z);
         }

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -25,8 +25,17 @@ int32_t Room_GetCeilingEx(const SECTOR *sector, XYZ_32 pos, bool fix_tilts);
 int32_t Room_GetFloorHeightForSector(
     const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
 
+typedef struct {
+    // Read the surface at (x,z) rather than the room's own plane.
+    bool fix_tilts;
+    // Report NO_HEIGHT where a solid ceiling caps the water. Without it, that
+    // ceiling is reported as the surface, which is what the OG does.
+    bool require_air_above;
+} ROOM_WATER_HEIGHT_ARGS;
+
 int32_t Room_GetWaterHeight(XYZ_32 pos, int16_t room_num);
-int32_t Room_GetWaterHeightEx(XYZ_32 pos, int16_t room_num, bool fix_tilts);
+int32_t Room_GetWaterHeightEx(
+    XYZ_32 pos, int16_t room_num, ROOM_WATER_HEIGHT_ARGS args);
 
 int32_t Room_FindGridShift(int32_t src, int32_t dst);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Lara swimming beneath a ceiling that sits below the waterline left surface ripples on it, as on the ceiling above the underwater switch in Sacred Lake. She now leaves nothing there, while ceilings level with the waterline ripple as before.

`Room_GetWaterHeight` reports the capping ceiling as the water surface wherever no dry room lies above it. That answer suits the callers that ask how deep Lara is, so it stays, but the wade splash took it for a real surface: Lara's body straddled that plane and the splash placed its ripples on it. `Room_GetWaterHeightEx` now takes its options as a struct, and the wade splash asks for a surface with air above it. Every other caller receives the height it always has, keeping regressions risk minimal.

The wade splash also no longer takes the water height from `Lara_Control`, since it now works this out for itself; that is the only call site to change.

Resolves TRX826

#### Testing

- [x] Play the Jungle recording from the ticket, at `/tp 34 29 88`
  No ripples on the submerged ceiling; bubbles still pop into rings at the waterline.
- [x] Swim under the ceiling by the underwater switch in Sacred Lake, `/tp 45 3 47`
  Nothing appears on the ceiling; the switch and the bubbles are unaffected.
- [x] Swim on the surface of Sacred Lake and tread in place
  Ripples still form around Lara, and treading still gives the slower ones.
- [x] Wade through shallow water in a TR3 level
  Ripples still trail Lara at wading depth.
- [x] Drop into wading-depth water from a height in a TR3 level
  The splash rings still appear at the water surface.
- [x] Wade and swim at the surface in a TR4 level
  Same ripples and splashes as before; TR4 shares this path.
