### PR TITLE
items: queue items into the rooms they reach

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,7 @@
 **TR3**
 - fixed Willard being visible outside the hut at the beginning of the cutscene following Antarctica (resolves #5929)
 - fixed scenery that leans out of its room, such as the streetlight glow in It's a Madhouse!, flickering as the camera turns (OG bug)
+- fixed enemies and objects that reach out of their room, such as the Loch Ness monster in Highland Fling, flickering as the camera turns (OG bug)
 - fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)
 - fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
 - fixed a crash when a level holds fewer raptors than its raptor emitters can send out

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -34,11 +34,12 @@ static HANDLE_REGISTRY m_ItemHandles;
 static inline bool M_ItemBoundsIntersectsPortal(
     const ITEM *item, const ROOM *room, const PORTAL *const portal)
 {
-    // Axis-aligned bound intersection; ignores item rotation.
-    const BOUNDS_16 *const frame_bounds = &Item_GetBestFrame(item)->bounds;
-    if (frame_bounds == nullptr) {
-        return false;
-    }
+    // Axis-aligned bound intersection; ignores item rotation. The object's
+    // whole-animation box stands in for the frame being drawn, so an item
+    // that only reaches the neighbour partway through its animation is
+    // queued there from the start and the queue never has to be redone.
+    const BOUNDS_16 *const frame_bounds =
+        &Object_Get(item->object_id)->anim_bounds;
     const BOUNDS_32 bounds = {
         .min = {
             item->pos.x + frame_bounds->min.x,
@@ -78,6 +79,28 @@ static void M_RemoveFromDrawQueues(
     if (room != nullptr && room->portals != nullptr) {
         for (int32_t i = 0; i < room->portals->count; i++) {
             Room_RemoveDrawnItem(room->portals->portal[i].room_num, item_num);
+        }
+    }
+}
+
+// Put the item into a room's draw queues: the room itself and every portal
+// neighbour its box reaches into. Additive, so a queue an object's initialiser
+// arranged for itself - the far side of a door - is left alone.
+static void M_AddToDrawQueues(const int16_t item_num, const int16_t room_num)
+{
+    if (room_num == NO_ROOM) {
+        return;
+    }
+    Room_AddDrawnItem(room_num, item_num);
+    const ROOM *const room = Room_Get(room_num);
+    if (room == nullptr || room->portals == nullptr) {
+        return;
+    }
+    const ITEM *const item = &m_Items[item_num];
+    for (int32_t i = 0; i < room->portals->count; i++) {
+        const PORTAL *const portal = &room->portals->portal[i];
+        if (M_ItemBoundsIntersectsPortal(item, room, portal)) {
+            Room_AddDrawnItem(portal->room_num, item_num);
         }
     }
 }
@@ -653,18 +676,7 @@ void Item_UpdateRoom(const int16_t item_num, const int16_t room_num)
     const int16_t old_room_num = item->room_num;
 
     M_RemoveFromDrawQueues(item_num, old_room_num);
-    if (room_num != NO_ROOM) {
-        Room_AddDrawnItem(room_num, item_num);
-        const ROOM *const neighbor_room = Room_Get(room_num);
-        if (neighbor_room != nullptr && neighbor_room->portals != nullptr) {
-            for (int32_t i = 0; i < neighbor_room->portals->count; i++) {
-                const PORTAL *const portal = &neighbor_room->portals->portal[i];
-                if (M_ItemBoundsIntersectsPortal(item, neighbor_room, portal)) {
-                    Room_AddDrawnItem(portal->room_num, item_num);
-                }
-            }
-        }
-    }
+    M_AddToDrawQueues(item_num, room_num);
 
     if (old_room_num != room_num) {
         M_UnlinkChain(item_num, old_room_num);
@@ -690,6 +702,16 @@ void Item_UpdateRoom(const int16_t item_num, const int16_t room_num)
             };
             LUA_FireEventEx(LUA_EVENT_ROOM_CHANGE, args, 3);
         }
+    }
+}
+
+// Seed every item's draw queues once the rooms are in place. Item_Initialise
+// runs before the portals have their bounds, so the neighbour test can only be
+// answered here.
+void Item_InitialiseDrawQueues(void)
+{
+    for (int32_t i = 0; i < m_LevelItemCount; i++) {
+        M_AddToDrawQueues(i, m_Items[i].room_num);
     }
 }
 

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -141,6 +141,7 @@ void Item_SetVisible(ITEM *item, bool value);
 void Item_SetFinished(ITEM *item, bool value);
 
 void Item_UpdateRoom(int16_t item_num, int16_t room_num);
+void Item_InitialiseDrawQueues(void);
 
 int32_t Item_GlobalReplace(OBJECT_ID src_obj_id, OBJECT_ID dst_obj_id);
 

--- a/src/trx/game/level/finalize/gameplay_objects.c
+++ b/src/trx/game/level/finalize/gameplay_objects.c
@@ -1,3 +1,5 @@
+#include <trx/core/utils.h>
+#include <trx/game/anims.h>
 #include <trx/game/inject.h>
 #include <trx/game/items.h>
 #include <trx/game/items/walkable.h>
