### PR TITLE
Write repeated API descriptions once

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -77,7 +77,7 @@
         "trx.log.info(#trx.rooms .. \" rooms, first is \" .. trx.rooms[0].num)\nfor num, room in pairs(trx.rooms) do\n  room.cold = true\nend"
       ],
       "key": {
-        "description": "0-based room number.",
+        "description": "0-based room number, matching the numbers level editors show.",
         "type": "integer"
       },
       "module": "rooms",
@@ -3337,7 +3337,7 @@
           "name": "callback",
           "params": [
             {
-              "description": "0-based index of the item that was picked up.",
+              "description": "0-based item number, matching the numbers level editors show. The item that was picked up.",
               "name": "item_num",
               "type": "integer"
             }
@@ -3399,7 +3399,7 @@
               "type": "integer"
             },
             {
-              "description": "0-based index of the item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.",
+              "description": "0-based item number, matching the numbers level editors show. The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.",
               "name": "item_num",
               "type": "integer"
             }
@@ -4475,7 +4475,7 @@
       ],
       "params": [
         {
-          "description": "0-based room number.",
+          "description": "0-based room number, matching the numbers level editors show.",
           "name": "num",
           "type": "integer"
         }
@@ -6510,7 +6510,7 @@
           "name": "in_room",
           "params": [
             {
-              "description": "0-based room number.",
+              "description": "0-based room number, matching the numbers level editors show.",
               "name": "room_num",
               "type": "integer"
             }

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -77,7 +77,7 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item_num`** (integer). 0-based index of the item that was picked up.
+    - **`item_num`** (integer). 0-based item number, matching the numbers level editors show. The item that was picked up.
 
   Returns: events.Listener. The attached handler.
 
@@ -116,7 +116,7 @@ An event that carries a default the script may take over says so in its descript
   - **`callback`** (function).
     Called with:
     - **`timer`** (integer). A floor trigger's timer field, free for the level to use as a parameter. 0 for an animation command, which carries no timer.
-    - **`item_num`** (integer). 0-based index of the item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
+    - **`item_num`** (integer). 0-based item number, matching the numbers level editors show. The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
 
   Returns: events.Listener. The attached handler.
 

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -509,7 +509,7 @@ end
       The item is in the given room.
 
       Parameters:
-      - **`room_num`** (integer). 0-based room number.
+      - **`room_num`** (integer). 0-based room number, matching the numbers level editors show.
 
       Returns: Query. The narrowed query.
 

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -18,7 +18,7 @@ Module for inspecting and altering the rooms of the current level.
 
 Indexing the module reaches a room, and `#trx.rooms` is how many the level has. Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them in order, keyed by that number.
 
-- **`trx.rooms[key]`** (Room or `nil`). 0-based room number.
+- **`trx.rooms[key]`** (Room or `nil`). 0-based room number, matching the numbers level editors show.
 - **`#trx.rooms`** (integer). How many there are.
 
 Example:
@@ -181,7 +181,7 @@ end
   Retrieves a room by number. Rooms count from zero, matching the room numbers level editors show.
 
   Parameters:
-  - **`num`** (integer). 0-based room number.
+  - **`num`** (integer). 0-based room number, matching the numbers level editors show.
 
   Returns: Room or `nil`.
 

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -66,6 +66,11 @@ local checkers
 -- Bare type name -> the path that claimed it, so two modules cannot quietly
 -- declare the same name and have the later one answer for both.
 local checker_paths = {}
+-- Descriptions written once and pointed at from wherever they belong, keyed by
+-- a name of the module's choosing. `see` on a param, a return or a field pulls
+-- one in - what "0-based item number" means is the items module's to say, and
+-- every hook that carries one says it by pointing here.
+local notes = {}
 local containers = ordered()
 -- module -> { get, count, accepts }. What indexing the module table reaches.
 local module_containers = {}
@@ -1092,6 +1097,63 @@ function api.property(path, spec)
   return spec
 end
 
+-- Declares a description other declarations point at with `see`. Doc-only: it
+-- reaches no module table and a script never sees it.
+function api.note(name, text)
+  opening("api.note")
+  assert(type(name) == "string", "api.note: name must be a string")
+  assert(type(text) == "string", "api.note: text must be a string")
+  assert(notes[name] == nil, "api.note: '" .. name .. "' is already written")
+  notes[name] = text
+end
+
+-- A spec as the docs read it: what `see` points at, ahead of anything the spec
+-- adds of its own, and the same done to the arguments a callback takes.
+local function noted(spec)
+  if type(spec) ~= "table" then
+    return spec
+  end
+  local out = {}
+  for key, value in pairs(spec) do
+    out[key] = value
+  end
+  if out.see ~= nil then
+    local note = notes[out.see]
+    assert(note ~= nil, "api: no note called '" .. tostring(out.see) .. "'")
+    out.description = out.description ~= nil
+        and (note .. " " .. out.description)
+      or note
+    out.see = nil
+  end
+  if type(out.params) == "table" then
+    local params = {}
+    for i, param in ipairs(out.params) do
+      params[i] = noted(param)
+    end
+    out.params = params
+  end
+  return out
+end
+
+-- Params are a list; returns is one spec or a list of them.
+local function noted_list(list)
+  if list == nil then
+    return nil
+  end
+  local out = {}
+  for i, spec in ipairs(list) do
+    out[i] = noted(spec)
+  end
+  return out
+end
+
+local function noted_returns(returns)
+  if returns == nil or returns.type ~= nil then
+    return noted(returns)
+  end
+  return noted_list(returns)
+end
+
 -- The whole surface as plain data: what the docs generator consumes.
 function api.describe()
   local out = { types = {}, enums = {} }
@@ -1099,8 +1161,8 @@ function api.describe()
     return {
       module = name,
       description = spec.description,
-      key = spec.key,
-      value = spec.value,
+      key = noted(spec.key),
+      value = noted(spec.value),
       countable = spec.count ~= nil,
       examples = spec.examples,
     }
@@ -1117,8 +1179,8 @@ function api.describe()
     return {
       path = path,
       description = spec.description,
-      params = spec.params,
-      returns = spec.returns,
+      params = noted_list(spec.params),
+      returns = noted_returns(spec.returns),
       examples = spec.examples,
     }
   end)
@@ -1143,20 +1205,21 @@ function api.describe()
       })
     end
     for name, field in pairs(spec.fields or {}) do
