### PR TITLE
savegame: carry save crystals across levels

### DIFF
--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -336,6 +336,7 @@ void Lara_InitialiseInventory(const GF_LEVEL *const level)
         Inv_AddItemNTimes(O_QUEST_ITEM_4, resume->num_quest_item_4);
         Inv_AddItemNTimes(O_QUEST_ITEM_5, resume->num_quest_item_5);
         Inv_AddItemNTimes(O_QUEST_ITEM_6, resume->num_quest_item_6);
+        Inv_AddItemNTimes(O_SAVE_CRYSTAL_ITEM, resume->num_save_crystals);
 
         if (g_Config.gameplay.remember_gun_status) {
             lara_info->gun_status = resume->gun_status;

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -731,6 +731,7 @@ void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *const level)
     resume->num_quest_item_4 = Inv_RequestItem(O_QUEST_ITEM_4);
     resume->num_quest_item_5 = Inv_RequestItem(O_QUEST_ITEM_5);
     resume->num_quest_item_6 = Inv_RequestItem(O_QUEST_ITEM_6);
+    resume->num_save_crystals = Inv_RequestItem(O_SAVE_CRYSTAL_ITEM);
 
     resume->equipped_gun_type = lara->last_gun_type;
     resume->holsters_gun_type = lara->holsters_gun_type;
@@ -804,6 +805,7 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         resume->num_quest_item_4 = 0;
         resume->num_quest_item_5 = 0;
         resume->num_quest_item_6 = 0;
+        resume->num_save_crystals = 0;
         resume->flares = 0;
 
         resume->equipped_gun_type = LGT_UNARMED;
@@ -839,6 +841,7 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         resume->num_quest_item_4 = 0;
         resume->num_quest_item_5 = 0;
         resume->num_quest_item_6 = 0;
+        resume->num_save_crystals = 0;
         resume->flags.has_harpoon = false;
         resume->flags.has_m16 = false;
         resume->flags.has_mp5 = false;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -947,6 +947,9 @@ static bool M_ReadResumeInfo(JSON_READ_IO *const io, RESUME_INFO *const resume)
     M_SHOULD(JSON_READ(io, "num_quest_item_5", &resume->num_quest_item_5));
     M_SHOULD(JSON_READ(io, "num_quest_item_6", &resume->num_quest_item_6));
 
+    // Introduced in TRX 1.10
+    M_SHOULD(JSON_READ(io, "num_save_crystals", &resume->num_save_crystals));
+
     M_MUST(JSON_READ(io, "available", &resume->flags.available));
 
     // Introduced in TRX 1.2

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -351,6 +351,7 @@ static void M_WriteResumeInfo(
     JSONW_WRITE(io, "num_quest_item_4", resume->num_quest_item_4);
     JSONW_WRITE(io, "num_quest_item_5", resume->num_quest_item_5);
     JSONW_WRITE(io, "num_quest_item_6", resume->num_quest_item_6);
+    JSONW_WRITE(io, "num_save_crystals", resume->num_save_crystals);
     JSONW_WRITE(io, "gun_status", resume->gun_status);
     JSONW_WRITE(io, "gun_type", resume->equipped_gun_type);
     JSONW_WRITE(io, "holsters_gun_type", resume->holsters_gun_type);

--- a/src/trx/game/savegame/types.h
+++ b/src/trx/game/savegame/types.h
@@ -40,6 +40,7 @@ typedef struct {
     uint16_t flares;
     uint8_t num_quest_item_5;
     uint8_t num_quest_item_6;
+    uint8_t num_save_crystals;
 
     struct {
         bool available;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The resume info had no crystal count, so crystals Lara had picked up were dropped when she moved on to the next level.