### PR TITLE
Return a listener handle from Lua event hooks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -246,7 +246,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed `item.object_id` to be read-only
 - changed `trx.objects[id]` to return `nil` for an unknown id, where it used to return an object that answered to nothing
 - changed `trx.config.get()` to return the option's own type rather than always a string
-- changed `trx.events.detach()` to return whether a handler was removed
+- changed the event hooks to hand back a `trx.events.Listener` rather than a number, which detaches itself with `listener:detach()` and says whether it was still attached
 - changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
 - changed the Lua level events to a single `on_game_start`, which every kind of level fires, with `on_title_start` for the title screen; refer to migration notes
 - changed the Lua logging functions to take a single message rather than a list of strings

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -151,11 +151,19 @@ order: 3
    hook. The nine hooks are the whole API, and attaching is unchanged:
    `trx.events.before_control(fn)`.
 
-15. **Update scripts that use `trx.console.log.LogLevel`**
+15. **Update scripts that hold a listener id**
+   Attaching a handler hands back a `trx.events.Listener` rather than a plain
+   number. Stopping one is `listener:detach()`, or `trx.events.detach(listener)`
+   as before; both report whether it was still attached. A script that kept the
+   number and passed it around keeps the listener instead - `trx.events.detach`
+   no longer takes a number, and `listener.id` is the number if anything needs
+   it.
+
+16. **Update scripts that use `trx.console.log.LogLevel`**
    It was removed. Use `trx.log.LogLevel`, which is the same enum:
    `trx.console.log.generic(trx.log.LogLevel.ERROR, "...")`.
 
-16. **Update scripts that use the music module**
+17. **Update scripts that use the music module**
    The soundtrack is addressed through track and stream handles now.
    - `trx.music.play` now takes a track by catalog id - a `trx.catalog.music`
      value, which maps to the right track per game - rather than the level's own
@@ -175,7 +183,7 @@ order: 3
      main stream, `[2]` onwards the overlays - each of which can be paused,
      resumed, sought and stopped on its own.
 
-17. **Update scripts that address levels by number**
+18. **Update scripts that address levels by number**
    `trx.game.levels` is the levels the game numbers, and a gym is not one of
    them. Where a game flow has a gym, `trx.game.levels[1]` used to be the gym;
    now every entry after it has shifted down by one and the last level -
@@ -184,19 +192,19 @@ order: 3
    it; use `trx.game.play_gym()` and `trx.game.gym` for the gym. The same holds
    for `trx.game.cutscenes`, `trx.game.demos` and their `play_` functions.
 
-18. **Update Lara's outfit definitions**
+19. **Update Lara's outfit definitions**
    The `braid` entries for Lara's outfits were changed to arrays to support up
    to two instances. Additionally, a `joints_object` can now be specified to
    allow using TR4/5 outfits. `outfits.json5` must be updated accordingly; refer
    to the default shipped file and [outfits documentation](OUTFITS.md).
 
-19. **Update scripts that pass an incomplete position**
+20. **Update scripts that pass an incomplete position**
    `{ x = , y = , z = }` needs all three coordinates. A missing one used to read
    as zero in `trx.sound.play`, placing the sound at the edge of the world, and
    raised an unhelpful error elsewhere. It now names the coordinate and the
    argument it came in on.
 
-20. **Update scripts that use `trx.sound.is_available`**
+21. **Update scripts that use `trx.sound.is_available`**
    It was removed. A sample is available when `trx.sound.samples[id]` is not
    `nil`. `trx.sound.samples` is a collection of `trx.sound.Sample` handles keyed
    by id, each of which plays itself and reports its definition, and
@@ -208,7 +216,7 @@ order: 3
    `play` hands back the `trx.sound.Stream` it started. `trx.sound.stop_all` is
    unchanged.
 
-21. **Update scripts that read `item.status`**
+22. **Update scripts that read `item.status`**
    The `item.status` field and the `items.Status` enum were removed in favour of
    separate boolean axes:
    - `item.is_simulated` (read-only): its control routine runs each frame -
@@ -225,7 +233,7 @@ order: 3
    The item query narrows on each: `simulated`, `present`, `visible`, `finished`,
    `in_play`, `alive`, `targetable`.
 
-22. **Update game flows that anchor Bacon Lara**
+23. **Update game flows that anchor Bacon Lara**
    The `setup_bacon_lara` sequence event was removed. The anchor room is an
    `anchor_room` object property now, which a level editor can set on the object
    or on a single item, and a script can set in `on_game_start`:
@@ -237,7 +245,7 @@ order: 3
    The property is optional: at its default of -1, the room Bacon Lara is placed
    in is the anchor. Refer to the Atlantis level in the default game flow.
 
-23. **Update scripts that use the level lifecycle events**
+24. **Update scripts that use the level lifecycle events**
    `before_level_file`, `after_level_file`, `before_item_setup`,
    `after_item_setup` and `after_level_state` were removed. `on_game_start` is
    the one moment a level script gets before play: the level file is loaded, its
@@ -254,18 +262,18 @@ order: 3
    fires for cutscene and demo levels too, and the title screen has
    `on_title_start`.
 
