### PR TITLE
docs: write the Lua documentation impersonally

### DIFF
--- a/docs/trx/lua/GETTING_STARTED.md
+++ b/docs/trx/lua/GETTING_STARTED.md
@@ -5,7 +5,7 @@ order: 0
 
 ## Getting started
 
-You'll need:
+Scripting with Lua needs:
 
 - A TR1 or TR2 TRX build from the latest develop branch that adds Lua scripting.
 - Familiarity with the game flow JSON format.
@@ -28,8 +28,8 @@ Add per-level scripts in a level object:
 }
 ```
 
-Create a file `data/scripts/level1.lua` folder in your project and put the
-following content:
+Create a file `data/scripts/level1.lua` in the project and put the following
+content:
 
 ```lua
 trx.events.on_game_start(function(level)
@@ -37,7 +37,7 @@ trx.events.on_game_start(function(level)
 end)
 ```
 
-Start the game. In the logs, you should see the following:
+Start the game. The logs should show the following:
 
 ```
 INF | 2025-10-04 12:12:23.155 [data/scripts/level1.lua:2:?] hello from level 1!
@@ -45,8 +45,8 @@ INF | 2025-10-04 12:12:23.155 [data/scripts/level1.lua:2:?] hello from level 1!
 
 ---
 
-Optionally, you can also load a global script by adding a global property to
-your game flow configuration:
+A global script can be loaded as well, by adding a global property to the game
+flow configuration:
 
 ```json5
 {
@@ -57,7 +57,7 @@ your game flow configuration:
 
 ### Interactive commands
 
-You can also try out short lua commands in-game with the `/lua` console command:
+The `/lua` console command also runs short Lua commands in-game:
 
 ```text
 /lua

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5038,7 +5038,7 @@
       "title": "Object"
     },
     {
-      "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; you narrow one down and then read\nthe result.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nEach domain adds narrowings of its own on top of the ones below - see\n`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read\nleft to right, combining with AND: `q:spawnable():by_name(\"wolf\")`.\n",
+      "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; narrow one down, then read the\nresult.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nEach domain adds narrowings of its own on top of the ones below - see\n`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read\nleft to right, combining with AND: `q:spawnable():by_name(\"wolf\")`.\n",
       "name": "query",
       "order": 9,
       "title": "Query"
@@ -7173,7 +7173,7 @@
           }
         },
         {
-          "description": "Narrows by a test of your own, for what the domain does not name.",
+          "description": "Narrows by a test of the caller's own, for what the domain does not name.",
           "examples": [
             "local hurt = trx.items.query:where(function(id, item)\n  return item.hit_points < 10\nend)"
           ],
@@ -7572,7 +7572,7 @@
           "type": "Category"
         },
         {
-          "description": "How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen of your own wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.",
+          "description": "How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.",
           "name": "max_ally_kills",
           "type": "integer"
         },

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -14,8 +14,8 @@ order: 9
 
 A composable filter over a domain of things - the objects a level is built
 from, or the items alive in it. `trx.objects.query` and `trx.items.query` are
-each the identity query, matching everything; you narrow one down and then read
-the result.
+each the identity query, matching everything; narrow one down, then read the
+result.
 
 A query is immutable. Every method returns a fresh query, so a base can be kept
 and branched from without one narrowing leaking into another.
@@ -59,7 +59,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
       Returns: table. A list of `trx.objects.Object`s or `trx.items.Item`s.
 
     - [lua]`query:where(predicate)`  
-      Narrows by a test of your own, for what the domain does not name.
+      Narrows by a test of the caller's own, for what the domain does not name.
 
       Parameters:
       - **`predicate`** (function).

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -56,7 +56,7 @@ here reads `nil`.
     - **`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.
     - **`crystals`**: Category. The save crystals, where the game has them.
     - **`kills`**: Category. The enemies the level counts, allies among them.
-    - **`max_ally_kills`**: integer. How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen of your own wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.
+    - **`max_ally_kills`**: integer. How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.
     - **`max_enemy_kills`**: integer. How many of `kills.max` are enemies rather than allies.
     - **`pickups`**: Category. The items lying in the level for Lara to take.
     - **`secrets`**: Category. The level's secrets. Which ones Lara holds is `secret_list`.

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -6,8 +6,8 @@ api.module("query", {
   description = [[
 A composable filter over a domain of things - the objects a level is built
 from, or the items alive in it. `trx.objects.query` and `trx.items.query` are
-each the identity query, matching everything; you narrow one down and then read
-the result.
+each the identity query, matching everything; narrow one down, then read the
+result.
 
 A query is immutable. Every method returns a fresh query, so a base can be kept
 and branched from without one narrowing leaking into another.
@@ -148,7 +148,7 @@ local Query = api.type("query.Query", {
 
   methods = {
     where = {
-      description = "Narrows by a test of your own, for what the domain does not name.",
+      description = "Narrows by a test of the caller's own, for what the domain does not name.",
       params = {
         {
           name = "predicate",

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -135,7 +135,7 @@ api.type("stats.Stats", {
     max_ally_kills = {
       type = "integer",
       description = "How many of `kills.max` are allies. The statistics screen holds them against "
-        .. "the player only once `allies_hurt`, so a screen of your own wants to do the same: "
+        .. "the player only once `allies_hurt`, so a screen written in Lua wants to do the same: "
         .. "`max_enemy_kills`, and these as well once she has turned on one.",
       impl = function(stats)
         return (raw.kill_split(stats))


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The reference addressed the reader directly in a few places while the rest of it did not. The declarations and the getting-started page now read the same way throughout.

The welcome in docs/trx/lua/README.md keeps its second person: it is addressed to the people writing scripts rather than describing anything.
