### PR TITLE
camera: clear the hand-back flag on flyby reset

### DIFF
--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -320,6 +320,9 @@ bool Camera_Flybymode_Cancel(void)
 void Camera_FlybyMode_Reset(void)
 {
     m_CurrentSequence = M_NO_SEQUENCE;
+    // Left standing, this would send the next update down the hand-back path
+    // and put the camera on Lara, even though no sequence is running.
+    m_State.flags.pending_trigger_check = false;
 }
 
 void Camera_FlybyMode_Deactivate(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A track path sequence leaves it standing, and the next update would then put the camera on Lara although no sequence is running.
