### PR TITLE
Improve stats Lua module reach

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.3...develop) - ××××-××-××
 - added the TR4 main menu playing the title level behind it, alternating its flybys with the cutscenes their triggers start, as in the original game
-- added `trx.camera.play_flyby()`, to start a flyby camera sequence, and `trx.events.on_flyby_end()`, which happens when one reaches its last camera
 - added partial support for TR4's in-game cutscenes
-- added a new Lua module, `trx.cutscenes`, for playing TR4's cutscenes and reading or rewriting which of them have run, with the `on_cutscene_trigger`, `on_cutscene_start` and `on_cutscene_end` events; a script can answer a cutscene trigger itself, set how a cutscene is framed, and say where one leaves Lara
-- added a new Lua module, `trx.stats`, for what a level keeps count of: its secrets, pickups, kills and save crystals, each alongside how many count towards completing the level and how many the level holds, plus the timer, the deaths, the ammunition and the distance travelled; secrets can be given to Lara or taken back, and every level's counters are readable, so a script can total up whichever levels it likes
-- added pickup families to `trx.objects.query` - `gun`, `ammo`, `supply`, `tool`, `key`, `puzzle`, `quest`, `examine`, `collectible` and `secret` - so a script can ask what a pickup is
-- added `trx.lara.inventory`, for reading what Lara carries and putting things into her backpack or taking them out, and `trx.lara.weapons`, for what the level allows her and how much ammunition she has
-- added `trx.game.is_ngplus`, which tells whether the run started from the passport's bonus entry
 - added TR4 camera mode, which is similar to TR3 but more responsive to Lara's actions such as picking up items
 - added the ability to paste commands in the developer console (with Ctrl+V)
 - added autocompletion to the developer console (with Tab and Shift+Tab to cycle the matches)
@@ -19,7 +13,6 @@
 - added a `damage` property to the `O_POWER_SAW` object
 - improved error messages related to bad command invocations
 - changed reflections UV mapping to be more correct
-- changed the Lua level events to a single `on_game_start`, which every kind of level fires, with `on_title_start` for the title screen; refer to migration notes
 - changed object properties to take effect as soon as they change, rather than only when the item is first set up
 - changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed the gameflow's `main_menu_picture` to be optional: a game that names no picture shows its title level behind the menu, and its title script says what plays there
@@ -148,15 +141,18 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added a new Lua module, `trx.mod`, to list the game's mods and read the loaded one
 - added a new Lua module, `trx.savegame`, to read the save slots and start a saved game
 - added a new Lua module, `trx.lua`, with `eval_expr()` and `eval_file()`, to evaluate Lua code at runtime
+- added a new Lua module, `trx.cutscenes`, for playing TR4's cutscenes, reading or rewriting which of them have run, and framing one, with the `on_cutscene_trigger`, `on_cutscene_start` and `on_cutscene_end` events
+- added a new Lua module, `trx.stats`, for what a level keeps count of – its secrets, pickups, kills, crystals, timer and deaths – alongside how much of each there was to find, for any level rather than only the one being played
 - added `trx.config.reset()`, to put a setting back to its default
 - added `trx.config.describe()`, to read a setting's shape and accepted values
 - added `trx.config.format_value()`, the current value spelled the way the console prints it
 - added `trx.config.accepted_values()`, what a setting takes, as text for an error message
 - added new Lua game state, `trx.game.is_loaded` and `trx.game.is_playable`
+- added `trx.game.is_ngplus`, which tells whether the run started from the passport's bonus entry
 - added `trx.console.register()`, for a script to add its own console command
 - added `trx.events.on_flip_effect()`, letting a script handle a flipeffect run by a trigger or an animation command (#4108)
 - added `trx.events.on_room_change()`, which happens whenever an item changes rooms
-- added `room:on_enter()` and `room:on_exit()`, which happen when Lara - or, with `watch = "all"`, any item - changes rooms
+- added `room:on_enter()` and `room:on_exit()`, which happen when Lara – or, with `watch = "all"`, any item – changes rooms
 - added `trx.events.on_trigger()` and the per-item `item:on_trigger()`, to react to a trigger of any kind being aimed at an item, with the trigger's type, mask, timer and one-shot flag
 - added `trx.events.on_show()` and `trx.events.on_hide()`, with the per-item `item:on_show()` and `item:on_hide()`, which happen when an item becomes visible or hidden
 - added `trx.events.on_finish()` and the per-item `item:on_finish()`, which happen when an item finishes its run, such as a sprung trap or a thrown switch
@@ -171,6 +167,8 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.lara.dry()` and `trx.lara.is_wet`, to dry Lara off after a swim and to check whether she needs it
 - added `trx.lara.is_flying`, to read and toggle the fly-mode cheat
 - added `trx.lara.teleport()`, to move Lara to a position, as `/tp` does
+- added `trx.lara.inventory`, for reading what Lara carries and putting things into her backpack or taking them out, and `trx.lara.weapons`, for what the level allows her and how much ammunition she has
+- added `trx.camera.play_flyby()`, to start a flyby camera sequence, and `trx.events.on_flyby_end()`, which happens when one reaches its last camera
 - added `trx.camera.is_flyby_active` and `trx.camera.cancel_flyby()`, to see and stop a flyby sequence
 - added `trx.game.LevelType.TITLE`, and a `demo` level type to the game flow, which could not be named before
 - added `trx.game.play_gym()`, to start the gym
@@ -181,6 +179,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.items.spawn()`, to place a new item in the level at runtime
 - added `trx.objects.swap_sprite()`, to exchange the sprites two objects are drawn from
 - added `trx.objects.query` and `trx.items.query`, composable filters over a level's objects and items that match names, families and state, and combine with `&`, `|` and `~`
+- added pickup families to `trx.objects.query` – `gun`, `ammo`, `supply`, `tool`, `key`, `puzzle`, `quest`, `examine`, `collectible` and `secret` – so a script can ask what a pickup is
 - added `trx.items.get()`, `trx.items.count()`, `trx.rooms.get()`, `trx.rooms.count()` and `trx.objects.get()`, replacing the `fn` namespaces- added `trx.rooms.find_valid_pos()`, to nudge a position into valid room geometry
 - added `trx.rooms.floor_height()` and the room method `floor_height()`, the height of the floor under a position
 - added item methods, `activate()`, `deactivate()`, `trigger()`, `destroy()`, `die()`, `shatter()`, `distance_to()`, `is_valid()`, `get_property()`, `set_property()` and `get_property_names()`, letting a script fire a trigger or antitrigger at an item exactly as a level would
@@ -198,7 +197,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.log.generic()` and the `trx.log.LogLevel` enum, to log at a level chosen at runtime
 - added the braid and crowbar constants to `trx.lara.ExtraMesh`, which the engine had but never exposed
 - added indexing and the length operator to `trx.items`, `trx.rooms` and `trx.objects`, so `trx.items[0]` is the first item and `#trx.items` is how many the level has
-- added `trx.api.strict()`, which checks a script's arguments against the API's own declarations - worth turning on while writing a level, and leaving off in play
+- added `trx.api.strict()`, which checks a script's arguments against the API's own declarations – worth turning on while writing a level, and leaving off in play
 - added `room:is_valid()`, so a room handle held across a level change can be checked the way an item handle can
 - added the track to the assault course record functions, so the quad bike's records can be read and written at last
 - added a new Lua string function, `trx.strings.collapse_ranges()`
@@ -226,6 +225,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed `trx.config.get()` to return the option's own type rather than always a string
 - changed `trx.events.detach()` to return whether a handler was removed
 - changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
+- changed the Lua level events to a single `on_game_start`, which every kind of level fires, with `on_title_start` for the title screen; refer to migration notes
 - changed the Lua logging functions to take a single message rather than a list of strings
 - changed Lua enums to answer to a constant's name in any case, so `trx.catalog.objects.wolf` and `trx.catalog.objects.WOLF` are the same constant
 - changed Lua enums to be read-only, including the table `pairs()` used to hand out; writing to one used to break every later lookup

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 - added `trx.camera.play_flyby()`, to start a flyby camera sequence, and `trx.events.on_flyby_end()`, which happens when one reaches its last camera
 - added partial support for TR4's in-game cutscenes
 - added a new Lua module, `trx.cutscenes`, for playing TR4's cutscenes and reading or rewriting which of them have run, with the `on_cutscene_trigger`, `on_cutscene_start` and `on_cutscene_end` events; a script can answer a cutscene trigger itself, set how a cutscene is framed, and say where one leaves Lara
-- added a new Lua module, `trx.stats`, for reading which of the level's secrets Lara has found, and for giving one to her or taking it back
+- added a new Lua module, `trx.stats`, for what a level keeps count of: its secrets, pickups, kills and save crystals, each alongside how many count towards completing the level and how many the level holds, plus the timer, the deaths, the ammunition and the distance travelled; secrets can be given to Lara or taken back, and every level's counters are readable, so a script can total up whichever levels it likes
 - added pickup families to `trx.objects.query` - `gun`, `ammo`, `supply`, `tool`, `key`, `puzzle`, `quest`, `examine`, `collectible` and `secret` - so a script can ask what a pickup is
 - added `trx.lara.inventory`, for reading what Lara carries and putting things into her backpack or taking them out, and `trx.lara.weapons`, for what the level allows her and how much ammunition she has
 - added `trx.game.is_ngplus`, which tells whether the run started from the passport's bonus entry

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -4910,39 +4910,6 @@
       "path": "sound.stop_all"
     },
     {
-      "description": "Marks a secret as found, as walking into its trigger would.",
-      "examples": [
-        "trx.stats.give_secret(1)"
-      ],
-      "params": [
-        {
-          "description": "The secret's number, counted from one.",
-          "name": "num",
-          "type": "integer"
-        }
-      ],
-      "path": "stats.give_secret",
-      "returns": {
-        "description": "`false` if the level has no such secret, or Lara already has it.",
-        "type": "boolean"
-      }
-    },
-    {
-      "description": "Takes a secret back, leaving it to be found again.",
-      "params": [
-        {
-          "description": "The secret's number, counted from one.",
-          "name": "num",
-          "type": "integer"
-        }
-      ],
-      "path": "stats.take_secret",
-      "returns": {
-        "description": "`false` if the level has no such secret, or Lara does not have it.",
-        "type": "boolean"
-      }
-    },
-    {
       "description": "Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.\n\nCandidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.",
       "examples": [
         "local matches = trx.strings.fuzzy_match(\"wolf\", {\n  { key = \"wolf\", value = trx.catalog.objects.WOLF },\n  { key = \"bear\", value = trx.catalog.objects.BEAR },\n})\nlocal best = matches[1]"
@@ -5177,7 +5144,7 @@
       "order": 15
     },
     {
-      "description": "Module for what the level being played keeps count of: what Lara has found in\nit, and how much there was to find.\n\nThe counts belong to the level, not to the session. Nothing here reads outside\none, so a script that runs at the title screen sees an empty list and zero\ncounts.",
+      "description": "Module for what a level keeps count of: what Lara has found in it, and how much\nthere was to find.\n\nThe module is the level being played, so `trx.stats.pickups.count` is what she\nhas picked up in it. Any other level's counters are reached the same way through\n`trx.game.Level.stats`. At the title screen there is no level, and everything\nhere reads `nil`.",
       "name": "stats",
       "order": 22
     },
@@ -5513,24 +5480,6 @@
       "writable": false
     },
     {
-      "description": "The secrets the level holds, in order, as a list of `{ num, found }`. `num` is\nthe number the player says, counted from one, and `found` is whether Lara has\nit.",
-      "path": "stats.secrets",
-      "type": "table",
-      "writable": false
-    },
-    {
-      "description": "How many secrets Lara has found in this level.",
-      "path": "stats.secret_count",
-      "type": "integer",
-      "writable": false
-    },
-    {
-      "description": "How many secrets the level counts towards completion. Not the length of\n`secrets`: the game flow can declare some of a level's secrets unobtainable,\nand those are left out of this count while still standing in the list.",
-      "path": "stats.max_secret_count",
-      "type": "integer",
-      "writable": false
-    },
-    {
       "description": "The active weather.",
       "enum": "weather.Type",
       "path": "weather.current",
@@ -5541,7 +5490,13 @@
   "types": [
     {
       "description": "A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.",
-      "extensions": [],
+      "extensions": [
+        {
+          "description": "What the level keeps count of, as a `trx.stats.Stats`, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.",
+          "name": "stats",
+          "type": "Stats"
+        }
+      ],
       "fields": [
         {
           "description": "The outfit Lara starts the level in.",
@@ -6949,6 +6904,163 @@
         }
       ],
       "path": "sound.Stream"
+    },
+    {
+      "description": "One thing a level is counted on, which is one row of the statistics screen. `raw` is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `give_secret` and `take_secret` are how they change.",
+          "name": "count",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How many of them count towards completing the level.",
+          "name": "max",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "How many of them the level holds, obtainable or not.",
+          "name": "raw",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "How many of them the game flow declares out of reach, and so must not be held against the player.",
+          "name": "unobtainable",
+          "type": "integer",
+          "writable": false
+        }
+      ],
+      "methods": [],
+      "path": "stats.Category"
+    },
+    {
+      "description": "What one level keeps count of. The counters are the level's own and can be written, which is what a script correcting or seeding them wants.",
+      "extensions": [
+        {
+          "description": "Whether Lara has turned on an ally in this level.",
+          "name": "allies_hurt",
+          "type": "boolean"
+        },
+        {
+          "description": "The save crystals, where the game has them.",
+          "name": "crystals",
+          "type": "Category"
+        },
+        {
+          "description": "The enemies the level counts, allies among them.",
+          "name": "kills",
+          "type": "Category"
+        },
+        {
+          "description": "How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen of your own wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.",
+          "name": "max_ally_kills",
+          "type": "integer"
+        },
+        {
+          "description": "How many of `kills.max` are enemies rather than allies.",
+          "name": "max_enemy_kills",
+          "type": "integer"
+        },
+        {
+          "description": "The items lying in the level for Lara to take.",
+          "name": "pickups",
+          "type": "Category"
+        },
+        {
+          "description": "The level's secrets. Which ones Lara holds is `secret_list`.",
+          "name": "secrets",
+          "type": "Category"
+        }
+      ],
+      "fields": [
+        {
+          "description": "How many of them hit something.",
+          "name": "ammo_hits",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How many rounds Lara has fired.",
+          "name": "ammo_used",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.",
+          "name": "deaths",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How far Lara has travelled, in world units.",
+          "name": "distance_travelled",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How many medipacks Lara has used, a small one counting as half of one.",
+          "name": "medipacks_used",
+          "type": "number",
+          "writable": true
+        },
+        {
+          "description": "How long the level has been played, in game frames.",
+          "name": "timer",
+          "type": "integer",
+          "writable": true
+        }
+      ],
+      "methods": [
+        {
+          "description": "Marks a secret as found, as walking into its trigger would.",
+          "examples": [
+            "trx.stats.give_secret(1)"
+          ],
+          "name": "give_secret",
+          "params": [
+            {
+              "description": "The secret's number, counted from one.",
+              "name": "num",
+              "type": "integer"
+            }
+          ],
+          "returns": {
+            "description": "`false` if the level has no such secret, or Lara already has it.",
+            "type": "boolean"
+          }
+        },
+        {
+          "description": "The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, counted from one, and `found` is whether Lara has it.",
+          "examples": [
+            "for _, secret in ipairs(trx.stats.secret_list()) do\n  trx.log.info(secret.num .. \": \" .. tostring(secret.found))\nend"
+          ],
+          "name": "secret_list",
+          "returns": {
+            "description": "The secrets, one by one.",
+            "type": "table"
+          }
+        },
+        {
+          "description": "Takes a secret back, leaving it to be found again.",
+          "name": "take_secret",
+          "params": [
+            {
+              "description": "The secret's number, counted from one.",
+              "name": "num",
+              "type": "integer"
+            }
+          ],
+          "returns": {
+            "description": "`false` if the level has no such secret, or Lara does not have it.",
+            "type": "boolean"
+          }
+        }
+      ],
+      "path": "stats.Stats"
     }
   ]
 }

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -87,6 +87,9 @@ Module for the game flow: which levels there are, and which one is being played.
     - **`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
     - **`water_particles`**: boolean. Whether water particles are visible in the level's water. *(read-only)*
 
+    Computed properties (derived, not stored on the object):
+    - **`stats`**: Stats. What the level keeps count of, as a `trx.stats.Stats`, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.
+
 ### Functions
 
 - [lua]`trx.game.play_level(num, [opts])`  

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -12,42 +12,86 @@ order: 22
 
 ## Stats module
 
-Module for what the level being played keeps count of: what Lara has found in
-it, and how much there was to find.
+Module for what a level keeps count of: what Lara has found in it, and how much
+there was to find.
 
-The counts belong to the level, not to the session. Nothing here reads outside
-one, so a script that runs at the title screen sees an empty list and zero
-counts.
+The module is the level being played, so `trx.stats.pickups.count` is what she
+has picked up in it. Any other level's counters are reached the same way through
+`trx.game.Level.stats`. At the title screen there is no level, and everything
+here reads `nil`.
 
-### Properties
+### Structures
 
-- **`trx.stats.secrets`** (table). The secrets the level holds, in order, as a list of `{ num, found }`. `num` is
-  the number the player says, counted from one, and `found` is whether Lara has
-  it. *(read-only)*
-- **`trx.stats.secret_count`** (integer). How many secrets Lara has found in this level. *(read-only)*
-- **`trx.stats.max_secret_count`** (integer). How many secrets the level counts towards completion. Not the length of
-  `secrets`: the game flow can declare some of a level's secrets unobtainable,
-  and those are left out of this count while still standing in the list. *(read-only)*
+- [lua]`trx.stats.Category`
 
-### Functions
+    One thing a level is counted on, which is one row of the statistics screen. `raw` is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.
 
-- [lua]`trx.stats.give_secret(num)`  
-  Marks a secret as found, as walking into its trigger would.
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
 
-  Parameters:
-  - **`num`** (integer). The secret's number, counted from one.
+    Properties:
+    - **`count`**: integer. How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `give_secret` and `take_secret` are how they change.
+    - **`max`**: integer. How many of them count towards completing the level. *(read-only)*
+    - **`raw`**: integer. How many of them the level holds, obtainable or not. *(read-only)*
+    - **`unobtainable`**: integer. How many of them the game flow declares out of reach, and so must not be held against the player. *(read-only)*
 
-  Returns: boolean. `false` if the level has no such secret, or Lara already has it.
+- [lua]`trx.stats.Stats`
 
-  Example:
-  ```lua
-  trx.stats.give_secret(1)
-  ```
+    What one level keeps count of. The counters are the level's own and can be written, which is what a script correcting or seeding them wants.
 
-- [lua]`trx.stats.take_secret(num)`  
-  Takes a secret back, leaving it to be found again.
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
 
-  Parameters:
-  - **`num`** (integer). The secret's number, counted from one.
+    Properties:
+    - **`ammo_hits`**: integer. How many of them hit something.
+    - **`ammo_used`**: integer. How many rounds Lara has fired.
+    - **`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
+    - **`distance_travelled`**: integer. How far Lara has travelled, in world units.
+    - **`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
+    - **`timer`**: integer. How long the level has been played, in game frames.
 
-  Returns: boolean. `false` if the level has no such secret, or Lara does not have it.
+    Computed properties (derived, not stored on the object):
+    - **`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.
+    - **`crystals`**: Category. The save crystals, where the game has them.
+    - **`kills`**: Category. The enemies the level counts, allies among them.
+    - **`max_ally_kills`**: integer. How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen of your own wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.
+    - **`max_enemy_kills`**: integer. How many of `kills.max` are enemies rather than allies.
+    - **`pickups`**: Category. The items lying in the level for Lara to take.
+    - **`secrets`**: Category. The level's secrets. Which ones Lara holds is `secret_list`.
+
+    Methods:
+
+    - [lua]`stats:give_secret(num)`  
+      Marks a secret as found, as walking into its trigger would.
+
+      Parameters:
+      - **`num`** (integer). The secret's number, counted from one.
+
+      Returns: boolean. `false` if the level has no such secret, or Lara already has it.
+
+      Example:
+      ```lua
+      trx.stats.give_secret(1)
+      ```
+
+    - [lua]`stats:secret_list()`  
+      The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, counted from one, and `found` is whether Lara has it.
+
+      Returns: table. The secrets, one by one.
+
+      Example:
+      ```lua
+      for _, secret in ipairs(trx.stats.secret_list()) do
+        trx.log.info(secret.num .. ": " .. tostring(secret.found))
+      end
+      ```
+
+    - [lua]`stats:take_secret(num)`  
+      Takes a secret back, leaving it to be found again.
+
+      Parameters:
+      - **`num`** (integer). The secret's number, counted from one.
+
+      Returns: boolean. `false` if the level has no such secret, or Lara does not have it.

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -176,7 +176,20 @@ local function install_meta(owner, tbl)
       if instance ~= nil then
         local handle = instance()
         if handle ~= nil then
