### PR TITLE
Drop the level number from on_game_start

### DIFF
--- a/data/trx/ship/games/tr1/scripts/gym.lua
+++ b/data/trx/ship/games/tr1/scripts/gym.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level, is_save)
+trx.events.on_game_start(function(is_save)
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
 end)

--- a/data/trx/ship/games/tr2/scripts/assault.lua
+++ b/data/trx/ship/games/tr2/scripts/assault.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level, is_save)
+trx.events.on_game_start(function(is_save)
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
   if is_save then
     return

--- a/data/trx/ship/games/tr2/scripts/floating.lua
+++ b/data/trx/ship/games/tr2/scripts/floating.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   -- The level gives its second and third secret each other's sprite, so with
   -- 3D pickups off the wrong dragon lies in each place. The models are right,
   -- it's the sprites that are wrongly ordered.

--- a/data/trx/ship/games/tr2/scripts/house.lua
+++ b/data/trx/ship/games/tr2/scripts/house.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level, is_save)
+trx.events.on_game_start(function(is_save)
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
   if trx.lara.extra_anim == -1 then
     trx.lara.set_extra_equipment(

--- a/data/trx/ship/games/tr2/scripts/level1.lua
+++ b/data/trx/ship/games/tr2/scripts/level1.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.monk_1)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_2)
 end)

--- a/data/trx/ship/games/tr2/scripts/level3.lua
+++ b/data/trx/ship/games/tr2/scripts/level3.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.monk_2)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_1)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_2)

--- a/data/trx/ship/games/tr2/scripts/level4.lua
+++ b/data/trx/ship/games/tr2/scripts/level4.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.monk_2)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_2)
 end)

--- a/data/trx/ship/games/tr2/scripts/monastry.lua
+++ b/data/trx/ship/games/tr2/scripts/monastry.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.monk_1)
   trx.creatures.add_ally(trx.catalog.objects.monk_2)
   trx.creatures.add_ally_target(trx.catalog.objects.bandit_1)

--- a/data/trx/ship/games/tr3/scripts/aldwych.lua
+++ b/data/trx/ship/games/tr3/scripts/aldwych.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.ceiling_spikes.properties.speed = 10
 end)

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   local props = trx.objects.strobe_light.properties
   props.requires_alarm_active = true
   trx.creatures.add_ally(trx.catalog.objects.prisoner)

--- a/data/trx/ship/games/tr3/scripts/chunnel.lua
+++ b/data/trx/ship/games/tr3/scripts/chunnel.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.quad_bike.properties.is_heavy = false
 end)

--- a/data/trx/ship/games/tr3/scripts/compound.lua
+++ b/data/trx/ship/games/tr3/scripts/compound.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.prisoner)
 end)

--- a/data/trx/ship/games/tr3/scripts/crash.lua
+++ b/data/trx/ship/games/tr3/scripts/crash.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.sthpac_mercenary)
   -- Setup shoals
   trx.items[114].properties.range = { x = 22, y = 6, z = 6 }

--- a/data/trx/ship/games/tr3/scripts/ganges.lua
+++ b/data/trx/ship/games/tr3/scripts/ganges.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   local props = trx.objects.quad_bike.properties
   props.track_1 = 9
   props.track_2 = 12

--- a/data/trx/ship/games/tr3/scripts/house.lua
+++ b/data/trx/ship/games/tr3/scripts/house.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   -- Setup shoals
   trx.items[55].properties.range = { x = 22, y = 2, z = 10 }
   trx.items[56].properties.range = { x = 18, y = 1, z = 10 }

--- a/data/trx/ship/games/tr3/scripts/jungle.lua
+++ b/data/trx/ship/games/tr3/scripts/jungle.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.monkey)
   -- Setup shoals
   trx.items[133].properties.range = { x = 10, y = 3, z = 22 }

--- a/data/trx/ship/games/tr3/scripts/mines.lua
+++ b/data/trx/ship/games/tr3/scripts/mines.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.rx_worker_3)
   for _, room in pairs(trx.rooms) do
     room.damaging = room.underwater

