### PR TITLE
Add spatial item Lua queries

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6445,6 +6445,29 @@
           }
         },
         {
+          "description": "The item stands inside a world-space box. The corners may come in any order.\n\nAn item is tested by its position, the point it stands at, rather than by the box it fills. Position is all this asks after, so the rest of the query says what else the item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are in the world as well.",
+          "examples": [
+            "local guards = trx.items.query\n  :in_box({ x = 51200, y = -2048, z = 30720 }, { x = 53248, y = 0, z = 32768 })\n  :present()\n  :matches()"
+          ],
+          "name": "in_box",
+          "params": [
+            {
+              "description": "One corner of the box.",
+              "name": "min",
+              "type": "vec3"
+            },
+            {
+              "description": "The opposite corner.",
+              "name": "max",
+              "type": "vec3"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
           "description": "The item is part of the game rather than set aside.",
           "name": "in_play",
           "returns": {
@@ -6459,6 +6482,26 @@
             {
               "description": "0-based room number.",
               "name": "room_num",
+              "type": "integer"
+            }
+          ],
+          "returns": {
+            "description": "The narrowed query.",
+            "type": "Query"
+          }
+        },
+        {
+          "description": "The item stands within a radius of a point. As with `in_box`, the item's position is the whole of the test.",
+          "name": "in_sphere",
+          "params": [
+            {
+              "description": "Middle of the sphere.",
+              "name": "centre",
+              "type": "vec3"
+            },
+            {
+              "description": "How far out it reaches. One sector is 1024.",
+              "name": "radius",
               "type": "integer"
             }
           ],

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -481,6 +481,25 @@ end
 
       Returns: Query. The narrowed query.
 
+    - [lua]`itemquery:in_box(min, max)`  
+      The item stands inside a world-space box. The corners may come in any order.
+
+      An item is tested by its position, the point it stands at, rather than by the box it fills. Position is all this asks after, so the rest of the query says what else the item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are in the world as well.
+
+      Parameters:
+      - **`min`** (vec3). One corner of the box.
+      - **`max`** (vec3). The opposite corner.
+
+      Returns: Query. The narrowed query.
+
+      Example:
+      ```lua
+      local guards = trx.items.query
+        :in_box({ x = 51200, y = -2048, z = 30720 }, { x = 53248, y = 0, z = 32768 })
+        :present()
+        :matches()
+      ```
+
     - [lua]`itemquery:in_play()`  
       The item is part of the game rather than set aside.
 
@@ -491,6 +510,15 @@ end
 
       Parameters:
       - **`room_num`** (integer). 0-based room number.
+
+      Returns: Query. The narrowed query.
+
+    - [lua]`itemquery:in_sphere(centre, radius)`  
+      The item stands within a radius of a point. As with `in_box`, the item's position is the whole of the test.
+
+      Parameters:
+      - **`centre`** (vec3). Middle of the sphere.
+      - **`radius`** (integer). How far out it reaches. One sector is 1024.
 
       Returns: Query. The narrowed query.
 

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -779,6 +779,18 @@ local function resolve_object(key)
   return trx.objects.query:by_name(key):ids()[1]
 end
 
+-- A spatial answer as a predicate: the numbers come back as a list, and a
+-- query asks after one item at a time.
+local function found_in(nums)
+  local set = {}
+  for _, num in ipairs(nums) do
+    set[num] = true
+  end
+  return function(num)
+    return set[num] == true
+  end
+end
+
 -- One of an item's own true-or-false axes, as a narrowing.
 local function axis_narrowing(field, description)
   return {
@@ -855,6 +867,53 @@ local ItemQuery = api.type("items.ItemQuery", {
         return function(_i, item)
           return item.room_num == room_num
         end
+      end),
+    },
+
+    in_box = {
+      description = "The item stands inside a world-space box. The corners may come in any order.\n\n"
+        .. "An item is tested by its position, the point it stands at, rather than by the box it "
+        .. "fills. Position is all this asks after, so the rest of the query says what else the "
+        .. "item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are "
+        .. "in the world as well.",
+      params = {
+        {
+          name = "min",
+          type = "vec3",
+          description = "One corner of the box.",
+        },
+        { name = "max", type = "vec3", description = "The opposite corner." },
+      },
+      returns = { type = "Query", description = "The narrowed query." },
+      examples = {
+        [[local guards = trx.items.query
+  :in_box({ x = 51200, y = -2048, z = 30720 }, { x = 53248, y = 0, z = 32768 })
+  :present()
+  :matches()]],
+      },
+      impl = trx.query.narrowing(function(min, max)
+        return found_in(raw.in_box(min, max))
+      end),
+    },
+
+    in_sphere = {
+      description = "The item stands within a radius of a point. As with `in_box`, the item's "
+        .. "position is the whole of the test.",
+      params = {
+        {
+          name = "centre",
+          type = "vec3",
+          description = "Middle of the sphere.",
+        },
+        {
+          name = "radius",
+          type = "integer",
+          description = "How far out it reaches. One sector is 1024.",
+        },
+      },
+      returns = { type = "Query", description = "The narrowed query." },
+      impl = trx.query.narrowing(function(centre, radius)
+        return found_in(raw.in_sphere(centre, radius))
       end),
     },
   },

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -190,6 +190,7 @@ static void M_Reset(void)
             .hit_points = 20,
             .max_hit_points = 20,
             .is_visible = true,
+            .is_present = true,
         };
     }
     m_Items[1].object_id = FAKE_OBJ_VASE;
@@ -207,6 +208,7 @@ void FakeItems_PlaceCrystal(void)
         .room_num = 1,
         .pos = { .x = 4 * 1024, .y = 0, .z = 0 },
         .is_visible = true,
+        .is_present = true,
     };
     m_Count++;
 }
