### PR TITLE
json+bson: carry 64-bit integers

### DIFF
--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -69,6 +69,20 @@ test_hash_exe = executable(
 )
 test('hash', test_hash_exe, suite: 'unit')
 
+test_bson_exe = executable(
+  'test_bson',
+  files('unit/test_bson.c') + test_stubs
+    + files(
+      '../trx/core/bson/parse.c',
+      '../trx/core/bson/write.c',
+      '../trx/core/json/base.c',
+      '../trx/core/memory.c',
+    ),
+  include_directories: [src_inc, test_inc],
+  build_by_default: false,
+)
+test('bson', test_bson_exe, suite: 'unit')
+
 test_handle_exe = executable(
   'test_handle',
   files('unit/test_handle.c') + test_stubs + files('../trx/core/handle.c'),

--- a/src/tests/unit/test_bson.c
+++ b/src/tests/unit/test_bson.c
@@ -1,0 +1,88 @@
+#include "harness.h"
+
+#include <trx/core/bson.h>
+#include <trx/core/json.h>
+#include <trx/core/memory.h>
+
+#define M_UNREAD (-1)
+
+static int64_t M_RoundTrip(const int64_t value)
+{
+    JSON_OBJECT *const obj = JSON_ObjectNew();
+    JSON_ObjectAppendInt64(obj, "value", value);
+    JSON_VALUE *const root = JSON_ValueFromObject(obj);
+
+    size_t size = 0;
+    void *const blob = BSON_Write(root, &size);
+    JSON_ValueFree(root);
+    if (blob == nullptr) {
+        return M_UNREAD;
+    }
+
+    JSON_VALUE *const parsed = BSON_Parse(blob, size);
+    Memory_Free(blob);
+    if (parsed == nullptr) {
+        return M_UNREAD;
+    }
+
+    const int64_t result =
+        JSON_ObjectGetInt64(JSON_ValueAsObject(parsed), "value", M_UNREAD);
+    JSON_ValueFree(parsed);
+    return result;
+}
+
+TEST(a_number_within_int32_survives_the_round_trip)
+{
+    CHECK_EQ_INT(M_RoundTrip(0), 0);
+    CHECK_EQ_INT(M_RoundTrip(1), 1);
+    CHECK_EQ_INT(M_RoundTrip(-1), -1);
+    CHECK_EQ_INT(M_RoundTrip(INT32_MAX), INT32_MAX);
+    CHECK_EQ_INT(M_RoundTrip(INT32_MIN), INT32_MIN);
+}
+
+TEST(a_number_past_int32_survives_the_round_trip)
+{
+    CHECK_EQ_INT(M_RoundTrip((int64_t)INT32_MAX + 1), (int64_t)INT32_MAX + 1);
+    CHECK_EQ_INT(M_RoundTrip((int64_t)INT32_MIN - 1), (int64_t)INT32_MIN - 1);
+    CHECK_EQ_INT(M_RoundTrip(INT64_MAX), INT64_MAX);
+    CHECK_EQ_INT(M_RoundTrip(INT64_MIN), INT64_MIN);
+}
+
+TEST(a_mask_with_its_top_bit_set_keeps_its_bits)
+{
+    // A uint64_t past INT64_MAX travels as a negative literal, so what has to
+    // hold is the bit pattern rather than the value.
+    const uint64_t mask = 0x8000000000000001ull;
+    CHECK((uint64_t)M_RoundTrip((int64_t)mask) == mask);
+
+    const uint64_t every_bit = ~0ull;
+    CHECK((uint64_t)M_RoundTrip((int64_t)every_bit) == every_bit);
+}
+
+TEST(a_document_mixing_widths_writes_the_size_it_measured)
+{
+    // Both passes classify each number independently, so a document holding
+    // more than one width is where they would disagree.
+    JSON_OBJECT *const obj = JSON_ObjectNew();
+    JSON_ObjectAppendInt(obj, "small", 7);
+    JSON_ObjectAppendInt64(obj, "large", (int64_t)1 << 40);
+    JSON_ObjectAppendDouble(obj, "fraction", 0.5);
+    JSON_ObjectAppendInt(obj, "small_again", -9);
+    JSON_VALUE *const root = JSON_ValueFromObject(obj);
+
+    size_t size = 0;
+    void *const blob = BSON_Write(root, &size);
+    JSON_ValueFree(root);
+    CHECK(blob != nullptr);
+
+    JSON_VALUE *const parsed = BSON_Parse(blob, size);
+    Memory_Free(blob);
+    CHECK(parsed != nullptr);
+
+    const JSON_OBJECT *const read = JSON_ValueAsObject(parsed);
+    CHECK_EQ_INT(JSON_ObjectGetInt(read, "small", -1), 7);
+    CHECK_EQ_INT(JSON_ObjectGetInt64(read, "large", -1), (int64_t)1 << 40);
+    CHECK(JSON_ObjectGetDouble(read, "fraction", -1.0) == 0.5);
+    CHECK_EQ_INT(JSON_ObjectGetInt(read, "small_again", 0), -9);
+    JSON_ValueFree(parsed);
+}

--- a/src/trx/core/bson/parse.c
+++ b/src/trx/core/bson/parse.c
@@ -4,6 +4,7 @@
 #include <trx/core/memory.h>
 #include <trx/debug.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -27,6 +28,13 @@ static void M_HandleValue(M_STATE *state, JSON_VALUE *value, uint8_t marker);
 static int32_t M_ReadI32(const char *const src)
 {
     int32_t value = 0;
+    memcpy(&value, src, sizeof(value));
+    return value;
+}
+
+static int64_t M_ReadI64(const char *const src)
+{
+    int64_t value = 0;
     memcpy(&value, src, sizeof(value));
     return value;
 }
@@ -90,6 +98,21 @@ static bool M_GetInt32ValueSize(M_STATE *state)
 
     state->dom_size += sizeof(JSON_NUMBER);
     state->data_size += snprintf(nullptr, 0, "%d", num) + 1;
+    return true;
+}
+
+static bool M_GetInt64ValueSize(M_STATE *state)
+{
+    ASSERT(state != nullptr);
+    if (state->offset + sizeof(int64_t) > state->size) {
+        state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
+        return false;
+    }
+    int64_t num = M_ReadI64(&state->src[state->offset]);
+    state->offset += sizeof(int64_t);
+
+    state->dom_size += sizeof(JSON_NUMBER);
+    state->data_size += snprintf(nullptr, 0, "%" PRId64, num) + 1;
     return true;
 }
 