-          return handle[key]
+          local member = handle[key]
+          -- A method wants the handle as its self, and the module is not one,
+          -- so the handle stands in. A colon call hands the module over as
+          -- self and a dot call hands over nothing, so the module table itself
+          -- is what tells the two apart - no argument of a script's can be it.
+          if type(member) == "function" then
+            return function(first, ...)
+              if first == tbl then
+                return member(handle, ...)
+              end
+              return member(handle, first, ...)
+            end
+          end
+          return member
         end
       end
       return nil

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -115,6 +115,18 @@ api.type("game.Level", {
       description = "Secrets the stats screen must not hold against the player.",
     },
   },
+
+  extensions = {
+    stats = {
+      type = "Stats",
+      description = "What the level keeps count of, as a `trx.stats.Stats`, or `nil` for a level "
+        .. "that counts nothing: the title screen and the cutscenes. The level being played is "
+        .. "also `trx.stats` itself.",
+      impl = function(level)
+        return trxc.stats.get(level.num)
+      end,
+    },
+  },
 })
 
 local function level_list(table_type)

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -4,61 +4,184 @@ local api = trx.api
 api.module("stats", {
   order = 22,
   description = [[
-Module for what the level being played keeps count of: what Lara has found in
-it, and how much there was to find.
+Module for what a level keeps count of: what Lara has found in it, and how much
+there was to find.
 
-The counts belong to the level, not to the session. Nothing here reads outside
-one, so a script that runs at the title screen sees an empty list and zero
-counts.]],
+The module is the level being played, so `trx.stats.pickups.count` is what she
+has picked up in it. Any other level's counters are reached the same way through
+`trx.game.Level.stats`. At the title screen there is no level, and everything
+here reads `nil`.]],
+  instance = raw.get_current,
 })
 
