### PR TITLE
output/binoculars: keep the mask black

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -81,6 +81,7 @@
 - fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
 - fixed Lara getting stuck on ropes if she enters the fly cheat while still using one (regression from 1.9)
 - fixed the inventory hint for using an item showing Enter rather than the key bound to Action (regression from 1.8.1)
+- fixed the black surround of the binoculars turning grey when looking in certain directions (regression from 1.9)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -248,6 +248,7 @@ static void M_DrawBinocularMask(const M_PRIV *const p)
     // Lighting routines need a W2V matrix to work; set up something for it.
     Matrix_LookAt(
         origin.x, origin.y, origin.z - WALL_L, origin.x, origin.y, origin.z, 0);
+    Output_CalculateStaticLight(SHADE_NEUTRAL);
 
     Matrix_PushUnit();
     Matrix_TranslateSet32(origin);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Looking with binoculars at certain rooms could result in the following lighting bug:

<img width="3840" height="2160" alt="20260731_102816_Desert_Railroad" src="https://github.com/user-attachments/assets/ba274308-e182-4c11-9d2c-19e9028d2658" />
<img width="3840" height="2160" alt="20260731_102815_Desert_Railroad" src="https://github.com/user-attachments/assets/a7ed3982-82ec-4580-b3a0-130614b28684" />

The binocular mask is drawn outside any room, so it kept whatever light the scene had last set up. In TR4 a light brighter than neutral leaves an overbright term that is added after texturing, which the mask's black vertex color cannot cancel, so the surround and its feathered rim washed out to grey in the directions where such a light was in play. We now reset it thus eliminating the bug.

Resolves TRX668