@@ -266,6 +289,8 @@ static bool M_GetValueSize(M_STATE *state, uint8_t marker)
         return M_GetBoolValueSize(state);
     case 0x10:
         return M_GetInt32ValueSize(state);
+    case 0x12:
+        return M_GetInt64ValueSize(state);
     default:
         state->error = BSON_PARSE_ERROR_INVALID_VALUE;
         return false;
@@ -337,6 +362,28 @@ static void M_HandleInt32Value(M_STATE *state, JSON_VALUE *value)
 
     number->number = state->data;
     sprintf(state->data, "%d", num);
+    number->number_size = strlen(number->number);
+    state->data += number->number_size + 1;
+
+    value->type = JSON_TYPE_NUMBER;
+    value->payload = number;
+}
+
+static void M_HandleInt64Value(M_STATE *state, JSON_VALUE *value)
+{
+    ASSERT(state != nullptr);
+    ASSERT(value != nullptr);
+
+    ASSERT(state->offset + sizeof(int64_t) <= state->size);
+    int64_t num = M_ReadI64(&state->src[state->offset]);
+    state->offset += sizeof(int64_t);
+
+    JSON_NUMBER *number = (JSON_NUMBER *)state->dom;
+    number->ref_count = 1;
+    state->dom += sizeof(JSON_NUMBER);
+
+    number->number = state->data;
+    sprintf(state->data, "%" PRId64, num);
     number->number_size = strlen(number->number);
     state->data += number->number_size + 1;
 
@@ -580,6 +627,9 @@ static void M_HandleValue(M_STATE *state, JSON_VALUE *value, uint8_t marker)
         break;
     case 0x10:
         M_HandleInt32Value(state, value);
+        break;
+    case 0x12:
+        M_HandleInt64Value(state, value);
         break;
     default:
         ASSERT_FAIL();

--- a/src/trx/core/bson/write.c
+++ b/src/trx/core/bson/write.c
@@ -63,6 +63,26 @@ static bool M_GetInt32WrappedSize(size_t *size, const char *key)
     return true;
 }
 