-api.property("stats.secrets", {
-  type = "table",
-  description = [[
-The secrets the level holds, in order, as a list of `{ num, found }`. `num` is
-the number the player says, counted from one, and `found` is whether Lara has
-it.]],
-  get = raw.secrets,
+-- The categories are ordered as the engine keeps them, so a name here stands
+-- for the number the C side addresses one by.
+local CATEGORY = {
+  pickups = 0,
+  kills = 1,
+  secrets = 2,
+  crystals = 3,
+}
+
+api.type("stats.Category", {
+  backing = "STATS_CATEGORY",
+  description = "One thing a level is counted on, which is one row of the statistics screen. `raw` "
+    .. "is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and "
+    .. "what it writes off is left out of what counts towards completion while still being in the "
+    .. "level.",
+
+  fields = {
+    count = {
+      from = "count",
+      type = "integer",
+      description = "How many of them Lara has. The secrets cannot be set this way: they are held "
+        .. "one by one, so `give_secret` and `take_secret` are how they change.",
+    },
+    max = {
+      from = "max",
+      type = "integer",
+      writable = false,
+      description = "How many of them count towards completing the level.",
+    },
+    raw = {
+      from = "raw",
+      type = "integer",
+      writable = false,
+      description = "How many of them the level holds, obtainable or not.",
+    },
+    unobtainable = {
+      from = "unobtainable",
+      type = "integer",
+      writable = false,
+      description = "How many of them the game flow declares out of reach, and so must not be held "
+        .. "against the player.",
+    },
+  },
 })
 
-api.property("stats.secret_count", {
-  type = "integer",
-  description = "How many secrets Lara has found in this level.",
-  get = raw.secret_count,
-})
+local function category(name, description)
+  return {
+    type = "Category",
+    description = description,
+    impl = function(stats)
+      return raw.category(stats, CATEGORY[name])
+    end,
+  }
+end
 
-api.property("stats.max_secret_count", {
-  type = "integer",
-  description = [[
-How many secrets the level counts towards completion. Not the length of
-`secrets`: the game flow can declare some of a level's secrets unobtainable,
-and those are left out of this count while still standing in the list.]],
-  get = raw.max_secret_count,
-})
-
-local num_param = {
+local secret_num_param = {
   name = "num",
   type = "integer",
   description = "The secret's number, counted from one.",
 }
 
-api.define("stats.give_secret", {
-  description = "Marks a secret as found, as walking into its trigger would.",
-  params = { num_param },
-  returns = {
-    type = "boolean",
-    description = "`false` if the level has no such secret, or Lara already has it.",
-  },
-  examples = { [[trx.stats.give_secret(1)]] },
-  impl = raw.give_secret,
-})
+api.type("stats.Stats", {
+  backing = "LEVEL_STATS",
+  description = "What one level keeps count of. The counters are the level's own and can be "
+    .. "written, which is what a script correcting or seeding them wants.",
 
-api.define("stats.take_secret", {
-  description = "Takes a secret back, leaving it to be found again.",
-  params = { num_param },
-  returns = {
-    type = "boolean",
-    description = "`false` if the level has no such secret, or Lara does not have it.",
+  fields = {
+    timer = {
+      from = "timer",
+      type = "integer",
+      description = "How long the level has been played, in game frames.",
+    },
+    deaths = {
+      from = "death_count",
+      type = "integer",
+      description = "How many times Lara has died. Unlike the rest, this is not cleared when the "
+        .. "level is entered again: a death stays with the level it happened on.",
+    },
+    ammo_used = {
+      from = "ammo_used",
+      type = "integer",
+      description = "How many rounds Lara has fired.",
+    },
+    ammo_hits = {
+      from = "ammo_hits",
+      type = "integer",
+      description = "How many of them hit something.",
+    },
+    distance_travelled = {
+      from = "distance_travelled",
+      type = "integer",
+      description = "How far Lara has travelled, in world units.",
+    },
+    medipacks_used = {
+      from = "medipacks_used",
+      type = "number",
+      description = "How many medipacks Lara has used, a small one counting as half of one.",
+    },
   },
-  impl = raw.take_secret,
+
+  extensions = {
+    pickups = category(
+      "pickups",
+      "The items lying in the level for Lara to take."
+    ),
+    kills = category(
+      "kills",
+      "The enemies the level counts, allies among them."
+    ),
+    secrets = category(
+      "secrets",
+      "The level's secrets. Which ones Lara holds is `secret_list`."
+    ),
+    crystals = category(
+      "crystals",
+      "The save crystals, where the game has them."
+    ),
+
+    max_ally_kills = {
+      type = "integer",
+      description = "How many of `kills.max` are allies. The statistics screen holds them against "
+        .. "the player only once `allies_hurt`, so a screen of your own wants to do the same: "
+        .. "`max_enemy_kills`, and these as well once she has turned on one.",
+      impl = function(stats)
+        return (raw.kill_split(stats))
+      end,
+    },
+    max_enemy_kills = {
+      type = "integer",
+      description = "How many of `kills.max` are enemies rather than allies.",
+      impl = function(stats)
+        return select(2, raw.kill_split(stats))
+      end,
+    },
+    allies_hurt = {
+      type = "boolean",
+      description = "Whether Lara has turned on an ally in this level.",
+      impl = raw.allies_hurt,
+    },
+  },
+
+  methods = {
+    secret_list = {
+      description = "The level's secrets, in order, as a list of `{ num, found }`. `num` is the "
+        .. "number the player says, counted from one, and `found` is whether Lara has it.",
+      returns = { type = "table", description = "The secrets, one by one." },
+      examples = {
+        [[for _, secret in ipairs(trx.stats.secret_list()) do
+  trx.log.info(secret.num .. ": " .. tostring(secret.found))
+end]],
+      },
+    },
+    give_secret = {
+      description = "Marks a secret as found, as walking into its trigger would.",
+      params = { secret_num_param },
+      returns = {
+        type = "boolean",
+        description = "`false` if the level has no such secret, or Lara already has it.",
+      },
+      examples = { [[trx.stats.give_secret(1)]] },
+    },
+    take_secret = {
+      description = "Takes a secret back, leaving it to be found again.",
+      params = { secret_num_param },
+      returns = {
+        type = "boolean",
+        description = "`false` if the level has no such secret, or Lara does not have it.",
+      },
+    },
+  },
 })

--- a/src/lua/commands/secret.lua
+++ b/src/lua/commands/secret.lua
@@ -26,7 +26,7 @@ end
 -- holds for take, and everything the level has when no verb was typed.
 local function targets(action)
   local out = {}
-  for _, secret in ipairs(trx.stats.secrets) do
+  for _, secret in ipairs(trx.stats.secret_list()) do
     if action == nil or secret.found == (action == "take") then
       out[#out + 1] = { key = tostring(secret.num), value = secret.num }
     end
@@ -36,14 +36,14 @@ end
 
 local function report()
   local held = {}
-  for _, secret in ipairs(trx.stats.secrets) do
+  for _, secret in ipairs(trx.stats.secret_list()) do
     if secret.found then
       held[#held + 1] = display(secret.num)
     end
   end
 
-  local count = trx.stats.secret_count
-  local max_count = trx.stats.max_secret_count
+  local count = trx.stats.secrets.count
+  local max_count = trx.stats.secrets.max
   if #held == 0 then
     return trx.locale.format("console/cmd/secret/none", count, max_count)
   end
@@ -74,7 +74,7 @@ local function change_one(action, num)
 end
 
 local function change_all(action)
-  for _, secret in ipairs(trx.stats.secrets) do
+  for _, secret in ipairs(trx.stats.secret_list()) do
     change(action, secret.num)
   end
   return trx.console.Result.OK, report()

--- a/src/tests/fakes/stats.c
+++ b/src/tests/fakes/stats.c
@@ -4,86 +4,102 @@
 
 #include <trx/game/stats.h>
 
-static bool m_Valid[STATS_MAX_SECRETS];
-static bool m_Found[STATS_MAX_SECRETS];
-static int32_t m_MaxSecretCount;
+static LEVEL_STATS m_Stats;
+static LEVEL_MAX_STATS m_MaxStats;
 
-static bool M_InRange(const int16_t secret_idx)
+// The bit a secret number stands for, or 0 when the level holds no such
+// secret. The real module reads the same mask off the level's scan.
+static uint32_t M_GetSecretMask(
+    const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    return secret_idx >= 0 && secret_idx < STATS_MAX_SECRETS;
+    if (level == nullptr || secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
+        return 0;
+    }
+    const uint32_t secret_mask = 1 << secret_idx;
+    return (secret_mask & m_MaxStats.all_secrets_mask) != 0 ? secret_mask : 0;
 }
 
-bool Stats_IsSecretValid(const int16_t secret_idx)
+LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *const level)
 {
-    return M_InRange(secret_idx) && m_Valid[secret_idx];
+    return level == nullptr ? nullptr : &m_Stats;
 }
 
-bool Stats_HasSecret(const int16_t secret_idx)
+bool Stats_HasLevelMaxStats(const GF_LEVEL *const level)
 {
-    return Stats_IsSecretValid(secret_idx) && m_Found[secret_idx];
+    return level != nullptr;
 }
 
-bool Stats_AddSecret(const int16_t secret_idx)
+LEVEL_MAX_STATS *Stats_GetLevelMaxStats(const GF_LEVEL *const level)
 {
-    if (!Stats_IsSecretValid(secret_idx) || m_Found[secret_idx]) {
+    return &m_MaxStats;
+}
+
+bool Stats_IsSecretValid(const GF_LEVEL *const level, const int16_t secret_idx)
+{
+    return M_GetSecretMask(level, secret_idx) != 0;
+}
+
+bool Stats_HasSecret(const GF_LEVEL *const level, const int16_t secret_idx)
+{
+    const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
+    return secret_mask != 0 && (m_Stats.secret_flags & secret_mask) != 0;
+}
+
+bool Stats_AddSecret(const GF_LEVEL *const level, const int16_t secret_idx)
+{
+    if (Stats_HasSecret(level, secret_idx)
+        || !Stats_IsSecretValid(level, secret_idx)) {
         return false;
     }
-    m_Found[secret_idx] = true;
+    m_Stats.secret_flags |= M_GetSecretMask(level, secret_idx);
+    m_Stats.secret_count++;
     return true;
 }
 
-bool Stats_RemoveSecret(const int16_t secret_idx)
+bool Stats_RemoveSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    if (!Stats_HasSecret(secret_idx)) {
+    if (!Stats_HasSecret(level, secret_idx)) {
         return false;
     }
-    m_Found[secret_idx] = false;
+    m_Stats.secret_flags &= ~M_GetSecretMask(level, secret_idx);
+    m_Stats.secret_count--;
     return true;
-}
-
-int32_t Stats_GetSecretCount(void)
-{
-    int32_t count = 0;
-    for (int16_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        count += Stats_HasSecret(i) ? 1 : 0;
-    }
-    return count;
-}
-
-int32_t Stats_GetMaxSecretCount(void)
-{
-    return m_MaxSecretCount;
 }
 
 static void M_Reset(void)
 {
-    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        m_Valid[i] = false;
-        m_Found[i] = false;
-    }
-    m_MaxSecretCount = 0;
+    m_Stats = (LEVEL_STATS) {};
+    m_MaxStats = (LEVEL_MAX_STATS) {};
 }
 
 FAKE_ON_RESET(M_Reset)
 
 void FakeStats_SetSecrets(const int32_t *const nums, const int32_t count)
 {
-    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        m_Valid[i] = false;
-        m_Found[i] = false;
-    }
+    m_Stats.secret_flags = 0;
+    m_Stats.secret_count = 0;
+    m_MaxStats.all_secrets_mask = 0;
     for (int32_t i = 0; i < count; i++) {
-        m_Valid[nums[i] - 1] = true;
+        m_MaxStats.all_secrets_mask |= 1 << (nums[i] - 1);
     }
-    m_MaxSecretCount = count;
+    m_MaxStats.max_secret_count = count;
 }
 
 void FakeStats_SetFound(const int32_t num, const bool found)
 {
-    m_Found[num - 1] = found;
+    const uint32_t secret_mask = 1 << (num - 1);
+    if (found) {
+        m_Stats.secret_flags |= secret_mask;
+    } else {
+        m_Stats.secret_flags &= ~secret_mask;
+    }
+    m_Stats.secret_count = 0;
+    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
+        m_Stats.secret_count += (m_Stats.secret_flags & (1 << i)) != 0 ? 1 : 0;
+    }
 }
 
 void FakeStats_SetMaxSecretCount(const int32_t count)
 {
-    m_MaxSecretCount = count;
+    m_MaxStats.max_secret_count = count;
 }

--- a/src/tests/fakes/stats.c
+++ b/src/tests/fakes/stats.c
@@ -2,36 +2,108 @@
 
 #include <harness/fake_calls.h>
 
+#include <trx/game/game/state.h>
+#include <trx/game/game_flow.h>
 #include <trx/game/stats.h>
 
-static LEVEL_STATS m_Stats;
-static LEVEL_MAX_STATS m_MaxStats;
+// One entry per level, addressed by the level's place in its table, which is
+// enough for a game flow the tests keep small.
+#define M_LEVEL_SLOTS 16
+
+static LEVEL_STATS m_Stats[M_LEVEL_SLOTS];
+static LEVEL_MAX_STATS m_MaxStats[M_LEVEL_SLOTS];
+static bool m_AlliesHurt[M_LEVEL_SLOTS];
+
+// Where a level's counters sit, or -1 for a level that counts nothing.
+static int32_t M_GetSlot(const GF_LEVEL *const level)
+{
+    if (level == nullptr || level->type == GFL_TITLE
+        || level->type == GFL_CUTSCENE || level->num < 0
+        || level->num >= M_LEVEL_SLOTS) {
+        return -1;
+    }
+    return level->num;
+}
 
 // The bit a secret number stands for, or 0 when the level holds no such
 // secret. The real module reads the same mask off the level's scan.
 static uint32_t M_GetSecretMask(
     const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    if (level == nullptr || secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS
+        || !Stats_HasLevelMaxStats(level)) {
         return 0;
     }
     const uint32_t secret_mask = 1 << secret_idx;
-    return (secret_mask & m_MaxStats.all_secrets_mask) != 0 ? secret_mask : 0;
+    return (secret_mask & Stats_GetLevelMaxStats(level)->all_secrets_mask) != 0
+        ? secret_mask
+        : 0;
+}
+
+static uint32_t M_GetUnobtainable(
+    const GF_LEVEL *const level, const STATS_CATEGORY_ID id)
+{
+    switch (id) {
+    case STATS_CAT_PICKUPS:
+        return level->unobtainable.pickups;
+    case STATS_CAT_KILLS:
+        return level->unobtainable.kills + level->unobtainable.ally_kills;
+    case STATS_CAT_SECRETS:
+        return level->unobtainable.secrets;
+    default:
+        return 0;
+    }
 }
 
 LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *const level)
 {
-    return level == nullptr ? nullptr : &m_Stats;
+    const int32_t slot = M_GetSlot(level);
+    return slot < 0 ? nullptr : &m_Stats[slot];
 }
 
 bool Stats_HasLevelMaxStats(const GF_LEVEL *const level)
 {
-    return level != nullptr;
+    return M_GetSlot(level) >= 0;
 }
 
 LEVEL_MAX_STATS *Stats_GetLevelMaxStats(const GF_LEVEL *const level)
 {
-    return &m_MaxStats;
+    const int32_t slot = M_GetSlot(level);
+    return slot < 0 ? nullptr : &m_MaxStats[slot];
+}
+
+bool Stats_GetCategory(
+    const GF_LEVEL *const level, const STATS_CATEGORY_ID id,
+    STATS_CATEGORY *const out)
+{
+    const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (stats == nullptr || id >= STATS_CAT_NUMBER_OF) {
+        return false;
+    }
+    const uint32_t unobtainable = M_GetUnobtainable(level, id);
+    const uint32_t max = Stats_GetLevelMaxStats(level)->maxes[id];
+    *out = (STATS_CATEGORY) {
+        .level = level,
+        .id = id,
+        .count = stats->counts[id],
+        .max = max,
+        .raw = max + unobtainable,
+        .unobtainable = unobtainable,
+    };
+    return true;
+}
+
+bool Stats_SetCategoryCount(
+    const GF_LEVEL *const level, const STATS_CATEGORY_ID id,
+    const uint32_t count)
+{
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (stats == nullptr || id >= STATS_CAT_NUMBER_OF
+        || id == STATS_CAT_SECRETS) {
+        return false;
+    }
+    stats->counts[id] = count;
+    return true;
 }
 
 bool Stats_IsSecretValid(const GF_LEVEL *const level, const int16_t secret_idx)
@@ -42,65 +114,130 @@ bool Stats_IsSecretValid(const GF_LEVEL *const level, const int16_t secret_idx)
 bool Stats_HasSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
     const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
-    return secret_mask != 0 && (m_Stats.secret_flags & secret_mask) != 0;
+    const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (secret_mask == 0 || stats == nullptr) {
+        return false;
+    }
+    return (stats->secret_flags & secret_mask) != 0;
 }
 
 bool Stats_AddSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    if (Stats_HasSecret(level, secret_idx)
-        || !Stats_IsSecretValid(level, secret_idx)) {
+    const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (secret_mask == 0 || stats == nullptr
+        || (stats->secret_flags & secret_mask) != 0) {
         return false;
     }
-    m_Stats.secret_flags |= M_GetSecretMask(level, secret_idx);
-    m_Stats.counts[STATS_CAT_SECRETS]++;
+    stats->secret_flags |= secret_mask;
+    stats->counts[STATS_CAT_SECRETS]++;
     return true;
 }
 
 bool Stats_RemoveSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    if (!Stats_HasSecret(level, secret_idx)) {
+    const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (secret_mask == 0 || stats == nullptr
+        || (stats->secret_flags & secret_mask) == 0) {
         return false;
     }
-    m_Stats.secret_flags &= ~M_GetSecretMask(level, secret_idx);
-    m_Stats.counts[STATS_CAT_SECRETS]--;
+    stats->secret_flags &= ~secret_mask;
+    stats->counts[STATS_CAT_SECRETS]--;
     return true;
+}
+
+bool Stats_HaveAlliesBeenHurt(const GF_LEVEL *const level)
+{
+    const int32_t slot = M_GetSlot(level);
+    return slot >= 0 && m_AlliesHurt[slot];
 }
 
 static void M_Reset(void)
 {
-    m_Stats = (LEVEL_STATS) {};
-    m_MaxStats = (LEVEL_MAX_STATS) {};
+    for (int32_t i = 0; i < M_LEVEL_SLOTS; i++) {
+        m_Stats[i] = (LEVEL_STATS) {};
+        m_MaxStats[i] = (LEVEL_MAX_STATS) {};
+        m_AlliesHurt[i] = false;
+    }
 }
 
 FAKE_ON_RESET(M_Reset)
 
 void FakeStats_SetSecrets(const int32_t *const nums, const int32_t count)
 {
-    m_Stats.secret_flags = 0;
-    m_Stats.counts[STATS_CAT_SECRETS] = 0;
-    m_MaxStats.all_secrets_mask = 0;
+    const GF_LEVEL *const level = Game_GetCurrentLevel();
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
+    stats->secret_flags = 0;
+    stats->counts[STATS_CAT_SECRETS] = 0;
+    max_stats->all_secrets_mask = 0;
     for (int32_t i = 0; i < count; i++) {
-        m_MaxStats.all_secrets_mask |= 1 << (nums[i] - 1);
+        max_stats->all_secrets_mask |= 1 << (nums[i] - 1);
     }
-    m_MaxStats.maxes[STATS_CAT_SECRETS] = count;
+    max_stats->maxes[STATS_CAT_SECRETS] = count;
 }
 
 void FakeStats_SetFound(const int32_t num, const bool found)
 {
-    const uint32_t secret_mask = 1 << (num - 1);
+    const GF_LEVEL *const level = Game_GetCurrentLevel();
     if (found) {
-        m_Stats.secret_flags |= secret_mask;
+        Stats_AddSecret(level, num - 1);
     } else {
-        m_Stats.secret_flags &= ~secret_mask;
-    }
-    m_Stats.counts[STATS_CAT_SECRETS] = 0;
-    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        m_Stats.counts[STATS_CAT_SECRETS] +=
-            (m_Stats.secret_flags & (1 << i)) != 0 ? 1 : 0;
+        Stats_RemoveSecret(level, num - 1);
     }
 }
 
 void FakeStats_SetMaxSecretCount(const int32_t count)
 {
-    m_MaxStats.maxes[STATS_CAT_SECRETS] = count;
+    Stats_GetLevelMaxStats(Game_GetCurrentLevel())->maxes[STATS_CAT_SECRETS] =
+        count;
+}
+
+void FakeStats_SetCount(
+    const int32_t level_num, const int32_t id, const int32_t count)
+{
+    Stats_GetLevelStats(GF_GetLevelByOrdinalNumber(GFLT_MAIN, level_num))
+        ->counts[id] = count;
+}
+
+void FakeStats_SetMax(
+    const int32_t level_num, const int32_t id, const int32_t max)
+{
+    Stats_GetLevelMaxStats(GF_GetLevelByOrdinalNumber(GFLT_MAIN, level_num))
+        ->maxes[id] = max;
+}
+
+void FakeStats_SetUnobtainable(
+    const int32_t level_num, const int32_t id, const int32_t count)
+{
+    GF_LEVEL *const level = GF_GetLevelByOrdinalNumber(GFLT_MAIN, level_num);
+    switch (id) {
+    case STATS_CAT_PICKUPS:
+        level->unobtainable.pickups = count;
+        break;
+    case STATS_CAT_KILLS:
+        level->unobtainable.kills = count;
+        break;
+    case STATS_CAT_SECRETS:
+        level->unobtainable.secrets = count;
+        break;
+    default:
+        break;
+    }
+}
+
+void FakeStats_SetKillSplit(
+    const int32_t level_num, const int32_t allies, const int32_t enemies)
+{
+    LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(
+        GF_GetLevelByOrdinalNumber(GFLT_MAIN, level_num));
+    max_stats->max_kill_ally_count = allies;
+    max_stats->max_kill_non_ally_count = enemies;
+    max_stats->maxes[STATS_CAT_KILLS] = allies + enemies;
+}
+
+void FakeStats_SetAlliesHurt(const int32_t level_num, const bool hurt)
+{
+    m_AlliesHurt[GF_GetLevelByOrdinalNumber(GFLT_MAIN, level_num)->num] = hurt;
 }

--- a/src/tests/fakes/stats.c
+++ b/src/tests/fakes/stats.c
@@ -52,7 +52,7 @@ bool Stats_AddSecret(const GF_LEVEL *const level, const int16_t secret_idx)
         return false;
     }
     m_Stats.secret_flags |= M_GetSecretMask(level, secret_idx);
-    m_Stats.secret_count++;
+    m_Stats.counts[STATS_CAT_SECRETS]++;
     return true;
 }
 
@@ -62,7 +62,7 @@ bool Stats_RemoveSecret(const GF_LEVEL *const level, const int16_t secret_idx)
         return false;
     }
     m_Stats.secret_flags &= ~M_GetSecretMask(level, secret_idx);
-    m_Stats.secret_count--;
+    m_Stats.counts[STATS_CAT_SECRETS]--;
     return true;
 }
 
@@ -77,12 +77,12 @@ FAKE_ON_RESET(M_Reset)
 void FakeStats_SetSecrets(const int32_t *const nums, const int32_t count)
 {
     m_Stats.secret_flags = 0;
-    m_Stats.secret_count = 0;
+    m_Stats.counts[STATS_CAT_SECRETS] = 0;
     m_MaxStats.all_secrets_mask = 0;
     for (int32_t i = 0; i < count; i++) {
         m_MaxStats.all_secrets_mask |= 1 << (nums[i] - 1);
     }
-    m_MaxStats.max_secret_count = count;
+    m_MaxStats.maxes[STATS_CAT_SECRETS] = count;
 }
 
 void FakeStats_SetFound(const int32_t num, const bool found)
@@ -93,13 +93,14 @@ void FakeStats_SetFound(const int32_t num, const bool found)
     } else {
         m_Stats.secret_flags &= ~secret_mask;
     }
-    m_Stats.secret_count = 0;
+    m_Stats.counts[STATS_CAT_SECRETS] = 0;
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        m_Stats.secret_count += (m_Stats.secret_flags & (1 << i)) != 0 ? 1 : 0;
+        m_Stats.counts[STATS_CAT_SECRETS] +=
+            (m_Stats.secret_flags & (1 << i)) != 0 ? 1 : 0;
     }
 }
 
 void FakeStats_SetMaxSecretCount(const int32_t count)
 {
-    m_MaxStats.max_secret_count = count;
+    m_MaxStats.maxes[STATS_CAT_SECRETS] = count;
 }

--- a/src/tests/fakes/stats.h
+++ b/src/tests/fakes/stats.h
@@ -5,3 +5,11 @@
 void FakeStats_SetSecrets(const int32_t *nums, int32_t count);
 void FakeStats_SetFound(int32_t num, bool found);
 void FakeStats_SetMaxSecretCount(int32_t count);
+
+// The category setters name the level rather than acting on the one being
+// played, which is what a test reading another level's counters needs.
+void FakeStats_SetCount(int32_t level_num, int32_t id, int32_t count);
+void FakeStats_SetMax(int32_t level_num, int32_t id, int32_t max);
+void FakeStats_SetUnobtainable(int32_t level_num, int32_t id, int32_t count);
+void FakeStats_SetKillSplit(int32_t level_num, int32_t allies, int32_t enemies);
+void FakeStats_SetAlliesHurt(int32_t level_num, bool hurt);

