### PR TITLE
Add Lua room queries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -201,7 +201,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.game.exit_game()`, to close the game
 - added `trx.items.spawn()`, to place a new item in the level at runtime
 - added `trx.objects.swap_sprite()`, to exchange the sprites two objects are drawn from
-- added `trx.objects.query` and `trx.items.query`, composable filters over a level's objects and items that match names, families and state, and combine with `&`, `|` and `~`
+- added `trx.objects.query`, `trx.items.query` and `trx.rooms.query`, composable filters over a level's objects, items and rooms that match names, families, state and the rooms a position is in, and combine with `&`, `|` and `~`
 - added pickup families to `trx.objects.query` – `gun`, `ammo`, `supply`, `tool`, `key`, `puzzle`, `quest`, `examine`, `collectible` and `secret` – so a script can ask what a pickup is
 - added `trx.items.get()`, `trx.items.count()`, `trx.rooms.get()`, `trx.rooms.count()` and `trx.objects.get()`, replacing the `fn` namespaces- added `trx.rooms.find_valid_pos()`, to nudge a position into valid room geometry
 - added `trx.rooms.floor_height()` and the room method `floor_height()`, the height of the floor under a position

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5347,6 +5347,12 @@
       "writable": false
     },
     {
+      "description": "The identity query over every room in the level. Narrow it and read it - see `trx.rooms.RoomQuery`.",
+      "path": "rooms.query",
+      "type": "RoomQuery",
+      "writable": false
+    },
+    {
       "description": "How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills to. Warmth only moves in a room carrying the `damaging` flag, such as the cold water of Antarctica.",
       "path": "rules.exposure.max",
       "type": "integer",
@@ -7413,6 +7419,34 @@
       ],
       "operators": [],
       "path": "rooms.Room"
+    },
+    {
+      "description": "A `trx.query.Query` over the rooms of the current level, with the narrowings below on top of the ones every query has. Rooms answer to no names, so the name layer is absent.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "The room contains a world position. Rooms overlap, so a position can be in several at once and every one of them matches, in room order. A room claims a point when the point is within its bounds, the outer ring of solid wall aside, and the column it stands in has a floor - the test the engine itself puts a position through. The hidden half of a flip pair is passed over.",
+          "examples": [
+            "trx.rooms.query:at(trx.lara.item.pos):first()"
+          ],
+          "name": "at",
+          "params": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "vec3"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "rooms.RoomQuery"
     },
     {
       "description": "A sound sample the current level carries. Reach them through `trx.sound.samples`. A handle to a sample the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -7443,6 +7443,14 @@
             "description": "The narrowed query.",
             "type": "Query"
           }
+        },
+        {
+          "description": "The room is filled with water.",
+          "name": "underwater",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
         }
       ],
       "operators": [],

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -7451,6 +7451,14 @@
           }
         },
         {
+          "description": "The room holds neither water nor swamp water.",
+          "name": "dry",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
           "description": "The room is filled with swamp water.",
           "name": "swamp",
           "returns": {

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -7314,6 +7314,12 @@
           "writable": false
         },
         {
+          "description": "Whether the room is filled with swamp water, which Lara wades through and sinks into rather than swimming.",
+          "name": "swamp",
+          "type": "boolean",
+          "writable": true
+        },
+        {
           "description": "Whether the room is filled with water.",
           "name": "underwater",
           "type": "boolean",
@@ -7439,6 +7445,14 @@
               "type": "vec3"
             }
           ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The room is filled with swamp water.",
+          "name": "swamp",
           "returns": {
             "description": "The narrowed query.",
             "type": "Query"

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -7459,6 +7459,25 @@
           }
         },
         {
+          "description": "The room is the half of a flip pair the level is not showing. Its geometry is still there to inspect, but nothing can be in it.",
+          "name": "flipped",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what `at` already applies.",
+          "examples": [
+            "trx.rooms.query:reachable():underwater():count()"
+          ],
+          "name": "reachable",
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
           "description": "The room is filled with swamp water.",
           "name": "swamp",
           "returns": {

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -32,6 +32,7 @@ end
 ### Properties
 
 - **`trx.rooms.flipped`** (boolean). Whether the room map is currently flipped. *(read-only)*
+- **`trx.rooms.query`** (RoomQuery). The identity query over every room in the level. Narrow it and read it - see `trx.rooms.RoomQuery`. *(read-only)*
 
 ### Enums
 
@@ -123,6 +124,25 @@ end
       - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
 
       Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+- [lua]`trx.rooms.RoomQuery`
+
+    A `trx.query.Query` over the rooms of the current level, with the narrowings below on top of the ones every query has. Rooms answer to no names, so the name layer is absent.
+
+    Methods:
+
+    - [lua]`roomquery:at(pos)`  
+      The room contains a world position. Rooms overlap, so a position can be in several at once and every one of them matches, in room order. A room claims a point when the point is within its bounds, the outer ring of solid wall aside, and the column it stands in has a floor - the test the engine itself puts a position through. The hidden half of a flip pair is passed over.
+
+      Parameters:
+      - **`pos`** (vec3). World position.
+
+      Returns: Query. The narrowed query.
+
+      Example:
+      ```lua
+      trx.rooms.query:at(trx.lara.item.pos):first()
+      ```
 
 ### Functions
 

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -62,6 +62,7 @@ end
     - **`damaging`**: boolean. Whether the room drains Lara's exposure meter.
     - **`flip_status`**: integer. Current flip status. Compare against `trx.rooms.FlipStatus`. *(read-only)*
     - **`num`**: integer. 0-based room number, matching the numbers level editors show. *(read-only)*
+    - **`swamp`**: boolean. Whether the room is filled with swamp water, which Lara wades through and sinks into rather than swimming.
     - **`underwater`**: boolean. Whether the room is filled with water.
     - **`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
 
