### PR TITLE
tools/lua_docs: indent a structure's description

### DIFF
--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -239,7 +239,7 @@ def render_enum(spec: dict) -> list[str]:
             head += f" - {count} names"
         out = [head, ""]
         if spec.get("description"):
-            out.append(f"{INDENT}{spec['description']}")
+            out.extend(render_prose(spec["description"], INDENT))
             out.append("")
         out.extend(render_examples(spec.get("examples"), INDENT))
         out.extend(render_enum_names(spec.get("names"), INDENT))
@@ -248,7 +248,7 @@ def render_enum(spec: dict) -> list[str]:
 
     out = [f"- [lua]`trx.{spec['path']}`", ""]
     if spec.get("description"):
-        out.append(f"{INDENT}{spec['description']}")
+        out.extend(render_prose(spec["description"], INDENT))
         out.append("")
     for value in spec.get("values") or []:
         out.append(f"{INDENT}- `trx.{spec['path']}.{value['name']}` = `{value['value']}`  ")
@@ -273,7 +273,7 @@ def render_property(spec: dict) -> list[str]:
 def render_type(spec: dict) -> list[str]:
     out = [f"- [lua]`trx.{spec['path']}`", ""]
     if spec.get("description"):
-        out.append(f"{INDENT}{spec['description']}")
+        out.extend(render_prose(spec["description"], INDENT))
         out.append("")
     out.append(
         f"{INDENT}Handles are live references: if the underlying object is destroyed,"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A type or enum description that runs to more than one paragraph was indented on its first line alone, so the rest ended the list item and landed at the page's top level. `render_prose` was written for exactly this and three callers were not using it, which could result in the Lua doc getting misrendered.

(No docs used this yet, so we haven't ran into it anywhere yet.)