### PR TITLE
Improve documentation for trx.query

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -4435,18 +4435,38 @@
       "path": "objects.swap_sprite"
     },
     {
-      "description": "Builds the identity query for a domain. `trx.objects` and `trx.items` call this to make the query a script reaches through `trx.objects.query` and `trx.items.query`.",
+      "description": "Builds a narrowing method for a domain's query type out of a predicate factory. `trx.items` and `trx.objects` declare their own filters with it.",
       "params": [
         {
-          "description": "What the query runs against: `enumerate`, `id_of`, `filters`, and an optional `names_of`/`default_names_of` name layer. See the module source.",
+          "description": "Called with the method's own arguments, returning a `predicate(id, handle)`.",
+          "name": "make",
+          "type": "function"
+        }
+      ],
+      "path": "query.narrowing",
+      "returns": {
+        "description": "The method to declare as an `impl`.",
+        "type": "function"
+      }
+    },
+    {
+      "description": "Builds the identity query over a domain, as an instance of that domain's query type. `trx.objects` and `trx.items` call this to make the query a script reaches through `trx.objects.query` and `trx.items.query`.",
+      "params": [
+        {
+          "description": "What the query runs against: `enumerate`, `id_of`, `searchable`, and an optional `names_of`/`default_names_of` name layer. See the module source.",
           "name": "domain",
+          "type": "table"
+        },
+        {
+          "description": "The query type the domain's narrowings were declared on.",
+          "name": "class",
           "type": "table"
         }
       ],
       "path": "query.new",
       "returns": {
         "description": "The identity query, matching everything until narrowed.",
-        "type": "table"
+        "type": "Query"
       }
     },
     {
@@ -5018,7 +5038,7 @@
       "title": "Object"
     },
     {
-      "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; you narrow one down and then read\nthe result.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nFour ways to narrow, which mix freely:\n\n- Chain methods read left to right and combine with AND:\n  `q:spawnable():by_name(\"wolf\")`. Each domain adds its own - see\n  `trx.objects.query` and `trx.items.query` for the ones it has.\n- The operators `&`, `|` and `~` are AND, OR and NOT over whole queries, for\n  what a chain cannot say: `q:pickup() | q:inventory_item()`, `~q:animation()`.\n  Both sides of `&`/`|` must come from the same domain.\n- `by_name(name)` ranks rather than filters: it matches the way a player types\n  a name, forgivingly, and orders what survives the rest of the query best\n  first. Some of a domain's filters are also searchable groups - `pickup` is\n  one - so their name matches every member. Only a domain that has names offers\n  `by_name`, `names` and `best`.\n- `where(predicate)` narrows by a test of your own, called with the id and the\n  handle, for what a domain does not name: `q:where(function(id, item) return\n  item.timer > 0 end)`.\n\nRead a query with a terminal:\n\n- `ids()` - the matching ids, a list. For objects these are object ids; for\n  items, their numbers.\n- `matches()` - the matching handles: `trx.objects.Object`s or\n  `trx.items.Item`s.\n- `first()` - the first matching handle, or `nil`.\n- `count()` - how many match.\n- `names()` - every name the matches answer to, for offering completions. The\n  group names any match belongs to come first.\n- `best()` - the ids tied for the best `by_name` score: one for a name only one\n  thing answers to, the whole group for a group name.\n",
+      "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; you narrow one down and then read\nthe result.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nEach domain adds narrowings of its own on top of the ones below - see\n`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read\nleft to right, combining with AND: `q:spawnable():by_name(\"wolf\")`.\n",
       "name": "query",
       "order": 9,
       "title": "Query"
@@ -5231,9 +5251,9 @@
       "writable": false
     },
     {
-      "description": "The identity query over every item in the level. Narrow it and read it - see [Query](../../QUERY.md).\n\nIts own narrowings, beyond the operators: `simulated`, `present`, `visible`, `finished`, `in_play`, `alive`, `targetable`, `of_object` (by object id or name) and `in_room`.\n\nExample: `trx.items.query:of_object(\"wolf\"):simulated():matches()`.",
+      "description": "The identity query over every item in the level. Narrow it and read it - see `trx.items.ItemQuery`.",
       "path": "items.query",
-      "type": "table",
+      "type": "ItemQuery",
       "writable": false
     },
     {
@@ -5315,9 +5335,9 @@
       "writable": false
     },
     {
-      "description": "The identity query over every object definition. Narrow it and read it - see\n[Query](../../QUERY.md).\n\nIts own narrowings, beyond the shared `by_name` and the operators: the states\n`loaded` and `spawnable`, and the families `creature`, `enemy`, `loyal`,\n`pickup`, `switch`, `receptacle`, `pushable`, `door`, `inventory_item`,\n`null_object` and `animation`.\n\n`pickup` narrows further, by what the thing is: `gun`, `ammo` for its clips,\n`supply` for what Lara spends, `tool` for what she carries and uses, and\n`key`, `puzzle`, `quest`, `examine` and `collectible` for the slot-numbered\nitems, by the slot each fills. `quest` carries the scion. `secret` is the\ntrinket a secret trigger sits under. These do not cover `pickup` between them:\na second state of something Lara already carries, such as a part-full\nwaterskin, is in none of them.\n\nEvery family is searchable: a `by_name` of the family's own name\nmatches every member, and `names` offers it for completion. Which families a\nquery answers to follows from what it kept, so one narrowed to what fights\noffers no `pickup`.\n\nExample: `trx.objects.query:spawnable():by_name(\"wolf\"):ids()`.",
+      "description": "The identity query over every object definition. Narrow it and read it - see `trx.objects.ObjectQuery`.",
       "path": "objects.query",
-      "type": "table",
+      "type": "ObjectQuery",
       "writable": false
     },
     {
@@ -6403,6 +6423,105 @@
       "path": "items.Item"
     },
     {
+      "description": "A `trx.query.Query` over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `of_object` is how a name reaches them.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "The item still has hit points.",
+          "name": "alive",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item has run its course.",
+          "name": "finished",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item is part of the game rather than set aside.",
+          "name": "in_play",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item is in the given room.",
+          "name": "in_room",
+          "params": [
+            {
+              "description": "0-based room number.",
+              "name": "room_num",
+              "type": "integer"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item is of the given object, named the way a player would name it or by its id.",
+          "examples": [
+            "trx.items.query:of_object(\"wolf\"):simulated():matches()"
+          ],
+          "name": "of_object",
+          "params": [
+            {
+              "description": "Object id, or a name `trx.objects.query` resolves.",
+              "name": "key",
+              "type": "any"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item is in the world, whether or not anything is simulating it.",
+          "name": "present",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item is being simulated: its control routine runs every frame.",
+          "name": "simulated",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "Lara's guns can lock onto the item.",
+          "name": "targetable",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item is drawn.",
+          "name": "visible",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "items.ItemQuery"
+    },
+    {
       "description": "Lara's own state, reachable straight off `trx.lara`.",
       "extensions": [],
       "fields": [
@@ -6820,6 +6939,328 @@
       ],
       "operators": [],
       "path": "objects.Object"
+    },
+    {
+      "description": "A `trx.query.Query` over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see `trx.query.NamedQuery`.\n\nThe families do not cover `pickup` between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "Clips for a weapon.",
+          "name": "ammo",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "An animation an object borrows rather than a thing of its own.",
+          "name": "animation",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A collectible, by the slot it fills.",
+          "name": "collectible",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The object is a creature.",
+          "name": "creature",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A door.",
+          "name": "door",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A creature that fights Lara rather than for her.",
+          "name": "enemy",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "An examine item, by the slot it fills.",
+          "name": "examine",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A weapon.",
+          "name": "gun",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "An icon in the inventory rather than a thing in the world.",
+          "name": "inventory_item",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A key, by the slot it fills.",
+          "name": "key",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The level loaded the object, so items of it exist.",
+          "name": "loaded",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "One of Lara's own: the butler, and Lara herself.",
+          "name": "loyal",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A placeholder that is never drawn.",
+          "name": "null_object",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "Something Lara can pick up.",
+          "name": "pickup",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A block Lara pushes and pulls.",
+          "name": "pushable",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A puzzle item, by the slot it fills.",
+          "name": "puzzle",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A quest item, by the slot it fills. This is what carries the scion.",
+          "name": "quest",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A slot a puzzle item goes into.",
+          "name": "receptacle",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The trinket a secret trigger sits under.",
+          "name": "secret",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The object is a thing in the world at all, rather than an inventory icon, an animation, or a null placeholder.",
+          "name": "spawnable",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A pickup Lara spends rather than keeps.",
+          "name": "supply",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A switch Lara throws.",
+          "name": "switch",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "A pickup named for itself rather than filling a numbered slot: the crowbar, the lasersight, the binoculars, the waterskins, the leadbar.",
+          "name": "tool",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "objects.ObjectQuery"
+    },
+    {
+      "description": "A filter over a domain, read with one of the terminals below once it is narrow enough.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "How many candidates match.",
+          "name": "count",
+          "returns": {
+            "type": "integer"
+          }
+        },
+        {
+          "description": "The first matching handle.",
+          "name": "first",
+          "returns": {
+            "description": "The handle, or `nil`.",
+            "nullable": true,
+            "type": "any"
+          }
+        },
+        {
+          "description": "The matching ids. For objects these are object ids; for items, their numbers.",
+          "name": "ids",
+          "returns": {
+            "description": "A list of integers.",
+            "type": "table"
+          }
+        },
+        {
+          "description": "The matching handles.",
+          "name": "matches",
+          "returns": {
+            "description": "A list of `trx.objects.Object`s or `trx.items.Item`s.",
+            "type": "table"
+          }
+        },
+        {
+          "description": "Narrows by a test of your own, for what the domain does not name.",
+          "examples": [
+            "local hurt = trx.items.query:where(function(id, item)\n  return item.hit_points < 10\nend)"
+          ],
+          "name": "where",
+          "params": [
+            {
+              "name": "predicate",
+              "params": [
+                {
+                  "description": "The candidate's id.",
+                  "name": "id",
+                  "type": "integer"
+                },
+                {
+                  "description": "The candidate itself, an `Object` or an `Item`.",
+                  "name": "handle",
+                  "type": "any"
+                }
+              ],
+              "type": "function"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        }
+      ],
+      "operators": [
+        {
+          "description": "Both queries match. Their domains must agree.",
+          "name": "band"
+        },
+        {
+          "description": "Everything the query does not match: `~q:animation()`.",
+          "name": "bnot"
+        },
+        {
+          "description": "Either query matches, for what a chain cannot say: `q:pickup() | q:inventory_item()`. Their domains must agree.",
+          "name": "bor"
+        }
+      ],
+      "path": "query.Query"
+    },
+    {
+      "description": "A query over a domain whose things answer to names, which adds the name layer to everything a `Query` has. A domain without names offers none of it.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "The ids tied for the best `by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `by_name`, every matching id.",
+          "name": "best",
+          "returns": {
+            "description": "A list of integers.",
+            "type": "table"
+          }
+        },
+        {
+          "description": "Ranks rather than filters: matches the way a player types a name, forgivingly, and orders what survives the rest of the query best first. Some of a domain's narrowings are also searchable groups, so their own name matches every member.",
+          "examples": [
+            "trx.objects.query:spawnable():by_name(\"wolf\"):ids()"
+          ],
+          "name": "by_name",
+          "params": [
+            {
+              "description": "What to look for.",
+              "name": "name",
+              "type": "string"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `pickup`.",
+          "name": "names",
+          "returns": {
+            "description": "A list of names.",
+            "type": "table"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "query.NamedQuery"
     },
     {
       "description": "A room in the current level.",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5473,7 +5473,9 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [],
+      "operators": [],
       "path": "game.Level"
     },
     {
@@ -5494,13 +5496,16 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [],
+      "operators": [],
       "path": "inventory.Entry"
     },
     {
       "description": "An inventory: what is in it, and how much ammunition goes with it.\n\n`trx.inventory` is the one Lara is carrying. A level's, reached as\n`trx.game.Level.inventory`, is what she will arrive there with, and holds only\nwhat travels between levels - a key or a puzzle piece belongs to the level it\nwas found in.\n\nGiving something to Lara's does what walking over it would: a weapon arrives\nwith its rounds, her meshes change, and the level's own guns turn into\nammunition for it. Giving it to a level's only says what she will arrive\ncarrying.",
       "extensions": [],
       "fields": [],
+      "handle": true,
       "methods": [
         {
           "description": "Whether `give` would do anything in the level being played. The level has to\ncarry the inventory model, which is not the same as the pickup being in it: a\nlevel with no shotgun lying about still draws one in the ring, which is what\nlets a cheat hand one over.\n\nThis asks about the level being played whichever inventory it is called on.",
@@ -5718,6 +5723,7 @@
           }
         }
       ],
+      "operators": [],
       "path": "inventory.Inventory"
     },
     {
@@ -5940,6 +5946,7 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "Brings the item to life, exactly as tripping a trigger on it would: its control routine starts running, and a creature also gets its AI, without which it would stand there and ignore Lara.\n\nObjects with no control routine cannot be activated, and an item that is already active is left alone.",
@@ -6392,6 +6399,7 @@
           ]
         }
       ],
+      "operators": [],
       "path": "items.Item"
     },
     {
@@ -6511,7 +6519,9 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [],
+      "operators": [],
       "path": "lara.Lara"
     },
     {
@@ -6562,7 +6572,9 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [],
+      "operators": [],
       "path": "mod.Mod"
     },
     {
@@ -6589,6 +6601,7 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "Whether the slot is still playing. A stream that has finished, or been stopped, leaves its handle stale.",
@@ -6625,6 +6638,7 @@
           "name": "unpause"
         }
       ],
+      "operators": [],
       "path": "music.Stream"
     },
     {
@@ -6638,6 +6652,7 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "Whether the loaded level still carries this track.",
@@ -6673,6 +6688,7 @@
           }
         }
       ],
+      "operators": [],
       "path": "music.Track"
     },
     {
@@ -6750,6 +6766,7 @@
           "writable": true
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `object.default_names`.",
@@ -6801,6 +6818,7 @@
           ]
         }
       ],
+      "operators": [],
       "path": "objects.Object"
     },
     {
@@ -6861,6 +6879,7 @@
           "writable": true
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "As `trx.rooms.floor_height`, looking from this room.",
@@ -6951,6 +6970,7 @@
           }
         }
       ],
+      "operators": [],
       "path": "rooms.Room"
     },
     {
@@ -6988,6 +7008,7 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "Whether the loaded level still carries this sample.",
@@ -7018,6 +7039,7 @@
           "name": "stop"
         }
       ],
+      "operators": [],
       "path": "sound.Sample"
     },
     {
@@ -7031,6 +7053,7 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "Whether this voice is still playing.",
@@ -7052,6 +7075,7 @@
           "name": "unpause"
         }
       ],
+      "operators": [],
       "path": "sound.Stream"
     },
     {
@@ -7083,7 +7107,9 @@
           "writable": false
         }
       ],
+      "handle": true,
       "methods": [],
+      "operators": [],
       "path": "stats.Category"
     },
     {
@@ -7163,6 +7189,7 @@
           "writable": true
         }
       ],
+      "handle": true,
       "methods": [
         {
           "description": "Marks a secret as found, as walking into its trigger would.",
@@ -7209,6 +7236,7 @@
           }
         }
       ],
+      "operators": [],
       "path": "stats.Stats"
     }
   ]

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -30,11 +30,7 @@ end
 
 ### Properties
 
-- **`trx.items.query`** (table). The identity query over every item in the level. Narrow it and read it - see [Query](../../QUERY.md).
-
-  Its own narrowings, beyond the operators: `simulated`, `present`, `visible`, `finished`, `in_play`, `alive`, `targetable`, `of_object` (by object id or name) and `in_room`.
-
-  Example: `trx.items.query:of_object("wolf"):simulated():matches()`. *(read-only)*
+- **`trx.items.query`** (ItemQuery). The identity query over every item in the level. Narrow it and read it - see `trx.items.ItemQuery`. *(read-only)*
 
 ### Enums
 
@@ -468,6 +464,68 @@ end
       ```lua
       trx.items[12]:trigger({ type = trx.items.TriggerType.ANTITRIGGER })
       ```
+
+- [lua]`trx.items.ItemQuery`
+
+    A `trx.query.Query` over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `of_object` is how a name reaches them.
+
+    Methods:
+
+    - [lua]`itemquery:alive()`  
+      The item still has hit points.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:finished()`  
+      The item has run its course.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:in_play()`  
+      The item is part of the game rather than set aside.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:in_room(room_num)`  
+      The item is in the given room.
+
+      Parameters:
+      - **`room_num`** (integer). 0-based room number.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:of_object(key)`  
+      The item is of the given object, named the way a player would name it or by its id.
+
+      Parameters:
+      - **`key`** (any). Object id, or a name `trx.objects.query` resolves.
+
+      Returns: Query. The narrowed query.
+
+      Example:
+      ```lua
+      trx.items.query:of_object("wolf"):simulated():matches()
+      ```
+
+    - [lua]`itemquery:present()`  
+      The item is in the world, whether or not anything is simulating it.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:simulated()`  
+      The item is being simulated: its control routine runs every frame.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:targetable()`  
+      Lara's guns can lock onto the item.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:visible()`  
+      The item is drawn.
+
+      Returns: Query. The narrowed query.
 
 ### Functions
 

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -29,28 +29,7 @@ trx.objects.wolf.properties.max_hit_points = 30
 
 ### Properties
 
-- **`trx.objects.query`** (table). The identity query over every object definition. Narrow it and read it - see
-  [Query](../../QUERY.md).
-
-  Its own narrowings, beyond the shared `by_name` and the operators: the states
-  `loaded` and `spawnable`, and the families `creature`, `enemy`, `loyal`,
-  `pickup`, `switch`, `receptacle`, `pushable`, `door`, `inventory_item`,
-  `null_object` and `animation`.
-
-  `pickup` narrows further, by what the thing is: `gun`, `ammo` for its clips,
-  `supply` for what Lara spends, `tool` for what she carries and uses, and
-  `key`, `puzzle`, `quest`, `examine` and `collectible` for the slot-numbered
-  items, by the slot each fills. `quest` carries the scion. `secret` is the
-  trinket a secret trigger sits under. These do not cover `pickup` between them:
-  a second state of something Lara already carries, such as a part-full
-  waterskin, is in none of them.
-
-  Every family is searchable: a `by_name` of the family's own name
-  matches every member, and `names` offers it for completion. Which families a
-  query answers to follows from what it kept, so one narrowed to what fights
-  offers no `pickup`.
-
-  Example: `trx.objects.query:spawnable():by_name("wolf"):ids()`. *(read-only)*
+- **`trx.objects.query`** (ObjectQuery). The identity query over every object definition. Narrow it and read it - see `trx.objects.ObjectQuery`. *(read-only)*
 
 ### Structures
 
@@ -109,6 +88,129 @@ trx.objects.wolf.properties.max_hit_points = 30
       Parameters:
       - **`name`** (string).
       - **`value`** (any).
+
+- [lua]`trx.objects.ObjectQuery`
+
+    A `trx.query.Query` over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see `trx.query.NamedQuery`.
+
+    The families do not cover `pickup` between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.
+
+    Methods:
+
+    - [lua]`objectquery:ammo()`  
+      Clips for a weapon.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:animation()`  
+      An animation an object borrows rather than a thing of its own.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:collectible()`  
+      A collectible, by the slot it fills.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:creature()`  
+      The object is a creature.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:door()`  
+      A door.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:enemy()`  
+      A creature that fights Lara rather than for her.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:examine()`  
+      An examine item, by the slot it fills.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:gun()`  
+      A weapon.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:inventory_item()`  
+      An icon in the inventory rather than a thing in the world.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:key()`  
+      A key, by the slot it fills.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:loaded()`  
+      The level loaded the object, so items of it exist.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:loyal()`  
+      One of Lara's own: the butler, and Lara herself.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:null_object()`  
+      A placeholder that is never drawn.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:pickup()`  
+      Something Lara can pick up.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:pushable()`  
+      A block Lara pushes and pulls.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:puzzle()`  
+      A puzzle item, by the slot it fills.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:quest()`  
+      A quest item, by the slot it fills. This is what carries the scion.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:receptacle()`  
+      A slot a puzzle item goes into.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:secret()`  
+      The trinket a secret trigger sits under.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:spawnable()`  
+      The object is a thing in the world at all, rather than an inventory icon, an animation, or a null placeholder.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:supply()`  
+      A pickup Lara spends rather than keeps.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:switch()`  
+      A switch Lara throws.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`objectquery:tool()`  
+      A pickup named for itself rather than filling a numbered slot: the crowbar, the lasersight, the binoculars, the waterskins, the leadbar.
+
+      Returns: Query. The narrowed query.
 
 ### Functions
 

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -20,43 +20,106 @@ the result.
 A query is immutable. Every method returns a fresh query, so a base can be kept
 and branched from without one narrowing leaking into another.
 
-Four ways to narrow, which mix freely:
+Each domain adds narrowings of its own on top of the ones below - see
+`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read
+left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
-- Chain methods read left to right and combine with AND:
-  `q:spawnable():by_name("wolf")`. Each domain adds its own - see
-  `trx.objects.query` and `trx.items.query` for the ones it has.
-- The operators `&`, `|` and `~` are AND, OR and NOT over whole queries, for
-  what a chain cannot say: `q:pickup() | q:inventory_item()`, `~q:animation()`.
-  Both sides of `&`/`|` must come from the same domain.
-- `by_name(name)` ranks rather than filters: it matches the way a player types
-  a name, forgivingly, and orders what survives the rest of the query best
-  first. Some of a domain's filters are also searchable groups - `pickup` is
-  one - so their name matches every member. Only a domain that has names offers
-  `by_name`, `names` and `best`.
-- `where(predicate)` narrows by a test of your own, called with the id and the
-  handle, for what a domain does not name: `q:where(function(id, item) return
-  item.timer > 0 end)`.
 
-Read a query with a terminal:
+### Structures
 
-- `ids()` - the matching ids, a list. For objects these are object ids; for
-  items, their numbers.
-- `matches()` - the matching handles: `trx.objects.Object`s or
-  `trx.items.Item`s.
-- `first()` - the first matching handle, or `nil`.
-- `count()` - how many match.
-- `names()` - every name the matches answer to, for offering completions. The
-  group names any match belongs to come first.
-- `best()` - the ids tied for the best `by_name` score: one for a name only one
-  thing answers to, the whole group for a group name.
+- [lua]`trx.query.Query`
 
+    A filter over a domain, read with one of the terminals below once it is narrow enough.
+
+    Operators:
+    - **`query & query`**. Both queries match. Their domains must agree.
+    - **`~query`**. Everything the query does not match: `~q:animation()`.
+    - **`query | query`**. Either query matches, for what a chain cannot say: `q:pickup() | q:inventory_item()`. Their domains must agree.
+
+    Methods:
+
+    - [lua]`query:count()`  
+      How many candidates match.
+
+      Returns: integer.
+
+    - [lua]`query:first()`  
+      The first matching handle.
+
+      Returns: any or `nil`. The handle, or `nil`.
+
+    - [lua]`query:ids()`  
+      The matching ids. For objects these are object ids; for items, their numbers.
+
+      Returns: table. A list of integers.
+
+    - [lua]`query:matches()`  
+      The matching handles.
+
+      Returns: table. A list of `trx.objects.Object`s or `trx.items.Item`s.
+
+    - [lua]`query:where(predicate)`  
+      Narrows by a test of your own, for what the domain does not name.
+
+      Parameters:
+      - **`predicate`** (function).
+        Called with:
+        - **`id`** (integer). The candidate's id.
+        - **`handle`** (any). The candidate itself, an `Object` or an `Item`.
+
+      Returns: Query. The narrowed query.
+
+      Example:
+      ```lua
+      local hurt = trx.items.query:where(function(id, item)
+        return item.hit_points < 10
+      end)
+      ```
+
+- [lua]`trx.query.NamedQuery`
+
+    A query over a domain whose things answer to names, which adds the name layer to everything a `Query` has. A domain without names offers none of it.
+
+    Methods:
+
+    - [lua]`namedquery:best()`  
+      The ids tied for the best `by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `by_name`, every matching id.
+
+      Returns: table. A list of integers.
+
+    - [lua]`namedquery:by_name(name)`  
+      Ranks rather than filters: matches the way a player types a name, forgivingly, and orders what survives the rest of the query best first. Some of a domain's narrowings are also searchable groups, so their own name matches every member.
+
+      Parameters:
+      - **`name`** (string). What to look for.
+
+      Returns: Query. The narrowed query.
+
+      Example:
+      ```lua
+      trx.objects.query:spawnable():by_name("wolf"):ids()
+      ```
+
+    - [lua]`namedquery:names()`  
+      Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `pickup`.
+
+      Returns: table. A list of names.
 
 ### Functions
 
-- [lua]`trx.query.new(domain)`  
-  Builds the identity query for a domain. `trx.objects` and `trx.items` call this to make the query a script reaches through `trx.objects.query` and `trx.items.query`.
+- [lua]`trx.query.narrowing(make)`  
+  Builds a narrowing method for a domain's query type out of a predicate factory. `trx.items` and `trx.objects` declare their own filters with it.
 
   Parameters:
-  - **`domain`** (table). What the query runs against: `enumerate`, `id_of`, `filters`, and an optional `names_of`/`default_names_of` name layer. See the module source.
+  - **`make`** (function). Called with the method's own arguments, returning a `predicate(id, handle)`.
 
-  Returns: table. The identity query, matching everything until narrowed.
+  Returns: function. The method to declare as an `impl`.
+
+- [lua]`trx.query.new(domain, class)`  
+  Builds the identity query over a domain, as an instance of that domain's query type. `trx.objects` and `trx.items` call this to make the query a script reaches through `trx.objects.query` and `trx.items.query`.
+
+  Parameters:
+  - **`domain`** (table). What the query runs against: `enumerate`, `id_of`, `searchable`, and an optional `names_of`/`default_names_of` name layer. See the module source.
+  - **`class`** (table). The query type the domain's narrowings were declared on.
+
+  Returns: Query. The identity query, matching everything until narrowed.

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -69,6 +69,12 @@ local module_containers = {}
 local container_properties = {}
 -- module -> function returning the handle it stands for.
 local module_instances = {}
+-- type path -> the class table of a type written in Lua, which is both what a
+-- value of that type carries as its metatable and where its methods live.
+local lua_classes = {}
+-- class -> the class it extends, for the checker to walk. Held apart from the
+-- class table, which a value indexes through.
+local class_parents = {}
 local strict_enabled = false
 local sealed = false
 
@@ -413,6 +419,22 @@ local function handle_checker(backing)
   end
 end
 
+-- A value of a type written in Lua carries its class as its metatable, and a
+-- derived class carries the one it extends. Walking that chain is what lets an
+-- ItemQuery satisfy a parameter declared as a Query.
+local function class_checker(class)
+  return function(v)
+    local candidate = getmetatable(v)
+    while candidate ~= nil do
+      if candidate == class then
+        return true
+      end
+      candidate = class_parents[candidate]
+    end
+    return false
+  end
+end
+
 -- Called once, from C, after the trx.* modules have loaded. Declarations are
 -- the engine's to make; a level script re-opening the surface would defeat the
 -- point of declaring it.
@@ -681,6 +703,30 @@ local function bind_type_methods(path)
   local spec = types.by_path[path]
   local backing = spec.backing
   local _, type_name = split_path(path)
+  local class = lua_classes[path]
+
+  -- A type written in Lua keeps its methods in the class table, so binding one
+  -- is an assignment and strict mode swaps the wrapper in the same way it does
+  -- for a module's functions.
+  if class ~= nil then
+    for name, method in pairs(spec.methods or {}) do
+      assert(
+        type(method.impl) == "function",
+        "api.type: " .. path .. "." .. name .. " needs an impl"
+      )
+      rawset(
+        class,
+        name,
+        bound(
+          method.impl,
+          path .. "." .. name,
+          method_params(method.params, type_name)
+        )
+      )
+    end
+    return
+  end
+
   for name, method in pairs(spec.methods or {}) do
     -- The wrapper goes in front of the C function, which struct.method hands
     -- back; without strict mode the name reaches C to bind directly.
@@ -725,6 +771,52 @@ end
 -- called. A member C can reach but nobody declares simply does not exist.
 function api.type(path, spec)
   opening("api.type", spec)
+  local _, type_name = split_path(path)
+
+  -- A type written in Lua names no C struct. The declaration owns its class
+  -- table and hands it back: the module gives a value that class as its
+  -- metatable, and every method a script can call is one declared here.
+  -- `extends` names a type whose methods this one inherits, for a domain that
+  -- adds its own to a shared base.
+  if spec.backing == nil then
+    local class = {}
+    class.__index = class
+    if spec.extends ~= nil then
+      local parent = lua_classes[spec.extends]
+      assert(
+        parent ~= nil,
+        "api.type: " .. path .. " extends an undeclared type"
+      )
+      -- The link is held here rather than on the class, which a value indexes
+      -- through: what a script reaches on one is its declared methods and
+      -- nothing else.
+      class_parents[class] = parent
+      setmetatable(class, { __index = parent })
+      -- Lua looks a metamethod up raw, so `__index` on the class is not what
+      -- reaches one: a derived class carries its own copy of the operators it
+      -- inherits.
+      for key, value in pairs(parent) do
+        if key:sub(1, 2) == "__" and key ~= "__index" then
+          rawset(class, key, value)
+        end
+      end
+    end
+
+    for name, operator in pairs(spec.operators or {}) do
+      assert(
+        type(operator.impl) == "function",
+        "api.type: operator '" .. name .. "' needs an impl"
+      )
+      rawset(class, "__" .. name, operator.impl)
+    end
+
+    lua_classes[path] = class
+    checkers[type_name] = class_checker(class)
+    record(types, path, spec)
+    bind_type_methods(path)
+    return class
+  end
+
   assert(
     type(spec.backing) == "string",
     "api.type: backing must be a C type name"
@@ -732,7 +824,6 @@ function api.type(path, spec)
   local backing = spec.backing
 
   -- Declaring the type is what makes its name checkable in a params list.
-  local _, type_name = split_path(path)
   checkers[type_name] = handle_checker(backing)
 
   for name, field in pairs(spec.fields or {}) do
@@ -966,10 +1057,21 @@ function api.describe()
     local entry = {
       path = path,
       description = spec.description,
+      -- A handle stands for something the engine owns and can outlive it; a
+      -- type written in Lua is the value itself, so the docs say so only of
+      -- the first.
+      handle = spec.backing ~= nil,
       fields = {},
       methods = {},
       extensions = {},
+      operators = {},
     }
+    for name, operator in pairs(spec.operators or {}) do
+      table.insert(entry.operators, {
+        name = name,
+        description = operator.description,
+      })
+    end
     for name, field in pairs(spec.fields or {}) do
       table.insert(entry.fields, {
         name = name,
@@ -1001,6 +1103,7 @@ function api.describe()
     table.sort(entry.fields, by_name)
     table.sort(entry.methods, by_name)
     table.sort(entry.extensions, by_name)
+    table.sort(entry.operators, by_name)
     table.insert(out.types, entry)
   end
   for _, path in ipairs(enums.order) do

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -779,50 +779,98 @@ local function resolve_object(key)
   return trx.objects.query:by_name(key):ids()[1]
 end
 
-local function axis_filter(field)
-  return function()
-    return function(_i, item)
-      return item[field]
-    end
-  end
+-- One of an item's own true-or-false axes, as a narrowing.
+local function axis_narrowing(field, description)
+  return {
+    description = description,
+    returns = { type = "Query", description = "The narrowed query." },
+    impl = trx.query.narrowing(function()
+      return function(_i, item)
+        return item[field]
+      end
+    end),
+  }
 end
 
-local filters = {
-  simulated = axis_filter("is_simulated"),
-  present = axis_filter("is_present"),
-  visible = axis_filter("is_visible"),
-  finished = axis_filter("is_finished"),
-  in_play = axis_filter("is_in_play"),
-  alive = axis_filter("is_alive"),
-  targetable = axis_filter("is_targetable"),
-  of_object = function(key)
-    local object_id = resolve_object(key)
-    return function(_i, item)
-      return object_id ~= nil and item.object_id == object_id
-    end
-  end,
-  in_room = function(room_num)
-    return function(_i, item)
-      return item.room_num == room_num
-    end
-  end,
-}
+local ItemQuery = api.type("items.ItemQuery", {
+  extends = "query.Query",
+  description = "A `trx.query.Query` over the items a level holds, with the narrowings below on top "
+    .. "of the ones every query has. Items answer to no names of their own, so `of_object` is how a "
+    .. "name reaches them.",
+
+  methods = {
+    simulated = axis_narrowing(
+      "is_simulated",
+      "The item is being simulated: its control routine runs every frame."
+    ),
+    present = axis_narrowing(
+      "is_present",
+      "The item is in the world, whether or not anything is simulating it."
+    ),
+    visible = axis_narrowing("is_visible", "The item is drawn."),
+    finished = axis_narrowing("is_finished", "The item has run its course."),
+    in_play = axis_narrowing(
+      "is_in_play",
+      "The item is part of the game rather than set aside."
+    ),
+    alive = axis_narrowing("is_alive", "The item still has hit points."),
+    targetable = axis_narrowing(
+      "is_targetable",
+      "Lara's guns can lock onto the item."
+    ),
+
+    of_object = {
+      description = "The item is of the given object, named the way a player would name it or by "
+        .. "its id.",
+      params = {
+        {
+          name = "key",
+          type = "any",
+          description = "Object id, or a name `trx.objects.query` resolves.",
+        },
+      },
+      returns = { type = "Query", description = "The narrowed query." },
+      examples = {
+        [[trx.items.query:of_object("wolf"):simulated():matches()]],
+      },
+      impl = trx.query.narrowing(function(key)
+        local object_id = resolve_object(key)
+        return function(_i, item)
+          return object_id ~= nil and item.object_id == object_id
+        end
+      end),
+    },
+
+    in_room = {
+      description = "The item is in the given room.",
+      params = {
+        {
+          name = "room_num",
+          type = "integer",
+          description = "0-based room number.",
+        },
+      },
+      returns = { type = "Query", description = "The narrowed query." },
+      impl = trx.query.narrowing(function(room_num)
+        return function(_i, item)
+          return item.room_num == room_num
+        end
+      end),
+    },
+  },
+})
 
 local item_query = trx.query.new({
   enumerate = enumerate,
   id_of = function(i)
     return i
   end,
-  filters = filters,
-})
+}, ItemQuery)
 
 api.property("items.query", {
-  type = "table",
+  type = "ItemQuery",
   description = "The identity query over every item in the level. Narrow it and read it - see "
-    .. "[Query](../../QUERY.md).\n\n"
-    .. "Its own narrowings, beyond the operators: `simulated`, `present`, `visible`, `finished`, "
-    .. "`in_play`, `alive`, `targetable`, `of_object` (by object id or name) and `in_room`.\n\n"
-    .. 'Example: `trx.items.query:of_object("wolf"):simulated():matches()`.',
+    .. "`trx.items.ItemQuery`.",
   get = function()
     return item_query
   end,

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -205,120 +205,150 @@ local function enumerate()
   return out
 end
 
--- The families an object belongs to. Membership is the engine's; the key is the
--- name a script narrows by and the name a player types, and the value is what
--- the engine calls the same family. Every one of them is searchable, so a
--- by_name of "pickup" matches every pickup and a command reaches a family by
--- name. Which families a command offers is then its own query's doing: /kill
--- narrows to what fights, so "pickup" is not among the names it answers to.
+-- The families an object belongs to. Membership is the engine's: `kind` is what
+-- the engine calls the family, and the name beside it is what a script narrows
+-- by and what a player types.
 local FAMILIES = {
-  creature = "creature",
-  -- One of Lara's own: the butler, and Lara herself.
-  loyal = "loyal",
-  pickup = "pickup",
-  -- What a pickup is. A weapon, its clips, and what Lara spends.
-  gun = "gun",
-  ammo = "ammo",
-  supply = "supply",
-  -- The pickups named for themselves rather than filling a numbered slot:
-  -- the crowbar, the lasersight, the binoculars, the waterskins, the leadbar.
-  tool = "tool",
-  -- The slot-numbered ones, by the slot they fill. `quest` carries the scion.
-  key = "key",
-  puzzle = "puzzle",
-  quest = "quest",
-  examine = "examine",
-  collectible = "collectible",
-  secret = "secret",
-  switch = "switch",
-  receptacle = "receptacle",
-  pushable = "pushable",
-  door = "door",
-  inventory_item = "inventory",
-  null_object = "null",
-  animation = "anim",
-}
-
--- The narrowings a query offers: a state an object is in, and a family it
--- belongs to.
-local filters = {
-  loaded = function()
-    return function(_id, object)
-      return object.loaded
-    end
-  end,
-  -- A thing that exists in the world at all, rather than an inventory icon, an
-  -- animation, or a null placeholder.
-  spawnable = function()
-    return function(id, object)
-      return object.loaded
-        and not raw.is_type(id, "null")
-        and not raw.is_type(id, "anim")
-        and not raw.is_type(id, "inventory")
-    end
-  end,
-  -- A creature that fights Lara rather than for her. The one family that is not
-  -- the engine's own, so it is spelled out here.
-  enemy = {
-    searchable = true,
-    test = function()
-      return function(id)
-        return raw.is_type(id, "creature") and not raw.is_type(id, "loyal")
-      end
-    end,
+  { "creature", "creature", "The object is a creature." },
+  {
+    "loyal",
+    "loyal",
+    "One of Lara's own: the butler, and Lara herself.",
+  },
+  { "pickup", "pickup", "Something Lara can pick up." },
+  { "gun", "gun", "A weapon." },
+  { "ammo", "ammo", "Clips for a weapon." },
+  { "supply", "supply", "A pickup Lara spends rather than keeps." },
+  {
+    "tool",
+    "tool",
+    "A pickup named for itself rather than filling a numbered slot: the crowbar, the lasersight, "
+      .. "the binoculars, the waterskins, the leadbar.",
+  },
+  { "key", "key", "A key, by the slot it fills." },
+  { "puzzle", "puzzle", "A puzzle item, by the slot it fills." },
+  {
+    "quest",
+    "quest",
+    "A quest item, by the slot it fills. This is what carries the scion.",
+  },
+  { "examine", "examine", "An examine item, by the slot it fills." },
+  { "collectible", "collectible", "A collectible, by the slot it fills." },
+  { "secret", "secret", "The trinket a secret trigger sits under." },
+  { "switch", "switch", "A switch Lara throws." },
+  { "receptacle", "receptacle", "A slot a puzzle item goes into." },
+  { "pushable", "pushable", "A block Lara pushes and pulls." },
+  { "door", "door", "A door." },
+  {
+    "inventory_item",
+    "inventory",
+    "An icon in the inventory rather than a thing in the world.",
+  },
+  { "null_object", "null", "A placeholder that is never drawn." },
+  {
+    "animation",
+    "anim",
+    "An animation an object borrows rather than a thing of its own.",
   },
 }
 
-for name, kind in pairs(FAMILIES) do
-  filters[name] = {
-    searchable = true,
-    test = function()
-      return function(id)
-        return raw.is_type(id, kind)
-      end
-    end,
-  }
+local QUERY = { type = "Query", description = "The narrowed query." }
+
+local function family_test(kind)
+  return function()
+    return function(id)
+      return raw.is_type(id, kind)
+    end
+  end
 end
+
+local function enemy_test()
+  return function(id)
+    return raw.is_type(id, "creature") and not raw.is_type(id, "loyal")
+  end
+end
+
+local methods = {
+  loaded = {
+    description = "The level loaded the object, so items of it exist.",
+    returns = QUERY,
+    impl = trx.query.narrowing(function()
+      return function(_id, object)
+        return object.loaded
+      end
+    end),
+  },
+  spawnable = {
+    description = "The object is a thing in the world at all, rather than an inventory icon, an "
+      .. "animation, or a null placeholder.",
+    returns = QUERY,
+    impl = trx.query.narrowing(function()
+      return function(id, object)
+        return object.loaded
+          and not raw.is_type(id, "null")
+          and not raw.is_type(id, "anim")
+          and not raw.is_type(id, "inventory")
+      end
+    end),
+  },
+  -- A creature that fights Lara rather than for her. The one family that is not
+  -- the engine's own, so it is spelled out here.
+  enemy = {
+    description = "A creature that fights Lara rather than for her.",
+    returns = QUERY,
+    impl = trx.query.narrowing(enemy_test),
+  },
+}
+
+-- Every family is searchable, so a `by_name` of the family's own name matches
+-- every member and a command reaches a family by name. Which families a query
+-- answers to follows from what it kept, so one narrowed to what fights offers
+-- no `pickup`.
+local searchable = { { key = "enemy", pred = enemy_test() } }
+for _, family in ipairs(FAMILIES) do
+  local name, kind, description = family[1], family[2], family[3]
+  local test = family_test(kind)
+  methods[name] = {
+    description = description,
+    returns = QUERY,
+    impl = trx.query.narrowing(test),
+  }
+  searchable[#searchable + 1] = { key = name, pred = test() }
+end
+
+-- The group names are offered for completion in this order.
+table.sort(searchable, function(a, b)
+  return a.key < b.key
+end)
+
+local ObjectQuery = api.type("objects.ObjectQuery", {
+  extends = "query.NamedQuery",
+  description = "A `trx.query.Query` over every object the engine knows, with the narrowings below "
+    .. "on top of the ones every query has. Objects answer to names, so it carries the name layer "
+    .. "too - see `trx.query.NamedQuery`.\n\n"
+    .. "The families do not cover `pickup` between them: a second state of something Lara already "
+    .. "carries, such as a part-full waterskin, is in none of them.",
+  methods = methods,
+})
 
 local object_query = trx.query.new({
   enumerate = enumerate,
   id_of = function(id)
     return id
   end,
-  filters = filters,
+  searchable = searchable,
   names_of = function(object)
     return object.names
   end,
   default_names_of = function(object)
     return object.default_names
   end,
-})
+}, ObjectQuery)
 
 api.property("objects.query", {
-  type = "table",
-  description = [[
-The identity query over every object definition. Narrow it and read it - see
-[Query](../../QUERY.md).
-
-Its own narrowings, beyond the shared `by_name` and the operators: the states
-`loaded` and `spawnable`, and the families `creature`, `enemy`, `loyal`,
-`pickup`, `switch`, `receptacle`, `pushable`, `door`, `inventory_item`,
-`null_object` and `animation`.
-
-`pickup` narrows further, by what the thing is: `gun`, `ammo` for its clips,
-`supply` for what Lara spends, `tool` for what she carries and uses, and
-`key`, `puzzle`, `quest`, `examine` and `collectible` for the slot-numbered
-items, by the slot each fills. `quest` carries the scion. `secret` is the
-trinket a secret trigger sits under. These do not cover `pickup` between them:
-a second state of something Lara already carries, such as a part-full
-waterskin, is in none of them.
-
-Every family is searchable: a `by_name` of the family's own name
-matches every member, and `names` offers it for completion. Which families a
-query answers to follows from what it kept, so one narrowed to what fights
-offers no `pickup`.
-
-Example: `trx.objects.query:spawnable():by_name("wolf"):ids()`.]],
+  type = "ObjectQuery",
+  description = "The identity query over every object definition. Narrow it and read it - see "
+    .. "`trx.objects.ObjectQuery`.",
   get = function()
     return object_query
   end,

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -12,51 +12,24 @@ the result.
 A query is immutable. Every method returns a fresh query, so a base can be kept
 and branched from without one narrowing leaking into another.
 
-Four ways to narrow, which mix freely:
-
-- Chain methods read left to right and combine with AND:
-  `q:spawnable():by_name("wolf")`. Each domain adds its own - see
-  `trx.objects.query` and `trx.items.query` for the ones it has.
-- The operators `&`, `|` and `~` are AND, OR and NOT over whole queries, for
-  what a chain cannot say: `q:pickup() | q:inventory_item()`, `~q:animation()`.
-  Both sides of `&`/`|` must come from the same domain.
-- `by_name(name)` ranks rather than filters: it matches the way a player types
-  a name, forgivingly, and orders what survives the rest of the query best
-  first. Some of a domain's filters are also searchable groups - `pickup` is
-  one - so their name matches every member. Only a domain that has names offers
-  `by_name`, `names` and `best`.
-- `where(predicate)` narrows by a test of your own, called with the id and the
-  handle, for what a domain does not name: `q:where(function(id, item) return
-  item.timer > 0 end)`.
-
-Read a query with a terminal:
-
-- `ids()` - the matching ids, a list. For objects these are object ids; for
-  items, their numbers.
-- `matches()` - the matching handles: `trx.objects.Object`s or
-  `trx.items.Item`s.
-- `first()` - the first matching handle, or `nil`.
-- `count()` - how many match.
-- `names()` - every name the matches answer to, for offering completions. The
-  group names any match belongs to come first.
-- `best()` - the ids tied for the best `by_name` score: one for a name only one
-  thing answers to, the whole group for a group name.
+Each domain adds narrowings of its own on top of the ones below - see
+`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read
+left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 ]],
 })
 
 -- A domain is what a query runs against. It supplies:
 --   enumerate() - every candidate as a { id, handle } pair, each id once.
 --   id_of(id, handle) - what ids() yields for a candidate.
---   filters - named narrowings. Each is a function(...) returning a
---     predicate(id, handle), or a table { test = <that function>, searchable =
---     true } for a nullary filter whose own name a by_name also matches.
+--   searchable - the filters whose own name a by_name also matches, as
+--     { key, pred } pairs in the order a completer offers them.
 --   names_of(handle) - optional. The names a thing answers to, best weight. Its
 --     presence is what gives a domain by_name, names and best.
 --   default_names_of(handle) - optional. A fallback set tried when nothing in
 --     names_of matched, for before a language file is loaded.
 
--- A fresh query over the same domain, carrying this one's metatable so the
--- domain's filters ride along.
+-- A fresh query over the same domain, carrying this one's class so the domain's
+-- own narrowings ride along.
 local function derive(self, pred, name)
   return setmetatable(
     { _domain = self._domain, _pred = pred, _name = name },
@@ -71,239 +44,328 @@ local function same_domain(a, b)
   )
 end
 
-local function band(a, b)
-  same_domain(a, b)
-  return derive(a, function(id, h)
-    return a._pred(id, h) and b._pred(id, h)
-  end, a._name or b._name)
+-- The pairs that pass the predicate, in enumeration order, before ranking.
+local function kept_pairs(self)
+  local kept = {}
+  for _, pair in ipairs(self._domain.enumerate()) do
+    if self._pred(pair[1], pair[2]) then
+      kept[#kept + 1] = pair
+    end
+  end
+  return kept
 end
 
-local function bor(a, b)
-  same_domain(a, b)
-  return derive(a, function(id, h)
-    return a._pred(id, h) or b._pred(id, h)
-  end, a._name or b._name)
+-- The names a lookup weighs: everything a thing answers to at full weight, and
+-- the name of every searchable group it belongs to at a weight a real name
+-- beats.
+local function candidates(domain, kept, names_getter)
+  local out = {}
+  for _, pair in ipairs(kept) do
+    for _, name in ipairs(names_getter(pair[2])) do
+      out[#out + 1] = { key = name, value = pair, weight = 2 }
+    end
+    for _, group in ipairs(domain.searchable) do
+      if group.pred(pair[1], pair[2]) then
+        out[#out + 1] = { key = group.key, value = pair, weight = 1 }
+      end
+    end
+  end
+  return out
 end
 
-local function bnot(a)
-  return derive(a, function(id, h)
-    return not a._pred(id, h)
-  end, a._name)
+-- The player's language is tried first; nothing there matching falls back on
+-- the names the engine was built with, present before any language file.
+local function rank(domain, name, kept)
+  local matches =
+    trx.strings.fuzzy_match(name, candidates(domain, kept, domain.names_of))
+  if #matches == 0 and domain.default_names_of ~= nil then
+    matches = trx.strings.fuzzy_match(
+      name,
+      candidates(domain, kept, domain.default_names_of)
+    )
+  end
+  -- One thing answers to several names, so it can match more than once. It
+  -- comes back the once, at its best rank.
+  local out, seen = {}, {}
+  for _, match in ipairs(matches) do
+    if not seen[match.value] then
+      seen[match.value] = true
+      out[#out + 1] = { pair = match.value, score = match.score }
+    end
+  end
+  return out
 end
 
-local function build(domain)
-  local index = {}
-  local meta = {
-    __index = index,
-    __band = band,
-    __bor = bor,
-    __bnot = bnot,
-  }
+-- The matches a terminal reads: ranked by name when one is set, otherwise the
+-- kept pairs in enumeration order.
+local function resolved(self)
+  local kept = kept_pairs(self)
+  if self._name == nil then
+    return kept
+  end
+  local out = {}
+  for _, entry in ipairs(rank(self._domain, self._name, kept)) do
+    out[#out + 1] = entry.pair
+  end
+  return out
+end
 
-  -- Each filter becomes a chain method that ANDs its predicate onto the query.
-  -- A searchable one also joins the name candidates below, under its own key.
-  local searchable = {}
-  for name, spec in pairs(domain.filters) do
-    local make = type(spec) == "function" and spec or spec.test
-    index[name] = function(self, ...)
+local QUERY = { type = "Query", description = "The narrowed query." }
+
+local Query = api.type("query.Query", {
+  description = "A filter over a domain, read with one of the terminals below once it is narrow "
+    .. "enough.",
+
+  operators = {
+    band = {
+      description = "Both queries match. Their domains must agree.",
+      impl = function(a, b)
+        same_domain(a, b)
+        return derive(a, function(id, h)
+          return a._pred(id, h) and b._pred(id, h)
+        end, a._name or b._name)
+      end,
+    },
+    bor = {
+      description = "Either query matches, for what a chain cannot say: "
+        .. "`q:pickup() | q:inventory_item()`. Their domains must agree.",
+      impl = function(a, b)
+        same_domain(a, b)
+        return derive(a, function(id, h)
+          return a._pred(id, h) or b._pred(id, h)
+        end, a._name or b._name)
+      end,
+    },
+    bnot = {
+      description = "Everything the query does not match: `~q:animation()`.",
+      impl = function(a)
+        return derive(a, function(id, h)
+          return not a._pred(id, h)
+        end, a._name)
+      end,
+    },
+  },
+
+  methods = {
+    where = {
+      description = "Narrows by a test of your own, for what the domain does not name.",
+      params = {
+        {
+          name = "predicate",
+          type = "function",
+          params = {
+            {
+              name = "id",
+              type = "integer",
+              description = "The candidate's id.",
+            },
+            {
+              name = "handle",
+              type = "any",
+              description = "The candidate itself, an `Object` or an `Item`.",
+            },
+          },
+        },
+      },
+      returns = QUERY,
+      examples = {
+        [[local hurt = trx.items.query:where(function(id, item)
+  return item.hit_points < 10
+end)]],
+      },
+      impl = function(self, pred)
+        return derive(self, function(id, h)
+          return self._pred(id, h) and pred(id, h)
+        end, self._name)
+      end,
+    },
+
+    ids = {
+      description = "The matching ids. For objects these are object ids; for items, their numbers.",
+      returns = { type = "table", description = "A list of integers." },
+      impl = function(self)
+        local out = {}
+        for _, pair in ipairs(resolved(self)) do
+          out[#out + 1] = self._domain.id_of(pair[1], pair[2])
+        end
+        return out
+      end,
+    },
+
+    matches = {
+      description = "The matching handles.",
+      returns = {
+        type = "table",
+        description = "A list of `trx.objects.Object`s or `trx.items.Item`s.",
+      },
+      impl = function(self)
+        local out = {}
+        for _, pair in ipairs(resolved(self)) do
+          out[#out + 1] = pair[2]
+        end
+        return out
+      end,
+    },
+
+    first = {
+      description = "The first matching handle.",
+      returns = {
+        type = "any",
+        nullable = true,
+        description = "The handle, or `nil`.",
+      },
+      impl = function(self)
+        local pair = resolved(self)[1]
+        return pair ~= nil and pair[2] or nil
+      end,
+    },
+
+    count = {
+      description = "How many candidates match.",
+      returns = { type = "integer" },
+      impl = function(self)
+        return #resolved(self)
+      end,
+    },
+  },
+})
+
+api.type("query.NamedQuery", {
+  extends = "query.Query",
+  description = "A query over a domain whose things answer to names, which adds the name layer to "
+    .. "everything a `Query` has. A domain without names offers none of it.",
+
+  methods = {
+    by_name = {
+      description = "Ranks rather than filters: matches the way a player types a name, forgivingly, "
+        .. "and orders what survives the rest of the query best first. Some of a domain's "
+        .. "narrowings are also searchable groups, so their own name matches every member.",
+      params = {
+        { name = "name", type = "string", description = "What to look for." },
+      },
+      returns = QUERY,
+      examples = { [[trx.objects.query:spawnable():by_name("wolf"):ids()]] },
+      impl = function(self, name)
+        return derive(self, self._pred, name)
+      end,
+    },
+
+    names = {
+      description = "Every name the matches answer to, for offering completions. The group names "
+        .. "any match belongs to come first, because a completer offers the list in order and a "
+        .. "group name that ties on score would otherwise sit behind a thing's own. Which groups "
+        .. "answer follows from what the query kept, so one narrowed to what fights offers no "
+        .. "`pickup`.",
+      returns = { type = "table", description = "A list of names." },
+      impl = function(self)
+        local domain = self._domain
+        local kept = kept_pairs(self)
+        local order, seen = {}, {}
+        local function add(name)
+          if not seen[name] then
+            seen[name] = true
+            order[#order + 1] = name
+          end
+        end
+        for _, group in ipairs(domain.searchable) do
+          for _, pair in ipairs(kept) do
+            if group.pred(pair[1], pair[2]) then
+              add(group.key)
+              break
+            end
+          end
+        end
+        for _, pair in ipairs(kept) do
+          local names = domain.names_of(pair[2])
+          if #names == 0 and domain.default_names_of ~= nil then
+            names = domain.default_names_of(pair[2])
+          end
+          for _, name in ipairs(names) do
+            add(name)
+          end
+        end
+        return order
+      end,
+    },
+
+    best = {
+      description = "The ids tied for the best `by_name` score: one for a name only one thing "
+        .. "answers to, the whole group for a group name. Without a `by_name`, every matching id.",
+      returns = { type = "table", description = "A list of integers." },
+      impl = function(self)
+        if self._name == nil then
+          return self:ids()
+        end
+        local domain = self._domain
+        local ranked = rank(domain, self._name, kept_pairs(self))
+        local out = {}
+        local top = ranked[1] ~= nil and ranked[1].score or nil
+        for _, entry in ipairs(ranked) do
+          if entry.score == top then
+            out[#out + 1] = domain.id_of(entry.pair[1], entry.pair[2])
+          end
+        end
+        return out
+      end,
+    },
+  },
+})
+
+-- A domain's own narrowing, as a method on its query type: the filter's
+-- predicate ANDed onto the query, which is what every one of them does.
+api.define("query.narrowing", {
+  description = "Builds a narrowing method for a domain's query type out of a predicate factory. "
+    .. "`trx.items` and `trx.objects` declare their own filters with it.",
+  params = {
+    {
+      name = "make",
+      type = "function",
+      description = "Called with the method's own arguments, returning a `predicate(id, handle)`.",
+    },
+  },
+  returns = {
+    type = "function",
+    description = "The method to declare as an `impl`.",
+  },
+  impl = function(make)
+    return function(self, ...)
       local pred = make(...)
       return derive(self, function(id, h)
         return self._pred(id, h) and pred(id, h)
       end, self._name)
     end
-    if type(spec) == "table" and spec.searchable then
-      searchable[#searchable + 1] = { key = name, pred = make() }
-    end
-  end
-
-  -- pairs() reaches the filters in whatever order it likes, and the group names
-  -- are offered for completion in this one.
-  table.sort(searchable, function(a, b)
-    return a.key < b.key
-  end)
-
-  -- A test of the caller's own, for a narrowing the domain does not name.
-  index.where = function(self, pred)
-    return derive(self, function(id, h)
-      return self._pred(id, h) and pred(id, h)
-    end, self._name)
-  end
-
-  -- The pairs that pass the predicate, in enumeration order, before ranking.
-  local function kept_pairs(self)
-    local kept = {}
-    for _, pair in ipairs(domain.enumerate()) do
-      if self._pred(pair[1], pair[2]) then
-        kept[#kept + 1] = pair
-      end
-    end
-    return kept
-  end
-
-  -- rank stays nil for a domain without names, and the name terminals go
-  -- undeclared, so a query that has no by_name has no names or best either.
-  local rank
-
-  if domain.names_of ~= nil then
-    -- The names a lookup weighs: everything a thing answers to at full weight,
-    -- and the name of every searchable group it belongs to at a weight a real
-    -- name beats.
-    local function candidates(kept, names_getter)
-      local out = {}
-      for _, pair in ipairs(kept) do
-        for _, name in ipairs(names_getter(pair[2])) do
-          out[#out + 1] = { key = name, value = pair, weight = 2 }
-        end
-        for _, group in ipairs(searchable) do
-          if group.pred(pair[1], pair[2]) then
-            out[#out + 1] = { key = group.key, value = pair, weight = 1 }
-          end
-        end
-      end
-      return out
-    end
-
-    -- The player's language is tried first; nothing there matching falls back
-    -- on the names the engine was built with, present before any language file.
-    rank = function(name, kept)
-      local matches =
-        trx.strings.fuzzy_match(name, candidates(kept, domain.names_of))
-      if #matches == 0 and domain.default_names_of ~= nil then
-        matches = trx.strings.fuzzy_match(
-          name,
-          candidates(kept, domain.default_names_of)
-        )
-      end
-      -- One thing answers to several names, so it can match more than once. It
-      -- comes back the once, at its best rank.
-      local out, seen = {}, {}
-      for _, match in ipairs(matches) do
-        if not seen[match.value] then
-          seen[match.value] = true
-          out[#out + 1] = { pair = match.value, score = match.score }
-        end
-      end
-      return out
-    end
-
-    index.by_name = function(self, name)
-      return derive(self, self._pred, name)
-    end
-
-    -- The names to complete against: a searchable group's name once any match
-    -- belongs to it, then what each match answers to. The groups come first
-    -- because a completer offers the list in order, and a group name that ties
-    -- with an object's on score would otherwise sit behind it. Localized names,
-    -- falling back on the built-in ones before a language is loaded.
-    index.names = function(self)
-      local kept = kept_pairs(self)
-      local order, seen = {}, {}
-      local function add(name)
-        if not seen[name] then
-          seen[name] = true
-          order[#order + 1] = name
-        end
-      end
-      for _, group in ipairs(searchable) do
-        for _, pair in ipairs(kept) do
-          if group.pred(pair[1], pair[2]) then
-            add(group.key)
-            break
-          end
-        end
-      end
-      for _, pair in ipairs(kept) do
-        local names = domain.names_of(pair[2])
-        if #names == 0 and domain.default_names_of ~= nil then
-          names = domain.default_names_of(pair[2])
-        end
-        for _, name in ipairs(names) do
-          add(name)
-        end
-      end
-      return order
-    end
-
-    -- The strongest matches: those tied for the top score. A name only one
-    -- thing answers to yields one; a group name yields the whole group.
-    index.best = function(self)
-      if self._name == nil then
-        return self:ids()
-      end
-      local ranked = rank(self._name, kept_pairs(self))
-      local out = {}
-      local top = ranked[1] ~= nil and ranked[1].score or nil
-      for _, entry in ipairs(ranked) do
-        if entry.score == top then
-          out[#out + 1] = domain.id_of(entry.pair[1], entry.pair[2])
-        end
-      end
-      return out
-    end
-  end
-
-  -- The matches a terminal reads: ranked by name when one is set, otherwise the
-  -- kept pairs in enumeration order.
-  local function resolved(self)
-    local kept = kept_pairs(self)
-    if self._name == nil or rank == nil then
-      return kept
-    end
-    local out = {}
-    for _, entry in ipairs(rank(self._name, kept)) do
-      out[#out + 1] = entry.pair
-    end
-    return out
-  end
-
-  index.ids = function(self)
-    local out = {}
-    for _, pair in ipairs(resolved(self)) do
-      out[#out + 1] = domain.id_of(pair[1], pair[2])
-    end
-    return out
-  end
-
-  index.matches = function(self)
-    local out = {}
-    for _, pair in ipairs(resolved(self)) do
-      out[#out + 1] = pair[2]
-    end
-    return out
-  end
-
-  index.first = function(self)
-    local pair = resolved(self)[1]
-    return pair ~= nil and pair[2] or nil
-  end
-
-  index.count = function(self)
-    return #resolved(self)
-  end
-
-  return setmetatable({
-    _domain = domain,
-    _pred = function()
-      return true
-    end,
-    _name = nil,
-  }, meta)
-end
+  end,
+})
 
 api.define("query.new", {
-  description = "Builds the identity query for a domain. `trx.objects` and `trx.items` call this to "
-    .. "make the query a script reaches through `trx.objects.query` and `trx.items.query`.",
+  description = "Builds the identity query over a domain, as an instance of that domain's query "
+    .. "type. `trx.objects` and `trx.items` call this to make the query a script reaches through "
+    .. "`trx.objects.query` and `trx.items.query`.",
   params = {
     {
       name = "domain",
       type = "table",
-      description = "What the query runs against: `enumerate`, `id_of`, `filters`, and an optional "
-        .. "`names_of`/`default_names_of` name layer. See the module source.",
+      description = "What the query runs against: `enumerate`, `id_of`, `searchable`, and an "
+        .. "optional `names_of`/`default_names_of` name layer. See the module source.",
+    },
+    {
+      name = "class",
+      type = "table",
+      description = "The query type the domain's narrowings were declared on.",
     },
   },
   returns = {
-    type = "table",
+    type = "Query",
     description = "The identity query, matching everything until narrowed.",
   },
-  impl = build,
+  impl = function(domain, class)
+    domain.searchable = domain.searchable or {}
+    return setmetatable({
+      _domain = domain,
+      _pred = function()
+        return true
+      end,
+      _name = nil,
+    }, class or Query)
+  end,
 })

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -853,6 +853,49 @@ test(
   end
 )
 
+test("a container walks from the index it counts from", function()
+  local api = fresh_env()
+  local zero, one = { [0] = "a", [1] = "b" }, { "a", "b" }
+
+  api.module("counted", {})
+  api.container("counted", {
+    description = "Indexing.",
+    key = { type = "integer", description = "0-based." },
+    value = { type = "string" },
+    get = function(key)
+      return zero[key]
+    end,
+    count = function()
+      return 2
+    end,
+  })
+
+  api.module("listed", {})
+  api.container("listed", {
+    description = "Indexing.",
+    key = { type = "integer", description = "1-based." },
+    value = { type = "string" },
+    base = 1,
+    get = function(key)
+      return one[key]
+    end,
+    count = function()
+      return #one
+    end,
+  })
+
+  local function walked(module)
+    local keys = {}
+    for key in pairs(module) do
+      keys[#keys + 1] = key
+    end
+    return table.concat(keys, ",")
+  end
+
+  assert(walked(trx.counted) == "0,1", walked(trx.counted))
+  assert(walked(trx.listed) == "1,2", walked(trx.listed))
+end)
+
 -- A suite that registers nothing prints "0 failed" and exits clean, which reads
 -- exactly like a suite that passed.
 assert(passed + failures > 0, "the suite registered no tests")

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -521,6 +521,152 @@ test(
   end
 )
 
+-- A type written in Lua: the declaration hands back the class a value carries
+-- as its metatable, and every method a script can call is one declared here.
+local function widget_class(api, spec)
+  return api.type("things.Widget", spec)
+end
+
+test("type() written in Lua binds its methods to the class", function()
+  local api, exposed = fresh_env()
+  local Widget = widget_class(api, {
+    description = "A widget.",
+    methods = {
+      poke = {
+        description = "...",
+        impl = function(self)
+          return self.name .. " poked"
+        end,
+      },
+    },
+  })
+
+  local widget = setmetatable({ name = "hinge" }, Widget)
+  assert(widget:poke() == "hinge poked")
+  assert(
+    exposed.methods.poke == nil,
+    "a type with no backing must ask C for nothing"
+  )
+end)
+
+test("a Lua type's methods must carry an impl", function()
+  local api = fresh_env()
+  assert(not pcall(widget_class, api, { methods = { poke = {} } }))
+end)
+
+test("a derived Lua type inherits methods and operators", function()
+  local api = fresh_env()
+  local Widget = api.type("things.Widget", {
+    operators = {
+      band = {
+        description = "...",
+        impl = function(a, b)
+          return a.name .. "+" .. b.name
+        end,
+      },
+    },
+    methods = {
+      poke = {
+        description = "...",
+        impl = function(self)
+          return self.name
+        end,
+      },
+    },
+  })
+  local Lever = api.type("things.Lever", {
+    extends = "things.Widget",
+    methods = {
+      pull = {
+        description = "...",
+        impl = function(self)
+          return self.name .. " pulled"
+        end,
+      },
+    },
+  })
+
+  local lever = setmetatable({ name = "lever" }, Lever)
+  assert(lever:pull() == "lever pulled")
+  assert(lever:poke() == "lever", "an inherited method is unreachable")
+  -- Lua looks a metamethod up raw, so the derived class needs its own copy.
+  assert(
+    (lever & setmetatable({ name = "other" }, Lever)) == "lever+other",
+    "an inherited operator is unreachable"
+  )
+  assert(getmetatable(Widget) == nil, "the base class gained a metatable")
+end)
+
+test("extending a type nobody declared raises", function()
+  local api = fresh_env()
+  assert(not pcall(api.type, "things.Lever", { extends = "things.Widget" }))
+end)
+
+test("a Lua type checks its own values, derived ones included", function()
+  local api = fresh_env()
+  local Widget = api.type("things.Widget", {
+    methods = {
+      poke = {
+        description = "...",
+        impl = function()
+          return true
+        end,
+      },
+    },
+  })
+  local Lever = api.type("things.Lever", { extends = "things.Widget" })
+  api.define("things.press", {
+    params = { { name = "widget", type = "Widget" } },
+    impl = function()
+      return true
+    end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.press, setmetatable({}, Widget)))
+  assert(
+    pcall(trx.things.press, setmetatable({}, Lever)),
+    "a derived value must satisfy the type it extends"
+  )
+  assert(not pcall(trx.things.press, {}), "a plain table passed as a Widget")
+  assert(not pcall(trx.things.press, 7))
+
+  -- Strict mode rebinds a Lua type's methods the same way it rebinds a
+  -- module's functions, and the handle it checks first is the value itself.
+  assert(pcall(function()
+    return setmetatable({}, Widget):poke()
+  end))
+  assert(not pcall(Widget.poke, {}), "self went unchecked")
+  api.strict(false)
+end)
+
+test("describe() marks which types are handles", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.type("things.Widget", { backing = "WIDGET", description = "..." })
+  api.type("things.Lever", {
+    description = "...",
+    operators = {
+      bnot = {
+        description = "Everything it does not match.",
+        impl = function() end,
+      },
+    },
+  })
+
+  local by_path = {}
+  for _, entry in ipairs(api.describe().types) do
+    by_path[entry.path] = entry
+  end
+  assert(by_path["things.Widget"].handle == true)
+  assert(
+    by_path["things.Lever"].handle == false,
+    "a type written in Lua is not a handle"
+  )
+  assert(#by_path["things.Lever"].operators == 1, "operators missing")
+  assert(by_path["things.Lever"].operators[1].name == "bnot")
+end)
+
 test("seal blocks further declarations", function()
   local api = fresh_env()
   api.seal()

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -32,6 +32,14 @@ DOCS_DIR = ROOT / "docs/trx/lua/reference"
 
 INDENT = "    "
 
+# How a declared operator reads in a script, by the metamethod it is declared
+# under. The name of the type stands in for either operand.
+OPERATORS = {
+    "band": "{0} & {0}",
+    "bor": "{0} | {0}",
+    "bnot": "~{0}",
+}
+
 
 def signature(path: str, params: list[dict] | None) -> str:
     parts = [
@@ -275,14 +283,15 @@ def render_type(spec: dict) -> list[str]:
     if spec.get("description"):
         out.extend(render_prose(spec["description"], INDENT))
         out.append("")
-    out.append(
-        f"{INDENT}Handles are live references: if the underlying object is destroyed,"
-    )
-    out.append(
-        f"{INDENT}using the handle raises an error rather than silently reading an"
-    )
-    out.append(f"{INDENT}unrelated one.")
-    out.append("")
+    if spec.get("handle"):
+        out.append(
+            f"{INDENT}Handles are live references: if the underlying object is destroyed,"
+        )
+        out.append(
+            f"{INDENT}using the handle raises an error rather than silently reading an"
+        )
+        out.append(f"{INDENT}unrelated one.")
+        out.append("")
 
     if spec.get("fields"):
         out.append(f"{INDENT}Properties:")
@@ -304,6 +313,19 @@ def render_type(spec: dict) -> list[str]:
                 render_lead(
                     f"{INDENT}- **`{ext['name']}`**: {ext['type']}. ",
                     ext.get("description") or "",
+                    f"{INDENT}  ",
+                )
+            )
+        out.append("")
+
+    if spec.get("operators"):
+        name = spec["path"].rsplit(".", 1)[-1].lower()
+        out.append(f"{INDENT}Operators:")
+        for operator in spec["operators"]:
+            out.extend(
+                render_lead(
+                    f"{INDENT}- **`{OPERATORS[operator['name']].format(name)}`**. ",
+                    operator.get("description") or "",
                     f"{INDENT}  ",
                 )
             )
@@ -451,7 +473,7 @@ def undocumented(api: dict) -> list[str]:
             if not value.get("description"):
                 out.append(f"{enum['path']}.{value['name']}")
     for spec in api.get("types", []):
-        for kind in ("fields", "methods", "extensions"):
+        for kind in ("fields", "methods", "extensions", "operators"):
             for member in spec.get(kind) or []:
                 if not member.get("description"):
                     out.append(f"{spec['path']}.{member['name']}")


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR makes trx.query properly documented - each method a user can call on a query now gets a signature, its arguments and a description. To achieve this, `api.type` can now express types written in Lua rather than ones backed by a C struct.

Before this, what a query could do was all prose. The terminals and `where` were a bulleted list in the query module's own description, and `trx.objects.query` carried a 23-line description naming its filters - `creature`, `enemy`, `pickup` and the rest - without saying what any of them take or hand back. None of them had an entry of its own, so none had a signature or a place in the reference beside the other functions.