@@ -145,12 +147,44 @@ static void M_PrepareTR4Items(LEVEL_CONTEXT *const ctx)
     }
 }
 
+static void M_ComputeAnimBounds(void)
+{
+    for (int32_t i = O_FIRST; i < O_NUMBER_OF; i++) {
+        OBJECT *const obj = Object_Get(i);
+        BOUNDS_16 bounds = {
+            .min = { INT16_MAX, INT16_MAX, INT16_MAX },
+            .max = { INT16_MIN, INT16_MIN, INT16_MIN },
+        };
+        for (int32_t j = 0; j < obj->anim_count; j++) {
+            const ANIM *const anim = Anim_GetAnim(obj->anim_idx + j);
+            if (anim->frame_ptr == nullptr || anim->interpolation == 0) {
+                continue;
+            }
+            const int32_t frame_count =
+                (anim->frame_end - anim->frame_base) / anim->interpolation + 1;
+            for (int32_t k = 0; k < frame_count; k++) {
+                const BOUNDS_16 *const frame_bounds =
+                    &anim->frame_ptr[k].bounds;
+                bounds.min.x = MIN(bounds.min.x, frame_bounds->min.x);
+                bounds.min.y = MIN(bounds.min.y, frame_bounds->min.y);
+                bounds.min.z = MIN(bounds.min.z, frame_bounds->min.z);
+                bounds.max.x = MAX(bounds.max.x, frame_bounds->max.x);
+                bounds.max.y = MAX(bounds.max.y, frame_bounds->max.y);
+                bounds.max.z = MAX(bounds.max.z, frame_bounds->max.z);
+            }
+        }
+        obj->anim_bounds =
+            bounds.min.x > bounds.max.x ? (BOUNDS_16) {} : bounds;
+    }
+}
+
 void Level_Finalize_LoadObjectsAndItems(LEVEL_CONTEXT *const ctx)
 {
     // Object and item setup/initialisation must take place after injections
     // have been processed. A cached item count must be used as individual
     // initialisations may increment the total item count.
     Object_SetupAllObjects();
+    M_ComputeAnimBounds();
     Walkable_ResetLevel();
     // Must precede Item_Initialise() below, which creates the ropes.
     Rope_Reset();

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -6,6 +6,7 @@
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_buf.h>
+#include <trx/game/items.h>
 #include <trx/game/level/finalize.h>
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
@@ -238,4 +239,5 @@ void Level_Finalize_LoadRooms(LEVEL_CONTEXT *const ctx)
     M_ComputePortalBounds();
     M_FixStaticsCollision();
     M_FixStaticsVisibility();
+    Item_InitialiseDrawQueues();
 }

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -104,6 +104,10 @@ typedef struct OBJECT {
 
     int16_t anim_idx;
     int16_t anim_count;
+    // The widest box any of the object's frames reaches. Unlike the box of
+    // the frame being drawn, it does not change as the object animates, so a
+    // decision taken from it holds for the whole level.
+    BOUNDS_16 anim_bounds;
     int16_t pivot_length;
     int16_t radius;
     int16_t shadow_size;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

An item is now offered to the neighbouring rooms it reaches into as soon as the level's rooms are in place, and the question is decided from the widest box any of the object's frames reaches rather than from the box of the frame currently being drawn.

Before this, a neighbour was only offered an item when that item's room was recomputed. That never happens for one that stands still, so such an item stayed queued in its own room alone for the whole level and vanished whenever that room dropped out of the draw list, even while the room it was leaning into was still on screen. The box that settled the question came from the frame on screen too, so the answer went stale the moment the item animated. Doing this at `Item_Initialise` is not an option, as it runs before the portals have their bounds.

The Loch Ness monster in Highland Fling shows both halves: it stands in one room and rears up through the ceiling into the one above, and it flickered in and out as the camera turned.

For players, enemies and objects that lean out of the room they belong to no longer come and go with the camera angle.

Resolves TRX874. Ref. f6bd91f785 and d2d20fd49c

#### Testing

- [x] Loch Ness Monster from the recording is now visible at all times

Regressions:

- [x] #2005 Vilcabamba entrance gates; Catacombs room 30, walk Lara forward and watch the trapdoor
- [x] #2438 Cowboy sometimes loses his head (TR1, OG bug)
- [x] #2452 City of Khamoon trapdoors and the cat statue's faces;
- [x] #3668 Atlantean Stronghold: `/play 3`, `/tp 16`
- [x] #1870 TR2 Lara's Home
- [x] The helicopter in Highland Fling crossing portals
- [x] Fish crossing room boundaries
- [x] Bats leaving their spawn room
- [x] The animating diver in Sleeping with the Fishes
- [x] #5929 Willard in the Antarctica cutscene

The changes here make things visible in _more_ rooms, so the risk runs the other way too.
The sharpest test is #2393, which has exact steps: `/play 10`, drop through the opening, kill the barracudas with a conventional weapon, `/tp 51 4 48`, then move the camera. Only the "visible" half is in scope — targeting doesn't go through this code.