-24. **Remove `ammo.pickup_qty_alt` from weapon definitions**
+25. **Remove `ammo.pickup_qty_alt` from weapon definitions**
    The field only applied to flares in Japanese NG, which is no longer a game
    mode. A flare box now always gives `ammo.pickup_qty` flares. The field is
    ignored if left in `weapons.json5`.
 
-25. **Update scripts that raise an item's maximum hit points**
+26. **Update scripts that raise an item's maximum hit points**
    Writing `max_hit_points` carries the item's current hit points with it, by
    the difference: an item that has taken no damage comes out at full health,
    and one that is already hurt stays hurt by as much. It no longer needs a
    companion write to `hit_points`.
 
-26. **Update weapon definitions**
+27. **Update weapon definitions**
    The ammunition keys in `weapons.json5` were renamed to say what they count.
    A shot is one pull of the trigger, which for the shotgun spends six rounds;
    the flare counts a flare where a weapon counts a shot. The old names are

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3306,8 +3306,8 @@
       ],
       "path": "events.on_game_start",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3323,8 +3323,8 @@
       ],
       "path": "events.on_title_start",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3347,8 +3347,8 @@
       ],
       "path": "events.on_pickup",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3361,8 +3361,8 @@
       ],
       "path": "events.before_control",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3375,8 +3375,8 @@
       ],
       "path": "events.after_control",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3409,8 +3409,8 @@
       ],
       "path": "events.on_flip_effect",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3443,8 +3443,8 @@
       ],
       "path": "events.on_room_change",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3472,8 +3472,8 @@
       ],
       "path": "events.on_trigger",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3496,8 +3496,8 @@
       ],
       "path": "events.on_show",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3520,8 +3520,8 @@
       ],
       "path": "events.on_hide",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3544,8 +3544,8 @@
       ],
       "path": "events.on_finish",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3568,8 +3568,8 @@
       ],
       "path": "events.on_enter_sim",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3592,8 +3592,8 @@
       ],
       "path": "events.on_leave_sim",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3616,8 +3616,8 @@
       ],
       "path": "events.on_activate",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3640,8 +3640,8 @@
       ],
       "path": "events.on_deactivate",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3664,8 +3664,8 @@
       ],
       "path": "events.on_destroy",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3688,8 +3688,8 @@
       ],
       "path": "events.on_enter_world",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3712,8 +3712,8 @@
       ],
       "path": "events.on_leave_world",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3741,8 +3741,8 @@
       ],
       "path": "events.on_hit",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3765,8 +3765,8 @@
       ],
       "path": "events.on_kill",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3789,8 +3789,8 @@
       ],
       "path": "events.on_cutscene_trigger",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3810,8 +3810,8 @@
       ],
       "path": "events.on_cutscene_start",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3834,8 +3834,8 @@
       ],
       "path": "events.on_cutscene_end",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
@@ -3858,25 +3858,24 @@
       ],
       "path": "events.on_flyby_end",
       "returns": {
-        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-        "type": "integer"
+        "description": "The attached handler.",
+        "type": "events.Listener"
       }
     },
     {
-      "description": "Removes a previously attached handler, which stops firing immediately.",
+      "description": "Removes a previously attached handler, which stops firing immediately. `listener:detach()` does the same to one held in hand.",
       "examples": [
-        "local id = trx.events.before_control(function()\n  -- handle control loop event\nend)\ntrx.events.detach(id)"
+        "local listener = trx.events.before_control(function()\n  -- handle control loop event\nend)\ntrx.events.detach(listener)"
       ],
       "params": [
         {
-          "description": "The id attach returned.",
-          "name": "listener_id",
-          "type": "integer"
+          "name": "listener",
+          "type": "events.Listener"
         }
       ],
       "path": "events.detach",
       "returns": {
-        "description": "Whether a handler with that id was attached. `false` means it had already been detached, or the id was never handed out.",
+        "description": "Whether the handler was still attached. `false` means it had already been detached, or the level it belonged to has ended.",
         "type": "boolean"
       }
     },
@@ -4355,7 +4354,7 @@
       "returns": {
         "description": "The stream it started, or `nil` if none did.",
         "nullable": true,
-        "type": "Stream"
+        "type": "music.Stream"
       }
     },
     {
@@ -4755,7 +4754,7 @@
       "returns": {
         "description": "The voice it started, or `nil` if none did.",
         "nullable": true,
-        "type": "Stream"
+        "type": "sound.Stream"
       }
     },
     {
@@ -5403,6 +5402,31 @@
     }
   ],
   "types": [
+    {
+      "description": "An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "The number the engine keys the handler by. Two listeners of the same handler carry the same one; it is never handed out twice within a session.",
+          "name": "id",
+          "type": "integer",
+          "writable": false
+        }
+      ],
+      "handle": false,
+      "methods": [
+        {
+          "description": "Stops the handler, which fires no more from here on. `trx.events.detach` does the same to a listener held elsewhere.",
+          "name": "detach",
+          "returns": {
+            "description": "Whether the handler was still attached.",
+            "type": "boolean"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "events.Listener"
+    },
     {
       "description": "A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.",
       "extensions": [
@@ -6058,8 +6082,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6082,8 +6106,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6106,8 +6130,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6130,8 +6154,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6154,8 +6178,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6178,8 +6202,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6202,8 +6226,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6231,8 +6255,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6255,8 +6279,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6279,8 +6303,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6303,8 +6327,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6327,8 +6351,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6356,8 +6380,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -6803,7 +6827,7 @@
           "returns": {
             "description": "The stream it started, or `nil` if none did.",
             "nullable": true,
-            "type": "Stream"
+            "type": "music.Stream"
           }
         }
       ],
@@ -7379,8 +7403,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         },
         {
@@ -7406,8 +7430,8 @@
             }
           ],
           "returns": {
-            "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
-            "type": "integer"
+            "description": "The attached handler.",
+            "type": "events.Listener"
           }
         }
       ],
