### PR TITLE
Fix settings and preset dialog text running off screen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,13 @@ repos:
     additional_dependencies:
       - pyjson5
 
+  - id: lint-test-deps
+    name: Unit tests reach no engine dependency
+    entry: tools/lint/checks/test_deps
+    language: python
+    pass_filenames: false
+    files: \.[ch]$
+
   - id: lint-lua-module-order
     name: Lua module order numbers are unique
     entry: tools/lint/checks/lua_module_order

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,7 @@
 - fixed the game displaying a GUI error dialog when it fails to start in headless mode
 - fixed the body bag trigger to also collect Bacon Lara, Qualopec Mummy and Skidoo Driver's corpses
 - fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
+- fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - fixed quick saves bypassing the save crystals mode
 - fixed the game displaying a GUI error dialog when it fails to start in headless mode
 - fixed the body bag trigger to also collect Bacon Lara, Qualopec Mummy and Skidoo Driver's corpses
+- fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/meson.build
+++ b/src/meson.build
@@ -877,6 +877,7 @@ common_sources = [
   'trx/game/ui/hud/console.c',
   'trx/game/ui/hud/console_logs.c',
   'trx/game/ui/hud/overlay.c',
+  'trx/game/ui/keys.c',
   'trx/game/ui/scaler.c',
   'trx/game/ui/scrollable.c',
   'trx/game/ui/settings.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -34,6 +34,10 @@ dep_lua = dependency('lua5.4', 'lua-5.4', 'lua54', 'lua')
 # core/strings does its regex with PCRE2.
 dep_pcre2 = dependency('libpcre2-8')
 
+# The injection files the UI layout test reads its font metrics from are zlib
+# compressed, the same as the game finds them.
+dep_zlib = dependency('zlib')
+
 # enum_map.c hashes with uthash, which is headers only.
 c_compiler.check_header('uthash.h', required: true)
 
@@ -910,6 +914,112 @@ test('lua_struct', test_lua_struct_exe, suite: 'unit')
 
 # api.lua is read from the repository root, two levels up from this project.
 repo_root = meson.current_source_dir() / '../..'
+
+# The UI layout test is the widest of the unit tests: it stands up the settings
+# dialogs and runs the real measure and layout passes over them. It reads the
+# shipped font.bin for glyph metrics and the shipped config for the strings -
+# both versioned in this repository - so it still needs no window and no build
+# of the game.
+test_ui_layout_exe = executable(
+  'test_ui_layout',
+  files('unit/test_ui_layout.c') + test_stubs
+    + files(
+      'unit/fake_engine_settings.c',
+      'unit/fake_engine_ui.c',
+      'unit/fake_engine_ui_draw.c',
+      'unit/font_bin.c',
+      '../trx/config/common.c',
+      '../trx/config/enum.c',
+      '../trx/config/map.c',
+      '../trx/config/override.c',
+      '../trx/config/presets.c',
+      '../trx/config/value.c',
+      '../trx/core/colors.c',
+      '../trx/core/completion.c',
+      '../trx/core/dynamic_enum.c',
+      '../trx/core/enum_map.c',
+      '../trx/core/event_manager.c',
+      '../trx/core/handle.c',
+      '../trx/core/json/base.c',
+      '../trx/core/json/parse.c',
+      '../trx/core/json/util/file.c',
+      '../trx/core/json/util/read_io.c',
+      '../trx/core/json/write.c',
+      '../trx/core/memory.c',
+      '../trx/core/strings/case_funcs.c',
+      '../trx/core/strings/common.c',
+      '../trx/core/value.c',
+      '../trx/core/vector.c',
+      '../trx/game/enum.c',
+      '../trx/game/game_strings/entries.c',
+      '../trx/game/gun/vars.c',
+      '../trx/game/objects/vars.c',
+      '../trx/game/rules.c',
+      '../trx/game/ui/common.c',
+      '../trx/game/ui/dialogs/color_editor.c',
+      '../trx/game/ui/dialogs/config_presets.c',
+      '../trx/game/ui/dialogs/gameplay_settings.c',
+      '../trx/game/ui/dialogs/graphic_settings.c',
+      '../trx/game/ui/dialogs/setting_helpers/enums.c',
+      '../trx/game/ui/dialogs/setting_helpers/handlers.c',
+      '../trx/game/ui/dialogs/setting_helpers/handlers_language.c',
+      '../trx/game/ui/dialogs/settings.c',
+      '../trx/game/ui/dialogs/settings_editor.c',
+      '../trx/game/ui/dialogs/settings_tabs.c',
+      '../trx/game/ui/dialogs/sound_settings.c',
+      '../trx/game/ui/dialogs/text.c',
+      '../trx/game/ui/events.c',
+      '../trx/game/ui/helpers.c',
+      '../trx/game/ui/scaler.c',
+      '../trx/game/ui/scrollable.c',
+      '../trx/game/ui/settings.c',
+      '../trx/game/ui/text.c',
+      '../trx/version.c',
+      '../trx/gl/enum.c',
+    )
+    + files(
+      '../trx/game/ui/elements/ammo_label.c',
+      '../trx/game/ui/elements/anchor.c',
+      '../trx/game/ui/elements/bar.c',
+      '../trx/game/ui/elements/bar_enemy_hp.c',
+      '../trx/game/ui/elements/bar_lara_air.c',
+      '../trx/game/ui/elements/bar_lara_exposure.c',
+      '../trx/game/ui/elements/bar_lara_hp.c',
+      '../trx/game/ui/elements/bar_lara_sprint.c',
+      '../trx/game/ui/elements/color_swatch.c',
+      '../trx/game/ui/elements/flash.c',
+      '../trx/game/ui/elements/fps_counter.c',
+      '../trx/game/ui/elements/frame.c',
+      '../trx/game/ui/elements/gradient_slider.c',
+      '../trx/game/ui/elements/hide.c',
+      '../trx/game/ui/elements/horizontal_line.c',
+      '../trx/game/ui/elements/label.c',
+      '../trx/game/ui/elements/modal.c',
+      '../trx/game/ui/elements/offset.c',
+      '../trx/game/ui/elements/pad.c',
+      '../trx/game/ui/elements/progress_button.c',
+      '../trx/game/ui/elements/prompt.c',
+      '../trx/game/ui/elements/requester.c',
+      '../trx/game/ui/elements/resize.c',
+      '../trx/game/ui/elements/row_arrows.c',
+      '../trx/game/ui/elements/scrollable_stack.c',
+      '../trx/game/ui/elements/sleek_bar.c',
+      '../trx/game/ui/elements/spacer.c',
+      '../trx/game/ui/elements/span.c',
+      '../trx/game/ui/elements/stack.c',
+      '../trx/game/ui/elements/tab_switch.c',
+      '../trx/game/ui/elements/window.c',
+    ),
+  include_directories: [src_inc, test_inc],
+  c_args: [
+    '-DPCRE2_CODE_UNIT_WIDTH=8',
+    '-DTEST_SHIP_CFG_DIR="' + repo_root / 'data/trx/ship/cfg' + '"',
+    '-DTEST_SHIP_GAMES_DIR="' + repo_root / 'data/trx/ship/games' + '"',
+  ],
+  dependencies: [dep_mathlibrary, dep_pcre2, dep_zlib],
+  build_by_default: false,
+)
+test('ui_layout', test_ui_layout_exe, suite: 'unit')
 
 lua_exe = find_program('lua', 'lua5.4', 'lua5.5', required: false)
 if lua_exe.found()

--- a/src/tests/unit/fake_engine_settings.c
+++ b/src/tests/unit/fake_engine_settings.c
@@ -1,0 +1,287 @@
+// The engine surface the settings dialogs reach for while they build a scene:
+// the file layer their presets come from, the input state they poll, and the
+// gameplay predicates that decide whether a row is shown at all.
+//
+// The file layer is a read-only shim over the shipped data in the repository,
+// so the dialogs see the presets players see. Writes go nowhere: a test that
+// measures a dialog has no business leaving a config file behind.
+
+#include "fake_engine_settings.h"
+
+#include <trx/config/file.h>
+#include <trx/config/priv.h>
+#include <trx/core/memory.h>
+#include <trx/core/strings.h>
+#include <trx/core/filesystem.h>
+#include <trx/core/shell.h>
+#include <trx/game/clock/timer.h>
+#include <trx/game/catalog/manager.h>
+#include <trx/game/console/common.h>
+#include <trx/game/creature/common.h>
+#include <trx/game/game/state.h>
+#include <trx/game/game_strings/manager.h>
+#include <trx/game/gun/common.h>
+#include <trx/game/input/common.h>
+#include <trx/game/lara/common.h>
+#include <trx/game/lara/vehicle.h>
+#include <trx/game/objects/common.h>
+#include <trx/game/output/draw.h>
+#include <trx/game/music/common.h>
+#include <trx/game/rooms/common.h>
+#include <trx/game/sound/common.h>
+#include <trx/game/shell/paths.h>
+#include <trx/game/stats/init.h>
+
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+INPUT_STATE g_Input = {};
+INPUT_STATE g_InputDB = {};
+
+// Every path variable resolves to the shipped config directory, which is where
+// the presets live.
+char *TRXPath_ExpandVars(const char *const path)
+{
+    const char *const opening = strchr(path, '%');
+    const char *const closing =
+        opening != nullptr ? strchr(opening + 1, '%') : nullptr;
+    if (closing == nullptr) {
+        return Memory_DupStr(path);
+    }
+    return String_Format("%s%s", TEST_SHIP_CFG_DIR, closing + 1);
+}
+
+bool File_Load(
+    const char *const path, char **const output_data, size_t *const output_size)
+{
+    FILE *const fp = fopen(path, "rb");
+    if (fp == nullptr) {
+        return false;
+    }
+    fseek(fp, 0, SEEK_END);
+    const long size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    char *const data = Memory_Alloc(size + 1);
+    const size_t read_size = fread(data, 1, size, fp);
+    fclose(fp);
+    data[read_size] = '\0';
+    *output_data = data;
+    if (output_size != nullptr) {
+        *output_size = read_size;
+    }
+    return true;
+}
+
+bool File_DirExists(const char *const path)
+{
+    struct stat info;
+    return stat(path, &info) == 0 && S_ISDIR(info.st_mode);
+}
+
+void *File_OpenDirectory(const char *const path)
+{
+    return opendir(path);
+}
+
+const char *File_ReadDirectory(void *const dir)
+{
+    const struct dirent *const entry = readdir(dir);
+    return entry != nullptr ? entry->d_name : nullptr;
+}
+
+void File_CloseDirectory(void *const dir)
+{
+    closedir(dir);
+}
+
+bool ConfigFile_Read(const CONFIG_IO_ARGS *const control)
+{
+    return false;
+}
+
+bool ConfigFile_Write(const CONFIG_IO_ARGS *const control)
+{
+    return true;
+}
+
+void Config_LoadFromJSON(JSON_OBJECT *const root_obj)
+{
+}
+
+void Config_DumpToJSON(JSON_OBJECT *const root_obj)
+{
+}
+
+void Config_Sanitize(void)
+{
+}
+
+void Shell_ExitSystem(const char *const message)
+{
+    printf("unexpected engine exit: %s\n", message);
+    abort();
+}
+
+void Shell_ExitSystemEx(
+    const char *const log_message, const char *const dialog_message)
+{
+    Shell_ExitSystem(log_message);
+}
+
+int32_t GameStringManager_SubscribeReload(
+    const EVENT_LISTENER listener, void *const user_data)
+{
+    return -1;
+}
+
+void GameStringManager_UnsubscribeReload(const int32_t listener_id)
+{
+}
+
+void Console_LogEx(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+}
+
+bool ClockTimer_CheckElapsedAndTake(CLOCK_TIMER *const timer, const double sec)
+{
+    return false;
+}
+
+bool Input_IsPressedEx(
+    const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
+    const INPUT_ROLE role)
+{
+    return false;
+}
+
+void Input_EnterListenMode(void)
+{
+}
+
+void Input_ExitListenMode(void)
+{
+}
+
+bool Creature_IsAlly(const ITEM *const item)
+{
+    return false;
+}
+
+bool Game_IsBonusFlagSet(const GAME_BONUS_FLAG flag)
+{
+    return false;
+}
+
+int32_t Gun_GetAmmoClipCount(const LARA_GUN_TYPE gun_type)
+{
+    return 1;
+}
+
+ITEM *Lara_GetItem(void)
+{
+    return nullptr;
+}
+
+LARA_INFO *Lara_GetLaraInfo(void)
+{
+    return nullptr;
+}
+
+ITEM *Lara_Vehicle_GetItem(void)
+{
+    return nullptr;
+}
+
+bool Lara_Vehicle_IsOnType(const OBJECT_ID obj_id)
+{
+    return false;
+}
+
+bool Object_IsType(const OBJECT_ID obj_id, const OBJECT_ID *const test_arr)
+{
+    return false;
+}
+
+ROOM *Room_Get(const int32_t room_num)
+{
+    return nullptr;
+}
+
+// Every option that a game could offer is worth measuring, so the predicates
+// that gate rows answer as permissively as they can.
+bool Stats_GameHasCrystals(void)
+{
+    return true;
+}
+
+bool Touch_HasHardwareSupport(void)
+{
+    return true;
+}
+
+void Output_DrawScreenGradientQuad(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 tl, const RGBA_8888 tr, const RGBA_8888 bl,
+    const RGBA_8888 br)
+{
+}
+
+void Shell_ExitSystemFmt(const char *const fmt, ...)
+{
+    Shell_ExitSystem(fmt);
+}
+
+MYFILE *File_Open(const char *const path, const FILE_OPEN_MODE mode)
+{
+    return nullptr;
+}
+
+void File_WriteData(
+    MYFILE *const file, const void *const data, const size_t size)
+{
+}
+
+void File_Close(MYFILE *const file)
+{
+}
+
+VECTOR *GameStringManager_GetAvailableLanguages(void)
+{
+    return nullptr;
+}
+
+const char *GameStringManager_GetLanguageName(const char *const code)
+{
+    return code;
+}
+
+bool GameStringManager_ReloadLanguage(const char *const lang)
+{
+    return true;
+}
+
+bool Catalog_NameToEnum(
+    const CATALOG_CONTEXT context, const char *const name,
+    CATALOG_ID *const out_id)
+{
+    return false;
+}
+
+void Music_SetVolume(const float volume)
+{
+}
+
+void Sound_SetMasterVolume(const float volume)
+{
+}
+
+int32_t Sound_Effect(
+    const SAMPLE_TRX_ID sfx_num, const XYZ_32 *const pos, const uint32_t flags)
+{
+    return 0;
+}

--- a/src/tests/unit/fake_engine_settings.h
+++ b/src/tests/unit/fake_engine_settings.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// The shipped config directory, passed in by the build so the file layer can
+// find the presets and the string layers.
+#ifndef TEST_SHIP_CFG_DIR
+    #error TEST_SHIP_CFG_DIR must be defined
+#endif

--- a/src/tests/unit/fake_engine_ui.c
+++ b/src/tests/unit/fake_engine_ui.c
@@ -1,0 +1,98 @@
+// Enough of the engine for the UI to measure and lay out a scene: the font
+// metrics, the viewport it sizes itself against, and no-op draw scheduling.
+//
+// The metrics come out of the game's own font.bin, so text measures here
+// exactly as it does in the game. Each game ships its own font, hence one per
+// version.
+
+#include "fake_engine_ui.h"
+
+#include "font_bin.h"
+
+#include <trx/core/strings.h>
+#include <trx/debug.h>
+#include <trx/game/input/common.h>
+#include <trx/game/objects/common.h>
+#include <trx/game/output/textures.h>
+#include <trx/game/viewport.h>
+#include <trx/version.h>
+
+static FONT_BIN m_Fonts[TR_VERSION_COUNT];
+static FONT_BIN *m_Font = nullptr;
+static OBJECT m_Objects[O_NUMBER_OF];
+static int32_t m_ViewportWidth = 640;
+static int32_t m_ViewportHeight = 480;
+
+void FakeUI_SetGame(const int32_t tr_version)
+{
+    g_TRVersion = tr_version;
+
+    FONT_BIN *const font = &m_Fonts[tr_version - 1];
+    if (font->sprite_count == 0) {
+        const char *const path = String_FormatStatic(
+            "%s/tr%d/injections/font.bin", TEST_SHIP_GAMES_DIR, tr_version);
+        // Without the font every measurement would come out zero, and a check
+        // on whether text fits would pass no matter what.
+        ASSERT(FontBin_Load(path, font));
+    }
+    m_Font = font;
+
+    m_Objects[O_ALPHABET] = (OBJECT) {
+        .loaded = true,
+        .mesh_idx = font->font_base[0],
+        .mesh_count = font->font_count[0],
+    };
+    m_Objects[O_ALPHABET_SMALL] = (OBJECT) {
+        .loaded = true,
+        .mesh_idx = font->font_base[1],
+        .mesh_count = font->font_count[1],
+    };
+}
+
+void FakeUI_SetViewport(const int32_t width, const int32_t height)
+{
+    m_ViewportWidth = width;
+    m_ViewportHeight = height;
+}
+
+void FakeUI_Shutdown(void)
+{
+    for (int32_t i = 0; i < TR_VERSION_COUNT; i++) {
+        FontBin_Free(&m_Fonts[i]);
+    }
+    m_Font = nullptr;
+}
+
+OBJECT *Object_Get(const OBJECT_ID object_id)
+{
+    return &m_Objects[object_id];
+}
+
+SPRITE_TEXTURE *Output_GetSpriteTexture(const int32_t texture_idx)
+{
+    if (m_Font == nullptr || texture_idx < 0
+        || texture_idx >= m_Font->sprite_count) {
+        return nullptr;
+    }
+    return &m_Font->sprites[texture_idx];
+}
+
+int32_t Viewport_GetWidth(const VIEWPORT_SPACE space)
+{
+    return m_ViewportWidth;
+}
+
+int32_t Viewport_GetHeight(const VIEWPORT_SPACE space)
+{
+    return m_ViewportHeight;
+}
+
+// The font resolves "\{input <role>}" through the current binding. Nothing here
+// binds keys, so every role reports the widest keycap in the sheet: a check
+// built on these metrics then holds for any binding a player can make.
+const char *Input_GetKeyName(
+    const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
+    const INPUT_ROLE role, const int32_t slot)
+{
+    return "\\{keyboard backspace}";
+}

--- a/src/tests/unit/fake_engine_ui.h
+++ b/src/tests/unit/fake_engine_ui.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+// The shipped games directory, passed in by the build so the font metrics can
+// be read from each game's font.bin.
+#ifndef TEST_SHIP_GAMES_DIR
+    #error TEST_SHIP_GAMES_DIR must be defined
+#endif
+
+// Point the font metrics at a game's glyph table and set g_TRVersion to match.
+void FakeUI_SetGame(int32_t tr_version);
+
+void FakeUI_SetViewport(int32_t width, int32_t height);
+
+void FakeUI_Shutdown(void);

--- a/src/tests/unit/fake_engine_ui_draw.c
+++ b/src/tests/unit/fake_engine_ui_draw.c
@@ -1,0 +1,63 @@
+// The UI's draw scheduling, doing nothing. A layout test runs the whole scene
+// pipeline, and the draw pass is the last of its three phases; discarding what
+// it schedules keeps the renderer and its GL dependency out of the tests while
+// still exercising measure and layout for real.
+
+#include <trx/game/ui/draw.h>
+
+void UI_InitDraw(void)
+{
+}
+
+void UI_ShutdownDraw(void)
+{
+}
+
+void UI_ClearDraw(void)
+{
+}
+
+void UI_ScheduleDrawScreenSprite(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t scale_h,
+    const int32_t scale_v, const int32_t sprite_idx, const RGBA_F colors[4])
+{
+}
+
+void UI_ScheduleDrawTextBackground(
+    const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
+    const int32_t z, const int32_t w, const int32_t h,
+    const TEXT_STYLE text_style)
+{
+}
+
+void UI_ScheduleDrawTextOutline(
+    const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
+    const int32_t z, const int32_t w, const int32_t h,
+    const TEXT_STYLE text_style)
+{
+}
+
+void UI_ScheduleDrawScreenFlatQuad(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 color)
+{
+}
+
+void UI_ScheduleDrawScreenGradientQuad(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 tl, const RGBA_8888 tr, const RGBA_8888 bl,
+    const RGBA_8888 br)
+{
+}
+
+void UI_ScheduleDrawHorizontalLine(
+    const UI_STYLE ui_style, const int32_t x0, const int32_t x1,
+    const int32_t y, const int32_t z)
+{
+}
+
+void UI_ScheduleDrawScreenCircle(
+    const int32_t cx, const int32_t cy, const int32_t r_inner,
+    const int32_t r_outer, const int32_t z, const RGBA_8888 color)
+{
+}

--- a/src/tests/unit/font_bin.c
+++ b/src/tests/unit/font_bin.c
@@ -1,0 +1,202 @@
+// The injection container, far enough to reach the font's sprite textures.
+//
+// Reading the shipped font.bin rather than a table generated alongside it means
+// the tests measure text with the same metrics the game does, and that there is
+// nothing to keep in step when the font changes.
+//
+// Layout: the "TRXJ" header, then a zlib payload holding the level tests, then
+// the chunks. Each chunk is a type, a block count and a total size; each block
+// a data type, an item count and a payload size. The sprite textures and the
+// sprite sequences naming the fonts both live in the texture chunks.
+
+#include "font_bin.h"
+
+#include <trx/core/memory.h>
+#include <trx/core/utils.h>
+#include <trx/game/inject/enum.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <zlib.h>
+
+#define M_MAGIC 0x4A585254 // "TRXJ"
+#define M_SPRITE_RECORD_SIZE 16
+
+typedef struct {
+    const char *data;
+    size_t size;
+    size_t pos;
+} M_CURSOR;
+
+static bool M_CanRead(const M_CURSOR *const cursor, const size_t bytes)
+{
+    return cursor->pos + bytes <= cursor->size;
+}
+
+static int32_t M_ReadS32(M_CURSOR *const cursor)
+{
+    int32_t value = 0;
+    memcpy(&value, cursor->data + cursor->pos, sizeof(value));
+    cursor->pos += sizeof(value);
+    return value;
+}
+
+static int16_t M_ReadS16(M_CURSOR *const cursor)
+{
+    int16_t value = 0;
+    memcpy(&value, cursor->data + cursor->pos, sizeof(value));
+    cursor->pos += sizeof(value);
+    return value;
+}
+
+static uint16_t M_ReadU16(M_CURSOR *const cursor)
+{
+    uint16_t value = 0;
+    memcpy(&value, cursor->data + cursor->pos, sizeof(value));
+    cursor->pos += sizeof(value);
+    return value;
+}
+
+static char *M_LoadPayload(const char *const path, size_t *const out_size)
+{
+    FILE *const fp = fopen(path, "rb");
+    if (fp == nullptr) {
+        return nullptr;
+    }
+    fseek(fp, 0, SEEK_END);
+    const long file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    char *const raw = Memory_Alloc(file_size);
+    const size_t read_size = fread(raw, 1, file_size, fp);
+    fclose(fp);
+
+    char *payload = nullptr;
+    M_CURSOR header = { .data = raw, .size = read_size };
+    if (read_size < 20 || (uint32_t)M_ReadS32(&header) != M_MAGIC) {
+        goto cleanup;
+    }
+    M_ReadS32(&header); // version
+    M_ReadS32(&header); // injection type
+    const int32_t uncompressed_size = M_ReadS32(&header);
+    const int32_t compressed_size = M_ReadS32(&header);
+    if (uncompressed_size <= 0
+        || header.pos + (size_t)compressed_size > read_size) {
+        goto cleanup;
+    }
+
+    payload = Memory_Alloc(uncompressed_size);
+    uLongf actual_size = uncompressed_size;
+    if (uncompress(
+            (Bytef *)payload, &actual_size, (const Bytef *)raw + header.pos,
+            compressed_size)
+        != Z_OK) {
+        Memory_FreePointer(&payload);
+        goto cleanup;
+    }
+    *out_size = actual_size;
+
+cleanup:
+    Memory_Free(raw);
+    return payload;
+}
+
+static void M_ReadSprites(
+    M_CURSOR *const cursor, const int32_t count, FONT_BIN *const out)
+{
+    if (!M_CanRead(cursor, (size_t)count * M_SPRITE_RECORD_SIZE)) {
+        return;
+    }
+    out->sprites = Memory_Realloc(
+        out->sprites, sizeof(SPRITE_TEXTURE) * (out->sprite_count + count));
+    for (int32_t i = 0; i < count; i++) {
+        SPRITE_TEXTURE *const sprite = &out->sprites[out->sprite_count + i];
+        *sprite = (SPRITE_TEXTURE) {
+            .tex_page = M_ReadU16(cursor),
+            .offset = M_ReadU16(cursor),
+            .width = M_ReadU16(cursor),
+            .height = M_ReadU16(cursor),
+            .x0 = M_ReadS16(cursor),
+            .y0 = M_ReadS16(cursor),
+            .x1 = M_ReadS16(cursor),
+            .y1 = M_ReadS16(cursor),
+        };
+    }
+    out->sprite_count += count;
+}
+
+// A sequence's mesh index counts from the sprites the injection has appended so
+// far, the way the game accumulates it while applying them.
+static void M_ReadSequences(
+    M_CURSOR *const cursor, const int32_t count, FONT_BIN *const out)
+{
+    int32_t base = 0;
+    int32_t font_idx = 0;
+    for (int32_t i = 0; i < count && M_CanRead(cursor, 12); i++) {
+        M_ReadS32(cursor); // object type
+        M_ReadS32(cursor); // object id
+        // A sprite sequence stores its count negated. Read it out before taking
+        // the absolute value: ABS is a macro, and would consume the field
+        // twice.
+        const int16_t raw_count = M_ReadS16(cursor);
+        const int32_t mesh_count = ABS(raw_count);
+        const int32_t mesh_idx = M_ReadS16(cursor);
+        if (font_idx < FONT_BIN_FONT_COUNT) {
+            out->font_base[font_idx] = base + mesh_idx;
+            out->font_count[font_idx] = mesh_count;
+            font_idx++;
+        }
+        base += mesh_count;
+    }
+}
+
+bool FontBin_Load(const char *const path, FONT_BIN *const out)
+{
+    *out = (FONT_BIN) {};
+
+    size_t payload_size = 0;
+    char *const payload = M_LoadPayload(path, &payload_size);
+    if (payload == nullptr) {
+        return false;
+    }
+
+    M_CURSOR cursor = { .data = payload, .size = payload_size };
+    if (!M_CanRead(&cursor, 12)) {
+        Memory_Free(payload);
+        return false;
+    }
+    M_ReadS32(&cursor); // level test count
+    cursor.pos += M_ReadS32(&cursor); // level test payload
+    const int32_t chunk_count = M_ReadS32(&cursor);
+
+    for (int32_t i = 0; i < chunk_count && M_CanRead(&cursor, 12); i++) {
+        const int32_t chunk_type = M_ReadS32(&cursor);
+        const int32_t block_count = M_ReadS32(&cursor);
+        const int32_t chunk_size = M_ReadS32(&cursor);
+        if (chunk_type != ICT_TEXTURE_DATA && chunk_type != ICT_TEXTURE_INFO) {
+            cursor.pos += chunk_size;
+            continue;
+        }
+
+        for (int32_t j = 0; j < block_count && M_CanRead(&cursor, 12); j++) {
+            const int32_t data_type = M_ReadS32(&cursor);
+            const int32_t data_count = M_ReadS32(&cursor);
+            const int32_t data_size = M_ReadS32(&cursor);
+            const size_t block_end = cursor.pos + data_size;
+            if (data_type == IDT_SPRITE_TEXTURES) {
+                M_ReadSprites(&cursor, data_count, out);
+            } else if (data_type == IDT_SPRITE_SEQUENCES) {
+                M_ReadSequences(&cursor, data_count, out);
+            }
+            cursor.pos = block_end;
+        }
+    }
+
+    Memory_Free(payload);
+    return out->sprite_count > 0;
+}
+
+void FontBin_Free(FONT_BIN *const font_bin)
+{
+    Memory_FreePointer(&font_bin->sprites);
+    *font_bin = (FONT_BIN) {};
+}

--- a/src/tests/unit/font_bin.h
+++ b/src/tests/unit/font_bin.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Reads the glyph metrics out of a shipped font.bin, which is what the game
+// loads them from. Only the sprite textures and the sprite sequences that name
+// the two fonts are of interest; everything else in the injection is skipped.
+
+#include <trx/game/output/types.h>
+
+#include <stdint.h>
+
+#define FONT_BIN_FONT_COUNT 2
+
+typedef struct {
+    SPRITE_TEXTURE *sprites;
+    int32_t sprite_count;
+    // Where each font's sprites start, and how many it has. font.bin carries
+    // the default font first and the small font second.
+    int32_t font_base[FONT_BIN_FONT_COUNT];
+    int32_t font_count[FONT_BIN_FONT_COUNT];
+} FONT_BIN;
+
+// Returns false if the file is missing or is not an injection this can read.
+bool FontBin_Load(const char *path, FONT_BIN *out);
+void FontBin_Free(FONT_BIN *font_bin);

--- a/src/tests/unit/stubs.c
+++ b/src/tests/unit/stubs.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 CONFIG g_Config = {};
+CONFIG g_SavedConfig = {};
 
 void Log_Message(
     const LOG_LEVEL level, const char *const file, const int32_t line,

--- a/src/tests/unit/test_ui_layout.c
+++ b/src/tests/unit/test_ui_layout.c
@@ -1,0 +1,295 @@
+// The settings dialogs size themselves from the text they hold, so a long
+// translation can push one past the edge of the screen. 4:3 is where that
+// bites: the canvas is 640 units wide there against 853 at 16:9, so a dialog
+// that fits a widescreen window has 213 units less to work with.
+//
+// These tests lay the dialogs out for real - the same measure and layout passes
+// the game runs - at 640x480, for every game and every shipped language, and
+// check that nothing ends up outside the canvas.
+
+#include "fake_engine_settings.h"
+#include "fake_engine_ui.h"
+#include "harness.h"
+
+#include <trx/config.h>
+#include <trx/config/presets.h>
+#include <trx/core/json.h>
+#include <trx/core/memory.h>
+#include <trx/core/strings.h>
+#include <trx/game/game_strings/entries.h>
+#include <trx/game/ui.h>
+#include <trx/game/input.h>
+#include <trx/game/ui/dialogs/config_presets.h>
+#include <trx/game/ui/dialogs/gameplay_settings.h>
+#include <trx/game/ui/dialogs/graphic_settings.h>
+#include <trx/game/ui/dialogs/sound_settings.h>
+
+#include <stdio.h>
+#include <string.h>
+
+// Rounding in the layout arithmetic can leave a node a hair over the edge
+// without anything being visibly clipped.
+#define M_SLACK 1.0f
+
+// A few widgets - the bar preview and the colour swatch among them - measure a
+// couple of units wider than the box they are given, and have done so for as
+// long as they have existed. The tolerance is set above that and far below the
+// hundreds of units a dialog spills when it sizes itself wrongly.
+#define M_BOX_SLACK 8.0f
+
+typedef struct {
+    const char *name;
+    UI_SETTINGS_DIALOG_STATE *(*init)(void);
+    void (*draw)(UI_SETTINGS_DIALOG_STATE *);
+    void (*free)(UI_SETTINGS_DIALOG_STATE *);
+} M_DIALOG;
+
+static const M_DIALOG m_Dialogs[] = {
+    { "gameplay", UI_GameplaySettings_Init, UI_GameplaySettings,
+      UI_GameplaySettings_Free },
+    { "graphics", UI_GraphicSettings_Init, UI_GraphicSettings,
+      UI_GraphicSettings_Free },
+    { "sound", UI_SoundSettings_Init, UI_SoundSettings, UI_SoundSettings_Free },
+};
+
+// The languages the game ships, base_strings.json5 being the English one.
+static const char *m_Languages[] = {
+    nullptr, "de", "en-gb", "fr", "gd", "it", "pl", "ru",
+};
+
+static void M_DefineStrings(JSON_OBJECT *const obj, const char *const prefix)
+{
+    for (const JSON_OBJECT_ELEMENT *elem = obj->start; elem != nullptr;
+         elem = elem->next) {
+        const char *const key = prefix == nullptr
+            ? elem->name->string
+            : String_FormatStatic("%s/%s", prefix, elem->name->string);
+        JSON_OBJECT *const child = JSON_ValueAsObject(elem->value);
+        if (child != nullptr) {
+            M_DefineStrings(child, key);
+        } else {
+            const char *const value = JSON_ValueGetString(elem->value, nullptr);
+            if (value != nullptr) {
+                GameString_Define(key, value);
+            }
+        }
+    }
+}
+
+// Overlay a shipped string layer on top of the built-in English defaults, the
+// way the game does when a player picks a language.
+static bool M_LoadLanguage(const char *const lang)
+{
+    const char *const path = lang == nullptr
+        ? TEST_SHIP_CFG_DIR "/base_strings.json5"
+        : String_FormatStatic(
+              "%s/base_strings-%s.json5", TEST_SHIP_CFG_DIR, lang);
+
+    char *data = nullptr;
+    size_t size = 0;
+    if (!File_Load(path, &data, &size)) {
+        return false;
+    }
+    JSON_VALUE *const root = JSON_ParseEx(
+        data, size, JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr, nullptr, nullptr);
+    Memory_Free(data);
+    if (root == nullptr) {
+        return false;
+    }
+    JSON_OBJECT *const obj = JSON_ValueAsObject(root);
+    if (obj != nullptr) {
+        M_DefineStrings(obj, nullptr);
+    }
+    JSON_ValueFree(root);
+    return true;
+}
+
+// Nothing in the UI clips, so a node whose ink reaches past its edge is text
+// the player cannot read. The edge is the safe width, not the canvas: dialogs
+// are meant to stay clear of the screen by UI_SCREEN_MARGIN.
+static void M_CheckNode(
+    const UI_NODE *const node, const float canvas_w, float *const worst,
+    float *const worst_box)
+{
+    if (node == nullptr) {
+        return;
+    }
+
+    // A node with no box was never laid out - a row scrolled out of its list,
+    // say - and the draw pass skips it along with everything under it.
+    if (node->w <= 0.0f || node->h <= 0.0f) {
+        return;
+    }
+
+    // Nothing in this UI clips, so text wider than the box it was given spills
+    // over whatever is beside it - the frame it sits in, or the row below.
+    const float outside_box = node->measure_w - node->w;
+    if (outside_box > *worst_box) {
+        *worst_box = outside_box;
+    }
+
+    // The scene root and a modal span the screen by definition and draw nothing
+    // of their own. The margin is about the dialog sitting inside them.
+    const bool is_full_screen = node->w >= canvas_w - M_SLACK;
+    if (!is_full_screen) {
+        const float node_right = node->x + MAX(node->w, node->measure_w);
+        const float over =
+            MAX(UI_SCREEN_MARGIN - node->x,
+                node_right - (canvas_w - UI_SCREEN_MARGIN));
+        if (over > *worst) {
+            *worst = over;
+        }
+    }
+
+    for (const UI_NODE *child = node->first_child; child != nullptr;
+         child = child->next_sibling) {
+        M_CheckNode(child, canvas_w, worst, worst_box);
+    }
+}
+
+// How far the worst node reaches outside the screen, and outside its own box.
+typedef struct {
+    float screen;
+    float box;
+} M_OVERFLOW;
+
+static M_OVERFLOW M_MeasureScene(void)
+{
+    M_OVERFLOW result = {};
+    M_CheckNode(
+        UI_GetSceneRoot(), UI_GetCanvasWidth(), &result.screen, &result.box);
+    return result;
+}
+
+static M_OVERFLOW M_MeasureDialogOverflow(const M_DIALOG *const dialog)
+{
+    UI_SETTINGS_DIALOG_STATE *const state = dialog->init();
+    UI_BeginScene();
+    dialog->draw(state);
+    UI_EndScene();
+    const M_OVERFLOW result = M_MeasureScene();
+    dialog->free(state);
+    return result;
+}
+
+static void M_SetUp(const int32_t tr_version, const char *const lang)
+{
+    GameString_Clear();
+    GameString_Init();
+    M_LoadLanguage(lang);
+    FakeUI_SetGame(tr_version);
+    FakeUI_SetViewport(640, 480);
+    g_Config.ui.text_scale = 1.0f;
+    UI_LoadText();
+}
+
+// Every check here rests on text measuring the way it does in the game, and a
+// font that failed to load would measure everything as nothing and quietly
+// pass. These widths are the sum of the glyph advances in each game's own font.
+TEST(ui_font_metrics)
+{
+    static const struct {
+        int32_t tr_version;
+        float width;
+    } expected[] = {
+        { 1, 259.0f },
+        { 2, 259.0f },
+        { 3, 282.0f },
+        { 4, 275.0f },
+    };
+
+    UI_InitText();
+    for (size_t i = 0; i < ARRAY_SIZE(expected); i++) {
+        M_SetUp(expected[i].tr_version, nullptr);
+        float width = 0.0f;
+        UI_Text_Measure(
+            "Remember guns between levels", &width, nullptr,
+            (UI_TEXT_SETTINGS) { .scale = 1.0f });
+        if (width != expected[i].width) {
+            TEST_FAIL(
+                "tr%d: expected width %.1f, got %.1f", expected[i].tr_version,
+                expected[i].width, width);
+        }
+    }
+    UI_ShutdownText();
+}
+
+// The list of settings a preset would change is the longest text in any of
+// these dialogs: a setting title and its before/after values, for every key the
+// preset touches. It wraps rather than sizing the dialog to the widest of them.
+TEST(ui_config_presets_confirm_fits_4_3)
+{
+    UI_InitText();
+    Config_Presets_ScanFiles();
+
+    for (int32_t tr_version = 1; tr_version <= TR_VERSION_COUNT; tr_version++) {
+        for (size_t i = 0; i < ARRAY_SIZE(m_Languages); i++) {
+            M_SetUp(tr_version, m_Languages[i]);
+
+            const int32_t preset_count = Config_Presets_GetCount();
+            if (preset_count == 0) {
+                TEST_FAIL("no presets found to confirm");
+                break;
+            }
+
+            for (int32_t preset = 0; preset < preset_count; preset++) {
+                UI_CONFIG_PRESETS_STATE *const state = UI_ConfigPresets_Init();
+                // Walk the list to the preset, then accept it, the way a player
+                // reaches the confirmation.
+                for (int32_t row = 0; row <= preset; row++) {
+                    g_InputDB = (INPUT_STATE) { .menu_down = true };
+                    UI_ConfigPresets_Control(state);
+                }
+                g_InputDB = (INPUT_STATE) { .menu_confirm = true };
+                UI_ConfigPresets_Control(state);
+                g_InputDB = (INPUT_STATE) {};
+
+                UI_BeginScene();
+                UI_ConfigPresetsApplyModal(state);
+                UI_EndScene();
+
+                const M_OVERFLOW over = M_MeasureScene();
+                const char *const lang =
+                    m_Languages[i] != nullptr ? m_Languages[i] : "en";
+                if (over.screen > M_SLACK) {
+                    TEST_FAIL(
+                        "tr%d %s preset %d: %.0f units off screen", tr_version,
+                        lang, preset, over.screen);
+                }
+                if (over.box > M_BOX_SLACK) {
+                    TEST_FAIL(
+                        "tr%d %s preset %d: %.0f units outside its box",
+                        tr_version, lang, preset, over.box);
+                }
+                UI_ConfigPresets_Free(state);
+            }
+        }
+    }
+    UI_ShutdownText();
+}
+
+TEST(ui_settings_dialogs_fit_4_3)
+{
+    UI_InitText();
+    for (int32_t tr_version = 1; tr_version <= TR_VERSION_COUNT; tr_version++) {
+        for (size_t i = 0; i < ARRAY_SIZE(m_Languages); i++) {
+            M_SetUp(tr_version, m_Languages[i]);
+            for (size_t j = 0; j < ARRAY_SIZE(m_Dialogs); j++) {
+                const M_OVERFLOW over = M_MeasureDialogOverflow(&m_Dialogs[j]);
+                const char *const lang =
+                    m_Languages[i] != nullptr ? m_Languages[i] : "en";
+                if (over.screen > M_SLACK) {
+                    TEST_FAIL(
+                        "tr%d %s %s: %.0f units off screen", tr_version, lang,
+                        m_Dialogs[j].name, over.screen);
+                }
+                if (over.box > M_BOX_SLACK) {
+                    TEST_FAIL(
+                        "tr%d %s %s: %.0f units outside its box", tr_version,
+                        lang, m_Dialogs[j].name, over.box);
+                }
+            }
+        }
+    }
+    UI_ShutdownText();
+}

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -12,7 +12,6 @@
 #include <trx/debug.h>
 #include <trx/game/game_flow/vars.h>
 #include <trx/game/game_strings/entries.h>
-#include <trx/game/shell.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/trx/game/gun/vars.c
+++ b/src/trx/game/gun/vars.c
@@ -5,7 +5,7 @@
 #include <trx/core/log.h>
 #include <trx/game/catalog/manager.h>
 #include <trx/game/const.h>
-#include <trx/game/shell.h>
+#include <trx/game/shell/common.h>
 
 WEAPON_INFO g_Weapons[NUM_WEAPONS] = {};
 

--- a/src/trx/game/input/backends/base.h
+++ b/src/trx/game/input/backends/base.h
@@ -2,7 +2,10 @@
 
 #include <trx/game/input/common.h>
 
-#include <SDL2/SDL_events.h>
+// Only the backends themselves look inside an event, and this header is what
+// anything asking a backend a question has to include - so keep the type
+// opaque here rather than pulling SDL2 in with it.
+typedef union SDL_Event SDL_Event;
 
 typedef struct {
     void (*init)(void);

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -5,6 +5,7 @@
 #include <trx/game/input/combo.h>
 #include <trx/version.h>
 
+#include <SDL2/SDL_events.h>
 #include <SDL2/SDL_keyboard.h>
 #include <string.h>
 

--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -8,6 +8,7 @@
 #include <trx/game/input/backends/controller.h>
 #include <trx/game/input/backends/keyboard.h>
 #include <trx/game/input/backends/touch.h>
+#include <trx/game/input/sdl.h>
 #include <trx/version.h>
 
 #include <SDL2/SDL_keyboard.h>

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -4,7 +4,6 @@
 #include <trx/core/json.h>
 #include <trx/game/input/enum.h>
 
-#include <SDL2/SDL_events.h>
 #include <stdint.h>
 
 #define INPUT_COMBO_MAX_KEYS 3
@@ -33,10 +32,6 @@ void Input_Update(void);
 // backends acquire whatever hardware is present, disabled ones release it.
 void Input_Discover(void);
 void Input_Reset(void);
-
-// Processes a SDL event to update global input state before polling.
-// @param event     Event to process.
-void Input_ProcessEvent(const SDL_Event *event);
 
 // Checks whether the given backend is available. A disabled backend is not
 // polled, not offered in the controls dialog, and holds no OS resources.
@@ -128,16 +123,6 @@ INPUT_STATE Input_GetDebounced(const INPUT_STATE input);
 
 // Get the human-readable name of the given role.
 const char *Input_GetRoleName(INPUT_ROLE role);
-
-// Serialize a scancode and modifier mask into a human-readable key
-// description, e.g. "ctrl+shift+up". The returned string must not be held onto.
-const char *Input_KeyDescFromSDL(SDL_Scancode scancode, SDL_Keymod mod);
-
-// Parse a human-readable key description into scancode and modifier mask.
-// e.g. "ctrl+shift+up" → scancode SDL_SCANCODE_UP, mod KMOD_CTRL|KMOD_SHIFT.
-// Returns true if parsing succeeded, false otherwise.
-bool Input_ParseKeyDesc(
-    const char *desc, SDL_Scancode *scancode, SDL_Keymod *mod);
 
 // Reset all roles in the input state to inactive.
 void InputState_Clear(INPUT_STATE *state);

--- a/src/trx/game/input/sdl.h
+++ b/src/trx/game/input/sdl.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// The parts of input that speak in SDL's own types: feeding it events, and
+// converting between scancodes and the key descriptions bindings are stored as.
+// They sit apart from the rest so that reading the input state, or naming a
+// bound key, needs no window system.
+
+#include <trx/game/input/enum.h>
+
+#include <SDL2/SDL_events.h>
+
+// Processes a SDL event to update global input state before polling.
+// @param event     Event to process.
+void Input_ProcessEvent(const SDL_Event *event);
+
+// Serialize a scancode and modifier mask into a human-readable key
+// description, e.g. "ctrl+shift+up". The returned string must not be held onto.
+const char *Input_KeyDescFromSDL(SDL_Scancode scancode, SDL_Keymod mod);
+
+// Parse a human-readable key description into scancode and modifier mask.
+// e.g. "ctrl+shift+up" → scancode SDL_SCANCODE_UP, mod KMOD_CTRL|KMOD_SHIFT.
+// Returns true if parsing succeeded, false otherwise.
+bool Input_ParseKeyDesc(
+    const char *desc, SDL_Scancode *scancode, SDL_Keymod *mod);

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -8,6 +8,7 @@
 #include <trx/game/output/shaders/mesh.h>
 #include <trx/game/output/shaders/ui.h>
 #include <trx/game/output/textures.h>
+#include <trx/game/output/textures_gl.h>
 #include <trx/game/output/uniforms.h>
 #include <trx/game/shell.h>
 #include <trx/gl/context.h>

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -11,6 +11,7 @@
 #include <trx/game/level/cache.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/output.h>
+#include <trx/game/output/textures_gl.h>
 #include <trx/game/output/vertex_range.h>
 #include <trx/game/sparks/enum.h>
 #include <trx/gl/utils.h>

--- a/src/trx/game/output/textures.h
+++ b/src/trx/game/output/textures.h
@@ -3,8 +3,6 @@
 #include <trx/game/output/scene_source.h>
 #include <trx/game/output/types.h>
 
-#include <GL/glew.h>
-
 #pragma pack(push, 1)
 typedef struct {
     float x0;
@@ -33,8 +31,6 @@ void Output_Textures_ObserveLevelLoad(void);
 void Output_Textures_UpdateEnvironmentMap(void);
 void Output_Textures_CycleAnimations(void);
 void Output_Textures_ApplyRenderSettings(void);
-GLuint Output_Textures_GetAtlasTexture(void);
-GLuint Output_Textures_GetEnvMapTexture(void);
 
 // TR4 reflections sample the env map straight out of the atlas, from the
 // sprite the OG uses for it (spriteinfo[objects[DEFAULT_SPRITES].mesh_index +

--- a/src/trx/game/output/textures_gl.h
+++ b/src/trx/game/output/textures_gl.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// The texture atlas handles, in the renderer's own terms. They sit apart from
+// the rest of the texture module because naming a sprite needs no GL:
+// everything that reads sprite geometry would otherwise pull the whole of GLEW
+// in for the sake of these two.
+
+#include <GL/glew.h>
+
+GLuint Output_Textures_GetAtlasTexture(void);
+GLuint Output_Textures_GetEnvMapTexture(void);

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -11,6 +11,7 @@
 #include <trx/game/input/backends/controller.h>
 #include <trx/game/input/backends/keyboard.h>
 #include <trx/game/input/common.h>
+#include <trx/game/input/sdl.h>
 #include <trx/game/lara.h>
 #include <trx/game/random.h>
 #include <trx/game/shell/common.h>

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -12,6 +12,7 @@
 #include <trx/game/input/backends/controller.h>
 #include <trx/game/input/backends/keyboard.h>
 #include <trx/game/input/common.h>
+#include <trx/game/input/sdl.h>
 #include <trx/game/lara.h>
 #include <trx/game/lua.h>
 #include <trx/game/random.h>

--- a/src/trx/game/shell/events.c
+++ b/src/trx/game/shell/events.c
@@ -3,12 +3,14 @@
 #include <trx/debug.h>
 #include <trx/game/console/common.h>
 #include <trx/game/input/common.h>
+#include <trx/game/input/sdl.h>
 #include <trx/game/lua/guard.h>
 #include <trx/game/replay/test_recorder.h>
 #include <trx/game/replay/test_replay.h>
 #include <trx/game/screenshot.h>
 #include <trx/game/shell.h>
 #include <trx/game/ui.h>
+#include <trx/game/ui/keys.h>
 
 // If true, next SDL_TEXT* event should be zeroed out.
 static bool m_ConsoleJustOpened = false;

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -12,7 +12,6 @@
 #include <trx/game/ui/text.h>
 #include <trx/game/viewport.h>
 
-#include <SDL2/SDL.h>
 #include <string.h>
 
 static struct {
@@ -26,27 +25,6 @@ static struct {
 };
 
 extern void UI_ClearDraw(void);
-
-static UI_INPUT M_TranslateInput(const uint32_t system_keycode)
-{
-    // clang-format off
-    switch (system_keycode) {
-    case SDLK_UP:        return UI_KEY_UP;
-    case SDLK_DOWN:      return UI_KEY_DOWN;
-    case SDLK_LEFT:      return UI_KEY_LEFT;
-    case SDLK_RIGHT:     return UI_KEY_RIGHT;
-    case SDLK_HOME:      return UI_KEY_HOME;
-    case SDLK_END:       return UI_KEY_END;
-    case SDLK_BACKSPACE: return UI_KEY_BACK;
-    case SDLK_RETURN:    return UI_KEY_RETURN;
-    case SDLK_ESCAPE:    return UI_KEY_ESCAPE;
-    case SDLK_TAB:
-        return (SDL_GetModState() & KMOD_SHIFT) != 0 ? UI_KEY_SHIFT_TAB
-                                                     : UI_KEY_TAB;
-    }
-    // clang-format on
-    return -1;
-}
 
 // Depth-first measure pass
 static void M_MeasureNode(UI_NODE *const node)
@@ -181,45 +159,6 @@ void UI_ToggleState(bool *const config_setting)
     Config_Update();
     Console_Log(
         *config_setting ? GS("general/osd/ui_on") : GS("general/osd/ui_off"));
-}
-
-void UI_HandleKeyDown(const uint32_t key)
-{
-    UI_FireEvent((EVENT) {
-        .name = "key_down",
-        .sender = nullptr,
-        .data = (void *)M_TranslateInput(key),
-    });
-}
-
-void UI_HandleKeyUp(const uint32_t key)
-{
-    UI_FireEvent((EVENT) {
-        .name = "key_up",
-        .sender = nullptr,
-        .data = (void *)M_TranslateInput(key),
-    });
-}
-
-void UI_HandleTextEdit(const char *const text)
-{
-    UI_FireEvent((EVENT) {
-        .name = "text_edit", .sender = nullptr, .data = (void *)text });
-}
-
-void UI_HandlePaste(void)
-{
-    if (!SDL_HasClipboardText()) {
-        return;
-    }
-
-    char *const text = SDL_GetClipboardText();
-    if (text == nullptr) {
-        return;
-    }
-
-    UI_HandleTextEdit(text);
-    SDL_free(text);
 }
 
 int32_t UI_GetCanvasWidth(void)

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -18,6 +18,7 @@ static struct {
     MEMORY_ARENA_ALLOCATOR alloc;
     UI_NODE *root; // The top-level container
     UI_NODE *current; // The current container into which we attach nodes
+    UI_NODE *scene_root; // The tree the last UI_EndScene laid out
 } m_Priv = {
     .alloc = {
         .default_chunk_size = 1024 * 4,
@@ -121,6 +122,11 @@ const UI_NODE *UI_GetCurrent(void)
     return m_Priv.current;
 }
 
+const UI_NODE *UI_GetSceneRoot(void)
+{
+    return m_Priv.scene_root;
+}
+
 // Scene management
 void UI_BeginScene(void)
 {
@@ -131,6 +137,7 @@ void UI_BeginScene(void)
 
 void UI_EndScene(void)
 {
+    m_Priv.scene_root = m_Priv.root;
     M_MeasureNode(m_Priv.root);
     M_LayoutNode(m_Priv.root, 0, 0, UI_GetCanvasWidth(), UI_GetCanvasHeight());
     M_DrawNode(m_Priv.root);

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/core/memory.h>
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/console/common.h>
 #include <trx/game/game_strings/entries.h>
@@ -178,6 +179,11 @@ int32_t UI_GetCanvasHeight(void)
 {
     return UI_Scaler_CalcInverse(
         Viewport_GetHeight(VIEWPORT_UI), UI_SCALER_TARGET_GENERIC);
+}
+
+float UI_GetSafeCanvasWidth(void)
+{
+    return MAX(0.0f, UI_GetCanvasWidth() - 2.0f * UI_SCREEN_MARGIN);
 }
 
 float UI_ScaleX(const float x)

--- a/src/trx/game/ui/common.h
+++ b/src/trx/game/ui/common.h
@@ -3,20 +3,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef enum {
-    UI_KEY_UP,
-    UI_KEY_DOWN,
-    UI_KEY_LEFT,
-    UI_KEY_RIGHT,
-    UI_KEY_HOME,
-    UI_KEY_END,
-    UI_KEY_BACK,
-    UI_KEY_RETURN,
-    UI_KEY_ESCAPE,
-    UI_KEY_TAB,
-    UI_KEY_SHIFT_TAB,
-} UI_INPUT;
-
 // Forward declaration of the node and its vtable.
 struct UI_NODE;
 typedef struct {

--- a/src/trx/game/ui/common.h
+++ b/src/trx/game/ui/common.h
@@ -54,6 +54,10 @@ void UI_PushCurrent(UI_NODE *child);
 void UI_PopCurrent(void);
 const UI_NODE *UI_GetCurrent(void);
 
+// The tree the last UI_EndScene measured and laid out. Its nodes stay valid
+// until the next UI_BeginScene resets the arena they live in.
+const UI_NODE *UI_GetSceneRoot(void);
+
 void UI_Init(void);
 void UI_Shutdown(void);
 void UI_ToggleState(bool *config_setting);

--- a/src/trx/game/ui/common.h
+++ b/src/trx/game/ui/common.h
@@ -36,10 +36,17 @@ typedef struct UI_NODE {
     void *data;
 } UI_NODE;
 
+// How far a dialog stays clear of the screen edges, in canvas units.
+#define UI_SCREEN_MARGIN 5.0f
+
 // Dimensions in virtual pixels of the screen area
 // (640x480 for any 4:3 resolution on 1.00 text scaling)
 int32_t UI_GetCanvasWidth(void);
 int32_t UI_GetCanvasHeight(void);
+
+// The width a dialog may occupy: the canvas less the screen margin at either
+// edge. What sizes itself to fit the screen fits to this.
+float UI_GetSafeCanvasWidth(void);
 float UI_ScaleX(float x);
 float UI_ScaleY(float y);
 

--- a/src/trx/game/ui/dialogs/config_presets.c
+++ b/src/trx/game/ui/dialogs/config_presets.c
@@ -5,6 +5,7 @@
 #include <trx/config/presets.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/utils.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/input.h>
 #include <trx/game/ui.h>
@@ -19,12 +20,17 @@
 #include <trx/game/ui/elements/spacer.h>
 #include <trx/game/ui/elements/stack.h>
 #include <trx/game/ui/elements/window.h>
+#include <trx/game/ui/scaler.h>
 #include <trx/game/ui/scrollable.h>
+#include <trx/game/ui/text.h>
 
 #include <string.h>
 
 #define M_CONFIRM_VISIBLE_ROWS 10
-#define M_CONFIRM_DIALOG_W 72.0f
+// A narrow list of changes should stay narrow; this is the floor, not the
+// width.
+#define M_CONFIRM_MIN_W 72.0f
+#define M_CONFIRM_PAD 6.0f
 #define M_LIST_ROW_SPACING 5.0f
 
 typedef enum {
@@ -76,12 +82,92 @@ static int32_t M_GetChangedSettingCount(const int32_t preset_idx)
     return changed_count;
 }
 
-static int32_t M_GetConfirmRowCount(const int32_t preset_idx)
+// The value line of a row, reading "was \{button right} becomes". The result is
+// the caller's to free: one row is measured for every changed setting, and the
+// rotating format buffer is eight deep, so a preset that changes more than that
+// would overwrite strings the caller still holds.
+static char *M_FormatValueChange(
+    const CONFIG_OPTION *const opt, const char *const target_raw)
 {
-    return M_GetChangedSettingCount(preset_idx) * 2;
+    const char *const current_value = Config_GetOptionValueAsString(opt, true);
+    char *const target_value =
+        Config_NormalizeOptionValueString(opt, target_raw, true);
+    char *const result =
+        String_Format("  %s \\{button right} %s", current_value, target_value);
+    Memory_Free(target_value);
+    return result;
 }
 
-static void M_DrawConfirmRows(UI_CONFIG_PRESETS_STATE *const s)
+// Draw text wrapped to the given width, one label per line. The confirm list
+// scrolls by line, so each line has to be a child of its own; a single label
+// holding newlines would scroll as one item and outgrow the screen.
+static void M_WrappedLines(const char *const text, const float max_width)
+{
+    char *const wrapped = UI_Text_WordWrap(text, 1.0f, max_width);
+    if (wrapped == nullptr) {
+        UI_Label(text);
+        return;
+    }
+    // Each label copies the text it is given, so cutting the buffer up in place
+    // is enough.
+    char *line = wrapped;
+    while (line != nullptr) {
+        char *const end = strchr(line, '\n');
+        if (end != nullptr) {
+            *end = '\0';
+        }
+        UI_Label(line);
+        line = end != nullptr ? end + 1 : nullptr;
+    }
+    Memory_Free(wrapped);
+}
+
+// Text wrapped to the given width as a single label. Labels render newlines, so
+// anything that does not scroll can stay one node.
+static void M_WrappedLabel(const char *const text, const float max_width)
+{
+    char *const wrapped = UI_Text_WordWrap(text, 1.0f, max_width);
+    UI_Label(wrapped != nullptr ? wrapped : text);
+    Memory_Free(wrapped);
+}
+
+// The width the dialog's text may occupy, in the units the layout sizes in. The
+// modal's padding and the window's chrome come off what the screen allows, and
+// a list of short rows keeps the dialog narrow rather than stretching it.
+static float M_GetConfirmContentWidth(UI_CONFIG_PRESETS_STATE *const s)
+{
+    const float scale = UI_Scaler_GetTextScale();
+    const float budget = UI_GetSafeCanvasWidth()
+        - (2.0f * M_CONFIRM_PAD + UI_Window_GetChromeWidth()) * scale;
+
+    const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
+    float natural = M_CONFIRM_MIN_W * scale;
+    if (preset != nullptr) {
+        for (int32_t i = 0; i < preset->setting_count; i++) {
+            const CONFIG_OPTION *const opt =
+                Config_GetOptionByPath(preset->keys[i]);
+            if (opt == nullptr
+                || strcmp(
+                       Config_GetOptionValueAsString(opt, false),
+                       preset->values[i])
+                    == 0) {
+                continue;
+            }
+            char *const value_change =
+                M_FormatValueChange(opt, preset->values[i]);
+            natural =
+                MAX(natural,
+                    UI_Label_MeasureW(M_GetPresetKeyLabel(preset->keys[i])));
+            natural = MAX(natural, UI_Label_MeasureW(value_change));
+            Memory_Free(value_change);
+        }
+    }
+
+    return MIN(natural, MAX(budget, M_CONFIRM_MIN_W * scale));
+}
+
+static void M_DrawConfirmRows(
+    UI_CONFIG_PRESETS_STATE *const s, const float content_width)
 {
     const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
     if (preset == nullptr) {
@@ -99,13 +185,10 @@ static void M_DrawConfirmRows(UI_CONFIG_PRESETS_STATE *const s)
         if (strcmp(current_value_raw, preset->values[i]) == 0) {
             continue;
         }
-        const char *const current_value =
-            Config_GetOptionValueAsString(opt, true);
-        char *const target_value =
-            Config_NormalizeOptionValueString(opt, preset->values[i], true);
-        UI_LabelFmt("%s", M_GetPresetKeyLabel(preset->keys[i]));
-        UI_LabelFmt("  %s \\{button right} %s", current_value, target_value);
-        Memory_Free(target_value);
+        char *const value_change = M_FormatValueChange(opt, preset->values[i]);
+        M_WrappedLines(M_GetPresetKeyLabel(preset->keys[i]), content_width);
+        M_WrappedLines(value_change, content_width);
+        Memory_Free(value_change);
     }
 }
 
@@ -113,7 +196,9 @@ static void M_Header(void *const user_data)
 {
     UI_CONFIG_PRESETS_STATE *const s = user_data;
     if (s->phase == M_PHASE_CONFIRM) {
-        UI_Label(GS("general/config_presets/confirm_description"));
+        M_WrappedLabel(
+            GS("general/config_presets/confirm_description"),
+            M_GetConfirmContentWidth(s));
         UI_Spacer(0.0f, UI_TEXT_HEIGHT);
     }
 }
@@ -123,7 +208,9 @@ static void M_Footer(void *const user_data)
     UI_CONFIG_PRESETS_STATE *const s = user_data;
     if (s->phase == M_PHASE_CONFIRM) {
         UI_Spacer(0.0f, UI_TEXT_HEIGHT);
-        UI_Label(GS("general/config_presets/confirm_restart_note"));
+        M_WrappedLabel(
+            GS("general/config_presets/confirm_restart_note"),
+            M_GetConfirmContentWidth(s));
     }
 }
 
@@ -241,11 +328,12 @@ bool UI_ConfigPresets_Control(UI_CONFIG_PRESETS_STATE *const s)
     }
     if (choice >= 0 && choice < count) {
         s->selected_idx = choice;
-        const int32_t row_count = M_GetConfirmRowCount(choice);
-        if (row_count > 0) {
+        if (M_GetChangedSettingCount(choice) > 0) {
             s->confirm_scroll.first_item = 0;
             s->confirm_scroll.sel_item = -1;
-            s->confirm_scroll.max_items = row_count;
+            // The stack counts its own lines once it has them; wrapping decides
+            // how many a row takes.
+            s->confirm_scroll.max_items = 0;
             s->phase = M_PHASE_CONFIRM;
         } else {
             s->phase = M_PHASE_NO_CHANGES;
@@ -298,16 +386,19 @@ void UI_ConfigPresetsApplyModal(UI_CONFIG_PRESETS_STATE *const s)
         return;
     }
 
+    const float content_width = M_GetConfirmContentWidth(s);
+
     const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
     const char *const preset_name =
         preset != nullptr ? GameString_Get(preset->name_gs) : "";
-    const char *const title = String_FormatStatic(
-        GS("general/config_presets/title_fmt"), preset_name);
+    char *const title =
+        String_Format(GS("general/config_presets/title_fmt"), preset_name);
+    char *const wrapped_title = UI_Text_WordWrap(title, 1.0f, content_width);
 
     UI_BeginModal(0.5f, 0.5f);
-    UI_BeginPad(6.0f, 6.0f);
+    UI_BeginPad(M_CONFIRM_PAD, M_CONFIRM_PAD);
     UI_BeginWindow((UI_WINDOW_SETTINGS) {
-        .title = title,
+        .title = wrapped_title != nullptr ? wrapped_title : title,
         .scrollable =
             s->phase == M_PHASE_CONFIRM ? &s->confirm_scroll : nullptr,
         .title_spacing = -1.0f,
@@ -319,28 +410,27 @@ void UI_ConfigPresetsApplyModal(UI_CONFIG_PRESETS_STATE *const s)
     });
 
     if (s->phase == M_PHASE_APPLIED) {
-        UI_BeginPad(6.0f, 6.0f);
-        UI_LabelFmt("%s", GS("general/config_presets/applied"));
+        UI_BeginPad(M_CONFIRM_PAD, M_CONFIRM_PAD);
+        M_WrappedLabel(GS("general/config_presets/applied"), content_width);
         UI_EndPad();
     } else if (s->phase == M_PHASE_NO_CHANGES) {
-        UI_BeginPad(6.0f, 6.0f);
-        UI_LabelFmt("%s", GS("general/config_presets/no_changes"));
+        UI_BeginPad(M_CONFIRM_PAD, M_CONFIRM_PAD);
+        M_WrappedLabel(GS("general/config_presets/no_changes"), content_width);
         UI_EndPad();
     } else if (s->phase == M_PHASE_CONFIRM) {
-        UI_BeginResize(M_CONFIRM_DIALOG_W, -1.0f);
-
         UI_BeginScrollableStack(
             &s->confirm_scroll,
             (UI_SCROLLABLE_STACK_SETTINGS) {
                 .orientation = UI_STACK_VERTICAL,
                 .spacing = 2.0f,
             });
-        M_DrawConfirmRows(s);
+        M_DrawConfirmRows(s, content_width);
         UI_EndScrollableStack();
-        UI_EndResize();
     }
 
     UI_EndWindow();
     UI_EndPad();
     UI_EndModal();
+    Memory_Free(wrapped_title);
+    Memory_Free(title);
 }

--- a/src/trx/game/ui/dialogs/controls_editor.c
+++ b/src/trx/game/ui/dialogs/controls_editor.c
@@ -590,7 +590,7 @@ void UI_ControlsEditor_Init(
     for (int32_t i = 0; i < INPUT_ROLE_NUMBER_OF; i++) {
         float w;
         UI_Label_Measure(Input_GetRoleName(i), &w, nullptr);
-        s->label_size = MAX(s->label_size, w / g_Config.ui.text_scale);
+        s->label_size = MAX(s->label_size, w / UI_Scaler_GetTextScale());
     }
     s->input_size = 80;
 }

--- a/src/trx/game/ui/dialogs/settings.c
+++ b/src/trx/game/ui/dialogs/settings.c
@@ -10,12 +10,18 @@
 #include <trx/game/ui/scaler.h>
 #include <trx/game/viewport.h>
 
+// How small the dialog may be scaled before a long string counts as too long.
+// The widest shipped translation needs 0.87; the room below that is headroom,
+// not licence to keep growing.
+#define M_MIN_FIT_SCALE 0.85f
+
 typedef struct UI_SETTINGS_DIALOG_STATE {
     UI_SETTINGS_PHASE phase;
     int32_t visible_rows;
 
     float max_content_width;
     float max_content_height;
+    float fit_scale;
 
     int32_t tab_count;
     UI_SETTINGS_TAB *tabs;
@@ -51,6 +57,25 @@ static float M_GetVisibleContentHeight(void)
         return 0.0f;
     }
     return visible_rows * UI_TEXT_HEIGHT;
+}
+
+// The dialog is as wide as its widest tab, and it is centred, so a tab wider
+// than the canvas loses text off both edges. Where that happens, the dialog is
+// drawn smaller until it fits. M_MIN_FIT_SCALE bounds how far that goes:
+// wording that still does not fit is a string to shorten, and the layout test
+// says so rather than the dialog shrinking away to nothing.
+static float M_GetFitScale(const float content_width)
+{
+    const float natural_width = content_width + UI_Window_GetChromeWidth();
+    if (natural_width <= 0.0f) {
+        return 1.0f;
+    }
+    const float available_width =
+        UI_GetSafeCanvasWidth() / UI_Scaler_GetTextScale();
+    if (natural_width <= available_width) {
+        return 1.0f;
+    }
+    return MAX(M_MIN_FIT_SCALE, available_width / natural_width);
 }
 
 static UI_SETTINGS_TAB *M_GetActiveTab(UI_SETTINGS_DIALOG_STATE *const s)
@@ -116,8 +141,9 @@ static void M_RecomputeSizes(UI_SETTINGS_DIALOG_STATE *const s)
     }
 
     s->visible_rows = M_GetVisibleRows();
-    s->max_content_width = max_content_width / g_Config.ui.text_scale;
+    s->max_content_width = max_content_width / UI_Scaler_GetTextScale();
     s->max_content_height = max_content_height;
+    s->fit_scale = M_GetFitScale(s->max_content_width);
 }
 
 static void M_WindowHeader(void *const user_data)
@@ -319,6 +345,7 @@ void UI_SettingsDialog(UI_SETTINGS_DIALOG_STATE *const s)
     const UI_SETTINGS_TAB *const tab = M_GetActiveTabConst(s);
     UI_SCROLLABLE *const active_scroll = M_GetTabScrollable(M_GetActiveTab(s));
 
+    UI_Scaler_PushTextScale(s->fit_scale);
     UI_BeginModal(0.5f, 0.6f);
     UI_BeginStackEx((UI_STACK_SETTINGS) {
         .orientation = UI_STACK_VERTICAL,
@@ -367,6 +394,7 @@ void UI_SettingsDialog(UI_SETTINGS_DIALOG_STATE *const s)
 
     UI_EndStack();
     UI_EndModal();
+    UI_Scaler_PopTextScale();
 
     if (tab != nullptr && tab->ops != nullptr
         && tab->ops->draw_overlay != nullptr) {

--- a/src/trx/game/ui/dialogs/settings_editor.c
+++ b/src/trx/game/ui/dialogs/settings_editor.c
@@ -12,6 +12,7 @@
 #include <trx/game/ui/dialogs/color_editor.h>
 #include <trx/game/ui/dialogs/setting_helpers/enums.h>
 #include <trx/game/ui/dialogs/text.h>
+#include <trx/game/ui/scaler.h>
 #include <trx/version.h>
 
 #include <math.h>
@@ -250,7 +251,7 @@ static float M_MeasureMaxValueWidth(const UI_SETTINGS_OPTION *const option)
     }
 
     if (M_IsBarColorEnum(option)) {
-        return M_BAR_WIDTH * g_Config.ui.text_scale;
+        return M_BAR_WIDTH * UI_Scaler_GetTextScale();
     }
 
     switch (M_GetConfigOption(option)->type) {
@@ -290,8 +291,8 @@ static float M_MeasureMaxValueWidth(const UI_SETTINGS_OPTION *const option)
     }
 
     case TVT_RGB_888:
-        return UI_Label_MeasureW("#FFFFFF") + 8.0f * g_Config.ui.text_scale
-            + 32.0f * g_Config.ui.text_scale;
+        return UI_Label_MeasureW("#FFFFFF") + 8.0f * UI_Scaler_GetTextScale()
+            + 32.0f * UI_Scaler_GetTextScale();
 
     case TVT_STRING:
         return UI_Label_MeasureW(*(char **)option->target);
@@ -525,7 +526,7 @@ void UI_SettingsEditor_Free(UI_SETTINGS_EDITOR_STATE *const s)
 
 float UI_SettingsEditor_GetContentWidth(const UI_SETTINGS_EDITOR_STATE *const s)
 {
-    return M_GetMaxLabelWidth(s) + 20.0f * g_Config.ui.text_scale
+    return M_GetMaxLabelWidth(s) + 20.0f * UI_Scaler_GetTextScale()
         + M_GetMaxValueWidth(s);
 }
 
@@ -753,8 +754,8 @@ void UI_SettingsEditor_Draw(
     UI_SETTINGS_EDITOR_STATE *const s, const UI_SCROLLABLE *const dialog_scroll,
     const UI_SETTINGS_PHASE dialog_phase, const float row_width)
 {
-    const float max_label_w = M_GetMaxLabelWidth(s) / g_Config.ui.text_scale;
-    const float max_value_w = M_GetMaxValueWidth(s) / g_Config.ui.text_scale;
+    const float max_label_w = M_GetMaxLabelWidth(s) / UI_Scaler_GetTextScale();
+    const float max_value_w = M_GetMaxValueWidth(s) / UI_Scaler_GetTextScale();
     float label_w = max_label_w;
     const float total_w = max_label_w + 20.0f + max_value_w;
     if (row_width > total_w) {

--- a/src/trx/game/ui/elements/bar.c
+++ b/src/trx/game/ui/elements/bar.c
@@ -7,7 +7,6 @@
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
 #include <trx/game/output.h>
-#include <trx/game/shell.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
 #include <trx/game/ui/scaler.h>

--- a/src/trx/game/ui/elements/bar.c
+++ b/src/trx/game/ui/elements/bar.c
@@ -6,7 +6,7 @@
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
-#include <trx/game/output.h>
+#include <trx/game/output/draw.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
 #include <trx/game/ui/scaler.h>

--- a/src/trx/game/ui/elements/color_swatch.c
+++ b/src/trx/game/ui/elements/color_swatch.c
@@ -5,6 +5,7 @@
 #include <trx/debug.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 typedef struct {
     float w;
@@ -15,8 +16,8 @@ typedef struct {
 static void M_Measure(UI_NODE *const node)
 {
     const M_DATA *const data = node->data;
-    node->measure_w = data->w * g_Config.ui.text_scale;
-    node->measure_h = data->h * g_Config.ui.text_scale;
+    node->measure_w = data->w * UI_Scaler_GetTextScale();
+    node->measure_h = data->h * UI_Scaler_GetTextScale();
 }
 
 static void M_Draw(const UI_NODE *const node)

--- a/src/trx/game/ui/elements/frame.c
+++ b/src/trx/game/ui/elements/frame.c
@@ -1,7 +1,6 @@
 #include <trx/game/ui/elements/frame.h>
 
 #include <trx/config.h>
-#include <trx/game/output.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
 

--- a/src/trx/game/ui/elements/gradient_slider.c
+++ b/src/trx/game/ui/elements/gradient_slider.c
@@ -6,6 +6,7 @@
 #include <trx/debug.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 #include <trx/game/ui/text.h>
 
 #include <math.h>
@@ -94,7 +95,7 @@ static void M_Measure(UI_NODE *const node)
 {
     const M_DATA *const data = node->data;
     node->measure_w = data->width;
-    node->measure_h = UI_TEXT_HEIGHT * 0.5f * g_Config.ui.text_scale;
+    node->measure_h = UI_TEXT_HEIGHT * 0.5f * UI_Scaler_GetTextScale();
 }
 
 void UI_GradientSlider(const UI_GRADIENT_SLIDER_SETTINGS settings)

--- a/src/trx/game/ui/elements/horizontal_line.c
+++ b/src/trx/game/ui/elements/horizontal_line.c
@@ -1,7 +1,6 @@
 #include <trx/game/ui/elements/horizontal_line.h>
 
 #include <trx/config.h>
-#include <trx/game/output.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
 

--- a/src/trx/game/ui/elements/horizontal_line.c
+++ b/src/trx/game/ui/elements/horizontal_line.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 static void M_Draw(const UI_NODE *node)
 {
@@ -15,7 +16,7 @@ static void M_Draw(const UI_NODE *node)
 static void M_Measure(UI_NODE *const node)
 {
     UI_MeasureWrapper(node);
-    node->measure_h = 2 * g_Config.ui.text_scale;
+    node->measure_h = 2 * UI_Scaler_GetTextScale();
 }
 
 void UI_HorizontalLine(void)

--- a/src/trx/game/ui/elements/label.c
+++ b/src/trx/game/ui/elements/label.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/core/strings.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 #include <trx/game/ui/text.h>
 
 #include <stdarg.h>
@@ -59,6 +60,9 @@ void UI_LabelEx(const char *text, const UI_LABEL_SETTINGS settings)
         sizeof(M_DATA) + (text != nullptr ? strlen(text) + 1 : 1));
     M_DATA *const data = node->data;
     data->settings = settings;
+    // Measuring happens once the tree is built, by which point no fit factor is
+    // pushed any more, so the label has to carry it.
+    data->settings.scale *= UI_Scaler_GetContentScale();
     data->text = (char *)node->data + sizeof(M_DATA);
     strcpy(data->text, text != nullptr ? text : "");
     UI_AddChild(node);

--- a/src/trx/game/ui/elements/modal.c
+++ b/src/trx/game/ui/elements/modal.c
@@ -1,6 +1,5 @@
 #include <trx/game/ui/elements/modal.h>
 
-#include <trx/game/output.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/elements/anchor.h>
 #include <trx/game/ui/helpers.h>

--- a/src/trx/game/ui/elements/pad.c
+++ b/src/trx/game/ui/elements/pad.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 typedef struct {
     float t;
@@ -63,5 +64,5 @@ void UI_EndPad(void)
 
 float UI_Pad_GetSize(const float size)
 {
-    return size * g_Config.ui.text_scale;
+    return size * UI_Scaler_GetTextScale();
 }

--- a/src/trx/game/ui/elements/prompt.c
+++ b/src/trx/game/ui/elements/prompt.c
@@ -11,6 +11,7 @@
 #include <trx/game/ui/elements/label.h>
 #include <trx/game/ui/events.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/keys.h>
 #include <trx/game/ui/text.h>
 
 #include <string.h>

--- a/src/trx/game/ui/elements/resize.c
+++ b/src/trx/game/ui/elements/resize.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/core/utils.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 typedef struct {
     float w;
@@ -67,8 +68,8 @@ void UI_BeginResizeEx(const UI_RESIZE_SETTINGS settings)
         },
         sizeof(M_DATA));
     M_DATA *const data = node->data;
-    data->w = settings.w * g_Config.ui.text_scale;
-    data->h = settings.h * g_Config.ui.text_scale;
+    data->w = settings.w * UI_Scaler_GetTextScale();
+    data->h = settings.h * UI_Scaler_GetTextScale();
     data->align_h = settings.align_h;
     data->align_v = settings.align_v;
     UI_AddChild(node);

--- a/src/trx/game/ui/elements/scrollable_stack.c
+++ b/src/trx/game/ui/elements/scrollable_stack.c
@@ -4,6 +4,7 @@
 #include <trx/core/utils.h>
 #include <trx/game/input.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 typedef struct {
     UI_SCROLLABLE *scroll;
@@ -40,7 +41,7 @@ static void M_Measure(UI_NODE *const node)
 
     const int32_t first = s->first_item;
     const int32_t last = MIN(first + s->vis_items, s->max_items);
-    const float scale = g_Config.ui.text_scale;
+    const float scale = UI_Scaler_GetTextScale();
 
     int32_t visible_count = 0;
     int32_t i = 0;
@@ -78,7 +79,7 @@ static void M_Layout(
     const UI_SCROLLABLE *const s = data->scroll;
     const int32_t first = s->first_item;
     const int32_t last = MIN(first + s->vis_items, s->max_items);
-    const float scale = g_Config.ui.text_scale;
+    const float scale = UI_Scaler_GetTextScale();
 
     float cx = x;
     float cy = y;

--- a/src/trx/game/ui/elements/sleek_bar.c
+++ b/src/trx/game/ui/elements/sleek_bar.c
@@ -4,6 +4,7 @@
 #include <trx/core/utils.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 #include <trx/version.h>
 
 typedef struct {
@@ -26,7 +27,7 @@ static RGBA_8888 m_FillColors[TR_VERSION_COUNT] = {
 static void M_Measure(UI_NODE *const node)
 {
     node->measure_w = 0.0f;
-    node->measure_h = 4.0f * g_Config.ui.text_scale;
+    node->measure_h = 4.0f * UI_Scaler_GetTextScale();
 }
 
 static void M_Draw(const UI_NODE *const node)

--- a/src/trx/game/ui/elements/spacer.c
+++ b/src/trx/game/ui/elements/spacer.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 static void M_Measure(UI_NODE *const node)
 {
@@ -17,7 +18,7 @@ void UI_Spacer(const float w, const float h)
             .draw = UI_DrawWrapper,
         },
         0);
-    node->measure_w = w * g_Config.ui.text_scale;
-    node->measure_h = h * g_Config.ui.text_scale;
+    node->measure_w = w * UI_Scaler_GetTextScale();
+    node->measure_h = h * UI_Scaler_GetTextScale();
     UI_AddChild(node);
 }

--- a/src/trx/game/ui/elements/stack.c
+++ b/src/trx/game/ui/elements/stack.c
@@ -4,6 +4,7 @@
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/ui/helpers.h>
+#include <trx/game/ui/scaler.h>
 
 #include <math.h>
 #include <stdint.h>
@@ -70,7 +71,7 @@ static void M_Measure(UI_NODE *const node)
     node->measure_h = 0.0f;
     UI_NODE *child = node->first_child;
     M_DATA *const data = node->data;
-    const float scale = g_Config.ui.text_scale;
+    const float scale = UI_Scaler_GetTextScale();
     while (child != nullptr) {
         if (data->settings.orientation == UI_STACK_VERTICAL) {
             node->measure_w = MAX(node->measure_w, child->measure_w);
@@ -118,7 +119,7 @@ static void M_Layout(
     // (configured) total spacing on the main axis. If only 1 child or 0
     // children, there's no gap to distribute leftover space into.
     const int32_t gaps = (child_count > 1) ? (child_count - 1) : 0;
-    const float scale = g_Config.ui.text_scale;
+    const float scale = UI_Scaler_GetTextScale();
     float base_spacing = 0.0f;
     switch (data->settings.orientation) {
     case UI_STACK_HORIZONTAL:

--- a/src/trx/game/ui/elements/window.c
+++ b/src/trx/game/ui/elements/window.c
@@ -71,6 +71,11 @@ static void M_Title(const char *const title)
     UI_EndFrame();
 }
 
+float UI_Window_GetChromeWidth(void)
+{
+    return 2.0f * (M_GetOuterPad() + M_GetBodyPadX());
+}
+
 void UI_BeginWindow(UI_WINDOW_SETTINGS settings)
 {
     const bool show_scroll_hints = M_ShouldShowScrollHints(&settings);

--- a/src/trx/game/ui/elements/window.h
+++ b/src/trx/game/ui/elements/window.h
@@ -17,3 +17,7 @@ typedef struct {
 
 void UI_BeginWindow(UI_WINDOW_SETTINGS settings);
 void UI_EndWindow(void);
+
+// The horizontal space a window spends on its own frame and padding, in the
+// units a caller sizes its content in.
+float UI_Window_GetChromeWidth(void);

--- a/src/trx/game/ui/hud/console.c
+++ b/src/trx/game/ui/hud/console.c
@@ -13,6 +13,7 @@
 #include <trx/game/ui/events.h>
 #include <trx/game/ui/helpers.h>
 #include <trx/game/ui/hud/console_logs.h>
+#include <trx/game/ui/keys.h>
 #include <trx/game/ui/scaler.h>
 #include <trx/game/ui/text.h>
 

--- a/src/trx/game/ui/keys.c
+++ b/src/trx/game/ui/keys.c
@@ -1,0 +1,69 @@
+// Translation of SDL keyboard events into the UI's own key roles. This is the
+// only part of the UI that talks to SDL, and it sits apart from the scene
+// module so that measuring and laying out a scene needs no window system.
+
+#include <trx/game/ui/keys.h>
+
+#include <trx/game/ui/events.h>
+
+#include <SDL2/SDL.h>
+
+static UI_INPUT M_TranslateInput(const uint32_t system_keycode)
+{
+    // clang-format off
+    switch (system_keycode) {
+    case SDLK_UP:        return UI_KEY_UP;
+    case SDLK_DOWN:      return UI_KEY_DOWN;
+    case SDLK_LEFT:      return UI_KEY_LEFT;
+    case SDLK_RIGHT:     return UI_KEY_RIGHT;
+    case SDLK_HOME:      return UI_KEY_HOME;
+    case SDLK_END:       return UI_KEY_END;
+    case SDLK_BACKSPACE: return UI_KEY_BACK;
+    case SDLK_RETURN:    return UI_KEY_RETURN;
+    case SDLK_ESCAPE:    return UI_KEY_ESCAPE;
+    case SDLK_TAB:
+        return (SDL_GetModState() & KMOD_SHIFT) != 0 ? UI_KEY_SHIFT_TAB
+                                                     : UI_KEY_TAB;
+    }
+    // clang-format on
+    return -1;
+}
+
+void UI_HandleKeyDown(const uint32_t key)
+{
+    UI_FireEvent((EVENT) {
+        .name = "key_down",
+        .sender = nullptr,
+        .data = (void *)M_TranslateInput(key),
+    });
+}
+
+void UI_HandleKeyUp(const uint32_t key)
+{
+    UI_FireEvent((EVENT) {
+        .name = "key_up",
+        .sender = nullptr,
+        .data = (void *)M_TranslateInput(key),
+    });
+}
+
+void UI_HandleTextEdit(const char *const text)
+{
+    UI_FireEvent((EVENT) {
+        .name = "text_edit", .sender = nullptr, .data = (void *)text });
+}
+
+void UI_HandlePaste(void)
+{
+    if (!SDL_HasClipboardText()) {
+        return;
+    }
+
+    char *const text = SDL_GetClipboardText();
+    if (text == nullptr) {
+        return;
+    }
+
+    UI_HandleTextEdit(text);
+    SDL_free(text);
+}

--- a/src/trx/game/ui/keys.h
+++ b/src/trx/game/ui/keys.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef enum {
+    UI_KEY_UP,
+    UI_KEY_DOWN,
+    UI_KEY_LEFT,
+    UI_KEY_RIGHT,
+    UI_KEY_HOME,
+    UI_KEY_END,
+    UI_KEY_BACK,
+    UI_KEY_RETURN,
+    UI_KEY_ESCAPE,
+    UI_KEY_TAB,
+    UI_KEY_SHIFT_TAB,
+} UI_INPUT;
+
+void UI_HandleKeyDown(uint32_t key);
+void UI_HandleKeyUp(uint32_t key);
+void UI_HandleTextEdit(const char *text);
+
+// Inserts the current clipboard contents (if any) into the currently
+// focused text field, as if it had been typed.
+void UI_HandlePaste(void);

--- a/src/trx/game/ui/scaler.c
+++ b/src/trx/game/ui/scaler.c
@@ -2,7 +2,13 @@
 
 #include <trx/config.h>
 #include <trx/core/utils.h>
+#include <trx/debug.h>
 #include <trx/game/viewport.h>
+
+#define M_MAX_SCALE_DEPTH 8
+
+static float m_TextScaleStack[M_MAX_SCALE_DEPTH] = { 1.0f };
+static size_t m_TextScaleDepth = 0;
 
 static float M_DoCalc(
     const float unit, const float base_width, const float base_height,
@@ -24,9 +30,9 @@ double UI_Scaler_GetScale(const UI_SCALER_TARGET target)
     case UI_SCALER_TARGET_BAR:
         return g_Config.ui.bar_scale;
     case UI_SCALER_TARGET_TEXT:
-        return g_Config.ui.text_scale;
+        return UI_Scaler_GetTextScale();
     case UI_SCALER_TARGET_ASSAULT_DIGITS:
-        return g_Config.ui.text_scale;
+        return UI_Scaler_GetTextScale();
     default:
         return 1.0;
     }
@@ -40,4 +46,28 @@ float UI_Scaler_Calc(const float unit, const UI_SCALER_TARGET target)
 float UI_Scaler_CalcInverse(const float unit, const UI_SCALER_TARGET target)
 {
     return unit * 0x10000 / MAX(1, UI_Scaler_Calc(0x10000, target));
+}
+
+float UI_Scaler_GetTextScale(void)
+{
+    return g_Config.ui.text_scale * m_TextScaleStack[m_TextScaleDepth];
+}
+
+float UI_Scaler_GetContentScale(void)
+{
+    return m_TextScaleStack[m_TextScaleDepth];
+}
+
+void UI_Scaler_PushTextScale(const float factor)
+{
+    ASSERT(m_TextScaleDepth + 1 < M_MAX_SCALE_DEPTH);
+    const float current = m_TextScaleStack[m_TextScaleDepth];
+    m_TextScaleDepth++;
+    m_TextScaleStack[m_TextScaleDepth] = current * factor;
+}
+
+void UI_Scaler_PopTextScale(void)
+{
+    ASSERT(m_TextScaleDepth > 0);
+    m_TextScaleDepth--;
 }

--- a/src/trx/game/ui/scaler.h
+++ b/src/trx/game/ui/scaler.h
@@ -12,3 +12,19 @@ typedef enum {
 double UI_Scaler_GetScale(const UI_SCALER_TARGET target);
 float UI_Scaler_Calc(float unit, UI_SCALER_TARGET target);
 float UI_Scaler_CalcInverse(float unit, UI_SCALER_TARGET target);
+
+// The size everything text-shaped is drawn at: the player's text scale, times
+// whatever fit factor is currently pushed. Widgets size themselves from this
+// rather than from the config, so a subtree can be scaled as a whole.
+float UI_Scaler_GetTextScale(void);
+
+// The fit factor on its own, without the player's text scale. Widgets that
+// carry their own scale - a label - fold this into it, because they are
+// measured after the tree is built and the factor is no longer pushed by then.
+float UI_Scaler_GetContentScale(void);
+
+// Scale the widgets created until the matching pop by an extra factor. A dialog
+// too wide for the canvas pushes the factor that brings it back within it;
+// nesting multiplies.
+void UI_Scaler_PushTextScale(float factor);
+void UI_Scaler_PopTextScale(void);

--- a/src/trx/game/ui/settings.c
+++ b/src/trx/game/ui/settings.c
@@ -7,7 +7,6 @@
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/game/game_strings/entries.h>
-#include <trx/game/shell.h>
 #include <trx/version.h>
 
 #include <uthash.h>

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -142,7 +142,7 @@ static float M_ScaleScreen(const float value)
 
 static float M_ScaleNeutral(const float value)
 {
-    return value * g_Config.ui.text_scale;
+    return value * UI_Scaler_GetTextScale();
 }
 
 static RGBA_F M_ToRGBA_F(const RGB_888 color)
@@ -487,9 +487,9 @@ static void M_Process(
 
     const float scale = scale_func(UI_TEXT_BASE_SCALE * settings.scale);
 
-    float x = scale_func(base_x / g_Config.ui.text_scale);
+    float x = scale_func(base_x / UI_Scaler_GetTextScale());
     float y = scale_func(
-        base_y / g_Config.ui.text_scale + settings.scale * UI_TEXT_HEIGHT);
+        base_y / UI_Scaler_GetTextScale() + settings.scale * UI_TEXT_HEIGHT);
     int32_t z = settings.z;
 
     float max_width = 0.0f;
@@ -718,7 +718,7 @@ void UI_Text_Draw(
 {
     M_Process(
         text, nullptr, nullptr, settings, base_x,
-        base_y - g_Config.ui.text_scale, M_ScaleScreen,
+        base_y - UI_Scaler_GetTextScale(), M_ScaleScreen,
         UI_ScheduleDrawScreenSprite);
 }
 
@@ -732,7 +732,7 @@ char *UI_Text_WordWrap(
     size_t glyph_count = 0;
     const M_GLYPH_INFO **glyphs = M_DecomposeWithCache(text, &glyph_count);
 
-    const float scale_f = scale * g_Config.ui.text_scale;
+    const float scale_f = scale * UI_Scaler_GetTextScale();
     size_t len = M_WordWrap(glyphs, glyph_count, scale_f, max_width, nullptr);
     char *const wrapped_text = Memory_Alloc(len);
     M_WordWrap(glyphs, glyph_count, scale_f, max_width, wrapped_text);

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -9,7 +9,7 @@
 #include <trx/debug.h>
 #include <trx/game/input/common.h>
 #include <trx/game/objects.h>
-#include <trx/game/output.h>
+#include <trx/game/output/textures.h>
 #include <trx/game/ui/common.h>
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/scaler.h>

--- a/tools/lint/checks/test_deps
+++ b/tools/lint/checks/test_deps
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# The unit tests are a project of their own so that they need none of the
+# engine's heavy dependencies - see the comment atop src/tests/meson.build. That
+# holds only as long as no header they include drags one in, and a developer
+# machine with SDL2 or GLEW installed will not notice when one does: it compiles
+# there and fails on a runner that has neither.
+#
+# This walks the includes of every source the test project compiles - its own,
+# and the engine sources the targets list - and reports any that reaches a
+# dependency the tests are not meant to have. The walk is textual rather than a
+# compiler pass, which is both quicker and enough: what it looks for is always
+# included outright, never behind a condition.
+
+import re
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harness import LintWarning, repo_check
+from shared.paths import REPO_DIR, SRC_DIR
+
+TEST_DIR = SRC_DIR / "tests"
+TEST_UNIT_DIR = TEST_DIR / "unit"
+
+# What the tests are allowed to reach: uthash, PCRE2, zlib and Lua are declared
+# in src/tests/meson.build. Anything else the engine links is out of bounds.
+FORBIDDEN = {
+    "SDL2/": "SDL2",
+    "GL/": "GLEW or OpenGL",
+    "libavcodec/": "ffmpeg",
+    "libavformat/": "ffmpeg",
+    "libavutil/": "ffmpeg",
+    "libswscale/": "ffmpeg",
+    "libswresample/": "ffmpeg",
+    "dwarfstack": "dwarfstack",
+}
+
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s+[<"]([^>"]+)[>"]', re.MULTILINE)
+
+# Any quoted path ending in .c that the test project's meson.build names, be it
+# a test source or an engine one compiled into a target.
+MESON_SOURCE_RE = re.compile(r"'([^']+\.c)'")
+
+
+@lru_cache(maxsize=None)
+def includes_of(path: Path) -> tuple[str, ...]:
+    try:
+        return tuple(INCLUDE_RE.findall(path.read_text(encoding="utf-8")))
+    except (OSError, UnicodeDecodeError):
+        return ()
+
+
+def resolve(name: str, parent: Path) -> Path | None:
+    for candidate in (
+        SRC_DIR / name,
+        parent.parent / name,
+        TEST_UNIT_DIR / name,
+    ):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def reached_by(path: Path) -> dict[str, list[str]]:
+    # Every forbidden dependency the includes under `path` lead to, following
+    # the ones that resolve inside the tree. The value is the chain of includes
+    # that got there, so the report names the one to cut.
+    found: dict[str, list[str]] = {}
+    trail: dict[Path, list[str]] = {path: []}
+    queue = [path]
+    while queue:
+        current = queue.pop()
+        for name in includes_of(current):
+            chain = trail[current] + [name]
+            for needle, dep_name in FORBIDDEN.items():
+                if needle in name:
+                    found.setdefault(dep_name, chain)
+            target = resolve(name, current)
+            if target is not None and target not in trail:
+                trail[target] = chain
+                queue.append(target)
+    return found
+
+
+def compiled_sources() -> list[Path]:
+    # Everything the test project builds: its own sources and the engine ones
+    # its targets list, both spelled relative to src/tests.
+    names = MESON_SOURCE_RE.findall(
+        (TEST_DIR / "meson.build").read_text(encoding="utf-8")
+    )
+    paths = {(TEST_DIR / name).resolve() for name in names}
+    paths |= set(TEST_UNIT_DIR.glob("*.c"))
+    return sorted(path for path in paths if path.is_file())
+
+
+def check() -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+    for path in compiled_sources():
+        for dep_name, chain in sorted(reached_by(path).items()):
+            warnings.append(
+                LintWarning(
+                    path.relative_to(REPO_DIR),
+                    f"reaches {dep_name} through {' -> '.join(chain)}; "
+                    f"the unit tests are built without it",
+                )
+            )
+    return warnings
+
+
+repo_check(check)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Settings text no longer runs off both sides of the screen in the longer languages, and the list of settings a preset would change now wraps inside its dialog instead of spilling past it. A dialog too wide for the screen is drawn smaller until it fits, down to a floor of 0.85, and dialogs keep five units clear of the edges.

- 4:3 is where this showed. The canvas is 640 units wide there against 853 at 16:9, and the German, French, Polish and Russian gameplay tabs need more than 640. Nothing that ships today reaches the floor, so no wording had to change; the floor is there to catch a future string that goes further.
- The preset confirmation was a separate fault. Its list was drawn in a box of a fixed 72 units, and sizing a box does not constrain what is drawn inside it, so the frame appeared that narrow while the setting names ran hundreds of units past it on both sides.
- New tests lay both dialogs out at 640x480 for every game and every shipped language, and check that nothing reaches past the screen or past the box it was given. Glyph metrics come from each game's font.bin, so there is no generated table to keep in step, and the suite needs no game data beyond what this repository versions.

Players see the settings screens fit the window at every aspect ratio and in every language.

Before:
<img width="2880" height="2160" alt="20260730_115945_Level_0" src="https://github.com/user-attachments/assets/37699f07-51bf-4642-b236-870ecd5cee46" />

After:
<img width="2880" height="2160" alt="20260730_115851_Level_0" src="https://github.com/user-attachments/assets/8cd24d55-9697-4cee-899f-35d0753f212d" />


Resolves #6000 / TRX843