@@ -221,6 +223,7 @@ void FakeItems_PlaceScion(void)
         .room_num = 1,
         .pos = { .x = 8 * 1024, .y = 0, .z = 0 },
         .is_visible = true,
+        .is_present = true,
     };
     m_Count++;
 }
@@ -282,7 +285,10 @@ void Item_Destroy(const int16_t item_num)
     item->is_destroyed = true;
     item->is_finished = true;
     item->hit_points = 0;
+    // is_destroyed is terminal and dominant: the engine detaches the item from
+    // its room and stops simulating it before setting it, and asserts as much.
     item->is_simulated = false;
+    item->is_present = false;
     Handle_RegistryBump(&m_Handles, item_num);
     m_Used[item_num] = false;
     m_Names[item_num][0] = '\0';

--- a/src/tests/lua/api/items.lua
+++ b/src/tests/lua/api/items.lua
@@ -840,4 +840,100 @@ test("a query cannot cross domains", function()
   end)
 end)
 
+-- The fake world stands item 0 at the origin and item 1 one sector along x.
+test("in_box finds what stands inside it, corners either way round", function()
+  local q = trx.items.query
+  local inside = q:in_box(
+    { x = -512, y = -512, z = -512 },
+    { x = 512, y = 512, z = 512 }
+  )
+  assert(
+    inside:count() == 1 and inside:first() == trx.items[0],
+    "the box took the wrong items"
+  )
+
+  local swapped = q:in_box(
+    { x = 512, y = 512, z = 512 },
+    { x = -512, y = -512, z = -512 }
+  )
+  assert(
+    swapped:count() == 1 and swapped:first() == trx.items[0],
+    "swapped corners span the same box"
+  )
+
+  local both = q:in_box(
+    { x = -512, y = -512, z = -512 },
+    { x = 2048, y = 512, z = 512 }
+  )
+  assert(both:count() == 2, "a box over both items must find both")
+end)
+
+test("in_box takes the edges, and nothing outside them", function()
+  trx.items[1].pos = { x = 1024, y = 0, z = 0 }
+  local q = trx.items.query
+
+  local edge = q:in_box({ x = 0, y = 0, z = 0 }, { x = 1024, y = 0, z = 0 })
+  assert(edge:count() == 2, "an item on the boundary is inside")
+
+  local past = q:in_box({ x = 0, y = 0, z = 0 }, { x = 1023, y = 0, z = 0 })
+  assert(past:count() == 1, "an item a unit outside is not")
+end)
+
+test("in_sphere measures from the middle", function()
+  local q = trx.items.query
+  local origin = { x = 0, y = 0, z = 0 }
+
+  trx.items[1].pos = { x = 1024, y = 0, z = 0 }
+  assert(q:in_sphere(origin, 1023):count() == 1)
+  assert(q:in_sphere(origin, 1024):count() == 2)
+
+  -- Radius counts in every direction, not along the axes.
+  trx.items[1].pos = { x = 1024, y = 1024, z = 0 }
+  assert(
+    q:in_sphere(origin, 1024):count() == 1,
+    "a corner is further away than an axis"
+  )
+  assert(q:in_sphere(origin, 1449):count() == 2)
+
+  raises(function()
+    q:in_sphere(origin, -1):count()
+  end)
+end)
+
+-- Position is the only question a spatial narrowing answers. Which of the items
+-- standing there count is the caller's to narrow, exactly as for any other
+-- query, so on its own it holds an item the world no longer does.
+test("a spatial narrowing answers on position alone", function()
+  local near = { x = -512, y = -512, z = -512 }
+  local far = { x = 100000, y = 100000, z = 100000 }
+  assert(trx.items.query:in_box(near, far):count() == 2)
+
+  trx.items[1]:destroy()
+  assert(
+    trx.items.query:in_box(near, far):count() == 2,
+    "the box stopped answering on position"
+  )
+  assert(
+    trx.items.query:in_box(near, far):present():count() == 1,
+    "narrowing to what is in the world is the caller's to ask for"
+  )
+end)
+
+test("a spatial narrowing chains with the rest", function()
+  trx.items[1].pos = { x = 1024, y = 0, z = 0 }
+
+  local q = trx.items.query:in_box(
+    { x = 0, y = 0, z = 0 },
+    { x = 512, y = 0, z = 0 }
+  )
+  assert(q:count() == 1 and q:ids()[1] == 0)
+
+  local sphere = trx.items.query:in_sphere({ x = 0, y = 0, z = 0 }, 1024)
+  assert(sphere:count() == 2)
+  assert(
+    sphere:of_object(fake.VASE):count() == 1,
+    "a spatial narrowing must chain with the rest"
+  )
+end)
+
 return h.report()

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -1,3 +1,4 @@
+#include <trx/core/utils.h>
 #include <trx/game/anims.h>
 #include <trx/game/const.h>
 #include <trx/game/creature.h>