@@ -7472,7 +7496,7 @@
           "returns": {
             "description": "The voice it started, or `nil` if none did.",
             "nullable": true,
-            "type": "Stream"
+            "type": "sound.Stream"
           }
         },
         {

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -18,6 +18,22 @@ A handler attached from a level script is detached automatically when the level 
 
 An event that carries a default the script may take over says so in its description; a handler answers such an event by returning true, and the default then stands down. Every other event ignores what its handlers return.
 
+### Structures
+
+- [lua]`trx.events.Listener`
+
+    An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.
+
+    Properties:
+    - **`id`**: integer. The number the engine keys the handler by. Two listeners of the same handler carry the same one; it is never handed out twice within a session. *(read-only)*
+
+    Methods:
+
+    - [lua]`listener:detach()`  
+      Stops the handler, which fires no more from here on. `trx.events.detach` does the same to a listener held elsewhere.
+
+      Returns: boolean. Whether the handler was still attached.
+
 ### Functions
 
 - [lua]`trx.events.on_game_start(callback)`  
@@ -35,7 +51,7 @@ An event that carries a default the script may take over says so in its descript
     - **`level_num`** (integer). Number of the level being started.
     - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
 - [lua]`trx.events.on_title_start(callback)`  
       Happens when the title screen's scene starts playing behind the menu, once
@@ -46,7 +62,7 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -63,7 +79,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item_num`** (integer). 0-based index of the item that was picked up.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -78,7 +94,7 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
 - [lua]`trx.events.after_control(callback)`  
   Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.
@@ -86,7 +102,7 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
 - [lua]`trx.events.on_flip_effect(effect_num, callback)`  
   Claims a flip effect number and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick an unused effect number, and handle it here from the level's script.
@@ -102,7 +118,7 @@ An event that carries a default the script may take over says so in its descript
     - **`timer`** (integer). A floor trigger's timer field, free for the level to use as a parameter. 0 for an animation command, which carries no timer.
     - **`item_num`** (integer). 0-based index of the item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -121,7 +137,7 @@ An event that carries a default the script may take over says so in its descript
     - **`old_room`** (integer). 0-based number of the room it left, or -1 if it had none.
     - **`new_room`** (integer). 0-based number of the room it entered, or -1 if it left the world.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -143,7 +159,7 @@ An event that carries a default the script may take over says so in its descript
     - **`item`** (Item). The `trx.items.Item` the trigger was aimed at.
     - **`trigger`** (table). What the trigger carried: `type` (an `items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -164,7 +180,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that became visible.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -183,7 +199,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that became hidden.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -202,7 +218,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that finished.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -221,7 +237,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that started being simulated.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -240,7 +256,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that stopped being simulated.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -259,7 +275,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that was activated.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -278,7 +294,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that was deactivated.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -297,7 +313,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` being removed. Valid only for the duration of the handler.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -316,7 +332,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that entered the world.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -335,7 +351,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that left the world.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -358,7 +374,7 @@ An event that carries a default the script may take over says so in its descript
     - **`item`** (Item). The `trx.items.Item` that took the damage.
     - **`damage`** (integer). Hit points taken, before clamping to zero.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -384,7 +400,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`item`** (Item). The `trx.items.Item` that was brought down.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -415,7 +431,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`num`** (integer). Number the trigger names.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -441,7 +457,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`num`** (integer). Number of the cutscene starting.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
 - [lua]`trx.events.on_cutscene_end(callback)`  
   Happens once a TR4 cutscene has finished and the scene it interrupted is back. This is where a script decides what follows.
@@ -451,7 +467,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`num`** (integer). Number of the cutscene that ended.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -469,7 +485,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`sequence`** (integer). Number of the sequence that ended.
 
-  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+  Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
@@ -478,18 +494,18 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.detach(listener_id)`  
-  Removes a previously attached handler, which stops firing immediately.
+- [lua]`trx.events.detach(listener)`  
+  Removes a previously attached handler, which stops firing immediately. `listener:detach()` does the same to one held in hand.
 
   Parameters:
-  - **`listener_id`** (integer). The id attach returned.
+  - **`listener`** (events.Listener).
 
-  Returns: boolean. Whether a handler with that id was attached. `false` means it had already been detached, or the id was never handed out.
+  Returns: boolean. Whether the handler was still attached. `false` means it had already been detached, or the level it belonged to has ended.
 
   Example:
   ```lua
-  local id = trx.events.before_control(function()
+  local listener = trx.events.before_control(function()
     -- handle control loop event
   end)
-  trx.events.detach(id)
+  trx.events.detach(listener)
   ```

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -194,7 +194,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -211,7 +211,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -228,7 +228,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -245,7 +245,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -262,7 +262,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -279,7 +279,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -296,7 +296,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -314,7 +314,7 @@ end
         - **`item`** (Item). This item.
         - **`damage`** (integer). Hit points taken, before clamping to zero.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -331,7 +331,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -348,7 +348,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -365,7 +365,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -382,7 +382,7 @@ end
         Called with:
         - **`item`** (Item). This item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -400,7 +400,7 @@ end
         - **`item`** (Item). This item.
         - **`trigger`** (table). What the trigger carried: `type`, `mask`, `timer` and `one_shot`. See `trx.events.on_trigger`.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -106,7 +106,7 @@ Module for playing and controlling the soundtrack.
       Parameters:
       - **`opts`** (table, optional). `mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.
 
-      Returns: Stream or `nil`. The stream it started, or `nil` if none did.
+      Returns: music.Stream or `nil`. The stream it started, or `nil` if none did.
 
 ### Functions
 
@@ -117,7 +117,7 @@ Module for playing and controlling the soundtrack.
   - **`id`** (integer). Track to play. To reach a track by the level's own slot, play it through a handle: `trx.music.tracks[slot]:play()`. Compare against `trx.catalog.music`.
   - **`opts`** (table, optional). `mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.
 
-  Returns: Stream or `nil`. The stream it started, or `nil` if none did.
+  Returns: music.Stream or `nil`. The stream it started, or `nil` if none did.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -104,7 +104,7 @@ end
         - **`item`** (Item). The `trx.items.Item` that changed rooms.
       - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
       Example:
       ```lua
@@ -122,7 +122,7 @@ end
         - **`item`** (Item). The `trx.items.Item` that changed rooms.
       - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
 
-      Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+      Returns: events.Listener. The attached handler.
 
 ### Functions
 

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -49,7 +49,7 @@ Module for playing sound effects.
       Parameters:
       - **`opts`** (table, optional). `pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.
 
-      Returns: Stream or `nil`. The voice it started, or `nil` if none did.
+      Returns: sound.Stream or `nil`. The voice it started, or `nil` if none did.
 
     - [lua]`sample:stop()`  
       Stops every voice playing this sample.
@@ -90,7 +90,7 @@ Module for playing sound effects.
   - **`id`** (integer). Sample to play. To reach a sample by the level's own slot, play it through a handle: `trx.sound.samples[slot]:play()`. Compare against `trx.catalog.samples`.
   - **`opts`** (table, optional). `pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.
 
-  Returns: Stream or `nil`. The voice it started, or `nil` if none did.
+  Returns: sound.Stream or `nil`. The voice it started, or `nil` if none did.
 
   Example:
   ```lua

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -810,6 +810,54 @@ function api.type(path, spec)
       rawset(class, "__" .. name, operator.impl)
     end
 
+    -- A field of a type written in Lua is a pair of accessors, since the value
+    -- has no struct behind it to address. Declaring any of them is what puts
+    -- the type's members under the registry's control: reading one the
+    -- declaration does not name comes back nil, and writing one raises, so a
+    -- value cannot quietly grow members the docs never see. A field is
+    -- writable when it declares a `set`, and read-only otherwise.
+    local getters, setters = {}, {}
+    local has_fields = false
+    for name, field in pairs(spec.fields or {}) do
+      assert(
+        type(field.get) == "function",
+        "api.type: field '" .. name .. "' needs a get"
+      )
+      assert(
+        field.set == nil or type(field.set) == "function",
+        "api.type: field '" .. name .. "' has a set that is not a function"
+      )
+      getters[name] = field.get
+      setters[name] = field.set
+      field.writable = field.set ~= nil
+      has_fields = true
+    end
+
+    if has_fields then
+      class.__index = function(self, key)
+        local getter = getters[key]
+        if getter ~= nil then
+          return getter(self)
+        end
+        -- The metamethods sit on the class alongside the methods, and are the
+        -- registry's business rather than a member of the type.
+        if type(key) == "string" and key:sub(1, 2) == "__" then
+          return nil
+        end
+        return class[key]
+      end
+      class.__newindex = function(self, key, value)
+        local setter = setters[key]
+        if setter == nil then
+          if getters[key] ~= nil then
+            error(("%s.%s is read-only"):format(path, tostring(key)), 2)
+          end
+          error(("%s has no member '%s'"):format(path, tostring(key)), 2)
+        end
+        setter(self, value)
+      end
+    end
+
     lua_classes[path] = class
     checkers[type_name] = class_checker(class)
     record(types, path, spec)

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -59,8 +59,13 @@ local namespaces = ordered()
 -- metatable so api.strict can swap the wrapper in.
 local namespace_dispatch = {}
 -- Type name -> predicate. Private: reachable, a script could hand strict mode a
--- checker that accepts anything.
+-- checker that accepts anything. A type answers to its bare name and to its
+-- full path alike, so a declaration in another module can say which Listener it
+-- means.
 local checkers
+-- Bare type name -> the path that claimed it, so two modules cannot quietly
+-- declare the same name and have the later one answer for both.
+local checker_paths = {}
 local containers = ordered()
 -- module -> { get, count, accepts }. What indexing the module table reaches.
 local module_containers = {}
@@ -422,6 +427,23 @@ end
 -- A value of a type written in Lua carries its class as its metatable, and a
 -- derived class carries the one it extends. Walking that chain is what lets an
 -- ItemQuery satisfy a parameter declared as a Query.
+-- A type answers to its path always, and to its bare name while that name means
+-- one type. Two modules with a type of the same name - music.Stream and
+-- sound.Stream - leave the bare name meaning neither, so a declaration that
+-- used it stops checking rather than checking against whichever module declared
+-- last, and says as much at boot.
+local function register_checker(path, type_name, check)
+  local claimed = checker_paths[type_name]
+  if claimed ~= nil and claimed ~= path then
+    checkers[type_name] = nil
+    checker_paths[type_name] = false
+  elseif claimed == nil then
+    checker_paths[type_name] = path
+    checkers[type_name] = check
+  end
+  checkers[path] = check
+end
+
 local function class_checker(class)
   return function(v)
     local candidate = getmetatable(v)
@@ -859,7 +881,7 @@ function api.type(path, spec)
     end
 
     lua_classes[path] = class
-    checkers[type_name] = class_checker(class)
+    register_checker(path, type_name, class_checker(class))
     record(types, path, spec)
     bind_type_methods(path)
     return class
@@ -872,7 +894,7 @@ function api.type(path, spec)
   local backing = spec.backing
 
   -- Declaring the type is what makes its name checkable in a params list.
-  checkers[type_name] = handle_checker(backing)
+  register_checker(path, type_name, handle_checker(backing))
 
   for name, field in pairs(spec.fields or {}) do
     local from = field.from or name

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -20,17 +20,56 @@ api.module("events", {
     .. "other event ignores what its handlers return.",
 })
 
+-- What every hook hands back. The engine keys a listener by a number, and the
+-- number is the module's business rather than a script's: a listener is worth
+-- holding on to, comparing and detaching, and worth nothing else.
+local Listener = api.type("events.Listener", {
+  description = "An attached handler. Every hook hands one back, and holding it is what makes the "
+    .. "handler detachable later. A listener is spent once detached, and a level change spends "
+    .. "every one a level script attached.",
+
+  fields = {
+    id = {
+      type = "integer",
+      description = "The number the engine keys the handler by. Two listeners of the same handler "
+        .. "carry the same one; it is never handed out twice within a session.",
+      get = function(self)
+        return rawget(self, "_id")
+      end,
+    },
+  },
+
+  methods = {
+    detach = {
+      description = "Stops the handler, which fires no more from here on. `trx.events.detach` does "
+        .. "the same to a listener held elsewhere.",
+      returns = {
+        type = "boolean",
+        description = "Whether the handler was still attached.",
+      },
+      impl = function(self)
+        return raw.detach(rawget(self, "_id"))
+      end,
+    },
+  },
+})
+
+-- A listener carries the engine's number and nothing a script can reach.
+local function listener_of(id)
+  return setmetatable({ _id = id }, Listener)
+end
+
 -- Each hook is a plain function closing over its event type.
 local function hook(event_type)
   assert(event_type ~= nil, "events: the engine has no such event type")
   return function(callback)
-    return raw.attach(event_type, callback)
+    return listener_of(raw.attach(event_type, callback))
   end
 end
 
-local LISTENER_ID = {
-  type = "integer",
-  description = "Listener id. Pass it to `trx.events.detach` to stop listening.",
+local LISTENER = {
+  type = "events.Listener",
+  description = "The attached handler.",
 }
 
 api.define("events.on_game_start", {
@@ -60,7 +99,7 @@ api.define("events.on_game_start", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   impl = hook(types.GAME_START),
 })
 
@@ -71,7 +110,7 @@ api.define("events.on_title_start", {
     arguments. `on_game_start` does not fire for the title level.
   ]],
   params = { { name = "callback", type = "function" } },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_title_start(function()
   trx.log.info("the menu is up")
@@ -95,7 +134,7 @@ api.define("events.on_pickup", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_pickup(function(item_num)
   trx.log.info(trx.items[item_num].object_id)
@@ -108,7 +147,7 @@ api.define("events.before_control", {
   description = "Happens on every logical game frame, before the main game logic runs. The handler "
     .. "takes no arguments.",
   params = { { name = "callback", type = "function" } },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   impl = hook(types.BEFORE_CONTROL),
 })
 
@@ -116,7 +155,7 @@ api.define("events.after_control", {
   description = "Happens on every logical game frame, after the main game logic runs. The handler "
     .. "takes no arguments.",
   params = { { name = "callback", type = "function" } },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   impl = hook(types.AFTER_CONTROL),
 })
 
@@ -157,14 +196,14 @@ api.define("events.on_flip_effect", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_flip_effect(62, function(timer, item_num)
   trx.log.info("flipeffect 62 ran with timer " .. timer)
 end)]],
   },
   impl = function(effect_num, callback)
-    return raw.attach(types.FLIP_EFFECT, callback, effect_num)
+    return listener_of(raw.attach(types.FLIP_EFFECT, callback, effect_num))
   end,
 })
 
@@ -195,16 +234,18 @@ api.define("events.on_room_change", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_room_change(function(item, old_room, new_room)
   trx.log.info(item.object_id .. " moved to room " .. new_room)
 end)]],
   },
   impl = function(callback)
