### PR TITLE
lua/api: drop the undeclared-member log line

### DIFF
--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -715,13 +715,9 @@ function api.type(path, spec)
   local _, type_name = split_path(path)
   checkers[type_name] = handle_checker(backing)
 
-  local declared = {}
-
   for name, field in pairs(spec.fields or {}) do
     local from = field.from or name
-    local writable = field.writable ~= false
-    struct.expose_field(backing, name, from, writable)
-    declared[from] = true
+    struct.expose_field(backing, name, from, field.writable ~= false)
   end
 
   for name, computed in pairs(spec.extensions or {}) do
@@ -730,25 +726,6 @@ function api.type(path, spec)
       "api.type: extension '" .. name .. "' needs an impl"
     )
     struct.expose_computed(backing, name, computed.impl)
-  end
-
-  -- Opt-in exposure is silent by nature: forgetting to declare a member means
-  -- it quietly does not exist. Say so, rather than let it vanish unnoticed.
-  local undeclared = {}
-  for _, member in ipairs(struct.members(backing)) do
-    if not declared[member.name] then
-      table.insert(undeclared, member.name)
-    end
-  end
-  if #undeclared > 0 then
-    table.sort(undeclared)
-    trx.log.debug(
-      backing
-        .. ": "
-        .. #undeclared
-        .. " member(s) not exposed to scripts: "
-        .. table.concat(undeclared, ", ")
-    )
   end
 
   record(types, path, spec)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`api.type` printed every backing member a type didn't expose, sometimes eighteen for a single type, on every load. But because the API is opt-in, that's the normal state, so the list wasn't actually useful.