--- a/data/trx/ship/games/tr3/scripts/nevada.lua
+++ b/data/trx/ship/games/tr3/scripts/nevada.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   local props = trx.objects.cobra.properties
   props.alert_radius = 1.25
   props.attack_radius = 0.666667

--- a/data/trx/ship/games/tr3/scripts/rapids.lua
+++ b/data/trx/ship/games/tr3/scripts/rapids.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   -- Setup shoals
   trx.items[15].properties.range = { x = 6, y = 5, z = 10 }
   trx.items[51].properties.range = { x = 18, y = 8, z = 18 }

--- a/data/trx/ship/games/tr3/scripts/shore.lua
+++ b/data/trx/ship/games/tr3/scripts/shore.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   -- Setup shoals
   trx.items[8].properties.range = { x = 14, y = 6, z = 22 }
   trx.items[12].properties.range = { x = 14, y = 6, z = 14 }

--- a/data/trx/ship/games/tr3/scripts/temple.lua
+++ b/data/trx/ship/games/tr3/scripts/temple.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   -- Setup shoals
   trx.items[0].properties.range = { x = 6, y = 3, z = 30 }
   trx.items[19].properties.range = { x = 6, y = 2, z = 18 }

--- a/data/trx/ship/games/tr3/scripts/thames.lua
+++ b/data/trx/ship/games/tr3/scripts/thames.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.propeller_2.properties.damage = 1000
   trx.objects.propeller_3.properties.damage = 1000
 end)

--- a/data/trx/ship/games/tr3/scripts/tinnos.lua
+++ b/data/trx/ship/games/tr3/scripts/tinnos.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   local query = trx.items.query:of_object(trx.catalog.objects.animating_ext_1)
   for _, item in ipairs(query:matches()) do
     item.properties.kill_on_trigger = true

--- a/data/trx/ship/games/tr3/scripts/tower.lua
+++ b/data/trx/ship/games/tr3/scripts/tower.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.punk_1)
 end)

--- a/data/trx/ship/games/tr3/scripts/zoo.lua
+++ b/data/trx/ship/games/tr3/scripts/zoo.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.creatures.add_ally(trx.catalog.objects.monkey)
   -- Setup shoals
   trx.items[65].properties.range = { x = 14, y = 6, z = 14 }

--- a/data/trx/ship/games/tr4/scripts/alexhub.lua
+++ b/data/trx/ship/games/tr4/scripts/alexhub.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[38].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[39].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[40].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/alexhub2.lua
+++ b/data/trx/ship/games/tr4/scripts/alexhub2.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_14.properties.collidable = false
   trx.objects.animating_15.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/ang_race.lua
+++ b/data/trx/ship/games/tr4/scripts/ang_race.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level, is_save)
+trx.events.on_game_start(function(is_save)
   trx.objects.animating_14.properties.collidable = false
   trx.objects.animating_15.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/angkor1.lua
+++ b/data/trx/ship/games/tr4/scripts/angkor1.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level, is_save)
+trx.events.on_game_start(function(is_save)
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_14.properties.collidable = false
   trx.objects.animating_15.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/bikebit.lua
+++ b/data/trx/ship/games/tr4/scripts/bikebit.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[56].properties.crowbar = true
 end)

--- a/data/trx/ship/games/tr4/scripts/cortyard.lua
+++ b/data/trx/ship/games/tr4/scripts/cortyard.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[1].properties.lift = true
   trx.objects.switch_type_generic_1.properties.switch_mode =
     trx.items.SwitchMode.HIDDEN_PICKUP

--- a/data/trx/ship/games/tr4/scripts/csplit1.lua
+++ b/data/trx/ship/games/tr4/scripts/csplit1.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[58].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[92].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[104].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/csplit2.lua
+++ b/data/trx/ship/games/tr4/scripts/csplit2.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.switch_type_generic_1.properties.switch_mode =
     trx.items.SwitchMode.SHOVE
 end)

