### PR TITLE
objects/rx_worker_3: fix patrol behavior

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - fixed the body bag trigger to also collect Bacon Lara, Qualopec Mummy and Skidoo Driver's corpses
 - fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
+- fixed RX Worker 3 in custom levels always looking at Lara when setup with patrol objects, and not properly detecting when she comes into range
 - fixed Lara getting stuck on ropes if she enters the fly cheat while still using one (regression from 1.9)
 - fixed the inventory hint for using an item showing Enter rather than the key bound to Action (regression from 1.8.1)
 - fixed the black surround of the binoculars turning grey when looking in certain directions (regression from 1.9)

--- a/src/trx/game/objects/creatures/rx_worker_3.c
+++ b/src/trx/game/objects/creatures/rx_worker_3.c
@@ -330,7 +330,7 @@ static void M_Control(const int16_t item_num)
     // bite and distance when the creature is friendly.
     ITEM *const lara_item = Lara_GetItem();
     const bool hurt_by_lara = creature->hurt_by_lara;
-    ITEM *const enemy = creature->enemy;
+    ITEM *enemy = creature->enemy;
     if (enemy == nullptr) {
         creature->enemy = lara_item;
         creature->hurt_by_lara = true;
@@ -358,9 +358,13 @@ static void M_Control(const int16_t item_num)
         lara_info.distance = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
     }
 
-    Creature_Mood(item, &info, false);
+    Creature_Mood(item, &info, !is_ally);
     angle = Creature_Turn(item, creature->maximum_turn);
 
+    enemy = creature->enemy;
+    if (!is_ally) {
+        creature->enemy = lara_item;
+    }
     if (item->hit_status
         || (!is_ally
             && (lara_info.distance < M_ALERT_DIST
@@ -370,6 +374,7 @@ static void M_Control(const int16_t item_num)
         }
         Creature_AlertAllGuards(item_num);
     }
+    creature->enemy = enemy;
 
     switch (item->current_anim_state) {
     case M_STATE_STOP:
@@ -416,6 +421,7 @@ static void M_Control(const int16_t item_num)
             item->goal_anim_state = M_STATE_STOP;
         } else if ((item->ai_bits & AI_PATROL_1) != 0) {
             item->goal_anim_state = M_STATE_WALK;
+            head = 0;
         } else if (creature->mood == MOOD_ESCAPE) {
             item->goal_anim_state = M_STATE_WALK;
         } else if (


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the flamethrowers from RX-Tech Mines always looking at Lara when they are on patrol, and resolves them not being alerted when Lara comes into view. This patrolling setup is not present in the OG levels.

Test level available for this setup; a quick check of RX-Tech Mines would be good too.

Resolves TRX888.
