### PR TITLE
input/keyboard: show Action for confirm hints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
 - fixed Lara getting stuck on ropes if she enters the fly cheat while still using one (regression from 1.9)
+- fixed the inventory hint for using an item showing Enter rather than the key bound to Action (regression from 1.8.1)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -536,6 +536,9 @@ static const char *M_GetName(
 {
     INPUT_ROLE actual_role = role;
     switch (role) {
+    case INPUT_ROLE_MENU_CONFIRM:
+        actual_role = INPUT_ROLE_ACTION;
+        break;
     case INPUT_ROLE_MENU_SHOW_INFO:
         actual_role = INPUT_ROLE_LOOK;
         break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The inventory's Use hint and the settings editor's edit hint read the name of the menu confirm role, which is hardcoded to Enter. On keyboard that role also answers to Action, so the name lookup now resolves it the same way it already resolves the info, fine adjust and coarse adjust roles.

Resolves TRX867