### PR TITLE
lara/col/land: ignore step glitch fix in QWOP state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 - fixed the inventory hint for using an item showing Enter rather than the key bound to Action (regression from 1.8.1)
 - fixed the black surround of the binoculars turning grey when looking in certain directions (regression from 1.9)
 - fixed a new game, or a level started from Play Any Level, running in the game mode the previous game was started in
+- fixed a shaky start to the QWOP animation if the option to fix the step glitch is enabled (regression from TR2X 0.8)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -197,6 +197,12 @@ static void M_CollideStop(ITEM *const item, const COLL_INFO *const coll)
     Item_SwitchToAnim(item, LA(LA_STAND_STILL), 0);
 }
 
+static bool M_IsQWOPState(const ITEM *const item)
+{
+    return item->current_anim_state == LS(LS_RUN)
+        && (item->gravity || item->fall_speed != 0);
+}
+
 static void M_Default(ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -438,7 +444,7 @@ static void M_Run(ITEM *const item, COLL_INFO *const coll)
 
     if (coll->side_mid.floor >= -STEPUP_HEIGHT
         && coll->side_mid.floor < -STEP_L / 2) {
-        if (g_Config.gameplay.fix_step_glitch
+        if (g_Config.gameplay.fix_step_glitch && !M_IsQWOPState(item)
             && (coll->side_front.floor < -STEPUP_HEIGHT
                 || coll->side_front.floor >= -STEP_L / 2)) {
             coll->side_mid.floor = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids the fix for the step glitch interfering with QWOP. It's impossible to step glitch from a QWOP anyway as hitting the wall during that move would reset the QWOP state. Recording available in the ticket.

Resolves TRX870.