--- a/src/tests/lua/api/stats.c
+++ b/src/tests/lua/api/stats.c
@@ -39,6 +39,49 @@ static int M_FakeSetMaxSecretCount(lua_State *const L)
     return 0;
 }
 
+// fake.set_count(level_num, category, n) - what Lara has of one thing in a
+// level, which need not be the one being played.
+static int M_FakeSetCount(lua_State *const L)
+{
+    FakeStats_SetCount(
+        (int32_t)luaL_checkinteger(L, 1), (int32_t)luaL_checkinteger(L, 2),
+        (int32_t)luaL_checkinteger(L, 3));
+    return 0;
+}
+
+static int M_FakeSetMax(lua_State *const L)
+{
+    FakeStats_SetMax(
+        (int32_t)luaL_checkinteger(L, 1), (int32_t)luaL_checkinteger(L, 2),
+        (int32_t)luaL_checkinteger(L, 3));
+    return 0;
+}
+
+static int M_FakeSetUnobtainable(lua_State *const L)
+{
+    FakeStats_SetUnobtainable(
+        (int32_t)luaL_checkinteger(L, 1), (int32_t)luaL_checkinteger(L, 2),
+        (int32_t)luaL_checkinteger(L, 3));
+    return 0;
+}
+
+// fake.set_kill_split(level_num, allies, enemies) - how the level's kill
+// maximum divides, which is what the statistics screen adjusts.
+static int M_FakeSetKillSplit(lua_State *const L)
+{
+    FakeStats_SetKillSplit(
+        (int32_t)luaL_checkinteger(L, 1), (int32_t)luaL_checkinteger(L, 2),
+        (int32_t)luaL_checkinteger(L, 3));
+    return 0;
+}
+
+static int M_FakeSetAlliesHurt(lua_State *const L)
+{
+    FakeStats_SetAlliesHurt(
+        (int32_t)luaL_checkinteger(L, 1), lua_toboolean(L, 2));
+    return 0;
+}
+
 static void M_PushFake(lua_State *const L)
 {
     FakeGame_PushLua(L);
@@ -48,12 +91,25 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "set_found");
     lua_pushcfunction(L, M_FakeSetMaxSecretCount);
     lua_setfield(L, -2, "set_max_secret_count");
