### PR TITLE
rooms: ignore trigger commands with no handler

### DIFF
--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -319,7 +319,9 @@ static bool M_TestSectorTrigger(
 
     for (const TRIGGER_CMD *cmd = trigger->command; cmd != nullptr;
          cmd = cmd->next_cmd) {
-        if (m_Handlers[cmd->type] != nullptr) {
+        // The command type is a 5-bit field, so it can name a type this
+        // engine has no handler for, TR4's cutscene trigger among them.
+        if (cmd->type < TO_NUMBER_OF && m_Handlers[cmd->type] != nullptr) {
             m_Handlers[cmd->type](trigger, cmd, &status);
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The command type is a 5-bit field, so a level can name a type past the end of the handler table. TR4's cutscene trigger is one, and reading past the table called whatever the neighbouring memory held.
