### PR TITLE
stats: guard the secret mask against demo levels

### DIFF
--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -312,15 +312,11 @@ OBJECT_ID Stats_GetSecretObject(
 uint32_t Stats_GetSecretMaskForItem(
     const GF_LEVEL *const level, const int16_t item_num)
 {
-    if (level == nullptr) {
+    if (!Stats_HasLevelMaxStats(level)) {
         return 0;
     }
 
     const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
-    if (max_stats == nullptr) {
-        return 0;
-    }
-
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
         if (max_stats->secret_item_masks[i].item_num == item_num) {
             return max_stats->secret_item_masks[i].secret_mask;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Starting a TR2 demo crashed on an assertion: demo levels live in their own level table and have no max stats, but the pickup initialiser asked for a secret mask regardless. Stats_GetSecretMaskForItem now checks for max stats up front, as Stats_GetSecretObject does.

Resolves TRX885