+    lua_pushcfunction(L, M_FakeSetCount);
+    lua_setfield(L, -2, "set_count");
+    lua_pushcfunction(L, M_FakeSetMax);
+    lua_setfield(L, -2, "set_max");
+    lua_pushcfunction(L, M_FakeSetUnobtainable);
+    lua_setfield(L, -2, "set_unobtainable");
+    lua_pushcfunction(L, M_FakeSetKillSplit);
+    lua_setfield(L, -2, "set_kill_split");
+    lua_pushcfunction(L, M_FakeSetAlliesHurt);
+    lua_setfield(L, -2, "set_allies_hurt");
 }
 
 int main(void)
 {
     const LUA_SURFACE_TEST test = {
         .module = "stats",
+        // A level hands back its statistics, which is how a script reaches a
+        // level other than the one being played.
+        .deps = { "game" },
         .tests = "api/stats",
         .push_fake = M_PushFake,
     };

--- a/src/tests/lua/api/stats.lua
+++ b/src/tests/lua/api/stats.lua
@@ -1,10 +1,22 @@
--- The level's secrets as a script sees them.
+-- What a level keeps count of, as a script sees it.
 --
--- Two counts answer different questions - how many secrets the level holds, and
--- how many of them count towards completion - so both are pinned here.
+-- Three numbers answer different questions - how much of a thing Lara has, how
+-- much of it counts towards completion, and how much the level holds - so all
+-- three are pinned here, as is reading them for a level other than the one
+-- being played.
 
 local h = require("harness")
 local test = h.test
+
+-- The numbers the C side addresses a category by, mirrored from stats.lua so a
+-- test can name one when it sets the fake up.
+local PICKUPS = 0
+local KILLS = 1
+local SECRETS = 2
+
+-- The fake's game flow opens with the gym, which has no number of its own, so
+-- the first level a script can address is the second in the table.
+local CAVES = 2
 
 local function level_with(nums)
   fake.set_current_level(1)
@@ -21,7 +33,7 @@ end
 
 test("the secrets come back in level order", function()
   level_with({ 1, 3, 7 })
-  local secrets = trx.stats.secrets
+  local secrets = trx.stats.secret_list()
   assert(#secrets == 3, "the level holds three secrets")
   assert(nums_of(secrets) == "1,3,7", "the numbers are the player's, from one")
   for _, secret in ipairs(secrets) do
@@ -33,24 +45,33 @@ test("a secret Lara holds reads as found", function()
   level_with({ 1, 2 })
   fake.set_found(2, true)
 
-  local secrets = trx.stats.secrets
+  local secrets = trx.stats.secret_list()
   assert(not secrets[1].found)
   assert(secrets[2].found)
-  assert(trx.stats.secret_count == 1)
+  assert(trx.stats.secrets.count == 1)
 end)
 
 test("give_secret marks one found", function()
   level_with({ 1, 2 })
   assert(trx.stats.give_secret(2))
-  assert(trx.stats.secrets[2].found, "the secret was not marked")
-  assert(trx.stats.secret_count == 1)
+  assert(trx.stats.secret_list()[2].found, "the secret was not marked")
+  assert(trx.stats.secrets.count == 1)
+end)
+
+-- The module stands for the level being played, so both spellings mean it.
+test("a verb reads the same called either way", function()
+  level_with({ 1, 2 })
+  assert(trx.stats:give_secret(1))
+  assert(trx.stats.give_secret(2))
+  assert(trx.stats:secret_list()[1].found)
+  assert(trx.stats.secrets.count == 2)
 end)
 
 test("giving a secret Lara already holds is refused", function()
   level_with({ 1 })
   assert(trx.stats.give_secret(1))
   assert(not trx.stats.give_secret(1), "the second give must not count")
-  assert(trx.stats.secret_count == 1)
+  assert(trx.stats.secrets.count == 1)
 end)
 
 test("take_secret leaves it to be found again", function()
@@ -58,8 +79,8 @@ test("take_secret leaves it to be found again", function()
   fake.set_found(1, true)
 
   assert(trx.stats.take_secret(1))
-  assert(not trx.stats.secrets[1].found)
-  assert(trx.stats.secret_count == 0)
+  assert(not trx.stats.secret_list()[1].found)
+  assert(trx.stats.secrets.count == 0)
   assert(not trx.stats.take_secret(1), "there is nothing left to take")
 end)
 
@@ -76,7 +97,7 @@ test("a number outside the range is refused rather than wrapped", function()
   for _, num in ipairs({ 0, -1, 17, 33, 65537 }) do
     assert(not trx.stats.give_secret(num), "gave secret " .. num)
   end
-  assert(trx.stats.secret_count == 0)
+  assert(trx.stats.secrets.count == 0)
 end)
 
 test("the completion count is not the length of the list", function()
@@ -84,19 +105,108 @@ test("the completion count is not the length of the list", function()
   -- The game flow declares one of them unobtainable, so the level asks for two.
   fake.set_max_secret_count(2)
 
-  assert(#trx.stats.secrets == 3, "all three are still there to find")
-  assert(trx.stats.max_secret_count == 2)
+  assert(#trx.stats.secret_list() == 3, "all three are still there to find")
+  assert(trx.stats.secrets.max == 2)
+end)
+
+test(
+  "what the level holds is what counts plus what is out of reach",
+  function()
+    fake.set_current_level(CAVES)
+    fake.set_max(1, PICKUPS, 34)
+    fake.set_unobtainable(1, PICKUPS, 2)
+
+    local pickups = trx.stats.pickups
+    assert(pickups.max == 34, "34 of them count")
+    assert(pickups.unobtainable == 2)
+    assert(pickups.raw == 36, "the level holds all 36")
+  end
+)
+
+test("a category the game flow writes nothing off reads zero", function()
+  fake.set_current_level(CAVES)
+  fake.set_max(1, KILLS, 12)
+
+  assert(trx.stats.kills.unobtainable == 0)
+  assert(trx.stats.kills.raw == 12)
+end)
+
+-- The statistics screen counts the allies against the player only once she has
+-- turned on one, so a screen written in Lua needs the same three numbers.
+test("the kill maximum says how it divides", function()
+  fake.set_current_level(CAVES)
+  fake.set_kill_split(1, 2, 10)
+
+  assert(trx.stats.kills.max == 12, "the maximum holds both")
+  assert(trx.stats.max_ally_kills == 2)
+  assert(trx.stats.max_enemy_kills == 10)
+  assert(not trx.stats.allies_hurt, "she has left them alone")
+
+  fake.set_allies_hurt(1, true)
+  assert(trx.stats.allies_hurt)
+end)
+
+test("a level answers for its own allies", function()
+  fake.set_current_level(CAVES)
+  fake.set_allies_hurt(2, true)
+
+  assert(not trx.stats.allies_hurt)
+  assert(trx.game.levels[2].stats.allies_hurt)
+end)
+
+test("a count can be written", function()
+  fake.set_current_level(CAVES)
+  trx.stats.pickups.count = 7
+  trx.stats.timer = 900
+
+  assert(trx.stats.pickups.count == 7)
+  assert(trx.stats.timer == 900)
+end)
+
+-- The mask behind them is the truth, so a count written straight over it could
+-- disagree with which secrets Lara actually holds.
+test("the secret count is not one of them", function()
+  level_with({ 1, 2 })
+  local ok = pcall(function()
+    trx.stats.secrets.count = 2
+  end)
+  assert(not ok, "the count must go through the secret verbs")
+  assert(trx.stats.secrets.count == 0)
+end)
+
+test("another level's counters are readable", function()
+  fake.set_current_level(CAVES)
+  fake.set_count(1, KILLS, 3)
+  fake.set_count(2, KILLS, 8)
+  fake.set_max(2, KILLS, 10)
+
+  local other = trx.game.levels[2].stats
+  assert(trx.stats.kills.count == 3, "the level being played counts its own")
+  assert(other.kills.count == 8)
+  assert(other.kills.max == 10)
+end)
+
+test("a hub is the levels a script adds up", function()
+  fake.set_current_level(CAVES)
+  fake.set_count(1, SECRETS, 1)
+  fake.set_count(2, SECRETS, 2)
+
+  local found = 0
+  for _, level in ipairs(trx.game.levels) do
+    if level.stats ~= nil then
+      found = found + level.stats.secrets.count
+    end
+  end
+  assert(found == 3, "the two levels hold three between them")
 end)
 
 test("nothing is counted outside a level", function()
   level_with({ 1, 2 })
   fake.set_current_level(nil)
 
-  assert(#trx.stats.secrets == 0, "the title screen holds no secrets")
-  assert(trx.stats.secret_count == 0)
-  assert(trx.stats.max_secret_count == 0)
-  assert(not trx.stats.give_secret(1), "there is no level to give one in")
-  assert(not trx.stats.take_secret(1))
+  assert(trx.stats.secrets == nil, "the title screen counts nothing")
+  assert(trx.stats.timer == nil)
+  assert(trx.stats.secret_list == nil, "nor is there anything to ask")
 end)
 
 -- The title screen is a level the game flow is on and the game is not, so the
@@ -107,10 +217,8 @@ test(
     level_with({ 1, 2 })
     fake.set_current_title()
 
-    assert(#trx.stats.secrets == 0)
-    assert(trx.stats.secret_count == 0)
-    assert(trx.stats.max_secret_count == 0)
-    assert(not trx.stats.give_secret(1))
+    assert(trx.stats.secrets == nil)
+    assert(trx.stats.timer == nil)
   end
 )
 

--- a/src/tests/lua/commands/secret.lua
+++ b/src/tests/lua/commands/secret.lua
@@ -11,7 +11,7 @@ end
 
 local function found_nums()
   local out = {}
-  for _, entry in ipairs(trx.stats.secrets) do
+  for _, entry in ipairs(trx.stats.secret_list()) do
     if entry.found then
       out[#out + 1] = entry.num
     end

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -382,7 +382,7 @@ unit_tests += {
   'name': 'lua/api/stats',
   'bundles': [b_lua_surface],
   'src': ['fakes/game.c', 'fakes/stats.c'],
-  'engine': ['game/lua/capi/stats.c'],
+  'engine': ['game/lua/capi/game.c', 'game/lua/capi/stats.c'],
 }
 
 unit_tests += {

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -24,6 +24,7 @@
 #include <trx/game/savegame.h>
 #include <trx/game/sound.h>
 #include <trx/game/sparks.h>
+#include <trx/game/stats.h>
 #include <trx/game/ui.h>
 
 void Level_Unload(void)
@@ -73,20 +74,7 @@ bool Level_Initialise(
     GF_SetCurrentLevel(level);
 
     if (level->type != GFL_TITLE) {
-        // TODO: move me elsewhere
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        if (resume != nullptr) {
-            resume->stats.timer = 0;
-            resume->stats.secret_flags = 0;
-            resume->stats.secret_count = 0;
-            resume->stats.crystal_count = 0;
-            resume->stats.pickup_count = 0;
-            resume->stats.kill_count = 0;
-            resume->stats.ammo_hits = 0;
-            resume->stats.ammo_used = 0;
-            resume->stats.medipacks_used = 0;
-            resume->stats.distance_travelled = 0;
-        }
+        Stats_ResetLevel(level);
     }
 
     if (level == nullptr) {

--- a/src/trx/game/lua/capi/stats.c
+++ b/src/trx/game/lua/capi/stats.c
@@ -9,13 +9,12 @@
 // Secrets are addressed by the number the player says, counted from one; the
 // bit index behind it stays in the engine.
 
-// The statistics belong to the level being played, and the engine has none to
-// read without one. This is the level the statistics themselves are read
-// against, not the one the game flow is on: the title screen has the second
+// The level the statistics are read against, which is the one being played
+// rather than the one the game flow is on: the title screen has the second
 // without the first.
-static bool M_HasLevel(void)
+static const GF_LEVEL *M_GetLevel(void)
 {
-    return Game_GetCurrentLevel() != nullptr;
+    return Game_GetCurrentLevel();
 }
 
 // The secret a number names, as an index, or -1 when the number is outside the
@@ -32,20 +31,18 @@ static int16_t M_GetSecretIdx(lua_State *const L, const int arg)
 // trxc.stats.secrets() -> { { num=, found= }, ... }
 static int M_L_StatsSecrets(lua_State *const L)
 {
+    const GF_LEVEL *const level = M_GetLevel();
     lua_newtable(L);
-    if (!M_HasLevel()) {
-        return 1;
-    }
 
     int32_t out_idx = 1;
     for (int16_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        if (!Stats_IsSecretValid(i)) {
+        if (!Stats_IsSecretValid(level, i)) {
             continue;
         }
         lua_newtable(L);
         lua_pushinteger(L, i + 1);
         lua_setfield(L, -2, "num");
-        lua_pushboolean(L, Stats_HasSecret(i));
+        lua_pushboolean(L, Stats_HasSecret(level, i));
         lua_setfield(L, -2, "found");
         lua_seti(L, -2, out_idx);
         out_idx++;
@@ -56,14 +53,20 @@ static int M_L_StatsSecrets(lua_State *const L)
 // trxc.stats.secret_count() -> int
 static int M_L_StatsSecretCount(lua_State *const L)
 {
-    lua_pushinteger(L, M_HasLevel() ? Stats_GetSecretCount() : 0);
+    const LEVEL_STATS *const stats = Stats_GetLevelStats(M_GetLevel());
+    lua_pushinteger(L, stats == nullptr ? 0 : stats->secret_count);
     return 1;
 }
 
 // trxc.stats.max_secret_count() -> int
 static int M_L_StatsMaxSecretCount(lua_State *const L)
 {
-    lua_pushinteger(L, M_HasLevel() ? Stats_GetMaxSecretCount() : 0);
+    const GF_LEVEL *const level = M_GetLevel();
+    lua_pushinteger(
+        L,
+        Stats_HasLevelMaxStats(level)
+            ? Stats_GetLevelMaxStats(level)->max_secret_count
+            : 0);
     return 1;
 }
 
@@ -72,7 +75,7 @@ static int M_L_StatsGiveSecret(lua_State *const L)
 {
     const int16_t secret_idx = M_GetSecretIdx(L, 1);
     lua_pushboolean(
-        L, M_HasLevel() && secret_idx >= 0 && Stats_AddSecret(secret_idx));
+        L, secret_idx >= 0 && Stats_AddSecret(M_GetLevel(), secret_idx));
     return 1;
 }
 
@@ -81,7 +84,7 @@ static int M_L_StatsTakeSecret(lua_State *const L)
 {
     const int16_t secret_idx = M_GetSecretIdx(L, 1);
     lua_pushboolean(
-        L, M_HasLevel() && secret_idx >= 0 && Stats_RemoveSecret(secret_idx));
+        L, secret_idx >= 0 && Stats_RemoveSecret(M_GetLevel(), secret_idx));
     return 1;
 }
 

--- a/src/trx/game/lua/capi/stats.c
+++ b/src/trx/game/lua/capi/stats.c
@@ -1,6 +1,9 @@
 #include <trx/game/game/state.h>
+#include <trx/game/game_flow.h>
 #include <trx/game/lua/common.h>
+#include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
+#include <trx/game/lua/struct.h>
 #include <trx/game/lua/utils.h>
 #include <trx/game/stats.h>
 
@@ -9,12 +12,102 @@
 // Secrets are addressed by the number the player says, counted from one; the
 // bit index behind it stays in the engine.
 
-// The level the statistics are read against, which is the one being played
-// rather than the one the game flow is on: the title screen has the second
-// without the first.
-static const GF_LEVEL *M_GetLevel(void)
+// A level lives in the game flow for the whole session, so what addresses its
+// statistics never goes stale. The ref carries the table in the high half and
+// the level's number in the low, the way a level handle does; a category
+// handle carries a category id below that again.
+#define M_PACK_LEVEL(table, num) (((table) << 16) | ((num) & 0xffff))
+#define M_LEVEL_TABLE(packed) (((packed) >> 16) & 0xff)
+#define M_LEVEL_NUM(packed) ((packed) & 0xffff)
+#define M_PACK_CAT(level, id) (((level) << 8) | (id))
+#define M_CAT_LEVEL(packed) ((packed) >> 8)
+#define M_CAT_ID(packed) ((packed) & 0xff)
+
+// The count is the level's, and the view is a copy of it, so a write goes back
+// to where it came from rather than into the copy.
+static const char *M_SetCategoryCount(
+    void *const self, const TRX_VALUE *const in)
 {
-    return Game_GetCurrentLevel();
+    const STATS_CATEGORY *const category = self;
+    if (!Stats_SetCategoryCount(category->level, category->id, in->as_int)) {
+        return "this count is not the level's to set";
+    }
+    return nullptr;
+}
+
+// clang-format off
+static const FIELD_DESC m_StatsFields[] = {
+    FIELD(LEVEL_STATS, timer),
+    FIELD(LEVEL_STATS, death_count),
+    FIELD(LEVEL_STATS, ammo_used),
+    FIELD(LEVEL_STATS, ammo_hits),
+    FIELD(LEVEL_STATS, distance_travelled),
+    FIELD(LEVEL_STATS, medipacks_used),
+
+    // What the level is counted on is reached a category at a time, so the
+    // counts behind it are not members here. The secret mask is not one
+    // either: which secrets Lara holds is what the secret verbs answer.
+};
+
+static const FIELD_DESC m_CategoryFields[] = {
+    FIELD_SET(STATS_CATEGORY, count, M_SetCategoryCount),
+    FIELD_RO(STATS_CATEGORY, max),
+    FIELD_RO(STATS_CATEGORY, raw),
+    FIELD_RO(STATS_CATEGORY, unobtainable),
+};
+// clang-format on
+
+// The level a handle names, or nullptr if the game flow no longer has one.
+static const GF_LEVEL *M_GetPackedLevel(const int32_t packed)
+{
+    return GF_GetLevelByOrdinalNumber(
+        (GF_LEVEL_TABLE_TYPE)M_LEVEL_TABLE(packed), M_LEVEL_NUM(packed));
+}
+
+TYPE_DEFINE(LEVEL_STATS, m_StatsFields)
+TYPE_DEFINE(STATS_CATEGORY, m_CategoryFields)
+
+static void *M_ResolveStats(const LUA_STRUCT_REF *const ref)
+{
+    return Stats_GetLevelStats(M_GetPackedLevel(ref->handle.id));
+}
+
+// The view a category handle stands for, refilled every time the handle is
+// read: it holds a level's counters at the moment it is asked for, and the
+// level goes on counting.
+static void *M_ResolveCategory(const LUA_STRUCT_REF *const ref)
+{
+    static STATS_CATEGORY category;
+    const GF_LEVEL *const level = M_GetPackedLevel(M_CAT_LEVEL(ref->handle.id));
+    return Stats_GetCategory(
+               level, (STATS_CATEGORY_ID)M_CAT_ID(ref->handle.id), &category)
+        ? &category
+        : nullptr;
+}
+
+// The level a script means, packed, or -1 where it has no statistics: the
+// title screen and the cutscenes. The statistics belong to the level being
+// played rather than the one the game flow is on, and the title screen has the
+// second without the first.
+static int32_t M_PackLevel(const GF_LEVEL *const level)
+{
+    if (Stats_GetLevelStats(level) == nullptr) {
+        return -1;
+    }
+    const GF_LEVEL_TABLE_TYPE table_type = GF_GetLevelTableType(level->type);
+    return M_PACK_LEVEL(
+        table_type, GF_GetLevelOrdinalNumber(table_type, level));
+}
+
+static void M_PushStats(lua_State *const L, const GF_LEVEL *const level)
+{
+    const int32_t packed = M_PackLevel(level);
+    if (packed < 0) {
+        lua_pushnil(L);
+        return;
+    }
+    LUA_Struct_Push(
+        L, &TYPE_LEVEL_STATS, M_ResolveStats, (TRX_HANDLE) { .id = packed });
 }
 
 // The secret a number names, as an index, or -1 when the number is outside the
@@ -28,10 +121,76 @@ static int16_t M_GetSecretIdx(lua_State *const L, const int arg)
     return (int16_t)(num - 1);
 }
 
-// trxc.stats.secrets() -> { { num=, found= }, ... }
-static int M_L_StatsSecrets(lua_State *const L)
+// The level a statistics handle was taken against.
+static const GF_LEVEL *M_CheckStatsLevel(lua_State *const L, const int arg)
 {
-    const GF_LEVEL *const level = M_GetLevel();
+    const LUA_STRUCT_REF *const ref =
+        LUA_Struct_CheckRef(L, arg, &TYPE_LEVEL_STATS);
+    return M_GetPackedLevel(ref->handle.id);
+}
+
+// trxc.stats.get(num) -> LEVEL_STATS handle or nil
+static int M_L_StatsGet(lua_State *const L)
+{
+    int32_t num;
+    if (!LUA_CheckBoundedInt(L, 1, 0, INT32_MAX, &num)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    M_PushStats(L, GF_GetLevelByOrdinalNumber(GFLT_MAIN, num));
+    return 1;
+}
+
+// trxc.stats.get_current() -> LEVEL_STATS handle or nil
+static int M_L_StatsGetCurrent(lua_State *const L)
+{
+    M_PushStats(L, Game_GetCurrentLevel());
+    return 1;
+}
+
+// trxc.stats.category(stats, id) -> STATS_CATEGORY handle or nil
+static int M_L_StatsCategory(lua_State *const L)
+{
+    const LUA_STRUCT_REF *const ref =
+        LUA_Struct_CheckRef(L, 1, &TYPE_LEVEL_STATS);
+    const STATS_CATEGORY_ID id = (STATS_CATEGORY_ID)LUA_CheckRange(
+        L, 2, STATS_CAT_NUMBER_OF, "unknown statistics category");
+
+    STATS_CATEGORY category;
+    if (!Stats_GetCategory(M_GetPackedLevel(ref->handle.id), id, &category)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    LUA_Struct_Push(
+        L, &TYPE_STATS_CATEGORY, M_ResolveCategory,
+        (TRX_HANDLE) { .id = M_PACK_CAT(ref->handle.id, id) });
+    return 1;
+}
+
+// trxc.stats.kill_split(stats) -> allies, enemies
+static int M_L_StatsKillSplit(lua_State *const L)
+{
+    const GF_LEVEL *const level = M_CheckStatsLevel(L, 1);
+    if (!Stats_HasLevelMaxStats(level)) {
+        return 0;
+    }
+    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
+    lua_pushinteger(L, max_stats->max_kill_ally_count);
+    lua_pushinteger(L, max_stats->max_kill_non_ally_count);
+    return 2;
+}
+
+// trxc.stats.allies_hurt(stats) -> bool
+static int M_L_StatsAlliesHurt(lua_State *const L)
+{
+    lua_pushboolean(L, Stats_HaveAlliesBeenHurt(M_CheckStatsLevel(L, 1)));
+    return 1;
+}
+
+// stats:secret_list() -> { { num=, found= }, ... }
+static int M_L_StatsSecretList(lua_State *const L)
+{
+    const GF_LEVEL *const level = M_CheckStatsLevel(L, 1);
     lua_newtable(L);
 
     int32_t out_idx = 1;
@@ -50,55 +209,45 @@ static int M_L_StatsSecrets(lua_State *const L)
     return 1;
 }
 
-// trxc.stats.secret_count() -> int
-static int M_L_StatsSecretCount(lua_State *const L)
-{
-    const LEVEL_STATS *const stats = Stats_GetLevelStats(M_GetLevel());
-    lua_pushinteger(L, stats == nullptr ? 0 : stats->counts[STATS_CAT_SECRETS]);
-    return 1;
-}
-
-// trxc.stats.max_secret_count() -> int
-static int M_L_StatsMaxSecretCount(lua_State *const L)
-{
-    const GF_LEVEL *const level = M_GetLevel();
-    lua_pushinteger(
-        L,
-        Stats_HasLevelMaxStats(level)
-            ? Stats_GetLevelMaxStats(level)->maxes[STATS_CAT_SECRETS]
-            : 0);
-    return 1;
-}
-
-// trxc.stats.give_secret(num) -> bool
+// stats:give_secret(num) -> bool
 static int M_L_StatsGiveSecret(lua_State *const L)
 {
-    const int16_t secret_idx = M_GetSecretIdx(L, 1);
-    lua_pushboolean(
-        L, secret_idx >= 0 && Stats_AddSecret(M_GetLevel(), secret_idx));
+    const GF_LEVEL *const level = M_CheckStatsLevel(L, 1);
+    const int16_t secret_idx = M_GetSecretIdx(L, 2);
+    lua_pushboolean(L, secret_idx >= 0 && Stats_AddSecret(level, secret_idx));
     return 1;
 }
 
-// trxc.stats.take_secret(num) -> bool
+// stats:take_secret(num) -> bool
 static int M_L_StatsTakeSecret(lua_State *const L)
 {
-    const int16_t secret_idx = M_GetSecretIdx(L, 1);
+    const GF_LEVEL *const level = M_CheckStatsLevel(L, 1);
+    const int16_t secret_idx = M_GetSecretIdx(L, 2);
     lua_pushboolean(
-        L, secret_idx >= 0 && Stats_RemoveSecret(M_GetLevel(), secret_idx));
+        L, secret_idx >= 0 && Stats_RemoveSecret(level, secret_idx));
     return 1;
 }
 
-static const luaL_Reg m_Module[] = {
-    { "secrets", M_L_StatsSecrets },
-    { "secret_count", M_L_StatsSecretCount },
-    { "max_secret_count", M_L_StatsMaxSecretCount },
+static const luaL_Reg m_StatsMethods[] = {
+    { "secret_list", M_L_StatsSecretList },
     { "give_secret", M_L_StatsGiveSecret },
     { "take_secret", M_L_StatsTakeSecret },
     { nullptr, nullptr },
 };
 
+static const luaL_Reg m_Module[] = {
+    { "get", M_L_StatsGet },
+    { "get_current", M_L_StatsGetCurrent },
+    { "category", M_L_StatsCategory },
+    { "kill_split", M_L_StatsKillSplit },
+    { "allies_hurt", M_L_StatsAlliesHurt },
+    { nullptr, nullptr },
+};
+
 static void M_Create(lua_State *const L)
 {
+    LUA_Struct_Register(L, &TYPE_LEVEL_STATS, m_StatsMethods);
+    LUA_Struct_Register(L, &TYPE_STATS_CATEGORY, nullptr);
     LUA_RegisterModule(L, "stats", m_Module);
 }
 

--- a/src/trx/game/lua/capi/stats.c
+++ b/src/trx/game/lua/capi/stats.c
@@ -54,7 +54,7 @@ static int M_L_StatsSecrets(lua_State *const L)
 static int M_L_StatsSecretCount(lua_State *const L)
 {
     const LEVEL_STATS *const stats = Stats_GetLevelStats(M_GetLevel());
-    lua_pushinteger(L, stats == nullptr ? 0 : stats->secret_count);
+    lua_pushinteger(L, stats == nullptr ? 0 : stats->counts[STATS_CAT_SECRETS]);
     return 1;
 }
 
@@ -65,7 +65,7 @@ static int M_L_StatsMaxSecretCount(lua_State *const L)
     lua_pushinteger(
         L,
         Stats_HasLevelMaxStats(level)
-            ? Stats_GetLevelMaxStats(level)->max_secret_count
+            ? Stats_GetLevelMaxStats(level)->maxes[STATS_CAT_SECRETS]
             : 0);
     return 1;
 }

--- a/src/trx/game/rooms/triggers/general.c
+++ b/src/trx/game/rooms/triggers/general.c
@@ -34,7 +34,7 @@ static void M_HandleSecret(
     TRIGGER_STATUS *const status)
 {
     const int16_t secret_num = (int16_t)(intptr_t)cmd->parameter;
-    if (Stats_AddSecret(secret_num)) {
+    if (Stats_AddSecret(Game_GetCurrentLevel(), secret_num)) {
         const MUSIC_PLAY_MODE mode =
             g_Config.audio.fix_secrets_killing_music ? MPM_OVERLAY : MPM_ONCE;
         Music_Play(MX_SECRET, mode);

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -994,9 +994,10 @@ static bool M_ReadResumeInfo(JSON_READ_IO *const io, RESUME_INFO *const resume)
     M_MUST(JSON_READ(io, "medipacks_used", &resume->stats.medipacks_used));
     M_MUST(
         JSON_READ(io, "distance_travelled", &resume->stats.distance_travelled));
-    M_MUST(JSON_READ(io, "kills", &resume->stats.kill_count));
-    M_SHOULD(JSON_READ(io, "crystals", &resume->stats.crystal_count));
-    M_MUST(JSON_READ(io, "pickups", &resume->stats.pickup_count));
+    M_MUST(JSON_READ(io, "kills", &resume->stats.counts[STATS_CAT_KILLS]));
+    M_SHOULD(
+        JSON_READ(io, "crystals", &resume->stats.counts[STATS_CAT_CRYSTALS]));
+    M_MUST(JSON_READ(io, "pickups", &resume->stats.counts[STATS_CAT_PICKUPS]));
     M_MUST(JSON_READ(io, "secrets", &resume->stats.secret_flags));
     M_SHOULD(JSON_READ(io, "death_count", &resume->stats.death_count));
     Stats_UpdateSecrets(&resume->stats);

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -374,10 +374,10 @@ static void M_WriteResumeInfo(
 
     JSONW_WRITE(io, "costume", resume->flags.costume);
     JSONW_WRITE(io, "timer", resume->stats.timer);
-    JSONW_WRITE(io, "kills", resume->stats.kill_count);
+    JSONW_WRITE(io, "kills", resume->stats.counts[STATS_CAT_KILLS]);
     JSONW_WRITE(io, "secrets", resume->stats.secret_flags);
-    JSONW_WRITE(io, "crystals", resume->stats.crystal_count);
-    JSONW_WRITE(io, "pickups", resume->stats.pickup_count);
+    JSONW_WRITE(io, "crystals", resume->stats.counts[STATS_CAT_CRYSTALS]);
+    JSONW_WRITE(io, "pickups", resume->stats.counts[STATS_CAT_PICKUPS]);
     JSONW_WRITE(io, "ammo_hits", resume->stats.ammo_hits);
     JSONW_WRITE(io, "ammo_used", resume->stats.ammo_used);
     JSONW_WRITE(io, "distance_travelled", resume->stats.distance_travelled);

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -7,6 +7,21 @@
 #include <trx/game/savegame.h>
 #include <trx/game/stats.h>
 
+// The bit a secret number stands for in the level's mask, or 0 when the level
+// holds no such secret.
+static uint32_t M_GetSecretMask(
+    const GF_LEVEL *const level, const int16_t secret_idx)
+{
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS
+        || !Stats_HasLevelMaxStats(level)) {
+        return 0;
+    }
+    const uint32_t secret_mask = 1 << secret_idx;
+    return (secret_mask & Stats_GetLevelMaxStats(level)->all_secrets_mask) != 0
+        ? secret_mask
+        : 0;
+}
+
 LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *const level)
 {
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
@@ -24,59 +39,27 @@ void Stats_ResetLevel(const GF_LEVEL *const level)
     stats->death_count = death_count;
 }
 
-int32_t Stats_GetSecretCount(void)
+bool Stats_IsSecretValid(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    const LEVEL_STATS *const stats =
-        Stats_GetLevelStats(Game_GetCurrentLevel());
-    return stats->secret_count;
+    return M_GetSecretMask(level, secret_idx) != 0;
 }
 
-int32_t Stats_GetMaxSecretCount(void)
+bool Stats_HasSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    return max_stats->max_secret_count;
-}
-
-bool Stats_IsSecretValid(const int16_t secret_idx)
-{
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
-        return false;
-    }
-    const uint32_t secret_mask = 1 << secret_idx;
-    return (secret_mask & max_stats->all_secrets_mask) != 0;
-}
-
-bool Stats_HasSecret(const int16_t secret_idx)
-{
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
+    const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
     const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
-    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
-        return false;
-    }
-    const uint32_t secret_mask = 1 << secret_idx;
-    if ((secret_mask & max_stats->all_secrets_mask) == 0) {
+    if (secret_mask == 0 || stats == nullptr) {
         return false;
     }
     return (stats->secret_flags & secret_mask) != 0;
 }
 
-bool Stats_RemoveSecret(const int16_t secret_idx)
+bool Stats_RemoveSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
+    const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
     LEVEL_STATS *const stats = Stats_GetLevelStats(level);
-    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
-        return false;
-    }
-    const uint32_t secret_mask = 1 << secret_idx;
-    if ((secret_mask & max_stats->all_secrets_mask) == 0) {
-        return false;
-    }
-    if (!(stats->secret_flags & secret_mask)) {
+    if (secret_mask == 0 || stats == nullptr
+        || (stats->secret_flags & secret_mask) == 0) {
         return false;
     }
     LOG_INFO("Removing secret %d", secret_idx);
@@ -85,19 +68,12 @@ bool Stats_RemoveSecret(const int16_t secret_idx)
     return true;
 }
 
-bool Stats_AddSecret(const int16_t secret_idx)
+bool Stats_AddSecret(const GF_LEVEL *const level, const int16_t secret_idx)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
+    const uint32_t secret_mask = M_GetSecretMask(level, secret_idx);
     LEVEL_STATS *const stats = Stats_GetLevelStats(level);
-    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
-        return false;
-    }
-    const uint32_t secret_mask = 1 << secret_idx;
-    if ((secret_mask & max_stats->all_secrets_mask) == 0) {
-        return false;
-    }
-    if (stats->secret_flags & secret_mask) {
+    if (secret_mask == 0 || stats == nullptr
+        || (stats->secret_flags & secret_mask) != 0) {
         return false;
     }
     LOG_INFO("Adding secret %d", secret_idx);
@@ -263,16 +239,16 @@ FINAL_STATS Stats_ComputeFinalStats(const bool include_bonus_levels)
     return result;
 }
 
-OBJECT_ID Stats_GetSecretObject(const int32_t secret_idx)
+OBJECT_ID Stats_GetSecretObject(
+    const GF_LEVEL *const level, const int32_t secret_idx)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level == nullptr) {
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS
+        || !Stats_HasLevelMaxStats(level)) {
         return NO_OBJECT;
     }
-    const LEVEL_MAX_STATS *const stats = Stats_GetLevelMaxStats(level);
-    ASSERT(stats != nullptr);
-    ASSERT(secret_idx >= 0 && secret_idx < STATS_MAX_SECRETS);
-    return stats->secret_objects[secret_idx].assigned_object_id;
+    return Stats_GetLevelMaxStats(level)
+        ->secret_objects[secret_idx]
+        .assigned_object_id;
 }
 
 uint32_t Stats_GetSecretMaskForItem(

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -7,11 +7,28 @@
 #include <trx/game/savegame.h>
 #include <trx/game/stats.h>
 
+LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *const level)
+{
+    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+    return resume == nullptr ? nullptr : &resume->stats;
+}
+
+void Stats_ResetLevel(const GF_LEVEL *const level)
+{
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (stats == nullptr) {
+        return;
+    }
+    const int32_t death_count = stats->death_count;
+    *stats = (LEVEL_STATS) {};
+    stats->death_count = death_count;
+}
+
 int32_t Stats_GetSecretCount(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-    return resume->stats.secret_count;
+    const LEVEL_STATS *const stats =
+        Stats_GetLevelStats(Game_GetCurrentLevel());
+    return stats->secret_count;
 }
 
 int32_t Stats_GetMaxSecretCount(void)
@@ -36,7 +53,7 @@ bool Stats_HasSecret(const int16_t secret_idx)
 {
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+    const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
     if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
         return false;
     }
@@ -44,14 +61,14 @@ bool Stats_HasSecret(const int16_t secret_idx)
     if ((secret_mask & max_stats->all_secrets_mask) == 0) {
         return false;
     }
-    return (resume->stats.secret_flags & secret_mask) != 0;
+    return (stats->secret_flags & secret_mask) != 0;
 }
 
 bool Stats_RemoveSecret(const int16_t secret_idx)
 {
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
     if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
         return false;
     }
@@ -59,12 +76,12 @@ bool Stats_RemoveSecret(const int16_t secret_idx)
     if ((secret_mask & max_stats->all_secrets_mask) == 0) {
         return false;
     }
-    if (!(resume->stats.secret_flags & secret_mask)) {
+    if (!(stats->secret_flags & secret_mask)) {
         return false;
     }
     LOG_INFO("Removing secret %d", secret_idx);
-    resume->stats.secret_flags &= ~secret_mask;
-    resume->stats.secret_count--;
+    stats->secret_flags &= ~secret_mask;
+    stats->secret_count--;
     return true;
 }
 
@@ -72,7 +89,7 @@ bool Stats_AddSecret(const int16_t secret_idx)
 {
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
     if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
         return false;
     }
@@ -80,12 +97,12 @@ bool Stats_AddSecret(const int16_t secret_idx)
     if ((secret_mask & max_stats->all_secrets_mask) == 0) {
         return false;
     }
-    if (resume->stats.secret_flags & secret_mask) {
+    if (stats->secret_flags & secret_mask) {
         return false;
     }
     LOG_INFO("Adding secret %d", secret_idx);
-    resume->stats.secret_flags |= secret_mask;
-    resume->stats.secret_count++;
+    stats->secret_flags |= secret_mask;
+    stats->secret_count++;
     return true;
 }
 
@@ -99,17 +116,17 @@ void Stats_UpdateSecrets(LEVEL_STATS *const stats)
 
 void Stats_MarkSecretCollected(const ITEM *const item)
 {
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    resume->stats.secret_flags |= Pickup_GetSecretMask(item);
-    Stats_UpdateSecrets(&resume->stats);
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    stats->secret_flags |= Pickup_GetSecretMask(item);
+    Stats_UpdateSecrets(stats);
 }
 
 bool Stats_CheckAllLevelSecretsPickedUp(void)
 {
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-    int32_t flags = resume->stats.secret_flags;
+    const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    int32_t flags = stats->secret_flags;
     size_t count = 0;
     while (flags != 0) {
         count += flags & 1;
@@ -127,81 +144,78 @@ bool Stats_CheckAllSecretsCollected(void)
 
 void Stats_AddMedipacksUsed(const double medipack_value)
 {
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    resume->stats.medipacks_used += medipack_value;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->medipacks_used += medipack_value;
+    }
 }
 
 void Stats_AddDeath(void)
 {
-    const GF_LEVEL *const current_level = Game_GetCurrentLevel();
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(current_level);
-    resume->stats.death_count++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats == nullptr) {
+        return;
+    }
+    stats->death_count++;
     const SAVEGAME_SLOT_REF save_slot = Savegame_GetBoundSlot();
     if (Savegame_IsValidSlotRef(save_slot)) {
-        Savegame_UpdateDeathCounters(save_slot, resume->stats.death_count);
+        Savegame_UpdateDeathCounters(save_slot, stats->death_count);
     }
 }
 
 void Stats_UpdateTimer(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.timer++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->timer++;
     }
 }
 
 void Stats_AddKill(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.kill_count++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->kill_count++;
     }
 }
 
 void Stats_AddCrystal(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.crystal_count++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->crystal_count++;
     }
 }
 
 void Stats_AddPickup(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.pickup_count++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->pickup_count++;
     }
 }
 
 void Stats_AddAmmoHits(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.ammo_hits++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->ammo_hits++;
     }
 }
 
 void Stats_AddAmmoUsed(void)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.ammo_used++;
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->ammo_used++;
     }
 }
 
 void Stats_AddDistanceTravelled(const XYZ_32 pos, const XYZ_32 last_pos)
 {
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
-    if (level != nullptr) {
-        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.distance_travelled += XYZ_32_GetDistance(pos, last_pos);
+    LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
+    if (stats != nullptr) {
+        stats->distance_travelled += XYZ_32_GetDistance(pos, last_pos);
     }
 }
 

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -22,6 +22,61 @@ static uint32_t M_GetSecretMask(
         : 0;
 }
 
+// What the level holds of a category, less what the game flow writes off.
+static uint32_t M_GetCategoryMax(
+    const LEVEL_MAX_STATS *const max_stats, const STATS_CATEGORY_ID id)
+{
+    switch (id) {
+    case STATS_CAT_PICKUPS:
+        return max_stats->max_pickup_count;
+    case STATS_CAT_KILLS:
+        return max_stats->max_kill_count;
+    case STATS_CAT_SECRETS:
+        return max_stats->max_secret_count;
+    case STATS_CAT_CRYSTALS:
+        return max_stats->max_crystal_count;
+    case STATS_CAT_NUMBER_OF:
+        break;
+    }
+    return 0;
+}
+
+// What the game flow declares out of reach. Crystals have no such declaration.
+static uint32_t M_GetCategoryUnobtainable(
+    const GF_LEVEL *const level, const STATS_CATEGORY_ID id)
+{
+    switch (id) {
+    case STATS_CAT_PICKUPS:
+        return level->unobtainable.pickups;
+    case STATS_CAT_KILLS:
+        return level->unobtainable.kills + level->unobtainable.ally_kills;
+    case STATS_CAT_SECRETS:
+        return level->unobtainable.secrets;
+    case STATS_CAT_CRYSTALS:
+    case STATS_CAT_NUMBER_OF:
+        break;
+    }
+    return 0;
+}
+
+static uint32_t M_GetCategoryCount(
+    const LEVEL_STATS *const stats, const STATS_CATEGORY_ID id)
+{
+    switch (id) {
+    case STATS_CAT_PICKUPS:
+        return stats->pickup_count;
+    case STATS_CAT_KILLS:
+        return stats->kill_count;
+    case STATS_CAT_SECRETS:
+        return stats->secret_count;
+    case STATS_CAT_CRYSTALS:
+        return stats->crystal_count;
+    case STATS_CAT_NUMBER_OF:
+        break;
+    }
+    return 0;
+}
+
 LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *const level)
 {
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
@@ -37,6 +92,54 @@ void Stats_ResetLevel(const GF_LEVEL *const level)
     const int32_t death_count = stats->death_count;
     *stats = (LEVEL_STATS) {};
     stats->death_count = death_count;
+}
+
+bool Stats_GetCategory(
+    const GF_LEVEL *const level, const STATS_CATEGORY_ID id,
+    STATS_CATEGORY *const out)
+{
+    const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (stats == nullptr || !Stats_HasLevelMaxStats(level)
+        || id >= STATS_CAT_NUMBER_OF) {
+        return false;
+    }
+
+    const uint32_t unobtainable = M_GetCategoryUnobtainable(level, id);
+    const uint32_t max = M_GetCategoryMax(Stats_GetLevelMaxStats(level), id);
+    *out = (STATS_CATEGORY) {
+        .level = level,
+        .id = id,
+        .count = M_GetCategoryCount(stats, id),
+        .max = max,
+        .raw = max + unobtainable,
+        .unobtainable = unobtainable,
+    };
+    return true;
+}
+
+bool Stats_SetCategoryCount(
+    const GF_LEVEL *const level, const STATS_CATEGORY_ID id,
+    const uint32_t count)
+{
+    LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+    if (stats == nullptr) {
+        return false;
+    }
+    switch (id) {
+    case STATS_CAT_PICKUPS:
+        stats->pickup_count = count;
+        return true;
+    case STATS_CAT_KILLS:
+        stats->kill_count = count;
+        return true;
+    case STATS_CAT_CRYSTALS:
+        stats->crystal_count = count;
+        return true;
+    case STATS_CAT_SECRETS:
+    case STATS_CAT_NUMBER_OF:
+        break;
+    }
+    return false;
 }
 
 bool Stats_IsSecretValid(const GF_LEVEL *const level, const int16_t secret_idx)

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -336,3 +336,9 @@ void Stats_MarkAlliesHostile(void)
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
     resume->hurt_allies = true;
 }
+
+bool Stats_HaveAlliesBeenHurt(const GF_LEVEL *const level)
+{
+    const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+    return resume != nullptr && resume->hurt_allies;
+}

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -22,23 +22,28 @@ static uint32_t M_GetSecretMask(
         : 0;
 }
 
-// What the level holds of a category, less what the game flow writes off.
-static uint32_t M_GetCategoryMax(
-    const LEVEL_MAX_STATS *const max_stats, const STATS_CATEGORY_ID id)
+static void M_SumStats(STATS_COMMON *const dst, const STATS_COMMON *const src)
 {
-    switch (id) {
-    case STATS_CAT_PICKUPS:
-        return max_stats->max_pickup_count;
-    case STATS_CAT_KILLS:
-        return max_stats->max_kill_count;
-    case STATS_CAT_SECRETS:
-        return max_stats->max_secret_count;
-    case STATS_CAT_CRYSTALS:
-        return max_stats->max_crystal_count;
-    case STATS_CAT_NUMBER_OF:
-        break;
+    for (int32_t i = 0; i < STATS_CAT_NUMBER_OF; i++) {
+        dst->counts[i] += src->counts[i];
     }
-    return 0;
+    dst->timer += src->timer;
+    dst->ammo_hits += src->ammo_hits;
+    dst->ammo_used += src->ammo_used;
+    dst->medipacks_used += src->medipacks_used;
+    dst->distance_travelled += src->distance_travelled;
+    dst->death_count += src->death_count;
+}
+
+static void M_SumMaxStats(
+    LEVEL_MAX_STATS *const dst, const LEVEL_MAX_STATS *const src)
+{
+    for (int32_t i = 0; i < STATS_CAT_NUMBER_OF; i++) {
+        dst->maxes[i] += src->maxes[i];
+    }
+    dst->max_kill_ally_count += src->max_kill_ally_count;
+    dst->max_kill_non_ally_count += src->max_kill_non_ally_count;
+    dst->max_pickup_secret_count += src->max_pickup_secret_count;
 }
 
 // What the game flow declares out of reach. Crystals have no such declaration.
@@ -53,24 +58,6 @@ static uint32_t M_GetCategoryUnobtainable(
     case STATS_CAT_SECRETS:
         return level->unobtainable.secrets;
     case STATS_CAT_CRYSTALS:
-    case STATS_CAT_NUMBER_OF:
-        break;
-    }
-    return 0;
-}
-
-static uint32_t M_GetCategoryCount(
-    const LEVEL_STATS *const stats, const STATS_CATEGORY_ID id)
-{
-    switch (id) {
-    case STATS_CAT_PICKUPS:
-        return stats->pickup_count;
-    case STATS_CAT_KILLS:
-        return stats->kill_count;
-    case STATS_CAT_SECRETS:
-        return stats->secret_count;
-    case STATS_CAT_CRYSTALS:
-        return stats->crystal_count;
     case STATS_CAT_NUMBER_OF:
         break;
     }
@@ -105,11 +92,11 @@ bool Stats_GetCategory(
     }
 
     const uint32_t unobtainable = M_GetCategoryUnobtainable(level, id);
-    const uint32_t max = M_GetCategoryMax(Stats_GetLevelMaxStats(level), id);
+    const uint32_t max = Stats_GetLevelMaxStats(level)->maxes[id];
     *out = (STATS_CATEGORY) {
         .level = level,
         .id = id,
-        .count = M_GetCategoryCount(stats, id),
+        .count = stats->counts[id],
         .max = max,
         .raw = max + unobtainable,
         .unobtainable = unobtainable,
@@ -122,24 +109,12 @@ bool Stats_SetCategoryCount(
     const uint32_t count)
 {
     LEVEL_STATS *const stats = Stats_GetLevelStats(level);
-    if (stats == nullptr) {
+    if (stats == nullptr || id >= STATS_CAT_NUMBER_OF
+        || id == STATS_CAT_SECRETS) {
         return false;
     }
-    switch (id) {
-    case STATS_CAT_PICKUPS:
-        stats->pickup_count = count;
-        return true;
-    case STATS_CAT_KILLS:
-        stats->kill_count = count;
-        return true;
-    case STATS_CAT_CRYSTALS:
-        stats->crystal_count = count;
-        return true;
-    case STATS_CAT_SECRETS:
-    case STATS_CAT_NUMBER_OF:
-        break;
-    }
-    return false;
+    stats->counts[id] = count;
+    return true;
 }
 
 bool Stats_IsSecretValid(const GF_LEVEL *const level, const int16_t secret_idx)
@@ -167,7 +142,7 @@ bool Stats_RemoveSecret(const GF_LEVEL *const level, const int16_t secret_idx)
     }
     LOG_INFO("Removing secret %d", secret_idx);
     stats->secret_flags &= ~secret_mask;
-    stats->secret_count--;
+    stats->counts[STATS_CAT_SECRETS]--;
     return true;
 }
 
@@ -181,15 +156,16 @@ bool Stats_AddSecret(const GF_LEVEL *const level, const int16_t secret_idx)
     }
     LOG_INFO("Adding secret %d", secret_idx);
     stats->secret_flags |= secret_mask;
-    stats->secret_count++;
+    stats->counts[STATS_CAT_SECRETS]++;
     return true;
 }
 
 void Stats_UpdateSecrets(LEVEL_STATS *const stats)
 {
-    stats->secret_count = 0;
+    stats->counts[STATS_CAT_SECRETS] = 0;
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        stats->secret_count += (stats->secret_flags & (1 << i)) ? 1 : 0;
+        stats->counts[STATS_CAT_SECRETS] +=
+            (stats->secret_flags & (1 << i)) ? 1 : 0;
     }
 }
 
