### PR TITLE
rooms: survive a trigger pass without a player

### DIFF
--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -489,6 +489,10 @@ bool Lara_HasState(const LARA_TRX_STATE *const test_arr)
     }
 
     const ITEM *const lara_item = Lara_GetItem();
+    if (lara_item == nullptr) {
+        return false;
+    }
+
     for (int32_t i = 0; test_arr[i] != LS_TRX_INVALID; i++) {
         if (test_arr[i] == LS_U(lara_item->current_anim_state)) {
             return true;

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -187,7 +187,10 @@ static bool M_TestSectorTrigger(
     const ITEM *const item, const SECTOR *const sector, const bool is_heavy)
 {
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (!is_heavy) {
+    // The non-heavy pass runs for the flyby camera as well, and a level it
+    // plays in need not hold a player for these to read.
+    const ITEM *const lara_item = Lara_GetItem();
+    if (!is_heavy && lara_item != nullptr) {
         if (sector->is_death_sector && M_TestLava(item)) {
             Lara_TouchDeathSector(Level_GetDeathTile());
         }
@@ -241,8 +244,7 @@ static bool M_TestSectorTrigger(
                 return false;
             }
             // A pad answers to the player standing on it, whoever asked.
-            const ITEM *const lara_item = Lara_GetItem();
-            if (lara_item->pos.y != lara_item->floor) {
+            if (lara_item == nullptr || lara_item->pos.y != lara_item->floor) {
                 return false;
             }
             if (item->object_id == O_LARA


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The flyby camera trips triggers as a non-heavy item, and a title level can carry a flyby without carrying Lara, so the player-only tests had nothing to read.