-    return raw.attach(types.ROOM_CHANGE, function(item_num, old_room, new_room)
-      callback(trx.items[item_num], old_room, new_room)
-    end)
+    return listener_of(
+      raw.attach(types.ROOM_CHANGE, function(item_num, old_room, new_room)
+        callback(trx.items[item_num], old_room, new_room)
+      end)
+    )
   end,
 })
 
@@ -236,7 +277,7 @@ api.define("events.on_trigger", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_trigger(function(item, trigger)
   if trigger.type == trx.items.TriggerType.ANTITRIGGER then
@@ -245,16 +286,15 @@ api.define("events.on_trigger", {
 end)]],
   },
   impl = function(callback)
-    return raw.attach(
-      types.TRIGGER,
-      function(item_num, kind, mask, timer, one_shot)
+    return listener_of(
+      raw.attach(types.TRIGGER, function(item_num, kind, mask, timer, one_shot)
         callback(trx.items[item_num], {
           type = kind,
           mask = mask,
           timer = timer,
           one_shot = one_shot,
         })
-      end
+      end)
     )
   end,
 })
@@ -285,12 +325,12 @@ local function visibility_hook(event_type, method, verb, examples)
         },
       },
     },
-    returns = LISTENER_ID,
+    returns = LISTENER,
     examples = examples,
     impl = function(callback)