--- a/data/trx/ship/games/tr4/scripts/highstrt.lua
+++ b/data/trx/ship/games/tr4/scripts/highstrt.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_13.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby1a.lua
+++ b/data/trx/ship/games/tr4/scripts/joby1a.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.switch_type_generic_1.properties.switch_mode =
     trx.items.SwitchMode.SHOVE
 end)

--- a/data/trx/ship/games/tr4/scripts/joby2.lua
+++ b/data/trx/ship/games/tr4/scripts/joby2.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_16.properties.collidable = false
   trx.items[116].properties.switch_mode = trx.items.SwitchMode.HIDDEN_REACH
   trx.items[118].properties.switch_mode = trx.items.SwitchMode.HIDDEN_REACH

--- a/data/trx/ship/games/tr4/scripts/joby3b.lua
+++ b/data/trx/ship/games/tr4/scripts/joby3b.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.switch_type_generic_2.properties.switch_mode =
     trx.items.SwitchMode.SHOVE
   trx.items[159].properties.pickup_mode = trx.items.PickupMode.CROWBAR

--- a/data/trx/ship/games/tr4/scripts/joby4a.lua
+++ b/data/trx/ship/games/tr4/scripts/joby4a.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_16.properties.collidable = false
   trx.items[89].properties.pickup_mode = trx.items.PickupMode.CROWBAR

--- a/data/trx/ship/games/tr4/scripts/joby4b.lua
+++ b/data/trx/ship/games/tr4/scripts/joby4b.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby4c.lua
+++ b/data/trx/ship/games/tr4/scripts/joby4c.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_13.properties.collidable = false
   trx.items[36].properties.switch_mode = trx.items.SwitchMode.HIDDEN_PICKUP
   trx.items[37].properties.switch_mode = trx.items.SwitchMode.HIDDEN_REACH

--- a/data/trx/ship/games/tr4/scripts/joby5a.lua
+++ b/data/trx/ship/games/tr4/scripts/joby5a.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_14.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/joby5b.lua
+++ b/data/trx/ship/games/tr4/scripts/joby5b.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/karnak1.lua
+++ b/data/trx/ship/games/tr4/scripts/karnak1.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[66].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[68].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[82].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/lake.lua
+++ b/data/trx/ship/games/tr4/scripts/lake.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[16].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[33].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[34].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/libend.lua
+++ b/data/trx/ship/games/tr4/scripts/libend.lua
@@ -1,3 +1,3 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[13].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/library.lua
+++ b/data/trx/ship/games/tr4/scripts/library.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[12].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[135].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[79].properties.pickup_mode = trx.items.PickupMode.CROWBAR

--- a/data/trx/ship/games/tr4/scripts/lowstrt.lua
+++ b/data/trx/ship/games/tr4/scripts/lowstrt.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[45].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 
   trx.objects.animating_13.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/nutrench.lua
+++ b/data/trx/ship/games/tr4/scripts/nutrench.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_16.properties.collidable = false
   trx.objects.switch_type_generic_1.properties.switch_mode =
     trx.items.SwitchMode.SHOVE

--- a/data/trx/ship/games/tr4/scripts/palaces.lua
+++ b/data/trx/ship/games/tr4/scripts/palaces.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[63].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[104].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.objects.switch_type_generic_2.properties.switch_mode =

--- a/data/trx/ship/games/tr4/scripts/palaces2.lua
+++ b/data/trx/ship/games/tr4/scripts/palaces2.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.objects.animating_16.properties.collidable = false
   trx.items[26].properties.crowbar = true
   trx.items[123].properties.crowbar = true

--- a/data/trx/ship/games/tr4/scripts/semer.lua
+++ b/data/trx/ship/games/tr4/scripts/semer.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[47].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[235].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[236].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/semer2.lua
+++ b/data/trx/ship/games/tr4/scripts/semer2.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[52].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[59].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[60].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/settomb1.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb1.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[3].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[4].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[87].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/data/trx/ship/games/tr4/scripts/settomb2.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb2.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[3].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[135].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 

