### PR TITLE
docs+lint: check the commit message prefix

### DIFF
--- a/docs/CHANGE_SUBMISSION.md
+++ b/docs/CHANGE_SUBMISSION.md
@@ -42,8 +42,10 @@ aim to respect the 50/72 rule and have the following form:
 
 The prefix should describe the module that the pull request touches the most.
 In general this is the name of the `.c` or `.h` file with the most changes.
-Note that this includes the folder names which are separated with `/`. Avoid
-underscores (`_`) in favor of dashes (`-`).
+Note that this includes the folder names which are separated with `/`. Spell
+the name as the file spells it, underscores and all (`game_flow`,
+`objects/save_crystal`). A change that belongs to two modules equally names
+both, joined with `+` (`camera+rooms: ...`).
 
 The description should be as concise as possible; any details should be given
 in the commit message body. Use simple, to the point words like `add`, `fix`,

--- a/tools/check_commit_msg
+++ b/tools/check_commit_msg
@@ -2,16 +2,26 @@
 """Fail the commit if its message breaks the 50/72 rule.
 
 Subject line <= 50 chars, a blank line, then body wrapped at <= 72 chars.
-Wired in as a prek/pre-commit commit-msg hook so it is enforced mechanically
-instead of by memory.
+The subject also has to open with a module prefix. Wired in as a
+prek/pre-commit commit-msg hook so it is enforced mechanically instead of by
+memory.
 """
 
+import re
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 MAX_SUBJECT = 50
 MAX_BODY = 72
+
+# `module-prefix: description`, the prefix at the very start of the subject.
+# A prefix names a file, so it spells the name as the file does: underscores
+# within a name, `/` between folders, `+` between two modules.
+SUBJECT_RE = re.compile(r"^[a-z0-9][a-z0-9_+./]*: \S")
+
+# Subjects git or a rebase writes itself, which the rule is not about.
+EXEMPT_PREFIXES = ("Merge ", "Revert ", "fixup! ", "squash! ", "amend! ")
 
 
 def main(argv: Sequence[str]) -> int:
@@ -45,6 +55,25 @@ def main(argv: Sequence[str]) -> int:
     subject = lines[0]
     if len(subject) > MAX_SUBJECT:
         errors.append(f"subject is {len(subject)} chars (max {MAX_SUBJECT})")
+    if not subject.startswith(EXEMPT_PREFIXES) and not SUBJECT_RE.match(
+        subject
+    ):
+        head = subject.split(":")[0]
+        if "," in head:
+            errors.append(
+                f"prefix `{head}` separates modules with a comma; join them"
+                " with `+`"
+            )
+        elif "-" in head:
+            errors.append(
+                f"prefix `{head}` uses a dash; spell the module as its file"
+                f" does (`{head.replace('-', '_')}`)"
+            )
+        else:
+            errors.append(
+                "subject must open with a lowercase module prefix, as in"
+                " `camera: keep the target on Lara`"
+            )
     if len(lines) > 1 and lines[1].strip():
         errors.append("second line must be blank (subject, blank, body)")
     for number, line in enumerate(lines[2:], start=3):


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A prefix spells its module as the file does, underscores and all, and two modules join with `+` rather than a comma. The commit-msg hook read the subject's length but not its shape, so either slip only ever came up in review.