-      return raw.attach(event_type, function(item_num)
+      return listener_of(raw.attach(event_type, function(item_num)
         callback(trx.items[item_num])
-      end)
+      end))
     end,
   }
 end
@@ -318,12 +358,12 @@ local function item_lifecycle_hook(
         },
       },
     },
-    returns = LISTENER_ID,
+    returns = LISTENER,
     examples = examples,
     impl = function(callback)
-      return raw.attach(event_type, function(item_num)
+      return listener_of(raw.attach(event_type, function(item_num)
         callback(trx.items[item_num])
-      end)
+      end))
     end,
   }
 end
@@ -505,16 +545,16 @@ attacker dealt. A death that does not go through damage - a script writing `hit_
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_hit(function(item, damage)
   trx.log.info(item.object_id .. " lost " .. damage .. " hit points")
 end)]],
   },
   impl = function(callback)
-    return raw.attach(types.HIT, function(item_num, damage)
+    return listener_of(raw.attach(types.HIT, function(item_num, damage)
       callback(trx.items[item_num], damage)
-    end)
+    end))
   end,
 })
 
@@ -542,16 +582,16 @@ more for the dagger that ends it.
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_kill(function(item)
   trx.log.info(item.object_id .. " is down")
 end)]],
   },
   impl = function(callback)
-    return raw.attach(types.KILL, function(item_num)
+    return listener_of(raw.attach(types.KILL, function(item_num)
       callback(trx.items[item_num])
-    end)
+    end))
   end,
 })
 
@@ -585,7 +625,7 @@ api.define("events.on_cutscene_trigger", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[-- only in the throne room; a flyby stands in for it elsewhere
 trx.events.on_cutscene_trigger(function(num)
@@ -618,7 +658,7 @@ api.define("events.on_cutscene_start", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   impl = hook(types.CUTSCENE_START),
 })
 
@@ -638,7 +678,7 @@ api.define("events.on_cutscene_end", {
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_cutscene_end(function(num)
   trx.log.info("cutscene " .. num .. " finished")
@@ -664,7 +704,7 @@ A sequence that a cutscene or the player interrupts does not fire it.]],
       },
     },
   },
-  returns = LISTENER_ID,
+  returns = LISTENER,
   examples = {
     [[trx.events.on_flyby_end(function(sequence)
   trx.camera.play_flyby(sequence)
@@ -674,24 +714,23 @@ end)]],
 })
 
 api.define("events.detach", {
-  description = "Removes a previously attached handler, which stops firing immediately.",
+  description = "Removes a previously attached handler, which stops firing immediately. "
+    .. "`listener:detach()` does the same to one held in hand.",
   params = {
-    {
-      name = "listener_id",
-      type = "integer",
-      description = "The id attach returned.",
-    },
+    { name = "listener", type = "events.Listener" },
   },
   returns = {
     type = "boolean",
-    description = "Whether a handler with that id was attached. `false` means it had already been "
-      .. "detached, or the id was never handed out.",
+    description = "Whether the handler was still attached. `false` means it had already been "
+      .. "detached, or the level it belonged to has ended.",
   },
   examples = {
-    [[local id = trx.events.before_control(function()
+    [[local listener = trx.events.before_control(function()
   -- handle control loop event
 end)
-trx.events.detach(id)]],
+trx.events.detach(listener)]],
   },
-  impl = raw.detach,
+  impl = function(listener)
+    return listener:detach()
+  end,
 })

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -91,9 +91,9 @@ local function item_hook(event_name)
   end
 end
 
-local ITEM_LISTENER_ID = {
-  type = "integer",
-  description = "Listener id. Pass it to `trx.events.detach` to stop listening.",
+local ITEM_LISTENER = {
+  type = "events.Listener",
+  description = "The attached handler.",
 }
 
 -- The item-lifecycle methods share a shape: a callback taking this item, over
@@ -113,7 +113,7 @@ local function item_lifecycle_method(event_name, description, examples)
         },
       },
     },
-    returns = ITEM_LISTENER_ID,
+    returns = ITEM_LISTENER,
     description = description,
     examples = examples,
     impl = item_hook(event_name),
@@ -419,7 +419,7 @@ api.type("items.Item", {
           },
         },
       },
-      returns = ITEM_LISTENER_ID,
+      returns = ITEM_LISTENER,
       description = "Happens every time a trigger is aimed at this item, of any kind. "
         .. "`trx.events.on_trigger`, narrowed to this item.",
       examples = {
@@ -449,7 +449,7 @@ end)]],
           },
         },
       },
-      returns = ITEM_LISTENER_ID,
+      returns = ITEM_LISTENER,
       description = "Happens when this item takes damage. `trx.events.on_hit`, narrowed to this "
         .. "item.",
       examples = {
@@ -474,7 +474,7 @@ end)]],
           },
         },
       },
-      returns = ITEM_LISTENER_ID,
+      returns = ITEM_LISTENER,
       description = "Happens when damage takes this item's hit points to zero. "
         .. "`trx.events.on_kill`, narrowed to this item.",
       examples = {

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -106,7 +106,7 @@ api.type("music.Track", {
         },
       },
       returns = {
-        type = "Stream",
+        type = "music.Stream",
         nullable = true,
         description = "The stream it started, or `nil` if none did.",
       },
@@ -231,7 +231,7 @@ api.define("music.play", {
     },
   },
   returns = {
-    type = "Stream",
+    type = "music.Stream",
     nullable = true,
     description = "The stream it started, or `nil` if none did.",
   },

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -76,9 +76,9 @@ local FLOOR_HEIGHT_PARAMS = {
   FLOOR_HEIGHT_OPTS,
 }
 
-local ROOM_LISTENER_ID = {
-  type = "integer",
-  description = "Listener id. Pass it to `trx.events.detach` to stop listening.",
+local ROOM_LISTENER = {
+  type = "events.Listener",
+  description = "The attached handler.",
 }
 
 api.module("rooms", {
@@ -142,7 +142,7 @@ api.type("rooms.Room", {
   methods = {
     on_enter = {
       params = ROOM_HOOK_PARAMS,
-      returns = ROOM_LISTENER_ID,
+      returns = ROOM_LISTENER,
       description = "Happens when something changes rooms into this one.",
       examples = {
         [[trx.rooms[7]:on_enter(function(item)
@@ -155,7 +155,7 @@ end)]],
     },
     on_exit = {
       params = ROOM_HOOK_PARAMS,
-      returns = ROOM_LISTENER_ID,
+      returns = ROOM_LISTENER,
       description = "Happens when something changes rooms out of this one.",
       impl = room_hook(function(old_room, new_room)
         return old_room

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -61,7 +61,7 @@ api.type("sound.Sample", {
         },
       },
       returns = {
-        type = "Stream",
+        type = "sound.Stream",
         nullable = true,
         description = "The voice it started, or `nil` if none did.",
       },
@@ -194,7 +194,7 @@ api.define("sound.play", {
     },
   },
   returns = {
-    type = "Stream",
+    type = "sound.Stream",
     nullable = true,
     description = "The voice it started, or `nil` if none did.",
   },

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -927,6 +927,55 @@ test("a Lua type's field must carry a get", function()
   )
 end)
 
+test("a type answers to its bare name and to its path", function()
+  local api = fresh_env()
+  local Widget = api.type("things.Widget", {})
+  api.define("things.press", {
+    params = { { name = "widget", type = "things.Widget" } },
+    impl = function()
+      return true
+    end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.press, setmetatable({}, Widget)))
+  assert(not pcall(trx.things.press, {}))
+  api.strict(false)
+end)
+
+-- Two modules with a type of the same name is allowed - music.Stream and
+-- sound.Stream are one - but the bare name stops naming either, so a
+-- declaration says which by its path instead of checking against whichever
+-- module happened to declare last.
+test("a name two modules claim stops naming either", function()
+  local api = fresh_env()
+  local Widget = api.type("things.Widget", {})
+  local Gadget = api.type("others.Widget", {})
+  api.define("things.press", {
+    params = { { name = "thing", type = "things.Widget" } },
+    impl = function()
+      return true
+    end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.press, setmetatable({}, Widget)))
+  assert(
+    not pcall(trx.things.press, setmetatable({}, Gadget)),
+    "the path must name one type and not the other"
+  )
+  api.strict(false)
+
+  assert(
+    not pcall(api.define, "things.poke", {
+        params = { { name = "thing", type = "Widget" } },
+        impl = function() end,
+      }) or not pcall(api.strict, true),
+    "the bare name must no longer check anything"
+  )
+  api.strict(false)
+end)
+
 test("a container walks from the index it counts from", function()
   local api = fresh_env()
   local zero, one = { [0] = "a", [1] = "b" }, { "a", "b" }

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -853,6 +853,80 @@ test(
   end
 )
 
+test("a Lua type's fields read and write through its accessors", function()
+  local api = fresh_env()
+  local state = {}
+  local Widget = api.type("things.Widget", {
+    fields = {
+      name = {
+        type = "string",
+        description = "...",
+        get = function(self)
+          return state[self].name
+        end,
+        set = function(self, value)
+          state[self].name = value
+        end,
+      },
+      size = {
+        type = "integer",
+        description = "...",
+        get = function(self)
+          return #state[self].name
+        end,
+      },
+    },
+    methods = {
+      poke = {
+        description = "...",
+        impl = function(self)
+          return self.name .. "!"
+        end,
+      },
+    },
+  })
+
+  local widget = setmetatable({}, Widget)
+  state[widget] = { name = "hinge" }
+
+  assert(widget.name == "hinge")
+  assert(widget.size == 5, "a field with no set is still readable")
+  assert(widget:poke() == "hinge!", "a method must still be reachable")
+
+  widget.name = "lever"
+  assert(widget.name == "lever")
+
+  -- Declared or absent: what the type does not name is neither readable nor
+  -- writable, so a value cannot grow a member the docs never see.
+  assert(widget.colour == nil)
+  local ok, err = pcall(function()
+    widget.size = 3
+  end)
+  assert(not ok and tostring(err):find("read%-only"), tostring(err))
+  assert(not pcall(function()
+    widget.colour = "red"
+  end))
+
+  local entry = api.describe().types[1]
+  local by_name = {}
+  for _, field in ipairs(entry.fields) do
+    by_name[field.name] = field
+  end
+  assert(by_name.name.writable == true)
+  assert(by_name.size.writable == false, "a field with no set is read-only")
+end)
+
+test("a Lua type's field must carry a get", function()
+  local api = fresh_env()
+  assert(
+    not pcall(
+      api.type,
+      "things.Widget",
+      { fields = { name = { type = "string" } } }
+    )
+  )
+end)
+
 test("a container walks from the index it counts from", function()
   local api = fresh_env()
   local zero, one = { [0] = "a", [1] = "b" }, { "a", "b" }

--- a/src/tests/lua/api/events.lua
+++ b/src/tests/lua/api/events.lua
@@ -10,7 +10,7 @@ local test, raises = h.test, h.raises
 
 test("a handler fires, and stops firing once detached", function()
   local calls = 0
-  local id = trx.events.before_control(function()
+  local listener = trx.events.before_control(function()
     calls = calls + 1
   end)
 
@@ -18,17 +18,49 @@ test("a handler fires, and stops firing once detached", function()
   fake.fire("before_control")
   assert(calls == 2, "handler did not fire twice")
 
-  assert(trx.events.detach(id) == true, "detach must report the removal")
+  assert(trx.events.detach(listener) == true, "detach must report the removal")
   fake.fire("before_control")
   assert(calls == 2, "a detached handler kept firing")
 end)
 
-test("detaching twice reports that there was nothing to remove", function()
-  local id = trx.events.after_control(function() end)
-  assert(trx.events.detach(id) == true)
-  assert(trx.events.detach(id) == false, "the second detach must report false")
-  assert(trx.events.detach(99999) == false, "an id never handed out")
+test("a listener detaches itself as well", function()
+  local calls = 0
+  local listener = trx.events.before_control(function()
+    calls = calls + 1
+  end)
+
+  fake.fire("before_control")
+  assert(listener:detach() == true, "the method must report the removal")
+  fake.fire("before_control")
+  assert(calls == 1, "a detached handler kept firing")
 end)
+
+test("detaching twice reports that there was nothing to remove", function()
+  local listener = trx.events.after_control(function() end)
+  assert(trx.events.detach(listener) == true)
+  assert(
+    trx.events.detach(listener) == false,
+    "the second detach must report false"
+  )
+  assert(listener:detach() == false, "and so must the method")
+end)
+
+test(
+  "a listener says which handler it is, and refuses to be edited",
+  function()
+    local listener = trx.events.after_control(function() end)
+    assert(
+      math.type(listener.id) == "integer",
+      "a listener knows its own number"
+    )
+    raises(function()
+      listener.id = 1
+    end, "read-only")
+    raises(function()
+      listener.whatever = 1
+    end)
+  end
+)
 
 test("the control events pass no arguments", function()
   local seen = "unset"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Attaching a Lua event handler hands back a `trx.events.Listener` rather than a plain number.

```lua
local listener = trx.events.on_pickup(function(item) end)
listener.id                     -- the number the engine keys it by, read-only
listener:detach()               -- stops the handler; true if it was still attached
trx.events.detach(listener)     -- the same, for one held elsewhere
```

Before this, every hook had to say in prose what the number was for and how to be rid of it; five modules carried a copy of that sentence and one had drifted. The type's own entry carries it once, and a hook's declaration is `returns = { type = "events.Listener" }`.

A type also answers to its full path now, so a declaration in another module says which type it means. Where two modules name a type alike - `music.Stream` and `sound.Stream` - the bare name names neither, and a declaration that used it fails at boot rather than checking against whichever module declared last.

For mod authors this is breaking: `trx.events.detach` no longer takes a number. `MIGRATING.md` has the entry.

The first of the two commits adds fields to types written in Lua, which is what lets `Listener` declare `id` with a getter and no setter.
