### PR TITLE
Unindent Lua API descriptions in the reference

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3242,7 +3242,7 @@
       }
     },
     {
-      "description": "    Marks a cutscene as played or unplayed. Marking one as played keeps its\n    trigger from firing; unmarking one lets it run again.\n\n    A trigger may name a number the game has no cutscene for - TR4 uses 32 to\n    ask for a full-motion video - and the engine remembers those the same way,\n    so `on_cutscene_trigger` hears about each of them once. This is what clears\n    that memory, and it takes any number a trigger may carry, not only the ones\n    `play` accepts.\n  ",
+      "description": "Marks a cutscene as played or unplayed. Marking one as played keeps its\ntrigger from firing; unmarking one lets it run again.\n\nA trigger may name a number the game has no cutscene for - TR4 uses 32 to\nask for a full-motion video - and the engine remembers those the same way,\nso `on_cutscene_trigger` hears about each of them once. This is what clears\nthat memory, and it takes any number a trigger may carry, not only the ones\n`play` accepts.",
       "examples": [
         "trx.cutscenes.set_played(7, true)"
       ],
@@ -3265,7 +3265,7 @@
       "path": "cutscenes.forget_played"
     },
     {
-      "description": "    Places Lara where the next cutscene to end leaves her. A cutscene stands\n    her at its own origin while it plays and puts her back where it found her\n    afterwards; this says to put her somewhere else instead, as the original\n    game does for the scenes that carry her along.\n\n    It holds for one cutscene, whether named before `play` or while the scene\n    runs, and is forgotten once she has been placed.\n  ",
+      "description": "Places Lara where the next cutscene to end leaves her. A cutscene stands\nher at its own origin while it plays and puts her back where it found her\nafterwards; this says to put her somewhere else instead, as the original\ngame does for the scenes that carry her along.\n\nIt holds for one cutscene, whether named before `play` or while the scene\nruns, and is forgotten once she has been placed.",
       "examples": [
         "trx.events.on_cutscene_start(function(num)\n  if num == 12 then\n    trx.cutscenes.set_lara_return({ x = 38912, y = 2048, z = 51200 })\n  end\nend)"
       ],
@@ -3285,7 +3285,7 @@
       "path": "cutscenes.set_lara_return"
     },
     {
-      "description": "    Happens as a level starts running, before its first frame is drawn. By then\n    the level file is loaded, its items are set up and any savegame state has\n    been applied, so this is where a script sets object properties, declares\n    allies, changes room state and plays sound effects. Every kind of level\n    fires it: a played level, a cutscene and the attract demo alike. The title\n    screen has `on_title_start` instead.\n  ",
+      "description": "Happens as a level starts running, before its first frame is drawn. By then\nthe level file is loaded, its items are set up and any savegame state has\nbeen applied, so this is where a script sets object properties, declares\nallies, changes room state and plays sound effects. Every kind of level\nfires it: a played level, a cutscene and the attract demo alike. The title\nscreen has `on_title_start` instead.",
       "params": [
         {
           "name": "callback",
@@ -3311,7 +3311,7 @@
       }
     },
     {
-      "description": "    Happens when the title screen's scene starts playing behind the menu, once\n    its level is loaded and its items are set up. The handler takes no\n    arguments. `on_game_start` does not fire for the title level.\n  ",
+      "description": "Happens when the title screen's scene starts playing behind the menu, once\nits level is loaded and its items are set up. The handler takes no\narguments. `on_game_start` does not fire for the title level.",
       "examples": [
         "trx.events.on_title_start(function()\n  trx.log.info(\"the menu is up\")\nend)"
       ],
@@ -3770,7 +3770,7 @@
       }
     },
     {
-      "description": "    Happens when a cutscene trigger fires, before the engine acts on it. A\n    handler answers the trigger by returning true - having played a cutscene of\n    its own, run something else, or decided nothing should run. If no handler\n    answers, the engine plays the cutscene the trigger names.\n\n    A trigger Lara stands on fires every frame, so this happens only for a\n    cutscene that has not run yet and while none is playing. Asking counts as\n    running it, whatever came of it, so the same handler is not asked again on\n    the next frame. Clear the mark with `trx.cutscenes.set_played` to hear\n    about one again.\n\n    The number a trigger names need not be one the game has a cutscene for -\n    TR4 uses 32 to ask for a full-motion video. Those reach a handler too, and\n    the engine has nothing of its own to do about them.\n  ",
+      "description": "Happens when a cutscene trigger fires, before the engine acts on it. A\nhandler answers the trigger by returning true - having played a cutscene of\nits own, run something else, or decided nothing should run. If no handler\nanswers, the engine plays the cutscene the trigger names.\n\nA trigger Lara stands on fires every frame, so this happens only for a\ncutscene that has not run yet and while none is playing. Asking counts as\nrunning it, whatever came of it, so the same handler is not asked again on\nthe next frame. Clear the mark with `trx.cutscenes.set_played` to hear\nabout one again.\n\nThe number a trigger names need not be one the game has a cutscene for -\nTR4 uses 32 to ask for a full-motion video. Those reach a handler too, and\nthe engine has nothing of its own to do about them.",
       "examples": [
         "-- only in the throne room; a flyby stands in for it elsewhere\ntrx.events.on_cutscene_trigger(function(num)\n  if num ~= 27 then\n    return false\n  end\n  if trx.lara.item.room_num == 55 then\n    trx.cutscenes.play(27)\n  else\n    trx.camera.play_flyby(3)\n  end\n  return true\nend)"
       ],
@@ -4970,7 +4970,7 @@
       "order": 11
     },
     {
-      "description": "    Module for TR4's in-game cutscenes, the animated scenes stored in\n    `cutseq.pak` and started by a cutscene trigger. A cutscene plays once:\n    the engine remembers which ones have run, and a script may consult or\n    rewrite that memory. The cutscene levels of TR1-TR3, which the game flow\n    lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.\n  ",
+      "description": "Module for TR4's in-game cutscenes, the animated scenes stored in\n`cutseq.pak` and started by a cutscene trigger. A cutscene plays once:\nthe engine remembers which ones have run, and a script may consult or\nrewrite that memory. The cutscene levels of TR1-TR3, which the game flow\nlists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.",
       "name": "cutscenes",
       "order": 13
     },