@@ -217,8 +193,8 @@ bool Stats_CheckAllLevelSecretsPickedUp(void)
 bool Stats_CheckAllSecretsCollected(void)
 {
     const FINAL_STATS final_stats = Stats_ComputeFinalStats(false);
-    return final_stats.stats.secret_count
-        >= final_stats.max_stats.max_secret_count;
+    return final_stats.stats.counts[STATS_CAT_SECRETS]
+        >= final_stats.max_stats.maxes[STATS_CAT_SECRETS];
 }
 
 void Stats_AddMedipacksUsed(const double medipack_value)
@@ -254,7 +230,7 @@ void Stats_AddKill(void)
 {
     LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
     if (stats != nullptr) {
-        stats->kill_count++;
+        stats->counts[STATS_CAT_KILLS]++;
     }
 }
 
@@ -262,7 +238,7 @@ void Stats_AddCrystal(void)
 {
     LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
     if (stats != nullptr) {
-        stats->crystal_count++;
+        stats->counts[STATS_CAT_CRYSTALS]++;
     }
 }
 
@@ -270,7 +246,7 @@ void Stats_AddPickup(void)
 {
     LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
     if (stats != nullptr) {
-        stats->pickup_count++;
+        stats->counts[STATS_CAT_PICKUPS]++;
     }
 }
 