+static bool M_GetInt64Size(size_t *size)
+{
+    ASSERT(size != nullptr);
+    *size += sizeof(int64_t);
+    return true;
+}
+
+static bool M_GetInt64WrappedSize(size_t *size, const char *key)
+{
+    ASSERT(size != nullptr);
+    ASSERT(key != nullptr);
+    if (!M_GetMarkerSize(size, key)) {
+        return false;
+    }
+    if (!M_GetInt64Size(size)) {
+        return false;
+    }
+    return true;
+}
+
 static bool M_GetDoubleSize(size_t *size)
 {
     ASSERT(size != nullptr);
@@ -83,39 +103,71 @@ static bool M_GetDoubleWrappedSize(size_t *size, const char *key)
     return true;
 }
 
+typedef enum {
+    M_NUMBER_INT32,
+    M_NUMBER_INT64,
+    M_NUMBER_DOUBLE,
+} M_NUMBER_KIND;
+
+// A JSON number is a literal, and BSON has three forms to put one in. The
+// sizing pass and the writing pass have to land on the same one, so both ask
+// here rather than each reading the literal their own way.
+static M_NUMBER_KIND M_ClassifyNumber(
+    const JSON_NUMBER *const number, int64_t *const int_value,
+    double *const dbl_value)
+{
+    ASSERT(number != nullptr);
+    const char *str = number->number;
+    ASSERT(str != nullptr);
+
+    // hexadecimal numbers
+    if (number->number_size >= 2 && (str[1] == 'x' || str[1] == 'X')) {
+        *int_value = (int64_t)json_strtoumax(str, nullptr, 0);
+    } else {
+        // skip leading sign
+        const char *digits = str;
+        if (digits[0] == '+' || digits[0] == '-') {
+            digits++;
+        }
+        ASSERT(digits[0] != '\0');
+
+        if (strcmp(digits, "Infinity") == 0) {
+            // BSON does not support Infinity.
+            *dbl_value = DBL_MAX;
+            return M_NUMBER_DOUBLE;
+        }
+        if (strcmp(digits, "NaN") == 0) {
+            // BSON does not support NaN.
+            *int_value = 0;
+            return M_NUMBER_INT32;
+        }
+        if (strchr(digits, '.') != nullptr) {
+            *dbl_value = atof(str);
+            return M_NUMBER_DOUBLE;
+        }
+        *int_value = strtoll(str, nullptr, 10);
+    }
+
+    return *int_value < INT32_MIN || *int_value > INT32_MAX ? M_NUMBER_INT64
+                                                            : M_NUMBER_INT32;
+}
+
 static bool M_GetNumberWrappedSize(
     size_t *size, const char *key, const JSON_NUMBER *number)
 {
     ASSERT(size != nullptr);
     ASSERT(key != nullptr);
 
-    char *str = number->number;
-    ASSERT(str != nullptr);
-
-    // hexadecimal numbers
-    if (number->number_size >= 2 && (str[1] == 'x' || str[1] == 'X')) {
-        return M_GetInt32WrappedSize(size, key);
-    }
-
-    // skip leading sign
-    if (str[0] == '+' || str[0] == '-') {
-        str += 1;
-    }
-    ASSERT(str[0] != '\0');
-
-    if (!strcmp(str, "Infinity")) {
-        // BSON does not support Infinity.
+    int64_t int_value = 0;
+    double dbl_value = 0.0;
+    switch (M_ClassifyNumber(number, &int_value, &dbl_value)) {
+    case M_NUMBER_INT64:
+        return M_GetInt64WrappedSize(size, key);
+    case M_NUMBER_DOUBLE:
         return M_GetDoubleWrappedSize(size, key);
-    } else if (!strcmp(str, "NaN")) {
-        // BSON does not support NaN.
-        return M_GetInt32WrappedSize(size, key);
-    } else if (strchr(str, '.')) {
-        return M_GetDoubleWrappedSize(size, key);
-    } else {
+    default:
         return M_GetInt32WrappedSize(size, key);
     }
-
-    return false;
 }
 
 static bool M_GetStringSize(size_t *size, const JSON_STRING *string)
@@ -294,6 +346,23 @@ static char *M_WriteInt32Wrapped(
     return M_WriteInt32(data, value);
 }
 
+static char *M_WriteInt64(char *data, const int64_t value)
+{
+    ASSERT(data != nullptr);
+    memcpy(data, &value, sizeof(value));
+    data += sizeof(int64_t);
+    return data;
+}
+
+static char *M_WriteInt64Wrapped(
+    char *data, const char *key, const int64_t value)
+{
+    ASSERT(data != nullptr);
+    ASSERT(key != nullptr);
+    data = M_WriteMarker(data, key, '\x12');
+    return M_WriteInt64(data, value);
+}
+
 static char *M_WriteDouble(char *data, const double value)
 {
     ASSERT(data != nullptr);
@@ -317,33 +386,17 @@ static char *M_WriteNumberWrapped(
     ASSERT(data != nullptr);
     ASSERT(key != nullptr);
     ASSERT(number != nullptr);
-    char *str = number->number;
 
-    // hexadecimal numbers
-    if (number->number_size >= 2 && (str[1] == 'x' || str[1] == 'X')) {
-        return M_WriteInt32Wrapped(
-            data, key, json_strtoumax(number->number, nullptr, 0));
+    int64_t int_value = 0;
+    double dbl_value = 0.0;
+    switch (M_ClassifyNumber(number, &int_value, &dbl_value)) {
+    case M_NUMBER_INT64:
+        return M_WriteInt64Wrapped(data, key, int_value);
+    case M_NUMBER_DOUBLE:
+        return M_WriteDoubleWrapped(data, key, dbl_value);
+    default:
+        return M_WriteInt32Wrapped(data, key, (int32_t)int_value);
     }
-
-    // skip leading sign
-    if (str[0] == '+' || str[0] == '-') {
-        str++;
-    }
-    ASSERT(str[0] != '\0');
-
-    if (!strcmp(str, "Infinity")) {
-        // BSON does not support Infinity.
-        return M_WriteDoubleWrapped(data, key, DBL_MAX);
-    } else if (!strcmp(str, "NaN")) {
-        // BSON does not support NaN.
-        return M_WriteInt32Wrapped(data, key, 0);
-    } else if (strchr(str, '.')) {
-        return M_WriteDoubleWrapped(data, key, atof(number->number));
-    } else {
-        return M_WriteInt32Wrapped(data, key, atoi(number->number));
-    }
-
-    return data;
 }
 
 static char *M_WriteString(char *data, const JSON_STRING *string)

--- a/src/trx/core/json/util/read_io.c
+++ b/src/trx/core/json/util/read_io.c
@@ -219,6 +219,22 @@ L_DEFINE_M_READ_NUM_CURRENT(uint16_t, U16, 0, UINT16_MAX)
 L_DEFINE_M_READ_NUM_CURRENT(uint32_t, U32, 0, UINT32_MAX)
 #undef L_DEFINE_M_READ_NUM_CURRENT
 
+#define L_DEFINE_M_READ_NUM64_CURRENT(type_, name)                             \
+    static bool M_ReadNumCurrent_##name(                                       \
+        JSON_READ_IO *const io, void *const target)                            \
+    {                                                                          \
+        if (io->current->type != JSON_TYPE_NUMBER) {                           \
+            M_SetError(io, "not a number");                                    \
+            return false;                                                      \
+        }                                                                      \
+        const type_ parsed = (type_)JSON_ValueGetInt64(io->current, 0);        \
+        memcpy(target, &parsed, sizeof(parsed));                               \
+        return true;                                                           \
+    }
+L_DEFINE_M_READ_NUM64_CURRENT(int64_t, S64)
+L_DEFINE_M_READ_NUM64_CURRENT(uint64_t, U64)
+#undef L_DEFINE_M_READ_NUM64_CURRENT
+
 static bool M_ReadNumCurrent_Double(
     JSON_READ_IO *const io, double *const target)
 {
@@ -355,6 +371,8 @@ L_DEFINE_JSON_READ_IO_TYPE(S16, int16_t, M_ReadNumCurrent_S16)
 L_DEFINE_JSON_READ_IO_TYPE(U16, uint16_t, M_ReadNumCurrent_U16)
 L_DEFINE_JSON_READ_IO_TYPE(S32, int32_t, M_ReadNumCurrent_S32)
 L_DEFINE_JSON_READ_IO_TYPE(U32, uint32_t, M_ReadNumCurrent_U32)
+L_DEFINE_JSON_READ_IO_TYPE(S64, int64_t, M_ReadNumCurrent_S64)
+L_DEFINE_JSON_READ_IO_TYPE(U64, uint64_t, M_ReadNumCurrent_U64)
 L_DEFINE_JSON_READ_IO_TYPE(Float, float, M_ReadNumCurrent_Float)
 L_DEFINE_JSON_READ_IO_TYPE(Double, double, M_ReadNumCurrent_Double)
 L_DEFINE_JSON_READ_IO_TYPE(String, const char *, M_ReadStringCurrent)

--- a/src/trx/core/json/util/read_io.h
+++ b/src/trx/core/json/util/read_io.h
@@ -22,6 +22,8 @@ typedef struct {
     X(U16, uint16_t)                                                           \
     X(S32, int32_t)                                                            \
     X(U32, uint32_t)                                                           \
+    X(S64, int64_t)                                                            \
+    X(U64, uint64_t)                                                           \
     X(Float, float)                                                            \
     X(Double, double)                                                          \
     X(XYZ16, XYZ_16)                                                           \

--- a/src/trx/core/json/util/write_io.c
+++ b/src/trx/core/json/util/write_io.c
@@ -98,6 +98,11 @@ void JSON_WriteIO_PushInt(JSON_WRITE_IO *const io, const int32_t value)
     M_PushValue(io, JSON_ValueFromInt(value));
 }
 
+void JSON_WriteIO_PushInt64(JSON_WRITE_IO *const io, const int64_t value)
+{
+    M_PushValue(io, JSON_ValueFromInt64(value));
+}
+
 void JSON_WriteIO_PushDouble(JSON_WRITE_IO *const io, const double value)
 {
     M_PushValue(io, JSON_ValueFromDouble(value));

--- a/src/trx/core/json/util/write_io.h
+++ b/src/trx/core/json/util/write_io.h
@@ -32,6 +32,7 @@ JSON_OBJECT *JSON_WriteIO_GetCurrentObject(JSON_WRITE_IO *io);
 
 void JSON_WriteIO_PushBool(JSON_WRITE_IO *io, bool value);
 void JSON_WriteIO_PushInt(JSON_WRITE_IO *io, int32_t value);
+void JSON_WriteIO_PushInt64(JSON_WRITE_IO *io, int64_t value);
 void JSON_WriteIO_PushDouble(JSON_WRITE_IO *io, double value);
 void JSON_WriteIO_PushRGB888(JSON_WRITE_IO *io, RGB_888 value);
 void JSON_WriteIO_PushXYZ16(JSON_WRITE_IO *io, XYZ_16 value);
@@ -54,6 +55,8 @@ void JSON_WriteIO_PushString(JSON_WRITE_IO *io, const char *value);
         uint16_t: JSON_WriteIO_PushInt,                                        \
         int32_t: JSON_WriteIO_PushInt,                                         \
         uint32_t: JSON_WriteIO_PushInt,                                        \
+        int64_t: JSON_WriteIO_PushInt64,                                       \
+        uint64_t: JSON_WriteIO_PushInt64,                                      \
         float: JSON_WriteIO_PushDouble,                                        \
         double: JSON_WriteIO_PushDouble,                                       \
         RGB_888: JSON_WriteIO_PushRGB888,                                      \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Add S64 and U64 to the JSON read and write helpers, and a 0x12 marker to BSON. Numbers were already stored as literals, so the width was only lost at the edges.

BSON writes in two passes: the first adds up how many bytes the document needs, the second fills them in. If the two disagreed on a number's width, the second would write past what the first reserved. One function now decides the width and both passes call it.