@@ -5037,7 +5037,7 @@
       "title": "Object"
     },
     {
-      "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; narrow one down, then read the\nresult.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nEach domain adds narrowings of its own on top of the ones below - see\n`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read\nleft to right, combining with AND: `q:spawnable():by_name(\"wolf\")`.\n",
+      "description": "A composable filter over a domain of things - the objects a level is built\nfrom, or the items alive in it. `trx.objects.query` and `trx.items.query` are\neach the identity query, matching everything; narrow one down, then read the\nresult.\n\nA query is immutable. Every method returns a fresh query, so a base can be kept\nand branched from without one narrowing leaking into another.\n\nEach domain adds narrowings of its own on top of the ones below - see\n`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read\nleft to right, combining with AND: `q:spawnable():by_name(\"wolf\")`.",
       "name": "query",
       "order": 9,
       "title": "Query"

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -12,12 +12,11 @@ order: 13
 
 ## Cutscenes module
 
-    Module for TR4's in-game cutscenes, the animated scenes stored in
-    `cutseq.pak` and started by a cutscene trigger. A cutscene plays once:
-    the engine remembers which ones have run, and a script may consult or
-    rewrite that memory. The cutscene levels of TR1-TR3, which the game flow
-    lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.
-  
+Module for TR4's in-game cutscenes, the animated scenes stored in
+`cutseq.pak` and started by a cutscene trigger. A cutscene plays once:
+the engine remembers which ones have run, and a script may consult or
+rewrite that memory. The cutscene levels of TR1-TR3, which the game flow
+lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.
 
 ### Properties
 
@@ -48,15 +47,14 @@ order: 13
   Returns: boolean.
 
 - [lua]`trx.cutscenes.set_played(num, played)`  
-      Marks a cutscene as played or unplayed. Marking one as played keeps its
-      trigger from firing; unmarking one lets it run again.
+  Marks a cutscene as played or unplayed. Marking one as played keeps its
+  trigger from firing; unmarking one lets it run again.
 
-      A trigger may name a number the game has no cutscene for - TR4 uses 32 to
-      ask for a full-motion video - and the engine remembers those the same way,
-      so `on_cutscene_trigger` hears about each of them once. This is what clears
-      that memory, and it takes any number a trigger may carry, not only the ones
-      `play` accepts.
-
+  A trigger may name a number the game has no cutscene for - TR4 uses 32 to
+  ask for a full-motion video - and the engine remembers those the same way,
+  so `on_cutscene_trigger` hears about each of them once. This is what clears
+  that memory, and it takes any number a trigger may carry, not only the ones
+  `play` accepts.
 
   Parameters:
   - **`num`** (integer). Cutscene number.
@@ -71,14 +69,13 @@ order: 13
   Forgets every cutscene, so all of them may run again.
 
 - [lua]`trx.cutscenes.set_lara_return(pos, [rot])`  
-      Places Lara where the next cutscene to end leaves her. A cutscene stands
-      her at its own origin while it plays and puts her back where it found her
-      afterwards; this says to put her somewhere else instead, as the original
-      game does for the scenes that carry her along.
+  Places Lara where the next cutscene to end leaves her. A cutscene stands
+  her at its own origin while it plays and puts her back where it found her
+  afterwards; this says to put her somewhere else instead, as the original
+  game does for the scenes that carry her along.
 
-      It holds for one cutscene, whether named before `play` or while the scene
-      runs, and is forgotten once she has been placed.
-
+  It holds for one cutscene, whether named before `play` or while the scene
+  runs, and is forgotten once she has been placed.
 
   Parameters:
   - **`pos`** (vec3). World position.

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -37,13 +37,12 @@ An event that carries a default the script may take over says so in its descript
 ### Functions
 
 - [lua]`trx.events.on_game_start(callback)`  
-      Happens as a level starts running, before its first frame is drawn. By then
-      the level file is loaded, its items are set up and any savegame state has
-      been applied, so this is where a script sets object properties, declares
-      allies, changes room state and plays sound effects. Every kind of level
-      fires it: a played level, a cutscene and the attract demo alike. The title
-      screen has `on_title_start` instead.
-
+  Happens as a level starts running, before its first frame is drawn. By then
+  the level file is loaded, its items are set up and any savegame state has
+  been applied, so this is where a script sets object properties, declares
+  allies, changes room state and plays sound effects. Every kind of level
+  fires it: a played level, a cutscene and the attract demo alike. The title
+  screen has `on_title_start` instead.
 
   Parameters:
   - **`callback`** (function).
@@ -54,10 +53,9 @@ An event that carries a default the script may take over says so in its descript
   Returns: events.Listener. The attached handler.
 
 - [lua]`trx.events.on_title_start(callback)`  
-      Happens when the title screen's scene starts playing behind the menu, once
-      its level is loaded and its items are set up. The handler takes no
-      arguments. `on_game_start` does not fire for the title level.
-
+  Happens when the title screen's scene starts playing behind the menu, once
+  its level is loaded and its items are set up. The handler takes no
+  arguments. `on_game_start` does not fire for the title level.
 
   Parameters:
   - **`callback`** (function).
@@ -410,21 +408,20 @@ An event that carries a default the script may take over says so in its descript
   ```
 
 - [lua]`trx.events.on_cutscene_trigger(callback)`  
-      Happens when a cutscene trigger fires, before the engine acts on it. A
-      handler answers the trigger by returning true - having played a cutscene of
-      its own, run something else, or decided nothing should run. If no handler
-      answers, the engine plays the cutscene the trigger names.
+  Happens when a cutscene trigger fires, before the engine acts on it. A
+  handler answers the trigger by returning true - having played a cutscene of
+  its own, run something else, or decided nothing should run. If no handler
+  answers, the engine plays the cutscene the trigger names.
 
-      A trigger Lara stands on fires every frame, so this happens only for a
-      cutscene that has not run yet and while none is playing. Asking counts as
-      running it, whatever came of it, so the same handler is not asked again on
-      the next frame. Clear the mark with `trx.cutscenes.set_played` to hear
-      about one again.
+  A trigger Lara stands on fires every frame, so this happens only for a
+  cutscene that has not run yet and while none is playing. Asking counts as
+  running it, whatever came of it, so the same handler is not asked again on
+  the next frame. Clear the mark with `trx.cutscenes.set_played` to hear
+  about one again.
 
-      The number a trigger names need not be one the game has a cutscene for -
-      TR4 uses 32 to ask for a full-motion video. Those reach a handler too, and
-      the engine has nothing of its own to do about them.
-
+  The number a trigger names need not be one the game has a cutscene for -
+  TR4 uses 32 to ask for a full-motion video. Those reach a handler too, and
+  the engine has nothing of its own to do about them.
 
   Parameters:
   - **`callback`** (function).

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -24,7 +24,6 @@ Each domain adds narrowings of its own on top of the ones below - see
 `trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read
 left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
-
 ### Structures
 
 - [lua]`trx.query.Query`

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -1154,6 +1154,31 @@ local function noted_returns(returns)
   return noted_list(returns)
 end
 
+-- A description written as a long-bracket string carries the indentation it was
+-- written at, and four spaces is a code block in markdown - which is how a
+-- module's own prose came out as one. The text is what the declaration says,
+-- not where it sat in the file, so the shared indent comes off. The deepest
+-- lines keep the rest of theirs, since a description may lay something out.
+local function dedent(text)
+  local shared
+  for line in text:gmatch("[^\n]+") do
+    if line:match("%S") ~= nil then
+      local indent = #line:match("^[ \t]*")
+      if shared == nil or indent < shared then
+        shared = indent
+      end
+    end
+  end
+  if shared == nil or shared == 0 then
+    return (text:gsub("^%s*\n", ""):gsub("%s+$", ""))
+  end
+  local out = {}
+  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+    out[#out + 1] = line:sub(shared + 1)
+  end
+  return (table.concat(out, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
+end
+
 -- The whole surface as plain data: what the docs generator consumes.
 function api.describe()
   local out = { types = {}, enums = {} }
@@ -1339,6 +1364,23 @@ function api.describe()
   table.sort(out.modules, function(a, b)
     return a.name < b.name
   end)
+
+  -- Every kind of entry carries prose under the same key, so the indentation
+  -- comes off in one pass rather than at each place one is collected. An
+  -- example is left alone: it is code, and its own indentation is the point.
+  local function dedent_prose(node)
+    if type(node) ~= "table" then
+      return
+    end
+    for key, value in pairs(node) do
+      if key == "description" and type(value) == "string" then
+        node[key] = dedent(value)
+      else
+        dedent_prose(value)
+      end
+    end
+  end
+  dedent_prose(out)
   return out
 end
 

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -164,6 +164,49 @@ test("type() passes the declaration to the C binder", function()
   assert(exposed.fields.secret == nil, "an undeclared member was exposed")
 end)
 
+-- A long-bracket description is written at the indentation of the declaration
+-- around it, and four spaces of it would read as a code block.
+test("describe() takes the indentation off a description", function()
+  local api = fresh_env()
+  api.module("things", {
+    description = [[
+      A module.
+
+      Written at the indentation the declaration sits at, with a line that
+        lays something out under it.
+    ]],
+  })
+  api.define("things.poke", {
+    description = [[
+      Pokes it.
+    ]],
+    impl = function() end,
+  })
+
+  local dumped = api.describe()
+  local module
+  for _, entry in ipairs(dumped.modules) do
+    if entry.name == "things" then
+      module = entry
+    end
+  end
+  assert(
+    module.description
+      == "A module.\n\nWritten at the indentation the declaration sits at, "
+        .. "with a line that\n  lays something out under it.",
+    "shared indent must go and the deeper line must keep the rest: "
+      .. module.description
+  )
+
+  local poke
+  for _, fn in ipairs(dumped.functions) do
+    if fn.path == "things.poke" then
+      poke = fn
+    end
+  end
+  assert(poke.description == "Pokes it.")
+end)
+
 test("describe() reports fields, methods and extensions", function()
   local api = fresh_env()
   api.module("things", { description = "..." })


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The dump now takes the shared indentation off every description, so the text is what the declaration says rather than where it sat in the file. Lines indented deeper than the rest keep the difference, so a description that lays something out is unchanged.

Before this, a description written as a `[[ ]]` string carried the indentation of the declaration around it. Four spaces read as a code block in markdown, so the cutscenes and argparse modules opened the reference with their prose rendered as code, as did five function descriptions.