@@ -433,6 +434,78 @@ static int M_L_ItemsCount(lua_State *const L)
     return 1;
 }
 
+// Every item whose position passes the test, as a list of item numbers. The
+// position is all this looks at; whether an item is in the world, simulated or
+// alive is for the caller to narrow by.
+static int M_PushItemsWhere(
+    lua_State *const L, bool (*const test)(XYZ_32 pos, const void *arg),
+    const void *const arg)
+{
+    lua_newtable(L);
+    int32_t found = 0;
+    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
+        if (!test(Item_Get(i)->pos, arg)) {
+            continue;
+        }
+        lua_pushinteger(L, i);
+        lua_rawseti(L, -2, ++found);
+    }
+    return 1;
+}
+
+typedef struct {
+    XYZ_32 min;
+    XYZ_32 max;
+} M_BOX;
+
+typedef struct {
+    XYZ_32 centre;
+    int64_t radius_sq;
+} M_SPHERE;
+
+static bool M_InBox(const XYZ_32 pos, const void *const arg)
+{
+    const M_BOX *const box = arg;
+    return pos.x >= box->min.x && pos.x <= box->max.x && pos.y >= box->min.y
+        && pos.y <= box->max.y && pos.z >= box->min.z && pos.z <= box->max.z;
+}
+
+static bool M_InSphere(const XYZ_32 pos, const void *const arg)
+{
+    const M_SPHERE *const sphere = arg;
+    const int64_t dx = pos.x - sphere->centre.x;
+    const int64_t dy = pos.y - sphere->centre.y;
+    const int64_t dz = pos.z - sphere->centre.z;
+    return dx * dx + dy * dy + dz * dz <= sphere->radius_sq;
+}
+
+// trxc.items.in_box({x,y,z}, {x,y,z}) -> list of item numbers
+static int M_L_ItemsInBox(lua_State *const L)
+{
+    const XYZ_32 a = LUA_CheckXYZ(L, 1);
+    const XYZ_32 b = LUA_CheckXYZ(L, 2);
+    const M_BOX box = {
+        .min = { .x = MIN(a.x, b.x), .y = MIN(a.y, b.y), .z = MIN(a.z, b.z) },
+        .max = { .x = MAX(a.x, b.x), .y = MAX(a.y, b.y), .z = MAX(a.z, b.z) },
+    };
+    return M_PushItemsWhere(L, M_InBox, &box);
+}
+
+// trxc.items.in_sphere({x,y,z}, radius) -> list of item numbers
+static int M_L_ItemsInSphere(lua_State *const L)
+{
+    const XYZ_32 centre = LUA_CheckXYZ(L, 1);
+    const int64_t radius = luaL_checkinteger(L, 2);
+    if (radius < 0) {
+        return luaL_argerror(L, 2, "radius must not be negative");
+    }
+    const M_SPHERE sphere = {
+        .centre = centre,
+        .radius_sq = radius * radius,
+    };
+    return M_PushItemsWhere(L, M_InSphere, &sphere);
+}
+
 // trxc.items.get(index | name) -> Item or nil
 static int M_L_ItemsGet(lua_State *const L)
 {
@@ -586,6 +659,8 @@ static const luaL_Reg m_Module[] = {
     { "count", M_L_ItemsCount },
     { "get", M_L_ItemsGet },
     { "get_bounds", M_L_ItemsGetBounds },
+    { "in_box", M_L_ItemsInBox },
+    { "in_sphere", M_L_ItemsInSphere },
     { "spawn", M_L_ItemsSpawn },
     { nullptr, nullptr },
 };


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds two narrowings to `trx.items.query`:

```lua
trx.items.query:in_box(min, max)          -- items standing inside a world-space box, corners either way round
trx.items.query:in_sphere(centre, radius) -- items within a radius of a point
```

The item's position is the whole of the test, so what else it must be is the rest of the query's to say: `trx.items.query:in_box(min, max):present()`.