+      local noted_field = noted(field)
       table.insert(entry.fields, {
         name = name,
-        type = field.type,
-        writable = field.writable ~= false,
-        description = field.description,
-        enum = field.enum,
+        type = noted_field.type,
+        writable = noted_field.writable ~= false,
+        description = noted_field.description,
+        enum = noted_field.enum,
       })
     end
     for name, method in pairs(spec.methods or {}) do
       table.insert(entry.methods, {
         name = name,
         description = method.description,
-        params = method.params,
-        returns = method.returns,
+        params = noted_list(method.params),
+        returns = noted_returns(method.returns),
         examples = method.examples,
       })
     end

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -129,7 +129,8 @@ api.define("events.on_pickup", {
         {
           name = "item_num",
           type = "integer",
-          description = "0-based index of the item that was picked up.",
+          see = "items.index",
+          description = "The item that was picked up.",
         },
       },
     },
@@ -189,7 +190,8 @@ api.define("events.on_flip_effect", {
         {
           name = "item_num",
           type = "integer",
-          description = "0-based index of the item that ran the effect: Lara for a pad trigger, "
+          see = "items.index",
+          description = "The item that ran the effect: Lara for a pad trigger, "
             .. "the activating object for a heavy trigger, the animating item for an animation "
             .. "command.",
         },

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -8,6 +8,11 @@ api.module("items", {
   description = "Module for controlling all moveables.",
 })
 
+api.note(
+  "items.index",
+  "0-based item number, matching the numbers level editors show."
+)
+
 api.enum("items.PickupMode", {
   backing = "PICKUP_MODE",
   description = "The values the `pickup_mode` item property can take. It selects the animation Lara "
@@ -859,7 +864,7 @@ local ItemQuery = api.type("items.ItemQuery", {
         {
           name = "room_num",
           type = "integer",
-          description = "0-based room number.",
+          see = "rooms.num",
         },
       },
       returns = { type = "Query", description = "The narrowed query." },

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -228,11 +228,16 @@ end)]],
   },
 })
 