@@ -309,33 +285,12 @@ FINAL_STATS Stats_ComputeFinalStats(const bool include_bonus_levels)
             continue;
         }
 
-        const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        if (resume != nullptr) {
-#define L_ADD(prop) result.stats.prop += resume->stats.prop;
-            L_ADD(kill_count);
-            L_ADD(crystal_count);
-            L_ADD(pickup_count);
-            L_ADD(secret_count);
-            L_ADD(timer);
-            L_ADD(ammo_hits);
-            L_ADD(ammo_used);
-            L_ADD(medipacks_used);
-            L_ADD(distance_travelled);
-            L_ADD(death_count);
-#undef L_ADD
+        const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
+        if (stats != nullptr) {
+            M_SumStats(&result.stats, (const STATS_COMMON *)stats);
         }
-
-        const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-        if (max_stats != nullptr) {
-#define L_ADD(prop) result.max_stats.prop += max_stats->prop;
-            L_ADD(max_kill_count);
-            L_ADD(max_kill_ally_count);
-            L_ADD(max_kill_non_ally_count);
-            L_ADD(max_crystal_count);
-            L_ADD(max_pickup_count);
-            L_ADD(max_secret_count);
-            L_ADD(max_pickup_secret_count);
-#undef L_ADD
+        if (Stats_HasLevelMaxStats(level)) {
+            M_SumMaxStats(&result.max_stats, Stats_GetLevelMaxStats(level));
         }
     }
 

--- a/src/trx/game/stats/common.h
+++ b/src/trx/game/stats/common.h
@@ -46,4 +46,8 @@ void Stats_AddMedipacksUsed(double medipack_value);
 void Stats_AddDistanceTravelled(XYZ_32 pos, XYZ_32 last_pos);
 void Stats_MarkAlliesHostile(void);
 
+// Whether Lara has hurt an ally in this level. The kill maximum only holds the
+// allies against her once she has.
+bool Stats_HaveAlliesBeenHurt(const GF_LEVEL *level);
+
 FINAL_STATS Stats_ComputeFinalStats(bool include_bonus_levels);

--- a/src/trx/game/stats/common.h
+++ b/src/trx/game/stats/common.h
@@ -13,6 +13,16 @@ LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *level);
 // however many times the level is entered.
 void Stats_ResetLevel(const GF_LEVEL *level);
 
+// What the level is counted on in one category, or false where there is
+// nothing to count: a level with no scan behind it.
+bool Stats_GetCategory(
+    const GF_LEVEL *level, STATS_CATEGORY_ID id, STATS_CATEGORY *out);
+
+// Puts a count back. False where the category cannot take one: the secrets are
+// held as a mask and go through the secret verbs, so that the two agree.
+bool Stats_SetCategoryCount(
+    const GF_LEVEL *level, STATS_CATEGORY_ID id, uint32_t count);
+
 bool Stats_HasSecret(const GF_LEVEL *level, int16_t secret_idx);
 bool Stats_RemoveSecret(const GF_LEVEL *level, int16_t secret_idx);
 bool Stats_AddSecret(const GF_LEVEL *level, int16_t secret_idx);

--- a/src/trx/game/stats/common.h
+++ b/src/trx/game/stats/common.h
@@ -13,17 +13,11 @@ LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *level);
 // however many times the level is entered.
 void Stats_ResetLevel(const GF_LEVEL *level);
 
-int32_t Stats_GetSecretCount(void);
-
-// How many secrets the level counts towards completion, which is what the mask
-// holds less the ones the game flow marks unobtainable.
-int32_t Stats_GetMaxSecretCount(void);
-
-bool Stats_HasSecret(int16_t secret_idx);
-bool Stats_RemoveSecret(int16_t secret_idx);
-bool Stats_AddSecret(int16_t secret_idx);
-bool Stats_IsSecretValid(int16_t secret_idx);
-OBJECT_ID Stats_GetSecretObject(int32_t secret_idx);
+bool Stats_HasSecret(const GF_LEVEL *level, int16_t secret_idx);
+bool Stats_RemoveSecret(const GF_LEVEL *level, int16_t secret_idx);
+bool Stats_AddSecret(const GF_LEVEL *level, int16_t secret_idx);
+bool Stats_IsSecretValid(const GF_LEVEL *level, int16_t secret_idx);
+OBJECT_ID Stats_GetSecretObject(const GF_LEVEL *level, int32_t secret_idx);
 uint32_t Stats_GetSecretMaskForItem(const GF_LEVEL *level, int16_t item_num);
 
 void Stats_UpdateSecrets(LEVEL_STATS *stats);

--- a/src/trx/game/stats/common.h
+++ b/src/trx/game/stats/common.h
@@ -4,7 +4,17 @@
 #include <trx/game/game_flow/types.h>
 #include <trx/game/stats/types.h>
 
+// The counters the level keeps, or nullptr where there are none to keep: the
+// title screen and the cutscenes.
+LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *level);
+
+// Clears what the level counts, ready for it to be played. The death count
+// stands apart and is left alone: a death belongs to the level it happened on
+// however many times the level is entered.
+void Stats_ResetLevel(const GF_LEVEL *level);
+
 int32_t Stats_GetSecretCount(void);
+
 // How many secrets the level counts towards completion, which is what the mask
 // holds less the ones the game flow marks unobtainable.
 int32_t Stats_GetMaxSecretCount(void);

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -293,11 +293,16 @@ __attribute__((destructor)) static void M_Shutdown(void)
     m_StatsCapacity = 0;
 }
 
+bool Stats_HasLevelMaxStats(const GF_LEVEL *const level)
+{
+    return m_Stats != nullptr && level != nullptr
+        && GF_GetLevelTableType(level->type) == GFLT_MAIN && level->num >= 0
+        && level->num < m_StatsCapacity;
+}
+
 LEVEL_MAX_STATS *Stats_GetLevelMaxStats(const GF_LEVEL *const level)
 {
-    ASSERT(m_Stats != nullptr);
-    ASSERT(level != nullptr);
-    ASSERT(level->num >= 0 && level->num < m_StatsCapacity);
+    ASSERT(Stats_HasLevelMaxStats(level));
     return &m_Stats[level->num];
 }
 

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -96,18 +96,18 @@ static JSON_OBJECT *M_SerializeLevelMaxStats(const LEVEL_MAX_STATS *const stats)
         out, "max_pickup_secret_count",
         (int64_t)stats->max_pickup_secret_count);
     JSON_ObjectAppendInt64(
-        out, "max_kill_count", (int64_t)stats->max_kill_count);
+        out, "max_kill_count", (int64_t)stats->maxes[STATS_CAT_KILLS]);
     JSON_ObjectAppendInt64(
         out, "max_kill_ally_count", (int64_t)stats->max_kill_ally_count);
     JSON_ObjectAppendInt64(
         out, "max_kill_non_ally_count",
         (int64_t)stats->max_kill_non_ally_count);
     JSON_ObjectAppendInt64(
-        out, "max_crystal_count", (int64_t)stats->max_crystal_count);
+        out, "max_crystal_count", (int64_t)stats->maxes[STATS_CAT_CRYSTALS]);
     JSON_ObjectAppendInt64(
-        out, "max_pickup_count", (int64_t)stats->max_pickup_count);
+        out, "max_pickup_count", (int64_t)stats->maxes[STATS_CAT_PICKUPS]);
     JSON_ObjectAppendInt64(
-        out, "max_secret_count", (int64_t)stats->max_secret_count);
+        out, "max_secret_count", (int64_t)stats->maxes[STATS_CAT_SECRETS]);
     JSON_ObjectAppendInt64(out, "all_secrets_mask", stats->all_secrets_mask);
 
     JSON_ARRAY *const secret_item_masks = JSON_ArrayNew();
@@ -145,20 +145,20 @@ static bool M_DeserializeLevelMaxStats(
         return false;
     }
 
-    out->max_pickup_secret_count = (size_t)JSON_ObjectGetInt64(
+    out->max_pickup_secret_count = (uint32_t)JSON_ObjectGetInt64(
         obj, "max_pickup_secret_count", (int64_t)out->max_pickup_secret_count);
-    out->max_kill_count = (size_t)JSON_ObjectGetInt64(
-        obj, "max_kill_count", (int64_t)out->max_kill_count);
-    out->max_kill_ally_count = (size_t)JSON_ObjectGetInt64(
+    out->maxes[STATS_CAT_KILLS] = (uint32_t)JSON_ObjectGetInt64(
+        obj, "max_kill_count", (int64_t)out->maxes[STATS_CAT_KILLS]);
+    out->max_kill_ally_count = (uint32_t)JSON_ObjectGetInt64(
         obj, "max_kill_ally_count", (int64_t)out->max_kill_ally_count);
-    out->max_kill_non_ally_count = (size_t)JSON_ObjectGetInt64(
+    out->max_kill_non_ally_count = (uint32_t)JSON_ObjectGetInt64(
         obj, "max_kill_non_ally_count", (int64_t)out->max_kill_non_ally_count);
-    out->max_crystal_count = (size_t)JSON_ObjectGetInt64(
-        obj, "max_crystal_count", (int64_t)out->max_crystal_count);
-    out->max_pickup_count = (size_t)JSON_ObjectGetInt64(
-        obj, "max_pickup_count", (int64_t)out->max_pickup_count);
-    out->max_secret_count = (size_t)JSON_ObjectGetInt64(
-        obj, "max_secret_count", (int64_t)out->max_secret_count);
+    out->maxes[STATS_CAT_CRYSTALS] = (uint32_t)JSON_ObjectGetInt64(
+        obj, "max_crystal_count", (int64_t)out->maxes[STATS_CAT_CRYSTALS]);
+    out->maxes[STATS_CAT_PICKUPS] = (uint32_t)JSON_ObjectGetInt64(
+        obj, "max_pickup_count", (int64_t)out->maxes[STATS_CAT_PICKUPS]);
+    out->maxes[STATS_CAT_SECRETS] = (uint32_t)JSON_ObjectGetInt64(
+        obj, "max_secret_count", (int64_t)out->maxes[STATS_CAT_SECRETS]);
     out->all_secrets_mask = (uint32_t)JSON_ObjectGetInt64(
         obj, "all_secrets_mask", out->all_secrets_mask);
 
@@ -382,12 +382,12 @@ void Stats_CalculateMaxStats(void)
         LOG_INFO(
             "Level %d (%s)", GF_GetLevelOrdinalNumber(GFLT_MAIN, level),
             level->title);
-        LOG_INFO("    pickups:   %d", max_stats->max_pickup_count);
-        LOG_INFO("    kills:     %d", max_stats->max_kill_count);
+        LOG_INFO("    pickups:   %d", max_stats->maxes[STATS_CAT_PICKUPS]);
+        LOG_INFO("    kills:     %d", max_stats->maxes[STATS_CAT_KILLS]);
         LOG_INFO("      allies:  %d", max_stats->max_kill_ally_count);
         LOG_INFO("      enemies: %d", max_stats->max_kill_non_ally_count);
-        LOG_INFO("    crystals:  %d", max_stats->max_crystal_count);
-        LOG_INFO("    secrets:   %d", max_stats->max_secret_count);
+        LOG_INFO("    crystals:  %d", max_stats->maxes[STATS_CAT_CRYSTALS]);
+        LOG_INFO("    secrets:   %d", max_stats->maxes[STATS_CAT_SECRETS]);
 #endif
     }
 
@@ -397,18 +397,19 @@ finish:
     for (int32_t i = 0; i < level_table->count; i++) {
         const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
         const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-        if (max_stats->max_crystal_count != 0) {
+        if (max_stats->maxes[STATS_CAT_CRYSTALS] != 0) {
             m_GameHasCrystals = true;
             break;
         }
     }
 
     const FINAL_STATS final_stats = Stats_ComputeFinalStats(true);
-    LOG_INFO("Max pickups: %d", final_stats.max_stats.max_pickup_count);
-    LOG_INFO("Max kills:   %d", final_stats.max_stats.max_kill_count);
+    LOG_INFO("Max pickups: %d", final_stats.max_stats.maxes[STATS_CAT_PICKUPS]);
+    LOG_INFO("Max kills:   %d", final_stats.max_stats.maxes[STATS_CAT_KILLS]);
     LOG_INFO("  allies:    %d", final_stats.max_stats.max_kill_ally_count);
     LOG_INFO("  enemies:   %d", final_stats.max_stats.max_kill_non_ally_count);
-    LOG_INFO("Max crystals: %d", final_stats.max_stats.max_crystal_count);
-    LOG_INFO("Max secrets: %d", final_stats.max_stats.max_secret_count);
+    LOG_INFO(
+        "Max crystals: %d", final_stats.max_stats.maxes[STATS_CAT_CRYSTALS]);
+    LOG_INFO("Max secrets: %d", final_stats.max_stats.maxes[STATS_CAT_SECRETS]);
     Benchmark_End(&benchmark, nullptr);
 }

--- a/src/trx/game/stats/init.h
+++ b/src/trx/game/stats/init.h
@@ -3,6 +3,13 @@
 #include <trx/game/game_flow/types.h>
 #include <trx/game/stats/types.h>
 
+// Whether the scan has anything to say about this level. Only the levels of
+// the game proper are scanned, so a title, a cutscene or a demo has no maxima
+// and asking for them is a programming error.
+bool Stats_HasLevelMaxStats(const GF_LEVEL *level);
+
 LEVEL_MAX_STATS *Stats_GetLevelMaxStats(const GF_LEVEL *level);
+
 bool Stats_GameHasCrystals(void);
+
 void Stats_CalculateMaxStats(void);

--- a/src/trx/game/stats/scan.c
+++ b/src/trx/game/stats/scan.c
@@ -39,7 +39,7 @@ static void M_IncludeKillableItem(
         LOG_TRACE(
             "+%d pickups from carrier %d", Carrier_GetItemCount(item_num),
             item_num);
-        stats->max_pickup_count += Carrier_GetItemCount(item_num);
+        stats->maxes[STATS_CAT_PICKUPS] += Carrier_GetItemCount(item_num);
     }
 }
 
@@ -56,7 +56,7 @@ static uint32_t M_ReserveSecretConcreteBit(
     const uint32_t secret_bit = 1 << position;
     if (!(stats->all_secrets_mask & secret_bit)) {
         stats->all_secrets_mask |= secret_bit;
-        stats->max_secret_count++;
+        stats->maxes[STATS_CAT_SECRETS]++;
         if (object_id != NO_OBJECT) {
             stats->max_pickup_secret_count++;
         }
@@ -141,7 +141,7 @@ static void M_CheckTriggers(
                         && (Object_Get(O_PUZZLE_OPTION_2)->loaded
                             || Object_Get(O_PUZZLE_ITEM_2)->loaded)) {
                         LOG_TRACE("+1 pickup from dragon");
-                        stats->max_pickup_count++;
+                        stats->maxes[STATS_CAT_PICKUPS]++;
                     }
                 }
                 break;
@@ -200,12 +200,12 @@ static void M_CalculateStats(LEVEL_MAX_STATS *const stats)
             && !Carrier_IsItemCarried(i)) {
             LOG_TRACE(
                 "+1 pickup from pickup item %d in room %d", i, item->room_num);
-            stats->max_pickup_count++;
+            stats->maxes[STATS_CAT_PICKUPS]++;
         } else if (item->object_id == O_SAVE_CRYSTAL_ITEM) {
             LOG_TRACE(
                 "+1 crystal from save crystal item %d in room %d", i,
                 item->room_num);
-            stats->max_crystal_count++;
+            stats->maxes[STATS_CAT_CRYSTALS]++;
         }
     }
 
