### PR TITLE
rooms: bleed statics into the rooms they fill

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,7 @@
 
 **TR3**
 - fixed Willard being visible outside the hut at the beginning of the cutscene following Antarctica (resolves #5929)
+- fixed scenery that leans out of its room, such as the streetlight glow in It's a Madhouse!, flickering as the camera turns (OG bug)
 - fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)
 - fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
 - fixed a crash when a level holds fewer raptors than its raptor emitters can send out

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -12,9 +12,7 @@
 
 #include <string.h>
 
-static inline bool M_BoundsIntersectsPortal(
-    const STATIC_MESH *const mesh, const ROOM *const room,
-    const PORTAL *const portal)
+static inline BOUNDS_32 M_GetStaticBounds(const STATIC_MESH *const mesh)
 {
     const STATIC_OBJECT_3D *const obj = Object_Get3DStatic(mesh->static_num);
 
@@ -52,7 +50,43 @@ static inline bool M_BoundsIntersectsPortal(
         }
     }
 
-    return Bounds32_Intersect(&bounds, &portal->bounds);
+    return bounds;
+}
+
+// Whether the mesh stands in any of the space the room owns. A room's box says
+// little on its own, since two rooms side by side cover much the same ground,
+// so the question is put to the sectors the mesh spans: the room holds that
+// column between its ceiling and its floor there, and a wall sector holds
+// nothing.
+static inline bool M_BoundsReachRoom(
+    const BOUNDS_32 *const bounds, const ROOM *const room)
+{
+    int32_t x_min = (bounds->min.x - room->pos.x) >> WALL_SHIFT;
+    int32_t x_max = (bounds->max.x - room->pos.x) >> WALL_SHIFT;
+    int32_t z_min = (bounds->min.z - room->pos.z) >> WALL_SHIFT;
+    int32_t z_max = (bounds->max.z - room->pos.z) >> WALL_SHIFT;
+    if (x_max < 0 || z_max < 0 || x_min >= room->size.x
+        || z_min >= room->size.z) {
+        return false;
+    }
+    CLAMP(x_min, 0, room->size.x - 1);
+    CLAMP(x_max, 0, room->size.x - 1);
+    CLAMP(z_min, 0, room->size.z - 1);
+    CLAMP(z_max, 0, room->size.z - 1);
+
+    for (int32_t x = x_min; x <= x_max; x++) {
+        for (int32_t z = z_min; z <= z_max; z++) {
+            const SECTOR *const sector = Room_GetUnitSector(room, x, z);
+            if (sector->floor.height <= sector->ceiling.height) {
+                continue;
+            }
+            if (bounds->min.y < sector->floor.height
+                && bounds->max.y > sector->ceiling.height) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 static void M_ComputePortalBounds(void)
@@ -130,7 +164,8 @@ static void M_FixStaticsVisibility(void)
             for (int32_t m = 0; m < orig_count; m++) {
                 const STATIC_MESH *const mesh =
                     Vector_Get(room_stat_vecs[i], m);
-                if (!M_BoundsIntersectsPortal(mesh, room, portal)) {
+                const BOUNDS_32 bounds = M_GetStaticBounds(mesh);
+                if (!M_BoundsReachRoom(&bounds, dest_room)) {
                     continue;
                 }
                 if (Vector_Contains(room_stat_vecs[portal->room_num], mesh)) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Whether a static reaches a neighbouring room was asked of the portal quad alone, which is flat, so a mesh clearing it entirely never bled and stayed clipped to its own room's window. The room is now asked whether it owns any of the space the mesh stands in, sector by sector.

The streetlights in It's a Madhouse! sit above their room's ceiling: the post crosses the ceiling portal and stayed, while the glow above it cleared the portal and came and went as the camera turned.

Resolves TRX854

#### Testing

- [x] The street lamp in It's a Madhouse!
- [x] The Bartoli gazebo
- [x] Spot check for regressions with a couple of statics known to protrude across rooms. These are reported when the level loads as such:

    ```
    WRN | 2026-07-31 13:24:02.906 [game/level/finalize/rooms.c:177:M_FixStaticsVisibility] Static #20 bleeds into room #53
    WRN | 2026-07-31 13:24:02.906 [game/level/finalize/rooms.c:177:M_FixStaticsVisibility] Static #25 bleeds into room #53
    WRN | 2026-07-31 13:24:02.906 [game/level/finalize/rooms.c:177:M_FixStaticsVisibility] Static #25 bleeds into room #52
    WRN | 2026-07-31 13:24:02.906 [game/level/finalize/rooms.c:177:M_FixStaticsVisibility] Static #24 bleeds into room #52
    WRN | 2026-07-31 13:24:02.906 [game/level/finalize/rooms.c:177:M_FixStaticsVisibility] Static #24 bleeds into room #64
    ```

    Try to look at them from across different rooms and get them to flicker.