+api.note(
+  "rooms.num",
+  "0-based room number, matching the numbers level editors show."
+)
+
 api.define("rooms.get", {
   description = "Retrieves a room by number. Rooms count from zero, matching the "
     .. "room numbers level editors show.",
   params = {
-    { name = "num", type = "integer", description = "0-based room number." },
+    { name = "num", type = "integer", see = "rooms.num" },
   },
   returns = { type = "Room", nullable = true },
   examples = {
@@ -427,7 +432,7 @@ api.container("rooms", {
   description = "Indexing the module reaches a room, and `#trx.rooms` is how many the level has. "
     .. "Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them "
     .. "in order, keyed by that number.",
-  key = { type = "integer", description = "0-based room number." },
+  key = { type = "integer", see = "rooms.num" },
   value = { type = "Room", nullable = true },
   examples = {
     [[trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[0].num)

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -976,6 +976,81 @@ test("a name two modules claim stops naming either", function()
   api.strict(false)
 end)
 
+-- The registry declares functions of its own, so a test finds its own by path.
+local function declared(api, path)
+  for _, fn in ipairs(api.describe().functions) do
+    if fn.path == path then
+      return fn
+    end
+  end
+  return nil
+end
+
+test("a note is written once and read wherever it is pointed at", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.note("things.number", "0-based thing number.")
+  api.define("things.get", {
+    params = {
+      { name = "num", type = "integer", see = "things.number" },
+      {
+        name = "callback",
+        type = "function",
+        params = {
+          { name = "num", type = "integer", see = "things.number" },
+        },
+      },
+    },
+    returns = { type = "integer", see = "things.number" },
+    impl = function() end,
+  })
+
+  local fn = declared(api, "things.get")
+  assert(fn.params[1].description == "0-based thing number.")
+  assert(
+    fn.params[2].params[1].description == "0-based thing number.",
+    "a callback's own arguments read it too"
+  )
+  assert(fn.returns.description == "0-based thing number.")
+  assert(fn.params[1].see == nil, "the pointer does not reach the docs")
+end)
+
+test("a note joins what the spec adds of its own", function()
+  local api = fresh_env()
+  api.note("things.number", "0-based thing number.")
+  api.define("things.get", {
+    params = {
+      {
+        name = "num",
+        type = "integer",
+        see = "things.number",
+        description = "The one that broke.",
+      },
+    },
+    impl = function() end,
+  })
+
+  assert(
+    declared(api, "things.get").params[1].description
+      == "0-based thing number. The one that broke."
+  )
+end)
+
+test("pointing at a note nobody wrote raises", function()
+  local api = fresh_env()
+  api.define("things.get", {
+    params = { { name = "num", type = "integer", see = "things.nothing" } },
+    impl = function() end,
+  })
+  assert(not pcall(api.describe))
+end)
+
+test("a note cannot be written twice", function()
+  local api = fresh_env()
+  api.note("things.number", "0-based thing number.")
+  assert(not pcall(api.note, "things.number", "something else"))
+end)
+
 test("a container walks from the index it counts from", function()
   local api = fresh_env()
   local zero, one = { [0] = "a", [1] = "b" }, { "a", "b" }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR lets a description that belongs in several places be written once and pointed at:

```lua
api.note("items.index", "0-based item number, matching the numbers level editors show.")

{ name = "item_num", type = "integer", see = "items.index" }
{ name = "item_num", type = "integer", see = "items.index", description = "The one that ran the effect." }
```

`see` works on a param, a return, a field, a container key or value, and on a callback's arguments, and joins any description the spec has of its own. Before this, "0-based index of the item" was spelled out at every param that carried one, and the wording had drifted between them.