--- a/data/trx/ship/games/tr4/scripts/train.lua
+++ b/data/trx/ship/games/tr4/scripts/train.lua
@@ -1,4 +1,4 @@
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.items[4].properties.crowbar = true
   trx.items[57].properties.crowbar = true
 end)

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -252,7 +252,7 @@ order: 3
    items are set up, any savegame state has been applied, and nothing has been
    drawn yet. A handler moves across as it stands:
    ```lua
-   trx.events.on_game_start(function(level_num, is_save)
+   trx.events.on_game_start(function(is_save)
      trx.creatures.add_ally(trx.catalog.objects.monkey)
      trx.items[65].properties.range = { x = 14, y = 6, z = 14 }
    end)
@@ -260,7 +260,9 @@ order: 3
    An object property no longer has to be written before its item is
    initialised, which is what the earlier moments were for. `on_game_start`
    fires for cutscene and demo levels too, and the title screen has
-   `on_title_start`.
+   `on_title_start`. The handler is not handed the level's number: the level
+   itself is `trx.game.current_level`, which says both what it is and where it
+   counts.
 
 25. **Remove `ammo.pickup_qty_alt` from weapon definitions**
    The field only applied to flares in Japanese NG, which is no longer a game

--- a/docs/trx/lua/GETTING_STARTED.md
+++ b/docs/trx/lua/GETTING_STARTED.md
@@ -32,7 +32,7 @@ Create a file `data/scripts/level1.lua` in the project and put the following
 content:
 
 ```lua
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   trx.log.info("hello from level 1!")
 end)
 ```

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3285,18 +3285,16 @@
       "path": "cutscenes.set_lara_return"
     },
     {
-      "description": "Happens as a level starts running, before its first frame is drawn. By then\nthe level file is loaded, its items are set up and any savegame state has\nbeen applied, so this is where a script sets object properties, declares\nallies, changes room state and plays sound effects. Every kind of level\nfires it: a played level, a cutscene and the attract demo alike. The title\nscreen has `on_title_start` instead.",
+      "description": "Happens as a level starts running, before its first frame is drawn. By then\nthe level file is loaded, its items are set up and any savegame state has\nbeen applied, so this is where a script sets object properties, declares\nallies, changes room state and plays sound effects. Every kind of level\nfires it: a played level, a cutscene and the attract demo alike. The title\nscreen has `on_title_start` instead.\n\nWhich level is starting is `trx.game.current_level`, whose `num` and `type`\nsay where it counts and what kind it is. A level script already knows both,\nwhich is why the handler is not handed them.",
+      "examples": [
+        "trx.events.on_game_start(function(is_save)\n  trx.log.info(trx.game.current_level.title .. \" is up\")\nend)"
+      ],
       "params": [
         {
           "name": "callback",
           "params": [
             {
-              "description": "Number of the level being started.",
-              "name": "level_num",
-              "type": "integer"
-            },
-            {
-              "description": "Whether the level is being resumed from a savegame rather than started fresh.",
+              "description": "Whether the level is being resumed from a savegame rather than started fresh. A cutscene and a demo are never resumed, and always report false.",
               "name": "is_save",
               "type": "boolean"
             }

--- a/docs/trx/lua/examples/README.md
+++ b/docs/trx/lua/examples/README.md
@@ -13,7 +13,7 @@ section](../../OBJECTS.md) as a reference for original values.
 
 ```lua
 -- Adjust HP of certain enemies