@@ -288,12 +288,12 @@ void Stats_ScanLevel(const GF_LEVEL *const level)
     BENCHMARK benchmark = Benchmark_Start();
     LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
     M_CalculateStats(max_stats);
-    max_stats->max_pickup_count += GF_GetSecretRewardCount(level);
-    max_stats->max_pickup_count -= level->unobtainable.pickups;
-    max_stats->max_secret_count -= level->unobtainable.secrets;
+    max_stats->maxes[STATS_CAT_PICKUPS] += GF_GetSecretRewardCount(level);
+    max_stats->maxes[STATS_CAT_PICKUPS] -= level->unobtainable.pickups;
+    max_stats->maxes[STATS_CAT_SECRETS] -= level->unobtainable.secrets;
     max_stats->max_kill_ally_count -= level->unobtainable.ally_kills;
     max_stats->max_kill_non_ally_count -= level->unobtainable.kills;
-    max_stats->max_kill_count =
+    max_stats->maxes[STATS_CAT_KILLS] =
         max_stats->max_kill_non_ally_count + max_stats->max_kill_ally_count;
     Benchmark_End(&benchmark, nullptr);
 }

--- a/src/trx/game/stats/types.h
+++ b/src/trx/game/stats/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/game/game_flow/types.h>
 #include <trx/game/objects/ids.h>
 #include <trx/game/stats/const.h>
 
@@ -51,3 +52,26 @@ typedef struct {
     STATS_COMMON stats;
     LEVEL_MAX_STATS max_stats;
 } FINAL_STATS;
+
+// One thing a level is counted on, which is one row of the statistics screen.
+typedef enum {
+    STATS_CAT_PICKUPS,
+    STATS_CAT_KILLS,
+    STATS_CAT_SECRETS,
+    STATS_CAT_CRYSTALS,
+    STATS_CAT_NUMBER_OF,
+} STATS_CATEGORY_ID;
+
+// What a level holds of one kind of thing, and how much of it Lara has. The
+// count is read at the moment the view is filled; the level and the id say
+// where it came from, so a writer can put a new one back.
+typedef struct {
+    const GF_LEVEL *level;
+    STATS_CATEGORY_ID id;
+    uint32_t count;
+    // What counts towards completion, which is what the level holds less the
+    // unobtainable part.
+    uint32_t max;
+    uint32_t raw;
+    uint32_t unobtainable;
+} STATS_CATEGORY;

--- a/src/trx/game/stats/types.h
+++ b/src/trx/game/stats/types.h
@@ -7,14 +7,25 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// One thing a level is counted on, which is one row of the statistics screen.
+typedef enum {
+    STATS_CAT_PICKUPS,
+    STATS_CAT_KILLS,
+    STATS_CAT_SECRETS,
+    STATS_CAT_CRYSTALS,
+    STATS_CAT_NUMBER_OF,
+} STATS_CATEGORY_ID;
+
 typedef struct {
-    size_t max_pickup_secret_count;
-    size_t max_kill_count;
-    size_t max_kill_ally_count;
-    size_t max_kill_non_ally_count;
-    size_t max_crystal_count;
-    size_t max_pickup_count;
-    size_t max_secret_count;
+    // What the level holds of each thing it is counted on, addressed by
+    // STATS_CATEGORY_ID, less what the game flow declares unobtainable.
+    uint32_t maxes[STATS_CAT_NUMBER_OF];
+    // How the kills divide, which the statistics screen needs: the allies only
+    // count against the player once she has hurt one.
+    uint32_t max_kill_ally_count;
+    uint32_t max_kill_non_ally_count;
+    // How many of the secrets are items to pick up rather than floor triggers.
+    uint32_t max_pickup_secret_count;
     uint32_t all_secrets_mask;
 
     struct {
@@ -30,17 +41,16 @@ typedef struct {
 } LEVEL_MAX_STATS;
 
 typedef struct STATS_COMMON {
+    // What Lara has of each thing the level is counted on, addressed by
+    // STATS_CATEGORY_ID.
+    uint32_t counts[STATS_CAT_NUMBER_OF];
+    // The rest is counted against nothing, so it stands on its own.
     uint32_t timer;
-    uint32_t kill_count;
     uint32_t ammo_used;
     uint32_t ammo_hits;
     uint32_t distance_travelled;
     double medipacks_used;
-    uint16_t crystal_count;
-    uint16_t pickup_count;
     int32_t death_count;
-    uint16_t secrets_mask;
-    uint16_t secret_count;
 } STATS_COMMON;
 
 typedef struct {
@@ -52,15 +62,6 @@ typedef struct {
     STATS_COMMON stats;
     LEVEL_MAX_STATS max_stats;
 } FINAL_STATS;
-
-// One thing a level is counted on, which is one row of the statistics screen.
-typedef enum {
-    STATS_CAT_PICKUPS,
-    STATS_CAT_KILLS,
-    STATS_CAT_SECRETS,
-    STATS_CAT_CRYSTALS,
-    STATS_CAT_NUMBER_OF,
-} STATS_CATEGORY_ID;
 
 // What a level holds of one kind of thing, and how much of it Lara has. The
 // count is read at the moment the view is filled; the level and the id say

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -196,24 +196,23 @@ static bool M_HasHurtAlliesEver(const bool include_bonus_levels)
     return false;
 }
 
-static void M_FormatIconSecrets(
-    char *const out, const LEVEL_STATS *const level_stats)
+static void M_FormatIconSecrets(char *const out, const GF_LEVEL *const level)
 {
     char *ptr = out;
     int32_t num_secrets = 0;
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
-        if (!Stats_IsSecretValid(i)) {
+        if (!Stats_IsSecretValid(level, i)) {
             continue;
         }
 
-        const bool has_secret = Stats_HasSecret(i);
+        const bool has_secret = Stats_HasSecret(level, i);
         if (!has_secret && out == ptr) {
             // Do not reserve space pointlessly.
             // Good: [secret][ ][ ]
             // Bad:  [ ][ ][secret] – should be just [secret]
             continue;
         }
-        const OBJECT_ID obj_id = Stats_GetSecretObject(i);
+        const OBJECT_ID obj_id = Stats_GetSecretObject(level, i);
         if (obj_id != NO_OBJECT) {
             int32_t secret_num = 0;
             for (int32_t j = 0; g_SecretObjects[j] != NO_OBJECT; j++) {
@@ -312,7 +311,7 @@ static void M_RowFromRole(
 
     case M_ROW_ICON_SECRETS: {
         char buf[256];
-        M_FormatIconSecrets(buf, (LEVEL_STATS *)s->stats);
+        M_FormatIconSecrets(buf, GF_GetLevel(GFLT_MAIN, s->args.level_num));
         M_Row(s, GS("general/stats/secrets"), buf);
         break;
     }

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -150,10 +150,10 @@ static void M_AdjustMaxKills(
         return;
     }
     s->adjusted_max_stats = *s->max_stats;
-    s->adjusted_max_stats.max_kill_count =
+    s->adjusted_max_stats.maxes[STATS_CAT_KILLS] =
         s->adjusted_max_stats.max_kill_non_ally_count;
     if (include_allies) {
-        s->adjusted_max_stats.max_kill_count +=
+        s->adjusted_max_stats.maxes[STATS_CAT_KILLS] +=
             s->adjusted_max_stats.max_kill_ally_count;
     }
     s->max_stats = &s->adjusted_max_stats;
@@ -320,31 +320,33 @@ static void M_RowFromRole(
         M_Row(
             s, GS("general/stats/secrets"),
             String_FormatStatic(
-                GS("general/stats/detail_fmt"), s->stats->secret_count,
-                s->max_stats->max_secret_count));
+                GS("general/stats/detail_fmt"),
+                s->stats->counts[STATS_CAT_SECRETS],
+                s->max_stats->maxes[STATS_CAT_SECRETS]));
         break;
 
     case M_ROW_CRYSTALS:
         M_Row(
             s, GS("general/stats/crystals"),
             String_FormatStatic(
-                num_fmt, s->stats->crystal_count,
-                s->max_stats->max_crystal_count));
+                num_fmt, s->stats->counts[STATS_CAT_CRYSTALS],
+                s->max_stats->maxes[STATS_CAT_CRYSTALS]));
         break;
 
     case M_ROW_PICKUPS:
         M_Row(
             s, GS("general/stats/pickups"),
             String_FormatStatic(
-                num_fmt, s->stats->pickup_count,
-                s->max_stats->max_pickup_count));
+                num_fmt, s->stats->counts[STATS_CAT_PICKUPS],
+                s->max_stats->maxes[STATS_CAT_PICKUPS]));
         break;
 
     case M_ROW_KILLS:
         M_Row(
             s, GS("general/stats/kills"),
             String_FormatStatic(
-                num_fmt, s->stats->kill_count, s->max_stats->max_kill_count));
+                num_fmt, s->stats->counts[STATS_CAT_KILLS],
+                s->max_stats->maxes[STATS_CAT_KILLS]));
         break;
 
     case M_ROW_DEATHS:
@@ -465,11 +467,11 @@ static bool M_EmitConfiguredStatsRows(
         if (g_Config.ui.stats.show_pickups) {
             has_rows |= emit_row_func(s, M_ROW_PICKUPS, 0);
         }
-        if (M_ShowCrystals() && s->max_stats->max_crystal_count != 0) {
+        if (M_ShowCrystals() && s->max_stats->maxes[STATS_CAT_CRYSTALS] != 0) {
             has_rows |= emit_row_func(s, M_ROW_CRYSTALS, 0);
         }
         if (g_Config.ui.stats.show_secrets
-            && s->max_stats->max_secret_count != 0) {
+            && s->max_stats->maxes[STATS_CAT_SECRETS] != 0) {
             has_rows |= emit_row_func(s, M_ROW_AUTO_SECRETS, 0);
         }
         if (g_Config.ui.stats.show_time_taken) {
@@ -480,10 +482,10 @@ static bool M_EmitConfiguredStatsRows(
             has_rows |= emit_row_func(s, M_ROW_TIMER, 0);
         }
         if (g_Config.ui.stats.show_secrets
-            && s->max_stats->max_secret_count != 0) {
+            && s->max_stats->maxes[STATS_CAT_SECRETS] != 0) {
             has_rows |= emit_row_func(s, M_ROW_AUTO_SECRETS, 0);
         }
-        if (M_ShowCrystals() && s->max_stats->max_crystal_count != 0) {
+        if (M_ShowCrystals() && s->max_stats->maxes[STATS_CAT_CRYSTALS] != 0) {
             has_rows |= emit_row_func(s, M_ROW_CRYSTALS, 0);
         }
         if (g_Config.ui.stats.show_pickups) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`trx.stats` now represents the complete statistics for the current level, rather than just its secrets. Statistics for any other level are available through `trx.game.Level.stats`.

Each category – `pickups`, `kills`, `secrets`, `crystals` – carries:

- `count` – how many Lara has
- `max` – how many count towards completing the level
- `raw` – how many the level holds
- `unobtainable` – how many the game flow marks out of reach

`count` is writable; the other three are what the level and the game flow say. Secrets are the exception and go through `give_secret` and `take_secret`, which keep the underlying secret mask in sync.

The module also exposes:

- `timer`
- `deaths`
- `ammo_used`, `ammo_hits`
- `distance_travelled`
- `medipacks_used`
- `max_ally_kills`, `max_enemy_kills`
- `allies_hurt`
- `secret_list()`

The statistics screen holds the allies against the player only once she has hurt one, so a Lua screen can now match it: `max_enemy_kills + (allies_hurt and max_ally_kills or 0)`.

Because every level's statistics are now readable, Lua can build per-level or per-hub statistics screens. Previously, the engine only exposed a single final total, calculated in C from a fixed set of levels.

Like `trx.lara`, `trx.stats` is itself an instance of the type it exposes. This means the current level and any other level share the same API. Methods retrieved through the module are automatically bound to the current level, so `trx.stats.give_secret(1)` and `trx.stats:give_secret(1)` are equivalent.

Internally:

- `STATS_COMMON.counts[]` and `LEVEL_MAX_STATS.maxes[]`, indexed by `STATS_CATEGORY_ID`, replace four named counters and four named maxima
- `Stats_GetCategory()` answers for any of them, so the per-category switches are gone
- `Stats_GetLevelStats()`, `Stats_ResetLevel()` and the secret verbs take a level, so nothing reads the level being played implicitly
- savegame and `max_stats.cache.json` keys are unchanged, so existing saves and caches load without modification

Nothing changes for players.

#### Testing

- [x] Spot-check statistic counts in levels that have unavailable entities, one for each category (with fresh cache)
- [x] Light regression checks for the `/secret` command