@@ -143,6 +144,11 @@ end
       ```lua
       trx.rooms.query:at(trx.lara.item.pos):first()
       ```
+
+    - [lua]`roomquery:swamp()`  
+      The room is filled with swamp water.
+
+      Returns: Query. The narrowed query.
 
     - [lua]`roomquery:underwater()`  
       The room is filled with water.

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -150,6 +150,21 @@ end
 
       Returns: Query. The narrowed query.
 
+    - [lua]`roomquery:flipped()`  
+      The room is the half of a flip pair the level is not showing. Its geometry is still there to inspect, but nothing can be in it.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`roomquery:reachable()`  
+      The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what `at` already applies.
+
+      Returns: Query. The narrowed query.
+
+      Example:
+      ```lua
+      trx.rooms.query:reachable():underwater():count()
+      ```
+
     - [lua]`roomquery:swamp()`  
       The room is filled with swamp water.
 

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -144,6 +144,11 @@ end
       trx.rooms.query:at(trx.lara.item.pos):first()
       ```
 
+    - [lua]`roomquery:underwater()`  
+      The room is filled with water.
+
+      Returns: Query. The narrowed query.
+
 ### Functions
 
 - [lua]`trx.rooms.get(num)`  

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -145,6 +145,11 @@ end
       trx.rooms.query:at(trx.lara.item.pos):first()
       ```
 
+    - [lua]`roomquery:dry()`  
+      The room holds neither water nor swamp water.
+
+      Returns: Query. The narrowed query.
+
     - [lua]`roomquery:swamp()`  
       The room is filled with swamp water.
 

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -2,6 +2,7 @@ local raw = trxc.rooms
 local api = trx.api
 
 require("trx.log")
+require("trx.query")
 
 -- on_enter and on_exit narrow trx.events.on_room_change to one room: the two
 -- readings of a room change are that this room is the new one, or the old one.
