### PR TITLE
lara/cheat: abandon ropes in fly cheat

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - fixed the body bag trigger to also collect Bacon Lara, Qualopec Mummy and Skidoo Driver's corpses
 - fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
+- fixed Lara getting stuck on ropes if she enters the fly cheat while still using one (regression from 1.9)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -14,6 +14,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
+#include <trx/game/rope.h>
 #include <trx/game/sound.h>
 #include <trx/game/viewport.h>
 #include <trx/version.h>
@@ -332,6 +333,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     lara_info->interact_target.item_num = NO_ITEM;
     lara_info->interact_target.is_moving = false;
     lara_info->interact_target.move_count = 0;
+    lara_info->rope.index = NO_ROPE;
 
     Lara_Extinguish();
     M_ReinitialiseGunMeshes();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's rope reference is removed if she enters the fly cheat while using one, otherwise she is unable to move.

Resolves TRX862.