-trx.events.on_game_start(function(level)
+trx.events.on_game_start(function()
   -- Randomize bats HP
   for _, item in pairs(trx.items) do
     if item.object_id == trx.catalog.objects.bat then

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -44,13 +44,23 @@ An event that carries a default the script may take over says so in its descript
   fires it: a played level, a cutscene and the attract demo alike. The title
   screen has `on_title_start` instead.
 
+  Which level is starting is `trx.game.current_level`, whose `num` and `type`
+  say where it counts and what kind it is. A level script already knows both,
+  which is why the handler is not handed them.
+
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`level_num`** (integer). Number of the level being started.
-    - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh.
+    - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh. A cutscene and a demo are never resumed, and always report false.
 
   Returns: events.Listener. The attached handler.
+
+  Example:
+  ```lua
+  trx.events.on_game_start(function(is_save)
+    trx.log.info(trx.game.current_level.title .. " is up")
+  end)
+  ```
 
 - [lua]`trx.events.on_title_start(callback)`  
   Happens when the title screen's scene starts playing behind the menu, once

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -80,6 +80,10 @@ api.define("events.on_game_start", {
     allies, changes room state and plays sound effects. Every kind of level
     fires it: a played level, a cutscene and the attract demo alike. The title
     screen has `on_title_start` instead.
+
+    Which level is starting is `trx.game.current_level`, whose `num` and `type`
+    say where it counts and what kind it is. A level script already knows both,
+    which is why the handler is not handed them.
   ]],
   params = {
     {
@@ -87,19 +91,20 @@ api.define("events.on_game_start", {
       type = "function",
       params = {
         {
-          name = "level_num",
-          type = "integer",
-          description = "Number of the level being started.",
-        },
-        {
           name = "is_save",
           type = "boolean",
-          description = "Whether the level is being resumed from a savegame rather than started fresh.",
+          description = "Whether the level is being resumed from a savegame rather than started "
+            .. "fresh. A cutscene and a demo are never resumed, and always report false.",
         },
       },
     },
   },
   returns = LISTENER,
+  examples = {
+    [[trx.events.on_game_start(function(is_save)
+  trx.log.info(trx.game.current_level.title .. " is up")
+end)]],
+  },
   impl = hook(types.GAME_START),
 })
 

--- a/src/tests/lua/api/events.c
+++ b/src/tests/lua/api/events.c
@@ -53,13 +53,7 @@ static int M_FakeFire(lua_State *const L)
     } else if (strcmp(name, "on_pickup") == 0) {
         LUA_FireEventInt32(LUA_EVENT_PICKUP, luaL_checkinteger(L, 2));
     } else if (strcmp(name, "on_game_start") == 0) {
-        const LUA_EVENT_ARG args[] = {
-            { .type = LUA_EVENT_ARG_INT32,
-              .value = { .i32 = luaL_checkinteger(L, 2) } },
-            { .type = LUA_EVENT_ARG_BOOL,
-              .value = { .b = lua_toboolean(L, 3) } },
-        };
-        LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
+        LUA_FireEventBool(LUA_EVENT_GAME_START, lua_toboolean(L, 2));
     } else if (strcmp(name, "on_title_start") == 0) {
         LUA_FireEvent(LUA_EVENT_TITLE_START);
     } else if (strcmp(name, "on_flip_effect") == 0) {

--- a/src/tests/lua/api/events.lua
+++ b/src/tests/lua/api/events.lua
@@ -89,18 +89,17 @@ test("on_pickup passes the item number", function()
   assert(seen == 42, "on_pickup did not receive the item number")
 end)
 
-test("on_game_start passes the level number and the savegame flag", function()
-  local seen_level, seen_save = nil, nil
-  trx.events.on_game_start(function(level_num, is_save)
-    seen_level, seen_save = level_num, is_save
+test("on_game_start passes the savegame flag", function()
+  local seen = nil
+  trx.events.on_game_start(function(is_save)
+    seen = is_save
   end)
 
-  fake.fire("on_game_start", 3, true)
-  assert(seen_level == 3, "wrong level number")
-  assert(seen_save == true, "is_save must be a boolean, not a truthy number")
+  fake.fire("on_game_start", true)
+  assert(seen == true, "is_save must be a boolean, not a truthy number")
 
-  fake.fire("on_game_start", 3, false)
-  assert(seen_save == false, "a fresh start must report false")
+  fake.fire("on_game_start", false)
+  assert(seen == false, "a fresh start must report false")
 end)
 
 test("every handler attached to an event fires, in order", function()

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -57,11 +57,9 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
             level->music_track, is_cutscene ? MPM_ONCE : MPM_LOOP);
     }
 
-    const LUA_EVENT_ARG args[] = {
-        { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = level->num } },
-        { .type = LUA_EVENT_ARG_BOOL, .value = { .b = seq_ctx == GFSC_SAVED } },
-    };
-    LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
+    // Which level this is, and what kind, is trx.game.current_level's to
+    // answer; the event carries only what the level itself cannot say.
+    LUA_FireEventBool(LUA_EVENT_GAME_START, seq_ctx == GFSC_SAVED);
     return true;
 }
 

--- a/src/trx/game/lua/capi/events.c
+++ b/src/trx/game/lua/capi/events.c
@@ -393,4 +393,12 @@ bool LUA_FireEventInt32(const LUA_EVENT_TYPE ev, const int32_t arg)
     return LUA_FireEventEx(ev, args, 1);
 }
 
