### PR TITLE
Improve object clipping

### DIFF
--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -1,4 +1,6 @@
 #include <trx/core/log.h>
+#include <trx/core/math/const.h>
+#include <trx/core/math/trig.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
@@ -15,18 +17,41 @@ static inline bool M_BoundsIntersectsPortal(
     const PORTAL *const portal)
 {
     const STATIC_OBJECT_3D *const obj = Object_Get3DStatic(mesh->static_num);
-    const BOUNDS_32 bounds = {
+
+    // The draw bounds are the object's own, and the mesh is drawn turned by
+    // its Y rotation (see M_DrawSingleRoom). A box taken without that turn
+    // sits askew of the mesh it stands for, and one at an angle the axes do
+    // not share misses the portal it leans through.
+    const int32_t cos_y = Math_Cos(mesh->rot.y);
+    const int32_t sin_y = Math_Sin(mesh->rot.y);
+    const int32_t xs[2] = { obj->draw_bounds.min.x, obj->draw_bounds.max.x };
+    const int32_t zs[2] = { obj->draw_bounds.min.z, obj->draw_bounds.max.z };
+
+    BOUNDS_32 bounds = {
         .min = {
-            .x = mesh->pos.x + obj->draw_bounds.min.x,
+            .x = INT32_MAX,
             .y = mesh->pos.y + obj->draw_bounds.min.y,
-            .z = mesh->pos.z + obj->draw_bounds.min.z,
+            .z = INT32_MAX,
         },
         .max = {
-            .x = mesh->pos.x + obj->draw_bounds.max.x,
+            .x = INT32_MIN,
             .y = mesh->pos.y + obj->draw_bounds.max.y,
-            .z = mesh->pos.z + obj->draw_bounds.max.z,
+            .z = INT32_MIN,
         },
     };
+    for (int32_t i = 0; i < 2; i++) {
+        for (int32_t j = 0; j < 2; j++) {
+            const int32_t x =
+                mesh->pos.x + ((xs[i] * cos_y + zs[j] * sin_y) >> W2V_SHIFT);
+            const int32_t z =
+                mesh->pos.z + ((zs[j] * cos_y - xs[i] * sin_y) >> W2V_SHIFT);
+            bounds.min.x = MIN(bounds.min.x, x);
+            bounds.max.x = MAX(bounds.max.x, x);
+            bounds.min.z = MIN(bounds.min.z, z);
+            bounds.max.z = MAX(bounds.max.z, z);
+        }
+    }
+
     return Bounds32_Intersect(&bounds, &portal->bounds);
 }
 

--- a/src/trx/game/output/func.c
+++ b/src/trx/game/output/func.c
@@ -81,18 +81,25 @@ CLIP Output_CheckBoundsClip(const BOUNDS_16 *const bounds)
     y_min += vp.h / 2;
     y_max += vp.h / 2;
 
+    // The corners left out above are the ones that would have widened the
+    // rectangle, so what remains is smaller than the box really covers and
+    // cannot be rejected on. It can sit off to one side while the box still
+    // crosses the view.
+    if (num_z < 8) {
+        return CLIP_PARTIALLY_VISIBLE;
+    }
+
     // clang-format off
     if (x_min > g_PhdRight
         || y_min > g_PhdBottom
         || x_max < g_PhdLeft
         || y_max < g_PhdTop) {
-        return CLIP_NOT_VISIBLE; // out of screen
+        return CLIP_NOT_VISIBLE; // outside the room's clip window
     }
     // clang-format on
 
     // clang-format off
-    if (num_z < 8 ||
-        x_min < 0 ||
+    if (x_min < 0 ||
         y_min < 0 ||
         x_max >= vp.w ||
         y_max >= vp.h) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Two fixes for statics and objects vanishing while they are still in view, both of them visible in the TR4 title level.

1. A bounding box is projected corner by corner, and a corner behind the near plane is left out. The corners that remain span a rectangle smaller than the box really covers, and the check rejected boxes on that rectangle, so a long arch went as soon as the camera reached it. Dropped corners are the only thing that makes the rectangle unreliable; crossing a viewport edge does not. The two no longer share a branch, so a box with all eight corners in front is still tested against the room's clip window.
2. Whether a static reaches through a portal was asked of a box taken straight from the object and placed at the mesh, while the mesh is drawn turned by its Y rotation. One at an angle the axes do not share sat askew of the mesh it stood for and missed the portal it leans through. The box now turns with the static. The TR4 title has three of them.

Players see statics and objects hold their place on screen where they used to blink out as the camera came near or passed through them. Resolves TRX852

#### Testing

- [x] Regression for #2005
- [x] Regression for #3761
- [x] Regression for #4271
- [x] TR4 arch (mesh 30) in the first title flyby should no longer disappear