@@ -305,6 +306,64 @@ api.define("rooms.find_valid_pos", {
     { type = "integer", description = "The 0-based room the position is in." },
   },
   impl = raw.find_valid_pos,
+})
+
+-- Every room of the level, each by its number.
+local function enumerate()
+  local out = {}
+  for i = 0, raw.count() - 1 do
+    local room = raw.get(i)
+    if room ~= nil then
+      out[#out + 1] = { i, room }
+    end
+  end
+  return out
+end
+
+local RoomQuery = api.type("rooms.RoomQuery", {
+  extends = "query.Query",
+  description = "A `trx.query.Query` over the rooms of the current level, with the narrowings below "
+    .. "on top of the ones every query has. Rooms answer to no names, so the name layer is absent.",
+
+  methods = {
+    at = {
+      description = "The room contains a world position. Rooms overlap, so a position can be in "
+        .. "several at once and every one of them matches, in room order. A room claims a point "
+        .. "when the point is within its bounds, the outer ring of solid wall aside, and the "
+        .. "column it stands in has a floor - the test the engine itself puts a position through. "
+        .. "The hidden half of a flip pair is passed over.",
+      params = {
+        { name = "pos", type = "vec3", description = "World position." },
+      },
+      returns = { type = "Query", description = "The narrowed query." },
+      examples = { [[trx.rooms.query:at(trx.lara.item.pos):first()]] },
+      impl = trx.query.narrowing(function(pos)
+        return function(_num, room)
+          -- A flipped room holds the half of a flip pair the level is not
+          -- showing. Its geometry still covers the point, and the engine's own
+          -- lookup passes it over, so this does too.
+          return room.flip_status ~= trx.rooms.FlipStatus.FLIPPED
+            and raw.point_inside(room, pos)
+        end
+      end),
+    },
+  },
+})
+
+local room_query = trx.query.new({
+  enumerate = enumerate,
+  id_of = function(i)
+    return i
+  end,
+}, RoomQuery)
+
+api.property("rooms.query", {
+  type = "RoomQuery",
+  description = "The identity query over every room in the level. Narrow it and read it - see "
+    .. "`trx.rooms.RoomQuery`.",
+  get = function()
+    return room_query
+  end,
 })
 
 api.container("rooms", {

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -113,6 +113,12 @@ api.type("rooms.Room", {
       type = "boolean",
       description = "Whether the room is filled with water.",
     },
+    swamp = {
+      from = "flags.swamp",
+      type = "boolean",
+      description = "Whether the room is filled with swamp water, which Lara wades through and "
+        .. "sinks into rather than swimming.",
+    },
     wind = {
       from = "flags.wind",
       type = "boolean",
@@ -343,6 +349,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
       "underwater",
       "The room is filled with water."
     ),
+    swamp = flag_narrowing("swamp", "The room is filled with swamp water."),
 
     at = {
       description = "The room contains a world position. Rooms overlap, so a position can be in "

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -320,12 +320,30 @@ local function enumerate()
   return out
 end
 
+-- One of a room's own true-or-false flags, as a narrowing.
+local function flag_narrowing(field, description)
+  return {
+    description = description,
+    returns = { type = "Query", description = "The narrowed query." },
+    impl = trx.query.narrowing(function()
+      return function(_num, room)
+        return room[field]
+      end
+    end),
+  }
+end
+
 local RoomQuery = api.type("rooms.RoomQuery", {
   extends = "query.Query",
   description = "A `trx.query.Query` over the rooms of the current level, with the narrowings below "
     .. "on top of the ones every query has. Rooms answer to no names, so the name layer is absent.",
 
   methods = {
+    underwater = flag_narrowing(
+      "underwater",
+      "The room is filled with water."
+    ),
+
     at = {
       description = "The room contains a world position. Rooms overlap, so a position can be in "
         .. "several at once and every one of them matches, in room order. A room claims a point "

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -360,6 +360,29 @@ local RoomQuery = api.type("rooms.RoomQuery", {
       end),
     },
 
+    reachable = {
+      description = "The room is part of the level as it stands: an ordinary room, or the half of "
+        .. "a flip pair the level is showing. This is what a script asking about the world wants, "
+        .. "and what `at` already applies.",
+      returns = { type = "Query", description = "The narrowed query." },
+      examples = { [[trx.rooms.query:reachable():underwater():count()]] },
+      impl = trx.query.narrowing(function()
+        return function(_num, room)
+          return room.flip_status ~= trx.rooms.FlipStatus.FLIPPED
+        end
+      end),
+    },
+    flipped = {
+      description = "The room is the half of a flip pair the level is not showing. Its geometry is "
+        .. "still there to inspect, but nothing can be in it.",
+      returns = { type = "Query", description = "The narrowed query." },
+      impl = trx.query.narrowing(function()
+        return function(_num, room)
+          return room.flip_status == trx.rooms.FlipStatus.FLIPPED
+        end
+      end),
+    },
+
     at = {
       description = "The room contains a world position. Rooms overlap, so a position can be in "
         .. "several at once and every one of them matches, in room order. A room claims a point "

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -350,6 +350,15 @@ local RoomQuery = api.type("rooms.RoomQuery", {
       "The room is filled with water."
     ),
     swamp = flag_narrowing("swamp", "The room is filled with swamp water."),
+    dry = {
+      description = "The room holds neither water nor swamp water.",
+      returns = { type = "Query", description = "The narrowed query." },
+      impl = trx.query.narrowing(function()
+        return function(_num, room)
+          return not room.underwater and not room.swamp
+        end
+      end),
+    },
 
     at = {
       description = "The room contains a world position. Rooms overlap, so a position can be in "

--- a/src/tests/fakes/rooms.c
+++ b/src/tests/fakes/rooms.c
@@ -83,6 +83,24 @@ BOUNDS_32 Room_GetRoomBounds(const ROOM *const room)
     };
 }
 
+// As the engine's own test: the room's bounds, and then a floor in the column
+// the point stands in. The fake rooms are a sector apart and four sectors wide,
+// so a point sits inside several of them at once.
+bool Room_PointInside(const ROOM *const room, const XYZ_32 point)
+{
+    if (room == nullptr) {
+        return false;
+    }
+    const BOUNDS_32 bounds = Room_GetRoomBounds(room);
+    if (point.x < bounds.min.x || point.x >= bounds.max.x
+        || point.y < bounds.min.y || point.y > bounds.max.y
+        || point.z < bounds.min.z || point.z >= bounds.max.z) {
+        return false;
+    }
+    // The fake level's floor rule, as Room_GetHeightEx has it.
+    return point.x >= 0;
+}
+
 void Room_FlipMap(void)
 {
     FAKE_RECORD("flip_map");

--- a/src/tests/lua/api/rooms.lua
+++ b/src/tests/lua/api/rooms.lua
@@ -340,6 +340,17 @@ test("dry is neither water nor swamp", function()
   assert(#ids == 2 and ids[1] == 0 and ids[2] == 1, "the rooms left over")
 end)
 
+-- Room 0 is the half of the flip pair the level is showing, room 1 the hidden
+-- one; rooms 2 and 3 have no pair at all.
+test("the query narrows by what the level is showing", function()
+  local ids = trx.rooms.query:reachable():ids()
+  assert(#ids == 3, "an ordinary room is reachable, and so is the shown half")
+  assert(ids[1] == 0 and ids[2] == 2 and ids[3] == 3)
+
+  local hidden = trx.rooms.query:flipped():ids()
+  assert(#hidden == 1 and hidden[1] == 1, "the half that is not being shown")
+end)
+
 test("the query composes with the rest of a query", function()
   trx.rooms[2].underwater = true
   local wet = trx.rooms.query

--- a/src/tests/lua/api/rooms.lua
+++ b/src/tests/lua/api/rooms.lua
@@ -310,6 +310,18 @@ test("the query narrows by height as well", function()
   )
 end)
 
+test("the query narrows by water", function()
+  trx.rooms[2].underwater = true
+  trx.rooms[3].underwater = true
+
+  local ids = trx.rooms.query:underwater():ids()
+  assert(#ids == 2 and ids[1] == 2 and ids[2] == 3, "the flooded rooms")
+  assert(
+    (~trx.rooms.query:underwater()):count() == 2,
+    "the rest are what is left"
+  )
+end)
+
 test("the query composes with the rest of a query", function()
   trx.rooms[2].underwater = true
   local wet = trx.rooms.query

--- a/src/tests/lua/api/rooms.lua
+++ b/src/tests/lua/api/rooms.lua
@@ -269,4 +269,56 @@ test("a room hook detaches through trx.events", function()
   assert(calls == 0, "a detached room hook kept firing")
 end)
 
+-- The fake rooms are four sectors wide and start a sector apart, so room 0
+-- covers x 0..4096, room 1 x 1024..5120, and so on. Room 1 is the hidden half
+-- of the flip pair.
+test("the query hands back every room a position is in", function()
+  local ids = trx.rooms.query:at({ x = 3500, y = 0, z = 1024 }):ids()
+  assert(#ids == 3, "a position in several rooms must answer for each")
+  assert(ids[1] == 0 and ids[2] == 2 and ids[3] == 3, "in room order")
+
+  assert(
+    trx.rooms.query:at({ x = 3500, y = 0, z = 1024 }):first().num == 0,
+    "first() must be the lowest-numbered room"
+  )
+  assert(
+    trx.rooms.query:at({ x = 500, y = 0, z = 1024 }):count() == 1,
+    "a position only one room covers"
+  )
+end)
+
+test("the query passes over the hidden half of a flip pair", function()
+  local ids = trx.rooms.query:at({ x = 1500, y = 0, z = 1024 }):ids()
+  for _, num in ipairs(ids) do
+    assert(num ~= 1, "the flipped room must not answer")
+  end
+end)
+
+test("a position with nothing to stand on is in no room", function()
+  assert(trx.rooms.query:at({ x = -1, y = 0, z = 0 }):count() == 0)
+  assert(trx.rooms.query:at({ x = -1, y = 0, z = 0 }):first() == nil)
+end)
+
+test("the query narrows by height as well", function()
+  assert(
+    trx.rooms.query:at({ x = 500, y = -1024, z = 1024 }):count() == 1,
+    "between the ceiling and the floor"
+  )
+  assert(
+    trx.rooms.query:at({ x = 500, y = 1024, z = 1024 }):count() == 0,
+    "below the floor is outside the room"
+  )
+end)
+
+test("the query composes with the rest of a query", function()
+  trx.rooms[2].underwater = true
+  local wet = trx.rooms.query
+    :at({ x = 3500, y = 0, z = 1024 })
+    :where(function(_num, room)
+      return room.underwater
+    end)
+    :ids()
+  assert(#wet == 1 and wet[1] == 2, "narrowing must AND with at()")
+end)
+
 return h.report()

--- a/src/tests/lua/api/rooms.lua
+++ b/src/tests/lua/api/rooms.lua
@@ -189,7 +189,6 @@ test("undeclared members are unreachable", function()
     "flags",
     "outside",
     "inside",
-    "swamp",
   }) do
     assert(r[name] == nil, name .. " must not be reachable")
   end
@@ -319,6 +318,17 @@ test("the query narrows by water", function()
   assert(
     (~trx.rooms.query:underwater()):count() == 2,
     "the rest are what is left"
+  )
+end)
+
+test("the query narrows by swamp", function()
+  trx.rooms[3].swamp = true
+
+  local ids = trx.rooms.query:swamp():ids()
+  assert(#ids == 1 and ids[1] == 3, "the swamp rooms")
+  assert(
+    trx.rooms.query:underwater():count() == 0,
+    "a swamp room is not an underwater one"
   )
 end)
 

--- a/src/tests/lua/api/rooms.lua
+++ b/src/tests/lua/api/rooms.lua
@@ -332,6 +332,14 @@ test("the query narrows by swamp", function()
   )
 end)
 
+test("dry is neither water nor swamp", function()
+  trx.rooms[2].underwater = true
+  trx.rooms[3].swamp = true
+
+  local ids = trx.rooms.query:dry():ids()
+  assert(#ids == 2 and ids[1] == 0 and ids[2] == 1, "the rooms left over")
+end)
+
 test("the query composes with the rest of a query", function()
   trx.rooms[2].underwater = true
   local wet = trx.rooms.query

--- a/src/trx/game/lua/capi/rooms.c
+++ b/src/trx/game/lua/capi/rooms.c
@@ -113,6 +113,15 @@ static int M_L_RoomsGetBounds(lua_State *const L)
     return 1;
 }
 
+// trxc.rooms.point_inside(room, {x,y,z}) -> bool
+static int M_L_RoomsPointInside(lua_State *const L)
+{
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ROOM);
+    const ROOM *const room = LUA_Struct_Deref(L, ref);
+    lua_pushboolean(L, Room_PointInside(room, LUA_CheckXYZ(L, 2)));
+    return 1;
+}
+
 // trxc.rooms.get_flipped_room(room) -> 0-based room number or nil
 static int M_L_RoomsGetFlippedRoom(lua_State *const L)
 {
@@ -225,6 +234,7 @@ static const luaL_Reg m_Module[] = {
     { "count", M_L_RoomsCount },
     { "get", M_L_RoomsGet },
     { "get_bounds", M_L_RoomsGetBounds },
+    { "point_inside", M_L_RoomsPointInside },
     { "flip", M_L_RoomsFlip },
     { "get_flipped", M_L_RoomsGetFlipped },
     { "flip_effect", M_L_RoomsFlipEffect },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Rooms get a query of their own, alongside the ones objects and items have.

```lua
trx.rooms.query:at(pos)        -- the rooms a world position is in
trx.rooms.query:underwater()   -- filled with water
trx.rooms.query:swamp()        -- filled with swamp water
trx.rooms.query:dry()          -- neither
trx.rooms.query:reachable()    -- ordinary rooms, and the half of a flip pair the level is showing
trx.rooms.query:flipped()      -- the hidden half
```

Rooms overlap, so `at` hands back every room whose bounds hold the point and whose column there has a floor, in room order. `room.swamp` is readable and writable now; the swamp narrowing needs it.