+bool LUA_FireEventBool(const LUA_EVENT_TYPE ev, const bool arg)
+{
+    const LUA_EVENT_ARG args[] = {
+        { .type = LUA_EVENT_ARG_BOOL, .value = { .b = arg } },
+    };
+    return LUA_FireEventEx(ev, args, 1);
+}
+
 REGISTER_LUA_CAPI(.create = M_Create, .shutdown = M_Shutdown)

--- a/src/trx/game/lua/events.h
+++ b/src/trx/game/lua/events.h
@@ -67,3 +67,6 @@ bool LUA_FireEvent(LUA_EVENT_TYPE ev);
 
 // Fire a Lua event of given type with int32 argument
 bool LUA_FireEventInt32(LUA_EVENT_TYPE ev, int32_t arg);
+
+// Fire a Lua event of given type with boolean argument
+bool LUA_FireEventBool(LUA_EVENT_TYPE ev, bool arg);

--- a/src/trx/game/phase/phase_cutscene.c
+++ b/src/trx/game/phase/phase_cutscene.c
@@ -44,11 +44,8 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     Lara_SetControllable(false);
     // The same event a played level fires: whatever the level is, this is the
     // moment it starts running.
-    const LUA_EVENT_ARG args[] = {
-        { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = p->args.level_num } },
-        { .type = LUA_EVENT_ARG_BOOL, .value = { .b = false } },
-    };
-    LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
+    // A cutscene level is never resumed from a save.
+    LUA_FireEventBool(LUA_EVENT_GAME_START, false);
     return (PHASE_CONTROL) {};
 }
 

--- a/src/trx/game/phase/phase_demo.c
+++ b/src/trx/game/phase/phase_demo.c
@@ -45,11 +45,8 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
 
     // The same event a played level fires: whatever the level is, this is the
     // moment it starts running.
-    const LUA_EVENT_ARG args[] = {
-        { .type = LUA_EVENT_ARG_INT32, .value = { .i32 = p->level_num } },
-        { .type = LUA_EVENT_ARG_BOOL, .value = { .b = false } },
-    };
-    LUA_FireEventEx(LUA_EVENT_GAME_START, args, 2);
+    // A demo is never resumed from a save.
+    LUA_FireEventBool(LUA_EVENT_GAME_START, false);
 
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The handler now takes `is_save` alone. The level that started is `trx.game.current_level`, whose `num` and `type` say where it counts and what kind of level it is, and a level script knows both already. A cutscene and a demo report `is_save` as false.

Before this, the handler took the level's place in the game flow's table. A script cannot address a level by that number: `trx.game.levels` counts the levels the game numbers, leaving out the gym and the levels the flow passes over, and a cutscene and a demo count in lists of their own.

The three places a level starts now fire the event through `LUA_FireEventBool`, added beside `LUA_FireEventInt32`.
