### PR TITLE
Settle what the Lua API calls its numbers and units

### DIFF
--- a/data/trx/ship/games/tr2/scripts/cut3.lua
+++ b/data/trx/ship/games/tr2/scripts/cut3.lua
@@ -3,7 +3,7 @@ local outfit_changed = false
 
 trx.events.after_control(function()
   local lara_item = trx.lara.item
-  if lara_item.anim >= suit_change_anim and not outfit_changed then
+  if lara_item.anim_num >= suit_change_anim and not outfit_changed then
     trx.lara.outfit = "tr2_diving_suit"
     outfit_changed = true
   end

--- a/data/trx/ship/games/tr3/scripts/cut8.lua
+++ b/data/trx/ship/games/tr3/scripts/cut8.lua
@@ -3,7 +3,7 @@ local equipment_set = false
 
 trx.events.after_control(function()
   local lara_item = trx.lara.item
-  if lara_item.frame >= drink_frame_num and not equipment_set then
+  if lara_item.frame_num >= drink_frame_num and not equipment_set then
     trx.lara.set_extra_equipment(
       trx.lara.Mesh.HAND_R,
       trx.lara.ExtraMesh.DRINK_CAN

--- a/data/trx/ship/games/tr4/scripts/title.lua
+++ b/data/trx/ship/games/tr4/scripts/title.lua
@@ -4,17 +4,17 @@
 -- cycle run again, so it repeats for as long as the menu is up. Each step
 -- pairs the cutscene a trigger starts with the flyby that follows it.
 local CYCLE = {
-  { cutscene = 28, next_flyby = 2 },
-  { cutscene = 29, next_flyby = 3 },
-  { cutscene = 30, next_flyby = 1 },
+  { cutscene_num = 28, next_flyby_num = 2 },
+  { cutscene_num = 29, next_flyby_num = 3 },
+  { cutscene_num = 30, next_flyby_num = 1 },
 }
 
 -- title.tr4 numbers its flyby sequences from 1; sequence 0 has no cameras.
-local FIRST_FLYBY = 1
+local FIRST_FLYBY_NUM = 1
 
-local function cycle_step(num)
+local function cycle_step(cutscene_num)
   for index, step in ipairs(CYCLE) do
-    if step.cutscene == num then
+    if step.cutscene_num == cutscene_num then
       return step, index
     end
   end
@@ -29,8 +29,8 @@ local DOORS = trx.catalog.objects.animating_6
 
 local function rewind_doors()
   for _, item in ipairs(trx.items.query:of_object(DOORS):matches()) do
-    item.anim = 0
-    item.frame = 0
+    item.anim_num = 0
+    item.frame_num = 0
     item.trigger_mask = 0
   end
 end
@@ -62,31 +62,31 @@ end
 trx.events.on_title_start(function()
   trx.cutscenes.forget_played()
   set_lara_visible(false)
-  trx.camera.play_flyby(FIRST_FLYBY)
+  trx.camera.play_flyby(FIRST_FLYBY_NUM)
 end)
 
 -- The menu always needs a camera of its own, so a sequence that runs out
 -- without a cutscene to follow it plays again.
-trx.events.on_flyby_end(function(sequence)
-  trx.camera.play_flyby(sequence)
+trx.events.on_flyby_end(function(sequence_num)
+  trx.camera.play_flyby(sequence_num)
 end)
 
-trx.events.on_cutscene_start(function(num)
+trx.events.on_cutscene_start(function(cutscene_num)
   set_lara_visible(true)
-  if num == CYCLE[1].cutscene then
+  if cutscene_num == CYCLE[1].cutscene_num then
     rewind_doors()
   end
 end)
 
-trx.events.on_cutscene_end(function(num)
+trx.events.on_cutscene_end(function(cutscene_num)
   set_lara_visible(false)
 
-  local step, index = cycle_step(num)
+  local step, index = cycle_step(cutscene_num)
   if step == nil then
     return
   end
   if index == #CYCLE then
     trx.cutscenes.forget_played()
   end
-  trx.camera.play_flyby(step.next_flyby)
+  trx.camera.play_flyby(step.next_flyby_num)
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -248,6 +248,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed `item.object_id` to be read-only
 - changed `trx.objects[id]` to return `nil` for an unknown id, where it used to return an object that answered to nothing
 - changed `trx.config.get()` to return the option's own type rather than always a string
+- changed the names that stand for a number to say which kind they are - `item.num`, `item.anim_num`, `slot_num`, `object_id` and the like; refer to migration notes
 - changed the event hooks to hand back a `trx.events.Listener` rather than a number, which detaches itself with `listener:detach()` and says whether it was still attached
 - changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
 - changed the Lua level events to a single `on_game_start`, which every kind of level fires, with `on_title_start` for the title screen; refer to migration notes

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -77,6 +77,26 @@ Other things:
     When expressions become extraordinarily complex, consider refactoring them
     into smaller conditions or functions.
 
+## Naming numbers
+
+A number that stands for something takes a suffix saying what kind it is.
+`item.room_num` beside `item.room` is the shape.
+
+- **`_num`** - needs a container to mean anything: `room_num` and `item_num`
+  need the level, `anim_num` the object, `slot_num` the save pool.
+- **`_id`** - reads on its own: `object_id`, `sample_id`, `track_id`, and a
+  listener's `id`. Point at the constants with `enum = "catalog.objects"`. An
+  identity the engine mints is better handed over as a handle than as its
+  number, and exposed for reading if at all.
+- **A bare noun is the thing itself**, not a number for it: `item.room` is a
+  handle. Quantities keep theirs as well - `damage`, `timer`, `volume`.
+- **Counting follows the source**: from 0 where the level data numbered it, from
+  1 where TRX made the list and the player sees the position.
+- **`idx` stays in C**, for indices into its own arrays.
+
+Where a description would be written twice, write it once with `api.note` and
+point at it with `see`.
+
 ## Tooling
 
 Internal tools are typically coded in a reasonably recent version of Python,

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -85,7 +85,7 @@ A number that stands for something takes a suffix saying what kind it is.
 - **`_num`** - needs a container to mean anything: `room_num` and `item_num`
   need the level, `anim_num` the object, `slot_num` the save pool.
 - **`_id`** - reads on its own: `object_id`, `sample_id`, `track_id`, and a
-  listener's `id`. Point at the constants with `enum = "catalog.objects"`. An
+  listener's `id`. Name the constants it takes: `type = "catalog.objects"`. An
   identity the engine mints is better handed over as a handle than as its
   number, and exposed for reading if at all.
 - **A bare noun is the thing itself**, not a number for it: `item.room` is a
@@ -94,8 +94,10 @@ A number that stands for something takes a suffix saying what kind it is.
   1 where TRX made the list and the player sees the position.
 - **`idx` stays in C**, for indices into its own arrays.
 
-Where a description would be written twice, write it once with `api.note` and
-point at it with `see`.
+A number that several declarations hold is a type of its own: declare it once
+with `api.number` and name it as their type. What it counts, and where it
+counts from, is then written once, and what holds one says only what is its
+own.
 
 ## Tooling
 

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -88,13 +88,13 @@ order: 3
    she was in no such animation. `if trx.lara.extra_anim ~= -1` is now always
    true, and comparing it against a number raises. Test the boolean:
    `if trx.lara.extra_anim then`. The animation number itself is no longer
-   exposed; read `trx.lara.item.anim` if you need it.
+   exposed; read `trx.lara.item.anim_num` if you need it.
 
 5. **Update scripts that compensate for `on_pickup`'s item number**
-   The handler passes a 1-based item number, as it is documented to; it used to
-   pass the 0-based engine index. A script that
-   worked around this with `trx.items[item_num + 1]` is now off by one, and
-   picks up the wrong item rather than failing - pass `item_num` straight
+   The handler passes the engine's own item number, counted from 0, as it
+   always did. What changed is `trx.items`, which counts from 0 now as well, so
+   a script that bridged the gap with `trx.items[item_num + 1]` is off by one
+   and reaches the wrong item rather than failing - pass `item_num` straight
    through.
 
 6. **Update scripts that write to a catalog or enum**
@@ -159,11 +159,23 @@ order: 3
    no longer takes a number, and `listener.id` is the number if anything needs
    it.
 
-16. **Update scripts that use `trx.console.log.LogLevel`**
+16. **Update scripts that name a number**
+   The public API now says what kind of number a name stands for: `_num` for a
+   number only the level it came from gives meaning to, `_id` for one TRX ships
+   names for, and a bare noun for the thing itself. The renames are mechanical:
+   - `item.index` is `item.num`
+   - `item.anim` is `item.anim_num`, and `item.frame` is `item.frame_num`
+   - `on_room_change`'s handler takes `old_room_num` and `new_room_num`
+   - `on_flyby_end`'s handler takes `sequence_num`
+   - the `on_cutscene_*` handlers take `cutscene_num`
+   - `trx.savegame`'s slot argument is `slot_num`
+   - `trx.inventory`'s object argument is `object_id`
+
+17. **Update scripts that use `trx.console.log.LogLevel`**
    It was removed. Use `trx.log.LogLevel`, which is the same enum:
    `trx.console.log.generic(trx.log.LogLevel.ERROR, "...")`.
 
-17. **Update scripts that use the music module**
+18. **Update scripts that use the music module**
    The soundtrack is addressed through track and stream handles now.
    - `trx.music.play` now takes a track by catalog id - a `trx.catalog.music`
      value, which maps to the right track per game - rather than the level's own
@@ -183,7 +195,7 @@ order: 3
      main stream, `[2]` onwards the overlays - each of which can be paused,
      resumed, sought and stopped on its own.
 
-18. **Update scripts that address levels by number**
+19. **Update scripts that address levels by number**
    `trx.game.levels` is the levels the game numbers, and a gym is not one of
    them. Where a game flow has a gym, `trx.game.levels[1]` used to be the gym;
    now every entry after it has shifted down by one and the last level -
@@ -192,19 +204,19 @@ order: 3
    it; use `trx.game.play_gym()` and `trx.game.gym` for the gym. The same holds
    for `trx.game.cutscenes`, `trx.game.demos` and their `play_` functions.
 
-19. **Update Lara's outfit definitions**
+20. **Update Lara's outfit definitions**
    The `braid` entries for Lara's outfits were changed to arrays to support up
    to two instances. Additionally, a `joints_object` can now be specified to
    allow using TR4/5 outfits. `outfits.json5` must be updated accordingly; refer
    to the default shipped file and [outfits documentation](OUTFITS.md).
 
-20. **Update scripts that pass an incomplete position**
+21. **Update scripts that pass an incomplete position**
    `{ x = , y = , z = }` needs all three coordinates. A missing one used to read
    as zero in `trx.sound.play`, placing the sound at the edge of the world, and
    raised an unhelpful error elsewhere. It now names the coordinate and the
    argument it came in on.
 
-21. **Update scripts that use `trx.sound.is_available`**
+22. **Update scripts that use `trx.sound.is_available`**
    It was removed. A sample is available when `trx.sound.samples[id]` is not
    `nil`. `trx.sound.samples` is a collection of `trx.sound.Sample` handles keyed
    by id, each of which plays itself and reports its definition, and
@@ -216,7 +228,7 @@ order: 3
    `play` hands back the `trx.sound.Stream` it started. `trx.sound.stop_all` is
    unchanged.
 
-22. **Update scripts that read `item.status`**
+23. **Update scripts that read `item.status`**
    The `item.status` field and the `items.Status` enum were removed in favour of
    separate boolean axes:
    - `item.is_simulated` (read-only): its control routine runs each frame -
@@ -233,7 +245,7 @@ order: 3
    The item query narrows on each: `simulated`, `present`, `visible`, `finished`,
    `in_play`, `alive`, `targetable`.
 
-23. **Update game flows that anchor Bacon Lara**
+24. **Update game flows that anchor Bacon Lara**
    The `setup_bacon_lara` sequence event was removed. The anchor room is an
    `anchor_room` object property now, which a level editor can set on the object
    or on a single item, and a script can set in `on_game_start`:
@@ -245,7 +257,7 @@ order: 3
    The property is optional: at its default of -1, the room Bacon Lara is placed
    in is the anchor. Refer to the Atlantis level in the default game flow.
 
-24. **Update scripts that use the level lifecycle events**
+25. **Update scripts that use the level lifecycle events**
    `before_level_file`, `after_level_file`, `before_item_setup`,
    `after_item_setup` and `after_level_state` were removed. `on_game_start` is
    the one moment a level script gets before play: the level file is loaded, its
@@ -264,18 +276,18 @@ order: 3
    itself is `trx.game.current_level`, which says both what it is and where it
    counts.
 
-25. **Remove `ammo.pickup_qty_alt` from weapon definitions**
+26. **Remove `ammo.pickup_qty_alt` from weapon definitions**
    The field only applied to flares in Japanese NG, which is no longer a game
    mode. A flare box now always gives `ammo.pickup_qty` flares. The field is
    ignored if left in `weapons.json5`.
 
-26. **Update scripts that raise an item's maximum hit points**
+27. **Update scripts that raise an item's maximum hit points**
    Writing `max_hit_points` carries the item's current hit points with it, by
    the difference: an item that has taken no damage comes out at full health,
    and one that is already hurt stays hurt by as much. It no longer needs a
    companion write to `hit_points`.
 
-27. **Update weapon definitions**
+28. **Update weapon definitions**
    The ammunition keys in `weapons.json5` were renamed to say what they count.
    A shot is one pull of the trigger, which for the shotgun spends six rounds;
    the flare counts a flare where a weapon counts a shot. The old names are

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2083,7 +2083,7 @@
     {
       "bulk": false,
       "count": 5,
-      "description": "The values the `pickup_mode` item property can take. It selects the animation Lara plays when collecting the item.",
+      "description": "<!--noref: pickup_mode--> The values the `pickup_mode` item property can take. It selects the animation Lara plays when collecting the item.",
       "path": "items.PickupMode",
       "values": [
         {
@@ -2116,7 +2116,7 @@
     {
       "bulk": false,
       "count": 4,
-      "description": "The values the `switch_mode` item property can take. It selects the animation Lara plays when interacting with the item.",
+      "description": "<!--noref: switch_mode--> The values the `switch_mode` item property can take. It selects the animation Lara plays when interacting with the item.",
       "path": "items.SwitchMode",
       "values": [
         {
@@ -2910,7 +2910,7 @@
       ],
       "params": [
         {
-          "description": "Dotted path, e.g. `visuals.water_color`.",
+          "description": "Dotted path, e.g. `visuals.water_color`. <!--noref: visuals.water_color-->",
           "name": "key",
           "type": "string"
         }
@@ -2938,7 +2938,7 @@
         "description": "What the setting is and how it is entered.",
         "fields": [
           {
-            "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.",
+            "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
             "name": "kind",
             "type": "string"
           },
@@ -4589,7 +4589,7 @@
       ],
       "path": "query.narrowing",
       "returns": {
-        "description": "The method to declare as an `impl`.",
+        "description": "The method to declare as an `impl`. <!--noref: impl-->",
         "type": "function"
       }
     },
@@ -4759,7 +4759,7 @@
       ]
     },
     {
-      "description": "Every rule there is, as dotted `group.field` keys.",
+      "description": "Every rule there is, as dotted `group.field` keys. <!--noref: group.field-->",
       "params": [],
       "path": "rules.list",
       "returns": {
@@ -4771,7 +4771,7 @@
       "description": "Reads a rule by its key, for code that does not know which one it wants.",
       "params": [
         {
-          "description": "Dotted path, e.g. `exposure.damage`.",
+          "description": "Dotted path, e.g. `exposure.damage`. <!--noref: exposure.damage-->",
           "name": "key",
           "type": "string"
         }
@@ -4786,7 +4786,7 @@
       "description": "Changes a rule by its key. A string is read as text, the way the console gives it; any other value is taken as the rule's own type.",
       "params": [
         {
-          "description": "Dotted path, e.g. `exposure.damage`.",
+          "description": "Dotted path, e.g. `exposure.damage`. <!--noref: exposure.damage-->",
           "name": "key",
           "type": "string"
         },
@@ -5031,7 +5031,7 @@
       }
     },
     {
-      "description": "Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, `false` or `off` for false, in any case. Anything else is not a boolean.",
+      "description": "Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, `false` or `off` for false, in any case. Anything else is not a boolean. <!--noref: on, off-->",
       "examples": [
         "local on = trx.strings.parse_bool(\"on\")"
       ],
@@ -5203,7 +5203,7 @@
       "order": 11
     },
     {
-      "description": "Module for TR4's in-game cutscenes, the animated scenes stored in\n`cutseq.pak` and started by a cutscene trigger. A cutscene plays once:\nthe engine remembers which ones have run, and a script may consult or\nrewrite that memory. The cutscene levels of TR1-TR3, which the game flow\nlists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.",
+      "description": "Module for TR4's in-game cutscenes, the animated scenes stored in\n`cutseq.pak` <!--noref: cutseq.pak--> and started by a cutscene trigger. A cutscene plays once:\nthe engine remembers which ones have run, and a script may consult or\nrewrite that memory. The cutscene levels of TR1-TR3, which the game flow\nlists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.",
       "name": "cutscenes",
       "order": 13
     },
@@ -5240,7 +5240,7 @@
       "order": 19
     },
     {
-      "description": "Logs a message to the terminal and to `TRX.log` in the installation directory.  Each call records the Lua script's filename, function name and line number.",
+      "description": "Logs a message to the terminal and to `TRX.log` in the installation directory. <!--noref: TRX.log--> Each call records the Lua script's filename, function name and line number.",
       "name": "log",
       "order": 26,
       "title": "Logging"
@@ -5869,7 +5869,7 @@
           "name": "flag",
           "params": [
             {
-              "description": "What the parsed value is keyed by. `help` is reserved.",
+              "description": "What the parsed value is keyed by. `help` is reserved. <!--noref: help-->",
               "name": "name",
               "type": "string"
             },
@@ -6482,7 +6482,7 @@
           "type": "math.Box"
         },
         {
-          "description": "Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
+          "description": "Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](docs/trx/OBJECTS.md).",
           "name": "properties",
           "type": "table"
         },
@@ -6535,7 +6535,7 @@
           "writable": true
         },
         {
-          "description": "Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of `trx.items.Item.properties`.",
+          "description": "Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of `trx.items.Item.properties`. <!--noref: max_hit_points-->",
           "name": "hit_points",
           "type": "integer",
           "writable": true
@@ -6613,7 +6613,7 @@
           "writable": true
         },
         {
-          "description": "Maximum hit points. Set the `max_hit_points` entry of `trx.items.Item.properties` to change it.",
+          "description": "Maximum hit points. Set the `max_hit_points` entry of `trx.items.Item.properties` to change it. <!--noref: max_hit_points-->",
           "name": "max_hit_points",
           "type": "integer",
           "writable": false
@@ -7682,12 +7682,12 @@
           "type": "table"
         },
         {
-          "description": "Every name the object answers to, in the player's language. An object has more than one: a large medipack is also a `medipack` and a `big medi`.",
+          "description": "Every name the object answers to, in the player's language. An object has more than one: a large medipack is also a `medipack` and a `big medi`. <!--noref: medipack-->",
           "name": "names",
           "type": "table"
         },
         {
-          "description": "The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `trx.items.Item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
+          "description": "The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `trx.items.Item.properties` to change one item only. Iterable with `pairs()`. See [Objects](docs/trx/OBJECTS.md).",
           "name": "properties",
           "type": "table"
         }

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2752,9 +2752,9 @@
       ],
       "params": [
         {
-          "description": "Time in seconds. Must be greater than zero.",
+          "description": "Must be greater than zero.",
           "name": "time",
-          "type": "number"
+          "type": "game.Seconds"
         },
         {
           "default": 1,
@@ -2807,9 +2807,9 @@
         "description": "The records.",
         "fields": [
           {
-            "description": "The time, in seconds.",
+            "description": "The time it took.",
             "name": "time",
-            "type": "number"
+            "type": "game.Seconds"
           },
           {
             "base": 1,
@@ -5681,9 +5681,9 @@
       "writable": false
     },
     {
-      "description": "How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills to. Warmth only moves in a room carrying the `trx.rooms.Room.damaging` flag, such as the cold water of Antarctica.",
+      "description": "How much warmth Lara holds, and what `trx.lara.exposure_bar` fills to. Warmth only moves in a room carrying the `trx.rooms.Room.damaging` flag, such as the cold water of Antarctica.",
       "path": "rules.exposure.max",
-      "type": "integer",
+      "type": "game.Frames",
       "writable": true
     },
     {
@@ -6457,9 +6457,9 @@
           "writable": true
         },
         {
-          "description": "How long it keeps the item going, in seconds.",
+          "description": "How long it keeps the item going.",
           "name": "timer",
-          "type": "number",
+          "type": "game.Seconds",
           "writable": true
         },
         {
@@ -6668,9 +6668,9 @@
           "writable": true
         },
         {
-          "description": "How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - `trx.items.Item:trigger` takes its timer in seconds instead.",
+          "description": "How long the item's trigger keeps it going. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. `trx.items.Item:trigger` takes its own timer as a `trx.game.Seconds`.",
           "name": "timer",
-          "type": "integer",
+          "type": "game.Frames",
           "writable": true
         },
         {
@@ -7173,10 +7173,10 @@
                 },
                 {
                   "default": 0,
-                  "description": "How long it should keep the item going, in seconds. `0` means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.",
+                  "description": "How long it should keep the item going. `0` means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.",
                   "name": "timer",
                   "optional": true,
-                  "type": "number"
+                  "type": "game.Seconds"
                 },
                 {
                   "description": "Never let it fire again.",
@@ -7347,15 +7347,15 @@
           "writable": true
         },
         {
-          "description": "Frames Lara has been dead for.",
+          "description": "How long Lara has been dead.",
           "name": "death_timer",
-          "type": "integer",
+          "type": "game.Frames",
           "writable": false
         },
         {
-          "description": "Frames Lara has been diving for.",
+          "description": "How long Lara has been diving.",
           "name": "dive_timer",
-          "type": "integer",
+          "type": "game.Frames",
           "writable": false
         },
         {
@@ -7425,9 +7425,9 @@
           "writable": true
         },
         {
-          "description": "Frames Lara has stood still for, which is what starts an idle animation.",
+          "description": "How long Lara has stood still, which is what starts an idle animation.",
           "name": "pose_count",
-          "type": "integer",
+          "type": "game.Frames",
           "writable": false
         },
         {
@@ -7563,9 +7563,9 @@
           "writable": false
         },
         {
-          "description": "How far into the track the stream is, in seconds.",
+          "description": "How far into the track the stream is.",
           "name": "timestamp",
-          "type": "number",
+          "type": "game.Seconds",
           "writable": false
         },
         {
@@ -7594,9 +7594,9 @@
           "name": "seek",
           "params": [
             {
-              "description": "Where to seek to, in seconds.",
+              "description": "Where to seek to.",
               "name": "timestamp",
-              "type": "number"
+              "type": "game.Seconds"
             }
           ],
           "returns": {
@@ -8612,9 +8612,9 @@
           "writable": true
         },
         {
-          "description": "How long the level has been played, in game frames.",
+          "description": "How long the level has been played.",
           "name": "timer",
-          "type": "integer",
+          "type": "game.Frames",
           "writable": true
         }
       ],
@@ -8681,6 +8681,23 @@
     }
   ],
   "units": [
+    {
+      "description": "A length of time counted in the frames the engine runs the world at, which\nis what the engine measures its own timers in.",
+      "path": "game.Frames",
+      "spellings": [
+        "game frames",
+        "in frames"
+      ],
+      "type": "integer"
+    },
+    {
+      "description": "A length of time in seconds, as a player would read it off a clock.",
+      "path": "game.Seconds",
+      "spellings": [
+        "in seconds"
+      ],
+      "type": "number"
+    },
     {
       "description": "An angle in the engine's own units, where 65536 is a full turn rather than\n2 pi. An angle counts in cycles, so one past the end of a turn wraps round\nto name the same direction: adding a half turn to a rotation always works.\n`trx.math.DEG_1` converts from degrees.",
       "path": "math.Angle",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -1,23 +1,27 @@
 {
   "constants": [
     {
-      "description": "One degree in TRX units. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.",
+      "description": "One degree. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.",
       "path": "math.DEG_1",
+      "type": "math.Angle",
       "value": 182
     },
     {
-      "description": "A 45-degree turn, in TRX units.",
+      "description": "A 45-degree turn.",
       "path": "math.DEG_45",
+      "type": "math.Angle",
       "value": 8192
     },
     {
-      "description": "A quarter turn, in TRX units. A full turn is four of these, and wraps to zero.",
+      "description": "A quarter turn. A full turn is four of these.",
       "path": "math.DEG_90",
+      "type": "math.Angle",
       "value": 16384
     },
     {
-      "description": "The size of one sector in world units. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.",
+      "description": "The size of one sector. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.",
       "path": "math.WALL_L",
+      "type": "math.Distance",
       "value": 1024
     }
   ],
@@ -3367,10 +3371,10 @@
           "type": "vec3"
         },
         {
-          "description": "Facing angle, in the engine's own angle units. Defaults to `0`.",
+          "description": "Facing angle. Defaults to `0`.",
           "name": "rot",
           "optional": true,
-          "type": "integer"
+          "type": "math.Angle"
         }
       ],
       "path": "cutscenes.set_lara_return"
@@ -4114,7 +4118,7 @@
           "description": "Facing angle.",
           "name": "angle_y",
           "optional": true,
-          "type": "integer"
+          "type": "math.Angle"
         },
         {
           "description": "How to spawn it.",
@@ -4405,9 +4409,8 @@
       "description": "Sine of an angle.",
       "params": [
         {
-          "description": "Angle in TRX units.",
           "name": "angle",
-          "type": "integer"
+          "type": "math.Angle"
         }
       ],
       "path": "math.sin",
@@ -4420,9 +4423,8 @@
       "description": "Cosine of an angle.",
       "params": [
         {
-          "description": "Angle in TRX units.",
           "name": "angle",
-          "type": "integer"
+          "type": "math.Angle"
         }
       ],
       "path": "math.cos",
@@ -4432,7 +4434,7 @@
       }
     },
     {
-      "description": "Angle of the vector (x, z), in TRX units.",
+      "description": "Angle of the vector (x, z).",
       "examples": [
         "-- face an item towards Lara\nlocal angle = trx.math.atan(lara.pos.z - pos.z, lara.pos.x - pos.x)"
       ],
@@ -4440,18 +4442,17 @@
         {
           "description": "How far the vector reaches north.",
           "name": "z",
-          "type": "integer"
+          "type": "math.Distance"
         },
         {
           "description": "How far it reaches east.",
           "name": "x",
-          "type": "integer"
+          "type": "math.Distance"
         }
       ],
       "path": "math.atan",
       "returns": {
-        "description": "In TRX units.",
-        "type": "integer"
+        "type": "math.Angle"
       }
     },
     {
@@ -4727,9 +4728,9 @@
       ],
       "path": "rooms.floor_height",
       "returns": {
-        "description": "The height, in world units, with `nil` where there is no floor.",
+        "description": "The height, with `nil` where there is no floor.",
         "nullable": true,
-        "type": "integer"
+        "type": "math.Distance"
       }
     },
     {
@@ -5251,7 +5252,7 @@
       "order": 29
     },
     {
-      "description": "Fixed-point trigonometry, matching the engine's own tables.\n\nTRX angles are 16-bit units where 65536 is a full turn, not radians. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would.",
+      "description": "Fixed-point trigonometry, matching the engine's own tables. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would. `trx.math.Angle` says what an angle is here.",
       "name": "math",
       "order": 27
     },
@@ -5506,9 +5507,9 @@
       "writable": false
     },
     {
-      "description": "Field of view a cutscene plays at, in the engine's own angle units. TR4 uses 11488, against 14560 for ordinary play.",
+      "description": "Field of view a cutscene plays at. TR4 uses 11488, against 14560 for ordinary play.",
       "path": "cutscenes.fov",
-      "type": "integer",
+      "type": "math.Angle",
       "writable": true
     },
     {
@@ -6655,7 +6656,7 @@
           "writable": false
         },
         {
-          "description": "Orientation, in the units `trx.math` counts angles in. An angle counts in cycles, so one past the end of the turn wraps round to name the same direction rather than raising: adding a half turn to a rotation always works.",
+          "description": "Orientation. Each component is a `trx.math.Angle`.",
           "name": "rot",
           "type": "vec3",
           "writable": true
@@ -6729,8 +6730,8 @@
             }
           ],
           "returns": {
-            "description": "In world units, measured between the two positions.",
-            "type": "integer"
+            "description": "Measured between the two positions.",
+            "type": "math.Distance"
           }
         },
         {
@@ -7271,9 +7272,9 @@
               "type": "vec3"
             },
             {
-              "description": "How far out it reaches. One sector is 1024.",
+              "description": "How far out it reaches.",
               "name": "radius",
-              "type": "integer"
+              "type": "math.Distance"
             }
           ],
           "returns": {
@@ -7454,43 +7455,43 @@
       "path": "lara.Lara"
     },
     {
-      "description": "An axis-aligned box, in the units the engine measures the world in. Whether it is placed in world coordinates or in something's own frame is for whatever hands it over to say.",
+      "description": "An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.",
       "extensions": [],
       "fields": [
         {
           "description": "East edge.",
           "name": "max_x",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         },
         {
           "description": "Bottom edge.",
           "name": "max_y",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         },
         {
           "description": "South edge.",
           "name": "max_z",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         },
         {
           "description": "West edge.",
           "name": "min_x",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         },
         {
-          "description": "Top edge. Y grows downwards.",
+          "description": "Top edge.",
           "name": "min_y",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         },
         {
           "description": "North edge.",
           "name": "min_z",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         }
       ],
@@ -8138,7 +8139,7 @@
       "description": "A room in the current level.",
       "extensions": [
         {
-          "description": "Where the room sits, in world coordinates.",
+          "description": "Where the room sits in the world.",
           "name": "bounds",
           "type": "math.Box"
         },
@@ -8224,9 +8225,9 @@
             }
           ],
           "returns": {
-            "description": "The height, in world units, with `nil` where there is no floor.",
+            "description": "The height, with `nil` where there is no floor.",
             "nullable": true,
-            "type": "integer"
+            "type": "math.Distance"
           }
         },
         {
@@ -8599,9 +8600,9 @@
           "writable": true
         },
         {
-          "description": "How far Lara has travelled, in world units.",
+          "description": "How far Lara has travelled.",
           "name": "distance_travelled",
-          "type": "integer",
+          "type": "math.Distance",
           "writable": true
         },
         {
@@ -8679,5 +8680,24 @@
       "path": "stats.Stats"
     }
   ],
-  "units": []
+  "units": [
+    {
+      "description": "An angle in the engine's own units, where 65536 is a full turn rather than\n2 pi. An angle counts in cycles, so one past the end of a turn wraps round\nto name the same direction: adding a half turn to a rotation always works.\n`trx.math.DEG_1` converts from degrees.",
+      "path": "math.Angle",
+      "spellings": [
+        "TRX units",
+        "angle units"
+      ],
+      "type": "integer"
+    },
+    {
+      "description": "A length in the units the engine measures the world in, where one sector is\n`trx.math.WALL_L`. Y grows downwards, so a greater Y is further down.",
+      "path": "math.Distance",
+      "spellings": [
+        "world units",
+        "world coordinates"
+      ],
+      "type": "integer"
+    }
+  ]
 }

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -29,9 +29,7 @@
         "for _, entry in pairs(trx.inventory) do\n  trx.log.info((\"%d x %s\"):format(entry.count, trx.catalog.objects[entry.object]))\nend"
       ],
       "key": {
-        "base": 1,
-        "description": "Position in the ring.",
-        "type": "integer"
+        "type": "inventory.EntryNum"
       },
       "module": "inventory",
       "value": {
@@ -1981,7 +1979,7 @@
     {
       "bulk": false,
       "count": 4,
-      "description": "How a console command went. What a command's `run` gives back.",
+      "description": "How a console command went. What a command's `trx.console.register.spec.run` gives back.",
       "path": "console.Result",
       "values": [
         {
@@ -2512,7 +2510,7 @@
     {
       "bulk": false,
       "count": 5,
-      "description": "How a track is played. Pass one as `opts.mode` to `trx.music.play`.",
+      "description": "How a track is played. Pass one as `trx.music.play.opts.mode`.",
       "path": "music.PlayMode",
       "values": [
         {
@@ -2631,13 +2629,27 @@
       }
     },
     {
-      "description": "Creates an argument parser. See the module description for the parser's methods.",
+      "description": "Creates an argument parser.",
       "examples": [
         "local p = trx.argparse.new({ prog = \"weather\" })\np:positional(\"state\", { choices = { \"snow\", \"rain\", \"none\" } })\nlocal parsed = p:parse(\"snow\")  -- { state = \"snow\" }"
       ],
       "params": [
         {
-          "description": "`prog`: the command word, for messages. `description`: what the command does.",
+          "description": "What the parser calls itself in messages.",
+          "fields": [
+            {
+              "description": "The command word.",
+              "name": "prog",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "description": "What the command does.",
+              "name": "description",
+              "optional": true,
+              "type": "string"
+            }
+          ],
           "name": "spec",
           "optional": true,
           "type": "table"
@@ -2645,8 +2657,8 @@
       ],
       "path": "argparse.new",
       "returns": {
-        "description": "A parser. Describe its arguments with `positional`, `any_of`, `rest` and `flag`, then read them with `parse` or offer completions with `complete`.",
-        "type": "table"
+        "description": "A parser, with no arguments declared on it yet.",
+        "type": "argparse.Parser"
       }
     },
     {
@@ -2709,6 +2721,7 @@
       ],
       "path": "assault.is_running",
       "returns": {
+        "description": "True from the start of a run until it is finished or stopped.",
         "type": "boolean"
       }
     },
@@ -2724,6 +2737,7 @@
       ],
       "path": "assault.is_visible",
       "returns": {
+        "description": "True while the timer is drawn, counting or not.",
         "type": "boolean"
       }
     },
@@ -2755,10 +2769,8 @@
       "description": "Removes a record, closing the gap behind it.",
       "params": [
         {
-          "base": 1,
-          "description": "Position in the table.",
           "name": "record_num",
-          "type": "integer"
+          "type": "assault.RecordNum"
         },
         {
           "default": 1,
@@ -2788,7 +2800,21 @@
       ],
       "path": "assault.stats.list_records",
       "returns": {
-        "description": "List of `{ time = seconds, attempt_num = which attempt it was }`.",
+        "description": "The records.",
+        "fields": [
+          {
+            "description": "The time, in seconds.",
+            "name": "time",
+            "type": "number"
+          },
+          {
+            "base": 1,
+            "description": "Which attempt it was.",
+            "name": "attempt_num",
+            "type": "integer"
+          }
+        ],
+        "list": true,
         "type": "table"
       }
     },
@@ -2832,7 +2858,7 @@
       "path": "camera.cancel_flyby"
     },
     {
-      "description": "Converts a TRX id into the slot this game's own files use for it - the number a builder reads off Tomb Editor.",
+      "description": "Converts a `trx.catalog.Id` into the `trx.catalog.Slot` this game's own files use for it.",
       "examples": [
         "local slot = trx.catalog.to_slot(trx.catalog.Context.OBJECTS, trx.catalog.objects.WOLF)"
       ],
@@ -2843,20 +2869,19 @@
           "type": "catalog.Context"
         },
         {
-          "description": "The TRX id.",
           "name": "id",
-          "type": "integer"
+          "type": "catalog.Id"
         }
       ],
       "path": "catalog.to_slot",
       "returns": {
         "description": "`nil` if this game has no slot for it - not every game has every object.",
         "nullable": true,
-        "type": "integer"
+        "type": "catalog.Slot"
       }
     },
     {
-      "description": "Converts a slot from this game's own files into the TRX id for it.",
+      "description": "Converts a `trx.catalog.Slot` from this game's own files into the `trx.catalog.Id` for it.",
       "examples": [
         "local object_id = trx.catalog.from_slot(trx.catalog.Context.OBJECTS, 7)"
       ],
@@ -2867,16 +2892,15 @@
           "type": "catalog.Context"
         },
         {
-          "description": "The game's own id.",
           "name": "slot",
-          "type": "integer"
+          "type": "catalog.Slot"
         }
       ],
       "path": "catalog.from_slot",
       "returns": {
         "description": "`nil` if this game has nothing in that slot.",
         "nullable": true,
-        "type": "integer"
+        "type": "catalog.Id"
       }
     },
     {
@@ -2911,7 +2935,24 @@
       ],
       "path": "config.describe",
       "returns": {
-        "description": "`kind` is one of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. `percent` marks a number stored 0-1 but entered and shown as a 0-100 percentage. For the enum kinds, `values` lists what the setting accepts.",
+        "description": "What the setting is and how it is entered.",
+        "fields": [
+          {
+            "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.",
+            "name": "kind",
+            "type": "string"
+          },
+          {
+            "description": "Marks a number stored 0-1 but entered and shown as a 0-100 percentage.",
+            "name": "percent",
+            "type": "boolean"
+          },
+          {
+            "description": "What the setting accepts, for the enum kinds. `nil` for the rest.",
+            "name": "values",
+            "type": "table"
+          }
+        ],
         "type": "table"
       }
     },
@@ -2929,6 +2970,7 @@
       ],
       "path": "config.format_value",
       "returns": {
+        "description": "The text, ready to print.",
         "type": "string"
       }
     },
@@ -3036,6 +3078,7 @@
       ],
       "path": "config.is_overridden",
       "returns": {
+        "description": "True while an override stands, and false once the last is lifted.",
         "type": "boolean"
       }
     },
@@ -3132,7 +3175,15 @@
           "type": "string"
         },
         {
-          "description": "`verbose`: show the command's output.",
+          "description": "How to run it.",
+          "fields": [
+            {
+              "description": "Show the command's output.",
+              "name": "verbose",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
           "name": "opts",
           "optional": true,
           "type": "table"
@@ -3141,13 +3192,43 @@
       "path": "console.eval"
     },
     {
-      "description": "Registers a console command written in Lua.\n\nEvery command has a `trx.argparse` parser. `args` is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits `args` takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.\n\n`run` receives the parsed values, a table keyed by argument name. What it gives back is a `trx.console.Result`, and returning nothing means `OK`. It may return a message after that, which is logged to the console - as an error, for any result but `OK`. A line the parser rejects is reported with what it expected, without reaching `run`.\n\nA command lives for the whole run, so it can only be registered from a global script. A level script raises if it calls this: it runs again every time its level is loaded.",
+      "description": "Registers a console command written in Lua.\n\nEvery command has a `trx.argparse` parser. `trx.console.register.spec.args` is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits `trx.console.register.spec.args` takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.\n\n`trx.console.register.spec.run` receives the parsed values, a table keyed by argument name. What it gives back is a `trx.console.Result`, and returning nothing means `OK`. It may return a message after that, which is logged to the console - as an error, for any result but `OK`. A line the parser rejects is reported with what it expected, without reaching `trx.console.register.spec.run`.\n\nA command lives for the whole run, so it can only be registered from a global script. A level script raises if it calls this: it runs again every time its level is loaded.",
       "examples": [
         "trx.console.register({\n  name = \"greet\",\n  aliases = { \"hello\", \"hi\" },\n  args = function(parser)\n    parser:positional(\"who\", { help = \"who to greet\" })\n  end,\n  run = function(args)\n    trx.console.log(\"hello \" .. args.who)\n  end,\n})"
       ],
       "params": [
         {
-          "description": "`name`: the word the player types. `help`: a game string key for the help text, optional. `args`: a function that shapes the parser, optional. `run`: the function, called with the parsed arguments. `aliases`: other words that reach the same command, optional; they dispatch but stay out of the command listing, and the help for `name` shows them.",
+          "description": "The command.",
+          "fields": [
+            {
+              "description": "The word the player types.",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "description": "A game string key for the help text.",
+              "name": "help",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "description": "Shapes the parser.",
+              "name": "args",
+              "optional": true,
+              "type": "function"
+            },
+            {
+              "description": "Called with the parsed arguments.",
+              "name": "run",
+              "type": "function"
+            },
+            {
+              "description": "Other words that reach the same command. They dispatch but stay out of the command listing, and the help for the command shows them.",
+              "name": "aliases",
+              "optional": true,
+              "type": "table"
+            }
+          ],
           "name": "spec",
           "type": "table"
         }
@@ -3159,10 +3240,28 @@
       "path": "console.clear"
     },
     {
-      "description": "Every registered console command, in registration order. Each is `{ name, aliases, help }`: `name` is the word the player types, `aliases` the other words that reach it (a list, or absent), and `help` the text the console shows for `name --help` (absent when the command carries none). The help command is built on this.",
+      "description": "Every registered console command, in registration order. The help command is built on this.",
       "path": "console.commands",
       "returns": {
-        "description": "A list of `{ name, aliases, help }`.",
+        "description": "The commands.",
+        "fields": [
+          {
+            "description": "The word the player types.",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "description": "The other words that reach it, or `nil` where it answers to one.",
+            "name": "aliases",
+            "type": "table"
+          },
+          {
+            "description": "What the console shows for `--help`, or `nil` where the command carries none.",
+            "name": "help",
+            "type": "string"
+          }
+        ],
+        "list": true,
         "type": "table"
       }
     },
@@ -3230,6 +3329,7 @@
       ],
       "path": "cutscenes.is_played",
       "returns": {
+        "description": "True once it has run, which is what keeps its trigger from firing again.",
         "type": "boolean"
       }
     },
@@ -3282,6 +3382,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3306,6 +3407,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "type": "function"
         }
@@ -3323,6 +3425,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3344,6 +3447,7 @@
       "description": "Happens on every logical game frame, before the main game logic runs. The handler takes no arguments.",
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "type": "function"
         }
@@ -3358,6 +3462,7 @@
       "description": "Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.",
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "type": "function"
         }
@@ -3369,18 +3474,18 @@
       }
     },
     {
-      "description": "Claims a flip effect number and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick an unused effect number, and handle it here from the level's script.\n\nA claimed number belongs to the script for the rest of the level: its stock engine effect does not run, even if the handler is later detached. Unclaimed numbers are unaffected.\n\nUnlike the other hooks, this happens at effect execution time, in the middle of a game frame.",
+      "description": "Claims a `trx.events.FlipEffectNum` and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick one nothing uses, and handle it here from the level's script.\n\nA claimed number belongs to the script for the rest of the level: its stock engine effect does not run, even if the handler is later detached. Unclaimed numbers are unaffected.\n\nUnlike the other hooks, this happens at effect execution time, in the middle of a game frame.",
       "examples": [
         "trx.events.on_flip_effect(62, function(timer, item_num)\n  trx.log.info(\"flipeffect 62 ran with timer \" .. timer)\nend)"
       ],
       "params": [
         {
-          "base": 0,
-          "description": "The flip effect number to claim, as the level editor numbers them. This is not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` names.",
+          "description": "The one to claim.",
           "name": "effect_num",
-          "type": "integer"
+          "type": "events.FlipEffectNum"
         },
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3410,6 +3515,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3444,6 +3550,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3452,9 +3559,9 @@
               "type": "items.Item"
             },
             {
-              "description": "What the trigger carried: `type` (a `trx.items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.",
+              "description": "What the trigger carried.",
               "name": "trigger",
-              "type": "table"
+              "type": "items.Trigger"
             }
           ],
           "type": "function"
@@ -3473,6 +3580,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3497,6 +3605,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3521,6 +3630,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3545,6 +3655,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3569,6 +3680,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3593,6 +3705,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3617,6 +3730,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3641,6 +3755,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3665,6 +3780,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3689,6 +3805,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3713,6 +3830,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3742,6 +3860,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3766,6 +3885,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3787,6 +3907,7 @@
       "description": "Happens when a TR4 cutscene's first frame is about to show, after the fade out.",
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3810,6 +3931,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3833,6 +3955,7 @@
       ],
       "params": [
         {
+          "description": "What to run when it happens.",
           "name": "callback",
           "params": [
             {
@@ -3856,6 +3979,7 @@
       ],
       "params": [
         {
+          "description": "What the hook handed back when the handler was attached.",
           "name": "listener",
           "type": "events.Listener"
         }
@@ -3873,13 +3997,19 @@
       ],
       "params": [
         {
-          "base": 1,
-          "description": "Position in `trx.game.levels`.",
           "name": "level_num",
-          "type": "integer"
+          "type": "game.LevelNum"
         },
         {
-          "description": "`select`: start the level as the level-select screen does, rebuilding Lara's inventory to what she would carry on reaching it. Without it the level continues from the one in progress.",
+          "description": "How to start it.",
+          "fields": [
+            {
+              "description": "Start the level as the level-select screen does, rebuilding Lara's inventory to what she would carry on reaching it. Without it the level continues from the one in progress.",
+              "name": "select",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
           "name": "opts",
           "optional": true,
           "type": "table"
@@ -3891,10 +4021,8 @@
       "description": "Plays a cutscene.",
       "params": [
         {
-          "base": 1,
-          "description": "Position in `trx.game.cutscenes`.",
           "name": "cutscene_num",
-          "type": "integer"
+          "type": "cutscenes.Num"
         }
       ],
       "path": "game.play_cutscene"
@@ -3903,11 +4031,10 @@
       "description": "Plays a demo, and returns the one that started.",
       "params": [
         {
-          "base": 1,
-          "description": "Position in `trx.game.demos`. Omit to play the next demo in rotation.",
+          "description": "Omit to play the next demo in rotation.",
           "name": "demo_num",
           "optional": true,
-          "type": "integer"
+          "type": "game.DemoNum"
         }
       ],
       "path": "game.play_demo",
@@ -3961,6 +4088,7 @@
       ],
       "path": "items.get",
       "returns": {
+        "description": "The item, or `nil` where nothing answers to the key.",
         "nullable": true,
         "type": "items.Item"
       }
@@ -3989,7 +4117,15 @@
           "type": "integer"
         },
         {
-          "description": "`activate`: bring the item to life, enabling AI for creatures.",
+          "description": "How to spawn it.",
+          "fields": [
+            {
+              "description": "Bring the item to life, enabling AI for creatures.",
+              "name": "activate",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
           "name": "opts",
           "optional": true,
           "type": "table"
@@ -4006,6 +4142,7 @@
       "description": "Returns the total number of allocated items. Same as `#trx.items`.",
       "path": "items.count",
       "returns": {
+        "description": "How many slots the level holds, live or not.",
         "type": "integer"
       }
     },
@@ -4053,7 +4190,7 @@
       }
     },
     {
-      "description": "Cures Lara's poisoning. Not the same as writing `0` to `poison`: the poison has a target as well as a current value, and clearing only the value lets it climb back.",
+      "description": "Cures Lara's poisoning. Not the same as writing `0` to `trx.lara.poison`: the poison has a target as well as a current value, and clearing only the value lets it climb back.",
       "path": "lara.cure_poison"
     },
     {
@@ -4149,6 +4286,7 @@
           "type": "log.LogLevel"
         },
         {
+          "description": "The line to log.",
           "name": "message",
           "type": "string"
         }
@@ -4162,6 +4300,7 @@
       ],
       "params": [
         {
+          "description": "The line to log.",
           "name": "message",
           "type": "string"
         }
@@ -4172,6 +4311,7 @@
       "description": "Logs a warning.",
       "params": [
         {
+          "description": "The line to log.",
           "name": "message",
           "type": "string"
         }
@@ -4182,6 +4322,7 @@
       "description": "Logs a warning. An alias of `trx.log.warn`.",
       "params": [
         {
+          "description": "The line to log.",
           "name": "message",
           "type": "string"
         }
@@ -4192,6 +4333,7 @@
       "description": "Logs an error.",
       "params": [
         {
+          "description": "The line to log.",
           "name": "message",
           "type": "string"
         }
@@ -4202,6 +4344,7 @@
       "description": "Logs a debug message.",
       "params": [
         {
+          "description": "The line to log.",
           "name": "message",
           "type": "string"
         }
@@ -4222,7 +4365,19 @@
       ],
       "path": "lua.eval_expr",
       "returns": {
-        "description": "`nil` when the code ran to completion. Otherwise a table with `kind` (`\"syntax\"` or `\"runtime\"`) and `message`, the error text. A failure comes back as a value rather than raising, so the caller decides what it means.",
+        "description": "`nil` when the code ran to completion, and what went wrong otherwise. A failure comes back as a value rather than raising, so the caller decides what it means.",
+        "fields": [
+          {
+            "description": "Either `\"syntax\"` or `\"runtime\"`.",
+            "name": "kind",
+            "type": "string"
+          },
+          {
+            "description": "The error text.",
+            "name": "message",
+            "type": "string"
+          }
+        ],
         "nullable": true,
         "type": "table"
       }
@@ -4283,16 +4438,19 @@
       ],
       "params": [
         {
+          "description": "How far the vector reaches north.",
           "name": "z",
           "type": "integer"
         },
         {
+          "description": "How far it reaches east.",
           "name": "x",
           "type": "integer"
         }
       ],
       "path": "math.atan",
       "returns": {
+        "description": "In TRX units.",
         "type": "integer"
       }
     },
@@ -4328,7 +4486,15 @@
           "type": "catalog.music"
         },
         {
-          "description": "`mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.",
+          "description": "How to play it.",
+          "fields": [
+            {
+              "description": "Plays once by default.",
+              "name": "mode",
+              "optional": true,
+              "type": "music.PlayMode"
+            }
+          ],
           "name": "opts",
           "optional": true,
           "type": "table"
@@ -4387,13 +4553,13 @@
           "description": "Mesh of the first.",
           "name": "mesh_num1",
           "optional": true,
-          "type": "integer"
+          "type": "objects.MeshNum"
         },
         {
           "description": "Mesh of the second.",
           "name": "mesh_num2",
           "optional": true,
-          "type": "integer"
+          "type": "objects.MeshNum"
         }
       ],
       "path": "objects.swap_mesh"
@@ -4431,7 +4597,36 @@
       "description": "Builds the identity query over a domain, as an instance of that domain's query type. `trx.objects` and `trx.items` call this to make the query a script reaches through `trx.objects.query` and `trx.items.query`.",
       "params": [
         {
-          "description": "What the query runs against: `enumerate`, `id_of`, `searchable`, and an optional `names_of`/`default_names_of` name layer. See the module source.",
+          "description": "What the query runs against.",
+          "fields": [
+            {
+              "description": "Every id the domain holds.",
+              "name": "enumerate",
+              "type": "function"
+            },
+            {
+              "description": "The id of a thing the domain hands out.",
+              "name": "id_of",
+              "type": "function"
+            },
+            {
+              "description": "Whether an id is one a name may reach.",
+              "name": "searchable",
+              "type": "function"
+            },
+            {
+              "description": "The names an id answers to, for a domain that has them.",
+              "name": "names_of",
+              "optional": true,
+              "type": "function"
+            },
+            {
+              "description": "The same names before a language file is loaded.",
+              "name": "default_names_of",
+              "optional": true,
+              "type": "function"
+            }
+          ],
           "name": "domain",
           "type": "table"
         },
@@ -4460,6 +4655,7 @@
       ],
       "path": "rooms.get",
       "returns": {
+        "description": "The room, or `nil` where the level has no such number.",
         "nullable": true,
         "type": "rooms.Room"
       }
@@ -4468,6 +4664,7 @@
       "description": "Returns the number of rooms in the level. Same as `#trx.rooms`.",
       "path": "rooms.count",
       "returns": {
+        "description": "How many rooms the loaded level holds.",
         "type": "integer"
       }
     },
@@ -4513,7 +4710,16 @@
           "type": "rooms.Num"
         },
         {
-          "description": "`fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
+          "description": "How to read the floor.",
+          "fields": [
+            {
+              "default": true,
+              "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
+              "name": "fix_tilts",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
           "name": "opts",
           "optional": true,
           "type": "table"
@@ -4521,6 +4727,7 @@
       ],
       "path": "rooms.floor_height",
       "returns": {
+        "description": "The height, in world units, with `nil` where there is no floor.",
         "nullable": true,
         "type": "integer"
       }
@@ -4556,6 +4763,7 @@
       "params": [],
       "path": "rules.list",
       "returns": {
+        "description": "The keys, in no particular order.",
         "type": "table"
       }
     },
@@ -4583,6 +4791,7 @@
           "type": "string"
         },
         {
+          "description": "The value to write, of the type the rule declares.",
           "name": "value",
           "type": "any"
         }
@@ -4612,6 +4821,7 @@
       ],
       "path": "rules.format_value",
       "returns": {
+        "description": "The text, ready to print.",
         "type": "string"
       }
     },
@@ -4713,7 +4923,15 @@
           "type": "catalog.samples"
         },
         {
-          "description": "`pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.",
+          "description": "How to play it.",
+          "fields": [
+            {
+              "description": "A world position to play from, which applies pan and volume. Omit to play at full volume.",
+              "name": "pos",
+              "optional": true,
+              "type": "vec3"
+            }
+          ],
           "name": "opts",
           "optional": true,
           "type": "table"
@@ -4742,7 +4960,7 @@
       "path": "sound.stop_all"
     },
     {
-      "description": "Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.\n\nCandidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.",
+      "description": "Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.\n\nCandidates are ranked, best first. Each carries a `trx.strings.fuzzy_match.sources.value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.",
       "examples": [
         "local matches = trx.strings.fuzzy_match(\"wolf\", {\n  { key = \"wolf\", value = trx.catalog.objects.WOLF },\n  { key = \"bear\", value = trx.catalog.objects.BEAR },\n})\nlocal best = matches[1]"
       ],
@@ -4753,14 +4971,62 @@
           "type": "string"
         },
         {
-          "description": "List of `{ key = <the name>, value = <anything>, weight = <integer> }`. The key is a non-empty string. A heavier candidate wins a tie; weight defaults to 1, and a weight of zero or less drops the candidate.",
+          "description": "The candidates.",
+          "fields": [
+            {
+              "description": "The name to match against. Non-empty.",
+              "name": "key",
+              "type": "string"
+            },
+            {
+              "description": "Anything of the caller's, handed back on the match.",
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "default": 1,
+              "description": "A heavier candidate wins a tie. Zero or less drops it.",
+              "name": "weight",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "list": true,
           "name": "sources",
           "type": "table"
         }
       ],
       "path": "strings.fuzzy_match",
       "returns": {
-        "description": "The matches, best first: `{ key, value, score, is_full, is_word }`. `is_full` means the whole candidate matched, `is_word` that a whole word did.",
+        "description": "The matches, best first.",
+        "fields": [
+          {
+            "description": "The candidate that matched.",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "description": "What the candidate carried.",
+            "name": "value",
+            "type": "any"
+          },
+          {
+            "description": "How well it matched.",
+            "name": "score",
+            "type": "number"
+          },
+          {
+            "description": "Whether the whole candidate matched.",
+            "name": "is_full",
+            "type": "boolean"
+          },
+          {
+            "description": "Whether a whole word matched.",
+            "name": "is_word",
+            "type": "boolean"
+          }
+        ],
+        "list": true,
         "type": "table"
       }
     },
@@ -4814,6 +5080,7 @@
       ],
       "params": [
         {
+          "description": "The text to search.",
           "name": "subject",
           "type": "string"
         },
@@ -4825,6 +5092,7 @@
       ],
       "path": "strings.regex_match",
       "returns": {
+        "description": "True where the pattern matches anywhere in the subject.",
         "type": "boolean"
       }
     },
@@ -4839,6 +5107,7 @@
       ],
       "path": "weapons.is_available",
       "returns": {
+        "description": "True where this game has the weapon at all.",
         "type": "boolean"
       }
     },
@@ -4871,6 +5140,7 @@
       ],
       "path": "weapons.shots_per_box",
       "returns": {
+        "description": "Shots, not rounds.",
         "type": "integer"
       }
     },
@@ -4897,7 +5167,7 @@
       "title": "API registry"
     },
     {
-      "description": "A small, declarative argument parser for console commands, in the shape of\nPython's argparse.\n\nA parser both reads a command's arguments and offers completions for them,\nfrom one declaration. Every command written with `trx.console.register` has\none; a command shapes it through the `args` function it hands over, and `run`\nthen receives a table of parsed values. A command that shapes nothing takes no\narguments, and is told so when given one.\n\nEvery parser answers `-h` and `--help` on its own, printing what it accepts.\n\nHow a positional reads a token is its `matcher`, one of:\n\n- `type` - coerce to `\"integer\"`, `\"number\"`, `\"string\"` or `\"boolean\"`.\n- `choices` - the allowed set: a list of values or a `function(parsed)`\n  returning one. The token must match one; the set is shown in errors and\n  completes.\n- `match` - a `function(token, parsed)` returning `value, ok`, for a shape of its own.\n\nThese do not combine on one positional; a value that is a number *or* a name is\ntwo matchers, declared with `any_of`. Separately, `suggest` offers completions\nwithout restricting or being shown in errors - for a free value with a long\nlist behind it, like a setting name.\n\nPositionals are read in order, and an optional one a token does not fit is\npassed over: the token goes to the next positional, and the one skipped stays\nnil. That is what lets a command take a leading argument it can also be used\nwithout - a verb before a value, a count before a name. Completion follows the\nsame path, so a slot offers what every argument reachable from it takes. A\ntoken nothing takes is reported against the first argument that refused it.\n\nA parser has these methods, each returning the parser so calls chain:\n\n- `positional(name, opts)` - a positional with one matcher (`opts.type`,\n  `opts.choices` or `opts.match`). `opts.optional` lets it be left out;\n  `opts.greedy` reads the rest of the line as one token, so a value with spaces\n  in it still arrives whole; `opts.suggest` completes it; `opts.help` describes\n  it.\n- `any_of(name, alternatives, opts)` - a positional whose value is the first of\n  several matchers to take the token. Each alternative is a matcher table,\n  `{ type = ... }` or `{ choices = ... }`. Same `opts` as `positional`.\n- `rest(name, opts)` - the rest of the line from here on, verbatim as one\n  string, or nil when an optional one is absent. Always the last argument;\n  `opts.suggest` completes it.\n- `flag(name, opts)` - a boolean that may sit anywhere. `opts.short` and\n  `opts.long` are the spellings, e.g. `\"-f\"` and `\"--force\"`; `opts.help`\n  describes it.\n- `parse(args)` - reads the argument string, returning a table of values, or\n  `nil` and a structured error the console layer turns into localized text. A\n  value carried by a `{ key, value }` choice comes back as its `value`;\n  `-h`/`--help` comes back as `{ help = true }`.\n- `complete(text, caret)` - the candidate completions for the token the caret\n  sits in, and the byte offsets `start, end` of the run they replace (reaching\n  to the end of the line for a greedy argument).\n- `usage()` - a short description of what the command accepts.\n\nA choice is either a bare string, where the key and value are the same, or a\n`{ key, value }` pair, where `key` is matched and shown and `value` is what\n`parse` gives back. Matching is forgiving, through `trx.strings.fuzzy_match`.",
+      "description": "A small, declarative argument parser for console commands, in the shape of\nPython's argparse.\n\nA parser both reads a command's arguments and offers completions for them,\nfrom one declaration. Every command written with `trx.console.register` has\none; a command shapes it through the `trx.console.register.spec.args` function\nit hands over, and `trx.console.register.spec.run` then receives a table of\nparsed values. A command that shapes nothing takes no arguments, and is told so\nwhen given one.\n\nEvery parser answers `-h` and `--help` on its own, printing what it accepts.\n\nHow a positional reads a token is its matcher: a type to coerce to, a set of\nchoices, or a function of its own. These do not combine on one positional; a\nvalue that is a number *or* a name is two matchers, declared with\n`trx.argparse.Parser:any_of`.\n\nPositionals are read in order, and an optional one a token does not fit is\npassed over: the token goes to the next positional, and the one skipped stays\nnil. That is what lets a command take a leading argument it can also be used\nwithout - a verb before a value, a count before a name. Completion follows the\nsame path, so a slot offers what every argument reachable from it takes. A\ntoken nothing takes is reported against the first argument that refused it.\n\nA choice is either a bare string, where the key and value are the same, or a\n`{ key, value }` pair, where the key is matched and shown and the value is what\n`trx.argparse.Parser:parse` gives back. Matching is forgiving, through\n`trx.strings.fuzzy_match`.",
       "name": "argparse",
       "order": 21
     },
@@ -4970,7 +5240,7 @@
       "order": 19
     },
     {
-      "description": "Logs a message to the terminal and to `TRX.log` in the installation directory. Each call records the Lua script's filename, function name and line number.",
+      "description": "Logs a message to the terminal and to `TRX.log` in the installation directory.  Each call records the Lua script's filename, function name and line number.",
       "name": "log",
       "order": 26,
       "title": "Logging"
@@ -5083,9 +5353,22 @@
   ],
   "numbers": [
     {
+      "base": 1,
+      "description": "Where a time sits in the table of best times, fastest first.",
+      "path": "assault.RecordNum"
+    },
+    {
       "base": 0,
       "description": "Flyby sequence number, as the level numbers them.",
       "path": "camera.SequenceNum"
+    },
+    {
+      "description": "A TRX id, in the catalog the context names. It is the same number in every game TRX ships, which is what lets a script name a thing once.",
+      "path": "catalog.Id"
+    },
+    {
+      "description": "A slot in this game's own files, which is the number a builder reads off Tomb Editor. It differs from game to game.",
+      "path": "catalog.Slot"
     },
     {
       "base": 0,
@@ -5094,8 +5377,52 @@
     },
     {
       "base": 0,
+      "description": "A flip effect number, as a level editor numbers them. Not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` names.",
+      "path": "events.FlipEffectNum"
+    },
+    {
+      "base": 1,
+      "description": "The number a level goes by, which is what the player is shown and what a gameflow names. Not its place in a table: a level the game flow skips does not count, and a gym level has no number at all and reads 0.",
+      "path": "game.LevelNum"
+    },
+    {
+      "base": 1,
+      "description": "Where a demo sits in the table of demos.",
+      "path": "game.DemoNum"
+    },
+    {
+      "base": 1,
+      "description": "Where an entry sits in the ring, in the order they are drawn.",
+      "path": "inventory.EntryNum"
+    },
+    {
+      "base": 0,
+      "description": "The animation's number within the object an item is of.",
+      "path": "items.AnimNum"
+    },
+    {
+      "base": 0,
+      "description": "The frame's number within the animation it belongs to.",
+      "path": "items.FrameNum"
+    },
+    {
+      "base": 0,
+      "description": "An animation state, as the object's own animations number them. What a state means is the object's business: the numbers of a wolf are not the numbers of a door.",
+      "path": "items.AnimState"
+    },
+    {
+      "base": 0,
       "description": "Item number, matching the numbers level editors show.",
       "path": "items.Num"
+    },
+    {
+      "description": "Track number, in the numbering the loaded level carries. Not a `trx.catalog.music` name, which is the soundtrack's own.",
+      "path": "music.TrackNum"
+    },
+    {
+      "base": 0,
+      "description": "The mesh's number within the object it belongs to.",
+      "path": "objects.MeshNum"
     },
     {
       "base": 0,
@@ -5106,6 +5433,10 @@
       "base": 1,
       "description": "Slot number within the pool. For the quick pool this is the on-screen order.",
       "path": "savegame.SlotNum"
+    },
+    {
+      "description": "Sample number, in the numbering the loaded level carries. Not a `trx.catalog.samples` name, which is the sound bank's own.",
+      "path": "sound.SampleNum"
     },
     {
       "base": 1,
@@ -5405,6 +5736,351 @@
   ],
   "types": [
     {
+      "description": "An argument parser, built up a call at a time. Every method hands the parser back, so the calls chain.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "Adds a positional whose value is the first of several matchers to take the token, for an argument that is a number or a name.",
+          "name": "any_of",
+          "params": [
+            {
+              "description": "What the parsed value is keyed by.",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "description": "The ways the token may read, tried in order.",
+              "fields": [
+                {
+                  "description": "As for `trx.argparse.Parser:positional`.",
+                  "name": "type",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "As for `trx.argparse.Parser:positional`.",
+                  "name": "choices",
+                  "optional": true,
+                  "type": "any"
+                },
+                {
+                  "description": "As for `trx.argparse.Parser:positional`.",
+                  "name": "match",
+                  "optional": true,
+                  "type": "function"
+                },
+                {
+                  "description": "Names this alternative, which earns it a line of its own in the help.",
+                  "name": "metavar",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "What this alternative is for.",
+                  "name": "help",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
+              "list": true,
+              "name": "alternatives",
+              "type": "table"
+            },
+            {
+              "description": "How the argument behaves.",
+              "fields": [
+                {
+                  "description": "Lets the argument be left out.",
+                  "name": "optional",
+                  "optional": true,
+                  "type": "boolean"
+                },
+                {
+                  "description": "Reads the rest of the line as one token, so a value with spaces in it still arrives whole.",
+                  "name": "greedy",
+                  "optional": true,
+                  "type": "boolean"
+                },
+                {
+                  "description": "What the argument is called in messages and in the synopsis. Its own name by default.",
+                  "name": "metavar",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.",
+                  "name": "suggest",
+                  "optional": true,
+                  "type": "function"
+                },
+                {
+                  "description": "What the argument is for, shown in the help.",
+                  "name": "help",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
+              "name": "opts",
+              "optional": true,
+              "type": "table"
+            }
+          ],
+          "returns": {
+            "description": "The parser.",
+            "type": "argparse.Parser"
+          }
+        },
+        {
+          "description": "The candidate completions for the token the caret sits in. Matching is against the text before the caret.",
+          "name": "complete",
+          "params": [
+            {
+              "description": "The line so far.",
+              "name": "text",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "description": "Where the caret sits, as a byte offset. The end of the line by default.",
+              "name": "caret",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "returns": [
+            {
+              "description": "The candidates, best first.",
+              "type": "table"
+            },
+            {
+              "description": "Where the run they replace starts. The run is the token, or the whole tail a greedy argument swallows; in whitespace it is empty, at the caret.",
+              "type": "integer"
+            },
+            {
+              "description": "Where that run ends.",
+              "type": "integer"
+            }
+          ]
+        },
+        {
+          "description": "Adds a boolean flag, which may sit anywhere in the line.",
+          "name": "flag",
+          "params": [
+            {
+              "description": "What the parsed value is keyed by. `help` is reserved.",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "description": "How it is spelled and what it is for.",
+              "fields": [
+                {
+                  "description": "The short spelling, such as `\"-f\"`.",
+                  "name": "short",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "The long spelling, such as `\"--force\"`.",
+                  "name": "long",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "What the flag is for, shown in the help.",
+                  "name": "help",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
+              "name": "opts",
+              "optional": true,
+              "type": "table"
+            }
+          ],
+          "returns": {
+            "description": "The parser.",
+            "type": "argparse.Parser"
+          }
+        },
+        {
+          "description": "Turns what a refused line reported into a localized line naming what was wrong and what was expected.",
+          "name": "format_error",
+          "params": [
+            {
+              "description": "What `trx.argparse.Parser:parse` handed back.",
+              "name": "err",
+              "type": "table"
+            }
+          ],
+          "returns": {
+            "description": "The line, ready to print.",
+            "type": "string"
+          }
+        },
+        {
+          "description": "Reads an argument line. A value carried by a `{ key, value }` choice comes back as its value, and `-h`/`--help` comes back as `{ help = true }`.",
+          "name": "parse",
+          "params": [
+            {
+              "description": "The line as the player typed it.",
+              "name": "args",
+              "optional": true,
+              "type": "string"
+            }
+          ],
+          "returns": [
+            {
+              "description": "The values, keyed by argument name, or `nil` where the line was refused.",
+              "nullable": true,
+              "type": "table"
+            },
+            {
+              "description": "What was wrong, for `trx.argparse.Parser:format_error` to put into words.",
+              "nullable": true,
+              "type": "table"
+            }
+          ]
+        },
+        {
+          "description": "Adds a positional argument, read one way.",
+          "name": "positional",
+          "params": [
+            {
+              "description": "What the parsed value is keyed by.",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "description": "How it reads its token, and how it behaves. It reads a token one way: name at most one of `trx.argparse.Parser.positional.opts.type`, `trx.argparse.Parser.positional.opts.choices` and `trx.argparse.Parser.positional.opts.match`, and use `trx.argparse.Parser:any_of` for several.",
+              "fields": [
+                {
+                  "description": "Coerce the token: `\"integer\"`, `\"number\"`, `\"string\"` or `\"boolean\"`.",
+                  "name": "type",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "The allowed set: a list of values, or a function of the values parsed so far returning one. The token must match one; the set is shown in errors and completes.",
+                  "name": "choices",
+                  "optional": true,
+                  "type": "any"
+                },
+                {
+                  "description": "A function of the token and the values parsed so far, returning the value and whether it took, for a shape of its own.",
+                  "name": "match",
+                  "optional": true,
+                  "type": "function"
+                },
+                {
+                  "description": "Lets the argument be left out.",
+                  "name": "optional",
+                  "optional": true,
+                  "type": "boolean"
+                },
+                {
+                  "description": "Reads the rest of the line as one token, so a value with spaces in it still arrives whole.",
+                  "name": "greedy",
+                  "optional": true,
+                  "type": "boolean"
+                },
+                {
+                  "description": "What the argument is called in messages and in the synopsis. Its own name by default.",
+                  "name": "metavar",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.",
+                  "name": "suggest",
+                  "optional": true,
+                  "type": "function"
+                },
+                {
+                  "description": "What the argument is for, shown in the help.",
+                  "name": "help",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
+              "name": "opts",
+              "optional": true,
+              "type": "table"
+            }
+          ],
+          "returns": {
+            "description": "The parser.",
+            "type": "argparse.Parser"
+          }
+        },
+        {
+          "description": "Adds an argument taking the rest of the line from here on, verbatim as one string, or `nil` where an optional one is absent. Always the last argument.",
+          "name": "rest",
+          "params": [
+            {
+              "description": "What the parsed value is keyed by.",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "description": "How the argument behaves.",
+              "fields": [
+                {
+                  "description": "Lets the argument be left out.",
+                  "name": "optional",
+                  "optional": true,
+                  "type": "boolean"
+                },
+                {
+                  "description": "Reads the rest of the line as one token, so a value with spaces in it still arrives whole.",
+                  "name": "greedy",
+                  "optional": true,
+                  "type": "boolean"
+                },
+                {
+                  "description": "What the argument is called in messages and in the synopsis. Its own name by default.",
+                  "name": "metavar",
+                  "optional": true,
+                  "type": "string"
+                },
+                {
+                  "description": "Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.",
+                  "name": "suggest",
+                  "optional": true,
+                  "type": "function"
+                },
+                {
+                  "description": "What the argument is for, shown in the help.",
+                  "name": "help",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
+              "name": "opts",
+              "optional": true,
+              "type": "table"
+            }
+          ],
+          "returns": {
+            "description": "The parser.",
+            "type": "argparse.Parser"
+          }
+        },
+        {
+          "description": "A short description of what the command accepts.",
+          "name": "usage",
+          "returns": {
+            "description": "The synopsis, and a line per argument.",
+            "type": "string"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "argparse.Parser"
+    },
+    {
       "description": "An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.",
       "extensions": [],
       "fields": [
@@ -5457,10 +6133,8 @@
           "writable": false
         },
         {
-          "base": 1,
-          "description": "The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0.",
           "name": "num",
-          "type": "integer",
+          "type": "game.LevelNum",
           "writable": false
         },
         {
@@ -5562,6 +6236,7 @@
             }
           ],
           "returns": {
+            "description": "True where the level carries the model to draw it with.",
             "type": "boolean"
           }
         },
@@ -5576,6 +6251,7 @@
             }
           ],
           "returns": {
+            "description": "0 where there is none.",
             "type": "integer"
           }
         },
@@ -5590,6 +6266,7 @@
             }
           ],
           "returns": {
+            "description": "The entry, or `nil` where there is none of it.",
             "nullable": true,
             "type": "inventory.Entry"
           }
@@ -5599,13 +6276,12 @@
           "name": "entry_at",
           "params": [
             {
-              "base": 1,
-              "description": "Position in the ring.",
               "name": "entry_num",
-              "type": "integer"
+              "type": "inventory.EntryNum"
             }
           ],
           "returns": {
+            "description": "The entry, or `nil` past the last one.",
             "nullable": true,
             "type": "inventory.Entry"
           }
@@ -5614,6 +6290,7 @@
           "description": "How many entries there are. `#trx.inventory` is the same number for the one Lara carries.",
           "name": "entry_count",
           "returns": {
+            "description": "Kinds of thing, not counts.",
             "type": "integer"
           }
         },
@@ -5652,6 +6329,7 @@
             }
           ],
           "returns": {
+            "description": "True for any count above 0.",
             "type": "boolean"
           }
         },
@@ -5666,6 +6344,7 @@
             }
           ],
           "returns": {
+            "description": "True where the weapon itself is in it.",
             "type": "boolean"
           }
         },
@@ -5731,6 +6410,7 @@
             }
           ],
           "returns": {
+            "description": "0 where she carries no ammunition for it.",
             "type": "integer"
           }
         },
@@ -5760,12 +6440,46 @@
       "path": "inventory.Inventory"
     },
     {
+      "description": "What a trigger carried when it fired.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "The code bits it set, `1` to `31`.",
+          "name": "mask",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether it fires only the once.",
+          "name": "one_shot",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "How long it keeps the item going, in seconds.",
+          "name": "timer",
+          "type": "number",
+          "writable": true
+        },
+        {
+          "description": "The kind of trigger it was.",
+          "name": "type",
+          "type": "items.TriggerType",
+          "writable": true
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "items.Trigger"
+    },
+    {
       "description": "An item, also known as a moveable.",
       "extensions": [
         {
-          "description": "The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around `trx.items.Item.pos` before `trx.items.Item.rot` turns it, and they change as the item animates.",
+          "description": "The item's bounding box for the frame it is on. The numbers are in the item's own frame, so they say how far the model reaches around `trx.items.Item.pos` before `trx.items.Item.rot` turns it, and they change as the item animates.",
           "name": "bounds",
-          "type": "table"
+          "type": "math.Box"
         },
         {
           "description": "Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
@@ -5780,16 +6494,14 @@
       ],
       "fields": [
         {
-          "base": 0,
-          "description": "The animation's number within the object.",
           "name": "anim_num",
-          "type": "integer",
+          "type": "items.AnimNum",
           "writable": true
         },
         {
-          "description": "Current animation state.",
+          "description": "The state the item is in.",
           "name": "anim_state",
-          "type": "integer",
+          "type": "items.AnimState",
           "writable": true
         },
         {
@@ -5805,16 +6517,15 @@
           "writable": true
         },
         {
-          "base": 0,
-          "description": "The frame's number within the animation. Negative values count back from the end.",
+          "description": "Negative values count back from the end.",
           "name": "frame_num",
-          "type": "integer",
+          "type": "items.FrameNum",
           "writable": true
         },
         {
-          "description": "Animation state the item is transitioning towards.",
+          "description": "The state the item is transitioning towards.",
           "name": "goal_anim_state",
-          "type": "integer",
+          "type": "items.AnimState",
           "writable": true
         },
         {
@@ -5995,7 +6706,7 @@
           "name": "destroy"
         },
         {
-          "description": "Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; `trx.items.Item:destroy` simply removes any item from the game.",
+          "description": "Runs the object's creature death handling: the corpse stays, and `trx.items.Item.die.explode` bursts its meshes as a rocket or grenade would. For creatures; `trx.items.Item:destroy` simply removes any item from the game.",
           "name": "die",
           "params": [
             {
@@ -6018,6 +6729,7 @@
             }
           ],
           "returns": {
+            "description": "In world units, measured between the two positions.",
             "type": "integer"
           }
         },
@@ -6026,11 +6738,13 @@
           "name": "get_property",
           "params": [
             {
+              "description": "Which property, as the object declares it.",
               "name": "name",
               "type": "string"
             }
           ],
           "returns": {
+            "description": "The value, of whatever type the property is declared with.",
             "nullable": true,
             "type": "any"
           }
@@ -6039,6 +6753,7 @@
           "description": "Names of every property this item's object declares.",
           "name": "get_property_names",
           "returns": {
+            "description": "The names, as a list of strings.",
             "type": "table"
           }
         },
@@ -6049,6 +6764,7 @@
           ],
           "name": "is_valid",
           "returns": {
+            "description": "False once the item it named is gone.",
             "type": "boolean"
           }
         },
@@ -6060,6 +6776,7 @@
           "name": "on_activate",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6084,6 +6801,7 @@
           "name": "on_deactivate",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6108,6 +6826,7 @@
           "name": "on_destroy",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6132,6 +6851,7 @@
           "name": "on_enter_sim",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6156,6 +6876,7 @@
           "name": "on_enter_world",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6180,6 +6901,7 @@
           "name": "on_finish",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6204,6 +6926,7 @@
           "name": "on_hide",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6228,6 +6951,7 @@
           "name": "on_hit",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6257,6 +6981,7 @@
           "name": "on_kill",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6281,6 +7006,7 @@
           "name": "on_leave_sim",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6305,6 +7031,7 @@
           "name": "on_leave_world",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6329,6 +7056,7 @@
           "name": "on_show",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6353,6 +7081,7 @@
           "name": "on_trigger",
           "params": [
             {
+              "description": "What to run when it happens to this item.",
               "name": "callback",
               "params": [
                 {
@@ -6361,9 +7090,9 @@
                   "type": "items.Item"
                 },
                 {
-                  "description": "What the trigger carried: `type`, `mask`, `timer` and `one_shot`.",
+                  "description": "What the trigger carried.",
                   "name": "trigger",
-                  "type": "table"
+                  "type": "items.Trigger"
                 }
               ],
               "type": "function"
@@ -6379,17 +7108,19 @@
           "name": "set_property",
           "params": [
             {
+              "description": "Which property, as the object declares it.",
               "name": "name",
               "type": "string"
             },
             {
+              "description": "What to write, of the type the property is declared with.",
               "name": "value",
               "type": "any"
             }
           ]
         },
         {
-          "description": "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with `explode`, on its own. It does not kill or remove the item.",
+          "description": "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with `trx.items.Item.die.explode`, on its own. It does not kill or remove the item.",
           "name": "shatter",
           "params": [
             {
@@ -6425,7 +7156,34 @@
           "name": "trigger",
           "params": [
             {
-              "description": "`type`: which `trx.items.TriggerType` to fire; a plain `TRIGGER` by default.\n\n`mask`: which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.\n\n`timer`: how long it should keep the item going, in seconds. `0`, the default, means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.\n\n`one_shot`: never let it fire again.",
+              "description": "What the trigger carries.",
+              "fields": [
+                {
+                  "description": "A plain `TRIGGER` by default.",
+                  "name": "type",
+                  "optional": true,
+                  "type": "items.TriggerType"
+                },
+                {
+                  "description": "Which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.",
+                  "name": "mask",
+                  "optional": true,
+                  "type": "integer"
+                },
+                {
+                  "default": 0,
+                  "description": "How long it should keep the item going, in seconds. `0` means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.",
+                  "name": "timer",
+                  "optional": true,
+                  "type": "number"
+                },
+                {
+                  "description": "Never let it fire again.",
+                  "name": "one_shot",
+                  "optional": true,
+                  "type": "boolean"
+                }
+              ],
               "name": "opts",
               "optional": true,
               "type": "table"
@@ -6696,6 +7454,52 @@
       "path": "lara.Lara"
     },
     {
+      "description": "An axis-aligned box, in the units the engine measures the world in. Whether it is placed in world coordinates or in something's own frame is for whatever hands it over to say.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "East edge.",
+          "name": "max_x",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Bottom edge.",
+          "name": "max_y",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "South edge.",
+          "name": "max_z",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "West edge.",
+          "name": "min_x",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Top edge. Y grows downwards.",
+          "name": "min_y",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "North edge.",
+          "name": "min_z",
+          "type": "integer",
+          "writable": true
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "math.Box"
+    },
+    {
       "description": "A mod the game can run. Everything on it is read-only.",
       "extensions": [],
       "fields": [
@@ -6764,9 +7568,9 @@
           "writable": false
         },
         {
-          "description": "The track this stream is playing, in the level's own numbering.",
+          "description": "The track this stream is playing.",
           "name": "track_num",
-          "type": "integer",
+          "type": "music.TrackNum",
           "writable": false
         }
       ],
@@ -6776,6 +7580,7 @@
           "description": "Whether the slot is still playing. A stream that has finished, or been stopped, leaves its handle stale.",
           "name": "is_valid",
           "returns": {
+            "description": "False once the slot has gone quiet.",
             "type": "boolean"
           }
         },
@@ -6815,9 +7620,8 @@
       "extensions": [],
       "fields": [
         {
-          "description": "The number the level gives this track.",
           "name": "num",
-          "type": "integer",
+          "type": "music.TrackNum",
           "writable": false
         }
       ],
@@ -6827,6 +7631,7 @@
           "description": "Whether the loaded level still carries this track.",
           "name": "is_valid",
           "returns": {
+            "description": "False once a level change has replaced the tracks.",
             "type": "boolean"
           }
         },
@@ -6844,7 +7649,15 @@
           "name": "play",
           "params": [
             {
-              "description": "`mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.",
+              "description": "How to play it.",
+              "fields": [
+                {
+                  "description": "Plays once by default.",
+                  "name": "mode",
+                  "optional": true,
+                  "type": "music.PlayMode"
+                }
+              ],
               "name": "opts",
               "optional": true,
               "type": "table"
@@ -6941,6 +7754,7 @@
           "description": "The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `trx.objects.Object.default_names`.",
           "name": "get_default_names",
           "returns": {
+            "description": "The names, as a list of strings.",
             "type": "table"
           }
         },
@@ -6948,6 +7762,7 @@
           "description": "Every name the object answers to, in the player's language. Prefer `trx.objects.Object.names`.",
           "name": "get_names",
           "returns": {
+            "description": "The names, as a list of strings.",
             "type": "table"
           }
         },
@@ -6956,11 +7771,13 @@
           "name": "get_property",
           "params": [
             {
+              "description": "Which property, as the object declares it.",
               "name": "name",
               "type": "string"
             }
           ],
           "returns": {
+            "description": "The value, of whatever type the property is declared with.",
             "nullable": true,
             "type": "any"
           }
@@ -6969,6 +7786,7 @@
           "description": "Names of every property this object declares.",
           "name": "get_property_names",
           "returns": {
+            "description": "The names, as a list of strings.",
             "type": "table"
           }
         },
@@ -6977,10 +7795,12 @@
           "name": "set_property",
           "params": [
             {
+              "description": "Which property, as the object declares it.",
               "name": "name",
               "type": "string"
             },
             {
+              "description": "What to write, of the type the property is declared with.",
               "name": "value",
               "type": "any"
             }
@@ -7194,6 +8014,7 @@
           "description": "How many candidates match.",
           "name": "count",
           "returns": {
+            "description": "The count, without building the list.",
             "type": "integer"
           }
         },
@@ -7230,6 +8051,7 @@
           "name": "where",
           "params": [
             {
+              "description": "The test each candidate is put through.",
               "name": "predicate",
               "params": [
                 {
@@ -7316,9 +8138,9 @@
       "description": "A room in the current level.",
       "extensions": [
         {
-          "description": "World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`.",
+          "description": "Where the room sits, in world coordinates.",
           "name": "bounds",
-          "type": "table"
+          "type": "math.Box"
         },
         {
           "description": "This room's flip pair, or `nil` if it has none.",
@@ -7328,7 +8150,7 @@
         {
           "description": "As `trx.rooms.Room.bounds`, but excluding the outer ring of sectors, which is solid wall.",
           "name": "internal_bounds",
-          "type": "table"
+          "type": "math.Box"
         }
       ],
       "fields": [
@@ -7386,13 +8208,23 @@
               "type": "vec3"
             },
             {
-              "description": "`fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
+              "description": "How to read the floor.",
+              "fields": [
+                {
+                  "default": true,
+                  "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
+                  "name": "fix_tilts",
+                  "optional": true,
+                  "type": "boolean"
+                }
+              ],
               "name": "opts",
               "optional": true,
               "type": "table"
             }
           ],
           "returns": {
+            "description": "The height, in world units, with `nil` where there is no floor.",
             "nullable": true,
             "type": "integer"
           }
@@ -7404,6 +8236,7 @@
           ],
           "name": "is_valid",
           "returns": {
+            "description": "False once the level that held the room has been left.",
             "type": "boolean"
           }
         },
@@ -7415,6 +8248,7 @@
           "name": "on_enter",
           "params": [
             {
+              "description": "What to run when it happens.",
               "name": "callback",
               "params": [
                 {
@@ -7426,7 +8260,16 @@
               "type": "function"
             },
             {
-              "description": "Options. `watch = \"lara\"` (the default) reacts to Lara alone; `watch = \"all\"` to every item.",
+              "description": "What to watch for.",
+              "fields": [
+                {
+                  "default": "lara",
+                  "description": "Either `\"lara\"`, which reacts to Lara alone, or `\"all\"`, which reacts to every item.",
+                  "name": "watch",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
               "name": "opts",
               "optional": true,
               "type": "table"
@@ -7442,6 +8285,7 @@
           "name": "on_exit",
           "params": [
             {
+              "description": "What to run when it happens.",
               "name": "callback",
               "params": [
                 {
@@ -7453,7 +8297,16 @@
               "type": "function"
             },
             {
-              "description": "Options. `watch = \"lara\"` (the default) reacts to Lara alone; `watch = \"all\"` to every item.",
+              "description": "What to watch for.",
+              "fields": [
+                {
+                  "default": "lara",
+                  "description": "Either `\"lara\"`, which reacts to Lara alone, or `\"all\"`, which reacts to every item.",
+                  "name": "watch",
+                  "optional": true,
+                  "type": "string"
+                }
+              ],
               "name": "opts",
               "optional": true,
               "type": "table"
@@ -7544,9 +8397,8 @@
       "extensions": [],
       "fields": [
         {
-          "description": "The number the level gives this sample.",
           "name": "num",
-          "type": "integer",
+          "type": "sound.SampleNum",
           "writable": false
         },
         {
@@ -7580,6 +8432,7 @@
           "description": "Whether the loaded level still carries this sample.",
           "name": "is_valid",
           "returns": {
+            "description": "False once a level change has replaced the samples.",
             "type": "boolean"
           }
         },
@@ -7588,7 +8441,15 @@
           "name": "play",
           "params": [
             {
-              "description": "`pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.",
+              "description": "How to play it.",
+              "fields": [
+                {
+                  "description": "A world position to play from, which applies pan and volume. Omit to play at full volume.",
+                  "name": "pos",
+                  "optional": true,
+                  "type": "vec3"
+                }
+              ],
               "name": "opts",
               "optional": true,
               "type": "table"
@@ -7613,9 +8474,9 @@
       "extensions": [],
       "fields": [
         {
-          "description": "The sample this voice is playing, in the level's own numbering.",
+          "description": "The sample this voice is playing.",
           "name": "sample_num",
-          "type": "integer",
+          "type": "sound.SampleNum",
           "writable": false
         }
       ],
@@ -7625,6 +8486,7 @@
           "description": "Whether this voice is still playing.",
           "name": "is_valid",
           "returns": {
+            "description": "False once the voice has fallen silent.",
             "type": "boolean"
           }
         },
@@ -7775,13 +8637,26 @@
           }
         },
         {
-          "description": "The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, and `found` is whether Lara has it.",
+          "description": "The level's secrets, in order.",
           "examples": [
             "for _, secret in ipairs(trx.stats.secret_list()) do\n  trx.log.info(secret.num .. \": \" .. tostring(secret.found))\nend"
           ],
           "name": "secret_list",
           "returns": {
             "description": "The secrets, one by one.",
+            "fields": [
+              {
+                "description": "Which secret it is.",
+                "name": "num",
+                "type": "stats.SecretNum"
+              },
+              {
+                "description": "Whether Lara has it.",
+                "name": "found",
+                "type": "boolean"
+              }
+            ],
+            "list": true,
             "type": "table"
           }
         },

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -40,12 +40,12 @@
     },
     {
       "countable": true,
-      "description": "Indexing the module reaches an item, and `#trx.items` is how many the level has. Items count from zero, matching the item numbers level editors show. `pairs()` walks them in order, keyed by that number.",
+      "description": "Indexing the module reaches an item, and `#trx.items` is how many the level has. `pairs()` walks them in order, keyed by the item number.",
       "examples": [
         "for num, item in pairs(trx.items) do\n  trx.log.info(item.object_id)\nend"
       ],
       "key": {
-        "description": "0-based index, or the item's unique name.",
+        "description": "0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.",
         "type": "any"
       },
       "module": "items",
@@ -3414,7 +3414,7 @@
     {
       "description": "Happens when an item changes rooms during play, which a cutscene or the attract demo is not. `trx.rooms.Room:on_enter` and `:on_exit` are this same event, narrowed to one room.",
       "examples": [
-        "trx.events.on_room_change(function(item, old_room, new_room)\n  trx.log.info(item.object_id .. \" moved to room \" .. new_room)\nend)"
+        "trx.events.on_room_change(function(item, old_room_num, new_room_num)\n  trx.log.info(item.object_id .. \" moved to room \" .. new_room_num)\nend)"
       ],
       "params": [
         {
@@ -3426,13 +3426,13 @@
               "type": "Item"
             },
             {
-              "description": "0-based number of the room it left, or -1 if it had none.",
-              "name": "old_room",
+              "description": "0-based room number, matching the numbers level editors show. -1 if it had none.",
+              "name": "old_room_num",
               "type": "integer"
             },
             {
-              "description": "0-based number of the room it entered, or -1 if it left the world.",
-              "name": "new_room",
+              "description": "0-based room number, matching the numbers level editors show. -1 if it left the world.",
+              "name": "new_room_num",
               "type": "integer"
             }
           ],
@@ -3770,7 +3770,7 @@
     {
       "description": "Happens when a cutscene trigger fires, before the engine acts on it. A\nhandler answers the trigger by returning true - having played a cutscene of\nits own, run something else, or decided nothing should run. If no handler\nanswers, the engine plays the cutscene the trigger names.\n\nA trigger Lara stands on fires every frame, so this happens only for a\ncutscene that has not run yet and while none is playing. Asking counts as\nrunning it, whatever came of it, so the same handler is not asked again on\nthe next frame. Clear the mark with `trx.cutscenes.set_played` to hear\nabout one again.\n\nThe number a trigger names need not be one the game has a cutscene for -\nTR4 uses 32 to ask for a full-motion video. Those reach a handler too, and\nthe engine has nothing of its own to do about them.",
       "examples": [
-        "-- only in the throne room; a flyby stands in for it elsewhere\ntrx.events.on_cutscene_trigger(function(num)\n  if num ~= 27 then\n    return false\n  end\n  if trx.lara.item.room_num == 55 then\n    trx.cutscenes.play(27)\n  else\n    trx.camera.play_flyby(3)\n  end\n  return true\nend)"
+        "-- only in the throne room; a flyby stands in for it elsewhere\ntrx.events.on_cutscene_trigger(function(cutscene_num)\n  if cutscene_num ~= 27 then\n    return false\n  end\n  if trx.lara.item.room_num == 55 then\n    trx.cutscenes.play(27)\n  else\n    trx.camera.play_flyby(3)\n  end\n  return true\nend)"
       ],
       "params": [
         {
@@ -3778,7 +3778,7 @@
           "params": [
             {
               "description": "Number the trigger names.",
-              "name": "num",
+              "name": "cutscene_num",
               "type": "integer"
             }
           ],
@@ -3799,7 +3799,7 @@
           "params": [
             {
               "description": "Number of the cutscene starting.",
-              "name": "num",
+              "name": "cutscene_num",
               "type": "integer"
             }
           ],
@@ -3815,7 +3815,7 @@
     {
       "description": "Happens once a TR4 cutscene has finished and the scene it interrupted is back. This is where a script decides what follows.",
       "examples": [
-        "trx.events.on_cutscene_end(function(num)\n  trx.log.info(\"cutscene \" .. num .. \" finished\")\nend)"
+        "trx.events.on_cutscene_end(function(cutscene_num)\n  trx.log.info(\"cutscene \" .. cutscene_num .. \" finished\")\nend)"
       ],
       "params": [
         {
@@ -3823,7 +3823,7 @@
           "params": [
             {
               "description": "Number of the cutscene that ended.",
-              "name": "num",
+              "name": "cutscene_num",
               "type": "integer"
             }
           ],
@@ -3839,15 +3839,15 @@
     {
       "description": "Happens when a flyby sequence reaches its last camera and hands the view back.\nA sequence that a cutscene or the player interrupts does not fire it.",
       "examples": [
-        "trx.events.on_flyby_end(function(sequence)\n  trx.camera.play_flyby(sequence)\nend)"
+        "trx.events.on_flyby_end(function(sequence_num)\n  trx.camera.play_flyby(sequence_num)\nend)"
       ],
       "params": [
         {
           "name": "callback",
           "params": [
             {
-              "description": "Number of the sequence that ended.",
-              "name": "sequence",
+              "description": "Number of the flyby sequence that ended.",
+              "name": "sequence_num",
               "type": "integer"
             }
           ],
@@ -3885,7 +3885,7 @@
       "params": [
         {
           "description": "1-based position in `trx.game.levels`.",
-          "name": "num",
+          "name": "level_num",
           "type": "integer"
         },
         {
@@ -3902,7 +3902,7 @@
       "params": [
         {
           "description": "1-based position in `trx.game.cutscenes`.",
-          "name": "num",
+          "name": "cutscene_num",
           "type": "integer"
         }
       ],
@@ -3913,7 +3913,7 @@
       "params": [
         {
           "description": "1-based position in `trx.game.demos`. Omit to play the next demo in rotation.",
-          "name": "num",
+          "name": "demo_num",
           "optional": true,
           "type": "integer"
         }
@@ -3956,13 +3956,13 @@
       "path": "game.screenshot"
     },
     {
-      "description": "Retrieves an item by index or by name. Items count from zero, matching the item numbers level editors show.",
+      "description": "Retrieves an item by number or by name.",
       "examples": [
         "local item = trx.items[0]\nitem.name = \"lara\"\nlocal lara = trx.items[\"lara\"]"
       ],
       "params": [
         {
-          "description": "0-based index, or the item's unique name.",
+          "description": "0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.",
           "name": "key",
           "type": "any"
         }
@@ -4467,7 +4467,7 @@
       }
     },
     {
-      "description": "Retrieves a room by number. Rooms count from zero, matching the room numbers level editors show.",
+      "description": "Retrieves a room by number.",
       "examples": [
         "local room = trx.rooms[14]\nroom.underwater = true"
       ],
@@ -4661,7 +4661,7 @@
       "params": [
         {
           "description": "1-based slot number. For the quick pool this is the on-screen order.",
-          "name": "index",
+          "name": "slot_num",
           "type": "integer"
         },
         {
@@ -4688,7 +4688,7 @@
       "params": [
         {
           "description": "1-based slot number. For the quick pool this is the on-screen order.",
-          "name": "index",
+          "name": "slot_num",
           "type": "integer"
         },
         {
@@ -4702,14 +4702,14 @@
       "path": "savegame.load"
     },
     {
-      "description": "Writes a saved game to a slot. A quick save with no index goes to the next slot in the rotation; with one, it saves to the slot named.",
+      "description": "Writes a saved game to a slot. A quick save with no slot number goes to the next slot in the rotation; with one, it saves to the slot named.",
       "examples": [
         "trx.savegame.save(1)"
       ],
       "params": [
         {
           "description": "1-based slot number. The quick pool uses the next slot in its rotation when it is omitted.",
-          "name": "index",
+          "name": "slot_num",
           "optional": true,
           "type": "integer"
         },
@@ -5562,7 +5562,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             }
           ],
@@ -5577,7 +5577,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             }
           ],
@@ -5592,7 +5592,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             }
           ],
@@ -5607,7 +5607,7 @@
           "params": [
             {
               "description": "1-based position.",
-              "name": "n",
+              "name": "entry_num",
               "type": "integer"
             }
           ],
@@ -5633,7 +5633,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             },
             {
@@ -5655,7 +5655,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             }
           ],
@@ -5685,7 +5685,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             }
           ],
@@ -5703,7 +5703,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             },
             {
@@ -5755,7 +5755,7 @@
             {
               "description": "The pickup, or the inventory icon it goes into.",
               "enum": "catalog.objects",
-              "name": "object",
+              "name": "object_id",
               "type": "integer"
             },
             {
@@ -5795,8 +5795,8 @@
       ],
       "fields": [
         {
-          "description": "Object-relative animation number, 0-indexed.",
-          "name": "anim",
+          "description": "The animation's number within the object, counted from 0.",
+          "name": "anim_num",
           "type": "integer",
           "writable": true
         },
@@ -5819,8 +5819,8 @@
           "writable": true
         },
         {
-          "description": "Object-relative frame number, 0-indexed. Negative values count back from the end.",
-          "name": "frame",
+          "description": "The frame's number within the animation, counted from 0. Negative values count back from the end.",
+          "name": "frame_num",
           "type": "integer",
           "writable": true
         },
@@ -5841,12 +5841,6 @@
           "name": "hit_points",
           "type": "integer",
           "writable": true
-        },
-        {
-          "description": "The index `trx.items[i]` takes, counted from 0. An item handed over by a query can say where it lives.",
-          "name": "index",
-          "type": "integer",
-          "writable": false
         },
         {
           "description": "Whether the item is a living creature with hit points remaining.",
@@ -5937,6 +5931,12 @@
           "name": "name",
           "type": "string",
           "writable": true
+        },
+        {
+          "description": "0-based item number, matching the numbers level editors show. An item handed over by a query can say where it lives.",
+          "name": "num",
+          "type": "integer",
+          "writable": false
         },
         {
           "description": "The item's object type.",
@@ -6786,7 +6786,7 @@
         },
         {
           "description": "The track this stream is playing, in the level's own numbering.",
-          "name": "track_id",
+          "name": "track_num",
           "type": "integer",
           "writable": false
         }
@@ -6836,8 +6836,8 @@
       "extensions": [],
       "fields": [
         {
-          "description": "The track's id, in the level's own numbering.",
-          "name": "id",
+          "description": "The number the level gives this track.",
+          "name": "num",
           "type": "integer",
           "writable": false
         }
@@ -7567,8 +7567,8 @@
       "extensions": [],
       "fields": [
         {
-          "description": "The sample's id, in the level's own numbering.",
-          "name": "id",
+          "description": "The number the level gives this sample.",
+          "name": "num",
           "type": "integer",
           "writable": false
         },
@@ -7637,7 +7637,7 @@
       "fields": [
         {
           "description": "The sample this voice is playing, in the level's own numbering.",
-          "name": "sample_id",
+          "name": "sample_num",
           "type": "integer",
           "writable": false
         }

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -24,18 +24,19 @@
   "containers": [
     {
       "countable": true,
-      "description": "Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries count from one, in the order they are drawn, and are built one at a time as they are asked for. `pairs()` walks them.",
+      "description": "Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries are keyed by the order they are drawn in, and are built one at a time as they are asked for. `pairs()` walks them.",
       "examples": [
         "for _, entry in pairs(trx.inventory) do\n  trx.log.info((\"%d x %s\"):format(entry.count, trx.catalog.objects[entry.object]))\nend"
       ],
       "key": {
-        "description": "1-based position.",
+        "base": 1,
+        "description": "Position in the ring.",
         "type": "integer"
       },
       "module": "inventory",
       "value": {
         "nullable": true,
-        "type": "Entry"
+        "type": "inventory.Entry"
       }
     },
     {
@@ -45,13 +46,16 @@
         "for num, item in pairs(trx.items) do\n  trx.log.info(item.object_id)\nend"
       ],
       "key": {
-        "description": "0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.",
-        "type": "any"
+        "description": "An item's unique name reaches it as well.",
+        "type": [
+          "items.Num",
+          "string"
+        ]
       },
       "module": "items",
       "value": {
         "nullable": true,
-        "type": "Item"
+        "type": "items.Item"
       }
     },
     {
@@ -62,28 +66,30 @@
       ],
       "key": {
         "description": "Object id, or its catalog name.",
-        "type": "any"
+        "type": [
+          "catalog.objects",
+          "string"
+        ]
       },
       "module": "objects",
       "value": {
         "nullable": true,
-        "type": "Object"
+        "type": "objects.Object"
       }
     },
     {
       "countable": true,
-      "description": "Indexing the module reaches a room, and `#trx.rooms` is how many the level has. Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them in order, keyed by that number.",
+      "description": "Indexing the module reaches a room, and `#trx.rooms` is how many the level has. `pairs()` walks them in order, keyed by the room number.",
       "examples": [
         "trx.log.info(#trx.rooms .. \" rooms, first is \" .. trx.rooms[0].num)\nfor num, room in pairs(trx.rooms) do\n  room.cold = true\nend"
       ],
       "key": {
-        "description": "0-based room number, matching the numbers level editors show.",
-        "type": "integer"
+        "type": "rooms.Num"
       },
       "module": "rooms",
       "value": {
         "nullable": true,
-        "type": "Room"
+        "type": "rooms.Room"
       }
     }
   ],
@@ -2609,6 +2615,7 @@
       ],
       "params": [
         {
+          "description": "Whether to check.",
           "name": "enabled",
           "type": "boolean"
         }
@@ -2619,6 +2626,7 @@
       "description": "Whether argument checking is on.",
       "path": "api.is_strict",
       "returns": {
+        "description": "False as the game starts, and true once something turns it on.",
         "type": "boolean"
       }
     },
@@ -2646,10 +2654,9 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.start"
@@ -2659,10 +2666,9 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.stop"
@@ -2672,10 +2678,9 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.finish"
@@ -2685,10 +2690,9 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.reset"
@@ -2698,10 +2702,9 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.is_running",
@@ -2714,10 +2717,9 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.is_visible",
@@ -2738,10 +2740,9 @@
         },
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.stats.add_record",
@@ -2754,16 +2755,16 @@
       "description": "Removes a record, closing the gap behind it.",
       "params": [
         {
-          "description": "1-based position in the table.",
-          "name": "record_id",
+          "base": 1,
+          "description": "Position in the table.",
+          "name": "record_num",
           "type": "integer"
         },
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.stats.remove_record",
@@ -2780,15 +2781,14 @@
       "params": [
         {
           "default": 1,
-          "enum": "assault.Track",
           "name": "track",
           "optional": true,
-          "type": "integer"
+          "type": "assault.Track"
         }
       ],
       "path": "assault.stats.list_records",
       "returns": {
-        "description": "List, counted from one, of `{ time = seconds, attempt_num = which attempt it was }`.",
+        "description": "List of `{ time = seconds, attempt_num = which attempt it was }`.",
         "type": "table"
       }
     },
@@ -2817,9 +2817,8 @@
       ],
       "params": [
         {
-          "description": "0-based sequence number.",
           "name": "sequence_num",
-          "type": "integer"
+          "type": "camera.SequenceNum"
         }
       ],
       "path": "camera.play_flyby",
@@ -2840,9 +2839,8 @@
       "params": [
         {
           "description": "Which catalog.",
-          "enum": "catalog.Context",
           "name": "context",
-          "type": "integer"
+          "type": "catalog.Context"
         },
         {
           "description": "The TRX id.",
@@ -2865,9 +2863,8 @@
       "params": [
         {
           "description": "Which catalog.",
-          "enum": "catalog.Context",
           "name": "context",
-          "type": "integer"
+          "type": "catalog.Context"
         },
         {
           "description": "The game's own id.",
@@ -3057,9 +3054,8 @@
       "description": "Logs at a level chosen at runtime.",
       "params": [
         {
-          "enum": "log.LogLevel",
           "name": "level",
-          "type": "integer"
+          "type": "log.LogLevel"
         },
         {
           "description": "Any value; a table is pretty-printed.",
@@ -3192,9 +3188,8 @@
       ],
       "params": [
         {
-          "enum": "catalog.objects",
           "name": "object_id",
-          "type": "integer"
+          "type": "catalog.objects"
         }
       ],
       "path": "creatures.add_ally"
@@ -3206,9 +3201,8 @@
       ],
       "params": [
         {
-          "enum": "catalog.objects",
           "name": "object_id",
-          "type": "integer"
+          "type": "catalog.objects"
         }
       ],
       "path": "creatures.add_ally_target"
@@ -3220,9 +3214,8 @@
       ],
       "params": [
         {
-          "description": "Cutscene number.",
           "name": "num",
-          "type": "integer"
+          "type": "cutscenes.Num"
         }
       ],
       "path": "cutscenes.play"
@@ -3231,9 +3224,8 @@
       "description": "Whether a cutscene trigger naming this number has already been answered.",
       "params": [
         {
-          "description": "Cutscene number.",
           "name": "num",
-          "type": "integer"
+          "type": "cutscenes.Num"
         }
       ],
       "path": "cutscenes.is_played",
@@ -3248,9 +3240,8 @@
       ],
       "params": [
         {
-          "description": "Cutscene number.",
           "name": "num",
-          "type": "integer"
+          "type": "cutscenes.Num"
         },
         {
           "description": "Whether it counts as played.",
@@ -3335,9 +3326,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "0-based item number, matching the numbers level editors show. The item that was picked up.",
+              "description": "The item that was picked up.",
               "name": "item_num",
-              "type": "integer"
+              "type": "items.Num"
             }
           ],
           "type": "function"
@@ -3384,6 +3375,7 @@
       ],
       "params": [
         {
+          "base": 0,
           "description": "The flip effect number to claim, as the level editor numbers them. This is not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` names.",
           "name": "effect_num",
           "type": "integer"
@@ -3397,9 +3389,9 @@
               "type": "integer"
             },
             {
-              "description": "0-based item number, matching the numbers level editors show. The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.",
+              "description": "The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.",
               "name": "item_num",
-              "type": "integer"
+              "type": "items.Num"
             }
           ],
           "type": "function"
@@ -3421,19 +3413,19 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that changed rooms.",
+              "description": "The item that changed rooms.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             },
             {
-              "description": "0-based room number, matching the numbers level editors show. -1 if it had none.",
+              "description": "-1 if it had none.",
               "name": "old_room_num",
-              "type": "integer"
+              "type": "rooms.Num"
             },
             {
-              "description": "0-based room number, matching the numbers level editors show. -1 if it left the world.",
+              "description": "-1 if it left the world.",
               "name": "new_room_num",
-              "type": "integer"
+              "type": "rooms.Num"
             }
           ],
           "type": "function"
@@ -3455,9 +3447,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` the trigger was aimed at.",
+              "description": "The item the trigger was aimed at.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             },
             {
               "description": "What the trigger carried: `type` (an `items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.",
@@ -3484,9 +3476,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that became visible.",
+              "description": "The item that became visible.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3508,9 +3500,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that became hidden.",
+              "description": "The item that became hidden.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3532,9 +3524,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that finished.",
+              "description": "The item that finished.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3556,9 +3548,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that started being simulated.",
+              "description": "The item that started being simulated.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3580,9 +3572,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that stopped being simulated.",
+              "description": "The item that stopped being simulated.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3604,9 +3596,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that was activated.",
+              "description": "The item that was activated.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3628,9 +3620,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that was deactivated.",
+              "description": "The item that was deactivated.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3652,9 +3644,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` being removed. Valid only for the duration of the handler.",
+              "description": "The item being removed. Valid only for the duration of the handler.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3676,9 +3668,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that entered the world.",
+              "description": "The item that entered the world.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3700,9 +3692,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that left the world.",
+              "description": "The item that left the world.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3724,9 +3716,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that took the damage.",
+              "description": "The item that took the damage.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             },
             {
               "description": "Hit points taken, before clamping to zero.",
@@ -3753,9 +3745,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "The `trx.items.Item` that was brought down.",
+              "description": "The item that was brought down.",
               "name": "item",
-              "type": "Item"
+              "type": "items.Item"
             }
           ],
           "type": "function"
@@ -3777,9 +3769,9 @@
           "name": "callback",
           "params": [
             {
-              "description": "Number the trigger names.",
+              "description": "The number the trigger names, which the game need not have a cutscene for.",
               "name": "cutscene_num",
-              "type": "integer"
+              "type": "cutscenes.Num"
             }
           ],
           "type": "function"
@@ -3798,9 +3790,8 @@
           "name": "callback",
           "params": [
             {
-              "description": "Number of the cutscene starting.",
               "name": "cutscene_num",
-              "type": "integer"
+              "type": "cutscenes.Num"
             }
           ],
           "type": "function"
@@ -3822,9 +3813,8 @@
           "name": "callback",
           "params": [
             {
-              "description": "Number of the cutscene that ended.",
               "name": "cutscene_num",
-              "type": "integer"
+              "type": "cutscenes.Num"
             }
           ],
           "type": "function"
@@ -3846,9 +3836,8 @@
           "name": "callback",
           "params": [
             {
-              "description": "Number of the flyby sequence that ended.",
               "name": "sequence_num",
-              "type": "integer"
+              "type": "camera.SequenceNum"
             }
           ],
           "type": "function"
@@ -3884,7 +3873,8 @@
       ],
       "params": [
         {
-          "description": "1-based position in `trx.game.levels`.",
+          "base": 1,
+          "description": "Position in `trx.game.levels`.",
           "name": "level_num",
           "type": "integer"
         },
@@ -3901,7 +3891,8 @@
       "description": "Plays a cutscene.",
       "params": [
         {
-          "description": "1-based position in `trx.game.cutscenes`.",
+          "base": 1,
+          "description": "Position in `trx.game.cutscenes`.",
           "name": "cutscene_num",
           "type": "integer"
         }
@@ -3912,7 +3903,8 @@
       "description": "Plays a demo, and returns the one that started.",
       "params": [
         {
-          "description": "1-based position in `trx.game.demos`. Omit to play the next demo in rotation.",
+          "base": 1,
+          "description": "Position in `trx.game.demos`. Omit to play the next demo in rotation.",
           "name": "demo_num",
           "optional": true,
           "type": "integer"
@@ -3923,7 +3915,7 @@
         {
           "description": "The demo that started, or `nil` if the game has no demos.",
           "nullable": true,
-          "type": "Level"
+          "type": "game.Level"
         }
       ]
     },
@@ -3962,15 +3954,15 @@
       ],
       "params": [
         {
-          "description": "0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.",
+          "description": "An item's unique name reaches it as well.",
           "name": "key",
-          "type": "any"
+          "type": "items.Num"
         }
       ],
       "path": "items.get",
       "returns": {
         "nullable": true,
-        "type": "Item"
+        "type": "items.Item"
       }
     },
     {
@@ -3981,9 +3973,8 @@
       "params": [
         {
           "description": "Object type to spawn.",
-          "enum": "catalog.objects",
           "name": "object_id",
-          "type": "integer"
+          "type": "catalog.objects"
         },
         {
           "description": "World position. Must lie inside the level.",
@@ -4008,7 +3999,7 @@
       "returns": {
         "description": "`nil` if the item pool is exhausted.",
         "nullable": true,
-        "type": "Item"
+        "type": "items.Item"
       }
     },
     {
@@ -4026,15 +4017,13 @@
       "params": [
         {
           "description": "Which of Lara's meshes.",
-          "enum": "lara.Mesh",
           "name": "mesh",
-          "type": "integer"
+          "type": "lara.Mesh"
         },
         {
           "description": "The mesh to hang on it.",
-          "enum": "lara.ExtraMesh",
           "name": "extra_mesh",
-          "type": "integer"
+          "type": "lara.ExtraMesh"
         }
       ],
       "path": "lara.set_extra_equipment"
@@ -4051,10 +4040,10 @@
           "type": "vec3"
         },
         {
-          "description": "0-based room to look in. Without it, the room is found from the position.",
+          "description": "Without it, the room is found from the position.",
           "name": "room_num",
           "optional": true,
-          "type": "integer"
+          "type": "rooms.Num"
         }
       ],
       "path": "lara.teleport",
@@ -4080,9 +4069,8 @@
       "params": [
         {
           "description": "Which of Lara's meshes.",
-          "enum": "lara.Mesh",
           "name": "mesh",
-          "type": "integer"
+          "type": "lara.Mesh"
         }
       ],
       "path": "lara.clear_equipment"
@@ -4157,9 +4145,8 @@
       ],
       "params": [
         {
-          "enum": "log.LogLevel",
           "name": "level",
-          "type": "integer"
+          "type": "log.LogLevel"
         },
         {
           "name": "message",
@@ -4337,9 +4324,8 @@
       "params": [
         {
           "description": "Track to play. To reach a track by the level's own slot, play it through a handle: `trx.music.tracks[slot]:play()`.",
-          "enum": "catalog.music",
           "name": "id",
-          "type": "integer"
+          "type": "catalog.music"
         },
         {
           "description": "`mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.",
@@ -4375,30 +4361,27 @@
       "params": [
         {
           "description": "Object id, or its catalog name: `trx.objects[\"wolf\"]`.",
-          "enum": "catalog.objects",
           "name": "key",
-          "type": "any"
+          "type": "catalog.objects"
         }
       ],
       "path": "objects.get",
       "returns": {
         "description": "`nil` if no such object exists.",
         "nullable": true,
-        "type": "Object"
+        "type": "objects.Object"
       }
     },
     {
       "description": "Swaps meshes between two objects. With no mesh numbers, swaps all of them; with both, swaps just those two. One without the other raises.",
       "params": [
         {
-          "enum": "catalog.objects",
           "name": "object_id1",
-          "type": "integer"
+          "type": "catalog.objects"
         },
         {
-          "enum": "catalog.objects",
           "name": "object_id2",
-          "type": "integer"
+          "type": "catalog.objects"
         },
         {
           "description": "Mesh of the first.",
@@ -4419,14 +4402,12 @@
       "description": "Swaps the sprites of two objects, which is how a pickup looks when 3D pickups\nare turned off. Raises if either object is drawn from meshes rather than a\nsprite.",
       "params": [
         {
-          "enum": "catalog.objects",
           "name": "object_id1",
-          "type": "integer"
+          "type": "catalog.objects"
         },
         {
-          "enum": "catalog.objects",
           "name": "object_id2",
-          "type": "integer"
+          "type": "catalog.objects"
         }
       ],
       "path": "objects.swap_sprite"
@@ -4463,7 +4444,7 @@
       "path": "query.new",
       "returns": {
         "description": "The identity query, matching everything until narrowed.",
-        "type": "Query"
+        "type": "query.Query"
       }
     },
     {
@@ -4473,15 +4454,14 @@
       ],
       "params": [
         {
-          "description": "0-based room number, matching the numbers level editors show.",
           "name": "num",
-          "type": "integer"
+          "type": "rooms.Num"
         }
       ],
       "path": "rooms.get",
       "returns": {
         "nullable": true,
-        "type": "Room"
+        "type": "rooms.Room"
       }
     },
     {
@@ -4503,9 +4483,8 @@
       "params": [
         {
           "description": "Use `-1` to clear the current effect.",
-          "enum": "catalog.flip_effects",
           "name": "effect_id",
-          "type": "integer"
+          "type": "catalog.flip_effects"
         },
         {
           "description": "Flip timer value.",
@@ -4528,10 +4507,10 @@
           "type": "vec3"
         },
         {
-          "description": "0-based room to look from. The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `room:floor_height`.",
+          "description": "The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `room:floor_height`.",
           "name": "room_num",
           "optional": true,
-          "type": "integer"
+          "type": "rooms.Num"
         },
         {
           "description": "`fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
@@ -4555,9 +4534,8 @@
           "type": "vec3"
         },
         {
-          "description": "0-based room to search from.",
           "name": "room_num",
-          "type": "integer"
+          "type": "rooms.Num"
         }
       ],
       "path": "rooms.find_valid_pos",
@@ -4568,8 +4546,8 @@
           "type": "vec3"
         },
         {
-          "description": "The 0-based room the position is in.",
-          "type": "integer"
+          "description": "The room the position is in.",
+          "type": "rooms.Num"
         }
       ]
     },
@@ -4642,10 +4620,9 @@
       "params": [
         {
           "description": "Which set of slots to look in. Defaults to `NORMAL`.",
-          "enum": "savegame.Pool",
           "name": "pool",
           "optional": true,
-          "type": "integer"
+          "type": "savegame.Pool"
         }
       ],
       "path": "savegame.slot_count",
@@ -4660,16 +4637,14 @@
       "description": "Whether a slot holds no save.",
       "params": [
         {
-          "description": "1-based slot number. For the quick pool this is the on-screen order.",
           "name": "slot_num",
-          "type": "integer"
+          "type": "savegame.SlotNum"
         },
         {
           "description": "Which set of slots to look in. Defaults to `NORMAL`.",
-          "enum": "savegame.Pool",
           "name": "pool",
           "optional": true,
-          "type": "integer"
+          "type": "savegame.Pool"
         }
       ],
       "path": "savegame.is_free",
@@ -4687,16 +4662,14 @@
       ],
       "params": [
         {
-          "description": "1-based slot number. For the quick pool this is the on-screen order.",
           "name": "slot_num",
-          "type": "integer"
+          "type": "savegame.SlotNum"
         },
         {
           "description": "Which set of slots to look in. Defaults to `NORMAL`.",
-          "enum": "savegame.Pool",
           "name": "pool",
           "optional": true,
-          "type": "integer"
+          "type": "savegame.Pool"
         }
       ],
       "path": "savegame.load"
@@ -4708,17 +4681,16 @@
       ],
       "params": [
         {
-          "description": "1-based slot number. The quick pool uses the next slot in its rotation when it is omitted.",
+          "description": "The quick pool uses the next slot in its rotation when it is omitted.",
           "name": "slot_num",
           "optional": true,
-          "type": "integer"
+          "type": "savegame.SlotNum"
         },
         {
           "description": "Which set of slots to look in. Defaults to `NORMAL`.",
-          "enum": "savegame.Pool",
           "name": "pool",
           "optional": true,
-          "type": "integer"
+          "type": "savegame.Pool"
         }
       ],
       "path": "savegame.save",
@@ -4737,9 +4709,8 @@
       "params": [
         {
           "description": "Sample to play. To reach a sample by the level's own slot, play it through a handle: `trx.sound.samples[slot]:play()`.",
-          "enum": "catalog.samples",
           "name": "id",
-          "type": "integer"
+          "type": "catalog.samples"
         },
         {
           "description": "`pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.",
@@ -4760,9 +4731,8 @@
       "params": [
         {
           "description": "Sample to stop. To reach a sample by the level's own slot, stop it through a handle: `trx.sound.samples[slot]:stop()`.",
-          "enum": "catalog.samples",
           "name": "id",
-          "type": "integer"
+          "type": "catalog.samples"
         }
       ],
       "path": "sound.stop"
@@ -4863,9 +4833,8 @@
       "params": [
         {
           "description": "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
-          "enum": "catalog.weapons",
           "name": "weapon",
-          "type": "integer"
+          "type": "catalog.weapons"
         }
       ],
       "path": "weapons.is_available",
@@ -4881,16 +4850,14 @@
       "params": [
         {
           "description": "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
-          "enum": "catalog.weapons",
           "name": "weapon",
-          "type": "integer"
+          "type": "catalog.weapons"
         }
       ],
       "path": "weapons.object",
       "returns": {
         "description": "The object id, or `nil` if this game has no such weapon.",
-        "enum": "catalog.objects",
-        "type": "integer"
+        "type": "catalog.objects"
       }
     },
     {
@@ -4898,9 +4865,8 @@
       "params": [
         {
           "description": "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
-          "enum": "catalog.weapons",
           "name": "weapon",
-          "type": "integer"
+          "type": "catalog.weapons"
         }
       ],
       "path": "weapons.shots_per_box",
@@ -4916,9 +4882,8 @@
       "params": [
         {
           "description": "The weather to show.",
-          "enum": "weather.Type",
           "name": "type",
-          "type": "integer"
+          "type": "weather.Type"
         }
       ],
       "path": "weather.set"
@@ -4984,6 +4949,7 @@
     },
     {
       "description": "What Lara is carrying, and what goes into it.\n\nThe module is the inventory she holds now, so `trx.inventory:count(object)`\nasks about her. Any level's is reached the same way through\n`trx.game.Level.inventory`, which is what it will hand her when she arrives\nthere rather than what she has this second.\n\nEvery function takes either the pickup lying in the world or the inventory icon\nit goes into. The engine maps one to the other, so a script names whichever it\nhas.",
+      "instance_type": "inventory.Inventory",
       "name": "inventory",
       "order": 4
     },
@@ -4994,6 +4960,7 @@
     },
     {
       "description": "Module for reading and nudging Lara's own state.\n\nHer position, room and hit points are not here: she is an item like any other and they live on it, as `trx.lara.item`.",
+      "instance_type": "lara.Lara",
       "name": "lara",
       "order": 3
     },
@@ -5062,6 +5029,7 @@
     },
     {
       "description": "Module for what a level keeps count of: what Lara has found in it, and how much\nthere was to find.\n\nThe module is the level being played, so `trx.stats.pickups.count` is what she\nhas picked up in it. Any other level's counters are reached the same way through\n`trx.game.Level.stats`. At the title screen there is no level, and everything\nhere reads `nil`.",
+      "instance_type": "stats.Stats",
       "name": "stats",
       "order": 24
     },
@@ -5113,12 +5081,43 @@
       "path": "rules.corpse"
     }
   ],
+  "numbers": [
+    {
+      "base": 0,
+      "description": "Flyby sequence number, as the level numbers them.",
+      "path": "camera.SequenceNum"
+    },
+    {
+      "base": 0,
+      "description": "Cutscene number, as a cutscene trigger names it.",
+      "path": "cutscenes.Num"
+    },
+    {
+      "base": 0,
+      "description": "Item number, matching the numbers level editors show.",
+      "path": "items.Num"
+    },
+    {
+      "base": 0,
+      "description": "Room number, matching the numbers level editors show.",
+      "path": "rooms.Num"
+    },
+    {
+      "base": 1,
+      "description": "Slot number within the pool. For the quick pool this is the on-screen order.",
+      "path": "savegame.SlotNum"
+    },
+    {
+      "base": 1,
+      "description": "The secret's number, as the player counts them.",
+      "path": "stats.SecretNum"
+    }
+  ],
   "properties": [
     {
       "description": "The track Lara is currently running, or `nil` if none.",
-      "enum": "assault.Track",
       "path": "assault.active_track",
-      "type": "integer",
+      "type": "assault.Track",
       "writable": false
     },
     {
@@ -5128,15 +5127,15 @@
       "writable": false
     },
     {
-      "description": "0-based number of the room the camera is in, or `nil` if unknown.",
+      "description": "The room the camera is in, or `nil` if unknown.",
       "path": "camera.room_num",
-      "type": "integer",
+      "type": "rooms.Num",
       "writable": false
     },
     {
-      "description": "The `trx.rooms.Room` the camera is in, or `nil` if unknown.",
+      "description": "The room the camera is in, or `nil` if unknown.",
       "path": "camera.room",
-      "type": "Room",
+      "type": "rooms.Room",
       "writable": false
     },
     {
@@ -5146,9 +5145,9 @@
       "writable": false
     },
     {
-      "description": "0-based number of the room the camera is looking at, or `nil` if unknown.",
+      "description": "The room the camera is looking at, or `nil` if unknown.",
       "path": "camera.target_room_num",
-      "type": "integer",
+      "type": "rooms.Num",
       "writable": false
     },
     {
@@ -5166,7 +5165,7 @@
     {
       "description": "Number of the cutscene playing, or `nil` if none is.",
       "path": "cutscenes.current",
-      "type": "integer",
+      "type": "cutscenes.Num",
       "writable": false
     },
     {
@@ -5208,13 +5207,13 @@
     {
       "description": "The level being played, or `nil` if none is.",
       "path": "game.current_level",
-      "type": "Level",
+      "type": "game.Level",
       "writable": false
     },
     {
       "description": "The gym level, or `nil` if this game has no gym.",
       "path": "game.gym",
-      "type": "Level",
+      "type": "game.Level",
       "writable": false
     },
     {
@@ -5248,21 +5247,21 @@
       "writable": false
     },
     {
-      "description": "The identity query over every item in the level. Narrow it and read it - see `trx.items.ItemQuery`.",
+      "description": "The identity query over every item in the level. Narrow it and read it.",
       "path": "items.query",
-      "type": "ItemQuery",
+      "type": "items.ItemQuery",
       "writable": false
     },
     {
-      "description": "Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit points are read and written there.",
+      "description": "Lara's own item, or `nil` outside a level. Her position, room and hit points are read and written there.",
       "path": "lara.item",
-      "type": "Item",
+      "type": "items.Item",
       "writable": false
     },
     {
       "description": "The item Lara's guns are locked onto, or `nil` if she has none.",
       "path": "lara.target",
-      "type": "Item",
+      "type": "items.Item",
       "writable": false
     },
     {
@@ -5302,9 +5301,9 @@
       "writable": false
     },
     {
-      "description": "The loaded mod, as a `trx.mod.Mod`.",
+      "description": "The loaded mod.",
       "path": "mod.current",
-      "type": "Mod",
+      "type": "mod.Mod",
       "writable": false
     },
     {
@@ -5320,21 +5319,21 @@
       "writable": false
     },
     {
-      "description": "The track playing now, as a `trx.music.Track`, or `nil` when nothing plays.",
+      "description": "The track playing now, or `nil` when nothing plays.",
       "path": "music.current_track",
-      "type": "Track",
+      "type": "music.Track",
       "writable": false
     },
     {
-      "description": "The ambient track that resumes once the current one-shot finishes, as a `trx.music.Track`, or `nil` when none is set.",
+      "description": "The ambient track that resumes once the current one-shot finishes, or `nil` when none is set.",
       "path": "music.looped_track",
-      "type": "Track",
+      "type": "music.Track",
       "writable": false
     },
     {
-      "description": "The identity query over every object definition. Narrow it and read it - see `trx.objects.ObjectQuery`.",
+      "description": "The identity query over every object definition. Narrow it and read it.",
       "path": "objects.query",
-      "type": "ObjectQuery",
+      "type": "objects.ObjectQuery",
       "writable": false
     },
     {
@@ -5344,9 +5343,9 @@
       "writable": false
     },
     {
-      "description": "The identity query over every room in the level. Narrow it and read it - see `trx.rooms.RoomQuery`.",
+      "description": "The identity query over every room in the level. Narrow it and read it.",
       "path": "rooms.query",
-      "type": "RoomQuery",
+      "type": "rooms.RoomQuery",
       "writable": false
     },
     {
@@ -5399,9 +5398,8 @@
     },
     {
       "description": "The active weather.",
-      "enum": "weather.Type",
       "path": "weather.current",
-      "type": "integer",
+      "type": "weather.Type",
       "writable": false
     }
   ],
@@ -5435,14 +5433,14 @@
       "description": "A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.",
       "extensions": [
         {
-          "description": "What the level keeps for Lara's return, as a `trx.inventory.Inventory`, or `nil` for a level that keeps nothing: the title screen and the cutscenes. It is what she will arrive there with rather than what she is carrying now, which is `trx.inventory` itself.",
+          "description": "What the level keeps for Lara's return, or `nil` for a level that keeps nothing: the title screen and the cutscenes. It is what she will arrive there with rather than what she is carrying now, which is `trx.inventory` itself.",
           "name": "inventory",
-          "type": "Inventory"
+          "type": "inventory.Inventory"
         },
         {
-          "description": "What the level keeps count of, as a `trx.stats.Stats`, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.",
+          "description": "What the level keeps count of, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.",
           "name": "stats",
-          "type": "Stats"
+          "type": "stats.Stats"
         }
       ],
       "fields": [
@@ -5454,12 +5452,12 @@
         },
         {
           "description": "The track that plays when the level starts.",
-          "enum": "catalog.music",
           "name": "music_track",
-          "type": "integer",
+          "type": "catalog.music",
           "writable": false
         },
         {
+          "base": 1,
           "description": "The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0.",
           "name": "num",
           "type": "integer",
@@ -5485,9 +5483,8 @@
         },
         {
           "description": "What kind of level it is.",
-          "enum": "game.LevelType",
           "name": "type",
-          "type": "integer",
+          "type": "game.LevelType",
           "writable": false
         },
         {
@@ -5538,9 +5535,8 @@
         },
         {
           "description": "The inventory icon this entry is drawn as.",
-          "enum": "catalog.objects",
           "name": "object",
-          "type": "integer",
+          "type": "catalog.objects",
           "writable": false
         }
       ],
@@ -5561,9 +5557,8 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             }
           ],
           "returns": {
@@ -5576,9 +5571,8 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             }
           ],
           "returns": {
@@ -5591,29 +5585,29 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             }
           ],
           "returns": {
             "nullable": true,
-            "type": "Entry"
+            "type": "inventory.Entry"
           }
         },
         {
-          "description": "The entry at a position, counted from one in the order they are drawn, or `nil` past the end.",
+          "description": "The entry at a position in the order they are drawn, or `nil` past the end.",
           "name": "entry_at",
           "params": [
             {
-              "description": "1-based position.",
+              "base": 1,
+              "description": "Position in the ring.",
               "name": "entry_num",
               "type": "integer"
             }
           ],
           "returns": {
             "nullable": true,
-            "type": "Entry"
+            "type": "inventory.Entry"
           }
         },
         {
@@ -5632,9 +5626,8 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             },
             {
               "description": "How many. Defaults to 1; below 1 raises.",
@@ -5654,9 +5647,8 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             }
           ],
           "returns": {
@@ -5669,9 +5661,8 @@
           "params": [
             {
               "description": "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
-              "enum": "catalog.weapons",
               "name": "weapon",
-              "type": "integer"
+              "type": "catalog.weapons"
             }
           ],
           "returns": {
@@ -5684,16 +5675,14 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             }
           ],
           "returns": {
             "description": "The icon's object id, or `nil` for a pickup that has none.",
-            "enum": "catalog.objects",
             "nullable": true,
-            "type": "integer"
+            "type": "catalog.objects"
           }
         },
         {
@@ -5702,9 +5691,8 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             },
             {
               "description": "How many. Below 0 raises.",
@@ -5722,9 +5710,8 @@
           "params": [
             {
               "description": "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
-              "enum": "catalog.weapons",
               "name": "weapon",
-              "type": "integer"
+              "type": "catalog.weapons"
             },
             {
               "description": "Shots. Below 0 raises.",
@@ -5739,9 +5726,8 @@
           "params": [
             {
               "description": "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
-              "enum": "catalog.weapons",
               "name": "weapon",
-              "type": "integer"
+              "type": "catalog.weapons"
             }
           ],
           "returns": {
@@ -5754,9 +5740,8 @@
           "params": [
             {
               "description": "The pickup, or the inventory icon it goes into.",
-              "enum": "catalog.objects",
               "name": "object_id",
-              "type": "integer"
+              "type": "catalog.objects"
             },
             {
               "description": "How many. Defaults to 1; below 1 raises.",
@@ -5788,14 +5773,15 @@
           "type": "table"
         },
         {
-          "description": "The `trx.rooms.Room` containing this item.",
+          "description": "The room containing this item.",
           "name": "room",
-          "type": "Room"
+          "type": "rooms.Room"
         }
       ],
       "fields": [
         {
-          "description": "The animation's number within the object, counted from 0.",
+          "base": 0,
+          "description": "The animation's number within the object.",
           "name": "anim_num",
           "type": "integer",
           "writable": true
@@ -5819,7 +5805,8 @@
           "writable": true
         },
         {
-          "description": "The frame's number within the animation, counted from 0. Negative values count back from the end.",
+          "base": 0,
+          "description": "The frame's number within the animation. Negative values count back from the end.",
           "name": "frame_num",
           "type": "integer",
           "writable": true
@@ -5933,16 +5920,15 @@
           "writable": true
         },
         {
-          "description": "0-based item number, matching the numbers level editors show. An item handed over by a query can say where it lives.",
+          "description": "An item handed over by a query can say where it lives.",
           "name": "num",
-          "type": "integer",
+          "type": "items.Num",
           "writable": false
         },
         {
           "description": "The item's object type.",
-          "enum": "catalog.objects",
           "name": "object_id",
-          "type": "integer",
+          "type": "catalog.objects",
           "writable": false
         },
         {
@@ -5952,9 +5938,9 @@
           "writable": true
         },
         {
-          "description": "0-based number of the room containing this item. Set `pos` to move the item between rooms.",
+          "description": "The room containing this item. Set `pos` to move the item between rooms.",
           "name": "room_num",
-          "type": "integer",
+          "type": "rooms.Num",
           "writable": false
         },
         {
@@ -6079,7 +6065,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6103,7 +6089,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6127,7 +6113,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6151,7 +6137,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6175,7 +6161,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6199,7 +6185,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6223,7 +6209,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6247,7 +6233,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 },
                 {
                   "description": "Hit points taken, before clamping to zero.",
@@ -6276,7 +6262,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6300,7 +6286,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6324,7 +6310,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6348,7 +6334,7 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -6372,10 +6358,10 @@
                 {
                   "description": "This item.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 },
                 {
-                  "description": "What the trigger carried: `type`, `mask`, `timer` and `one_shot`. See `trx.events.on_trigger`.",
+                  "description": "What the trigger carried: `type`, `mask`, `timer` and `one_shot`.",
                   "name": "trigger",
                   "type": "table"
                 }
@@ -6461,7 +6447,7 @@
           "name": "alive",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6469,7 +6455,7 @@
           "name": "finished",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6492,7 +6478,7 @@
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6500,7 +6486,7 @@
           "name": "in_play",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6508,14 +6494,13 @@
           "name": "in_room",
           "params": [
             {
-              "description": "0-based room number, matching the numbers level editors show.",
               "name": "room_num",
-              "type": "integer"
+              "type": "rooms.Num"
             }
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6535,7 +6520,7 @@
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6553,7 +6538,7 @@
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6561,7 +6546,7 @@
           "name": "present",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6569,7 +6554,7 @@
           "name": "simulated",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6577,7 +6562,7 @@
           "name": "targetable",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -6585,7 +6570,7 @@
           "name": "visible",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         }
       ],
@@ -6622,9 +6607,8 @@
         },
         {
           "description": "The weapon Lara is holding.",
-          "enum": "catalog.weapons",
           "name": "equipped_gun",
-          "type": "integer",
+          "type": "catalog.weapons",
           "writable": false
         },
         {
@@ -6641,9 +6625,8 @@
         },
         {
           "description": "What Lara's hands are doing.",
-          "enum": "lara.GunState",
           "name": "gun_status",
-          "type": "integer",
+          "type": "lara.GunState",
           "writable": false
         },
         {
@@ -6690,9 +6673,8 @@
         },
         {
           "description": "The weapon Lara is drawing, while she is drawing it.",
-          "enum": "catalog.weapons",
           "name": "requested_gun",
-          "type": "integer",
+          "type": "catalog.weapons",
           "writable": false
         },
         {
@@ -6703,9 +6685,8 @@
         },
         {
           "description": "Where Lara is with respect to water.",
-          "enum": "lara.WaterState",
           "name": "water_status",
-          "type": "integer",
+          "type": "lara.WaterState",
           "writable": false
         }
       ],
@@ -6756,9 +6737,8 @@
         },
         {
           "description": "What kind of mod it is.",
-          "enum": "mod.Type",
           "name": "type",
-          "type": "integer",
+          "type": "mod.Type",
           "writable": false
         }
       ],
@@ -6773,9 +6753,8 @@
       "fields": [
         {
           "description": "How the track is playing.",
-          "enum": "music.PlayMode",
           "name": "mode",
-          "type": "integer",
+          "type": "music.PlayMode",
           "writable": false
         },
         {
@@ -7022,7 +7001,7 @@
           "name": "ammo",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7030,7 +7009,7 @@
           "name": "animation",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7038,7 +7017,7 @@
           "name": "collectible",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7046,7 +7025,7 @@
           "name": "creature",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7054,7 +7033,7 @@
           "name": "door",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7062,7 +7041,7 @@
           "name": "enemy",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7070,7 +7049,7 @@
           "name": "examine",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7078,7 +7057,7 @@
           "name": "gun",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7086,7 +7065,7 @@
           "name": "inventory_item",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7094,7 +7073,7 @@
           "name": "key",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7102,7 +7081,7 @@
           "name": "loaded",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7110,7 +7089,7 @@
           "name": "loyal",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7118,7 +7097,7 @@
           "name": "null_object",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7126,7 +7105,7 @@
           "name": "pickup",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7134,7 +7113,7 @@
           "name": "pushable",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7142,7 +7121,7 @@
           "name": "puzzle",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7150,7 +7129,7 @@
           "name": "quest",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7158,7 +7137,7 @@
           "name": "receptacle",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7166,7 +7145,7 @@
           "name": "secret",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7174,7 +7153,7 @@
           "name": "spawnable",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7182,7 +7161,7 @@
           "name": "supply",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7190,7 +7169,7 @@
           "name": "switch",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7198,7 +7177,7 @@
           "name": "tool",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         }
       ],
@@ -7269,7 +7248,7 @@
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         }
       ],
@@ -7318,7 +7297,7 @@
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7344,7 +7323,7 @@
         {
           "description": "This room's flip pair, or `nil` if it has none.",
           "name": "flipped_room",
-          "type": "Room"
+          "type": "rooms.Room"
         },
         {
           "description": "As `bounds`, but excluding the outer ring of sectors, which is solid wall.",
@@ -7367,15 +7346,13 @@
         },
         {
           "description": "Current flip status.",
-          "enum": "rooms.FlipStatus",
           "name": "flip_status",
-          "type": "integer",
+          "type": "rooms.FlipStatus",
           "writable": false
         },
         {
-          "description": "0-based room number, matching the numbers level editors show.",
           "name": "num",
-          "type": "integer",
+          "type": "rooms.Num",
           "writable": false
         },
         {
@@ -7441,9 +7418,9 @@
               "name": "callback",
               "params": [
                 {
-                  "description": "The `trx.items.Item` that changed rooms.",
+                  "description": "The item that changed rooms.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -7468,9 +7445,9 @@
               "name": "callback",
               "params": [
                 {
-                  "description": "The `trx.items.Item` that changed rooms.",
+                  "description": "The item that changed rooms.",
                   "name": "item",
-                  "type": "Item"
+                  "type": "items.Item"
                 }
               ],
               "type": "function"
@@ -7512,7 +7489,7 @@
           ],
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7520,7 +7497,7 @@
           "name": "dry",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7528,7 +7505,7 @@
           "name": "flipped",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7539,7 +7516,7 @@
           "name": "reachable",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7547,7 +7524,7 @@
           "name": "swamp",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         },
         {
@@ -7555,7 +7532,7 @@
           "name": "underwater",
           "returns": {
             "description": "The narrowed query.",
-            "type": "Query"
+            "type": "query.Query"
           }
         }
       ],
@@ -7712,12 +7689,12 @@
         {
           "description": "The save crystals, where the game has them.",
           "name": "crystals",
-          "type": "Category"
+          "type": "stats.Category"
         },
         {
           "description": "The enemies the level counts, allies among them.",
           "name": "kills",
-          "type": "Category"
+          "type": "stats.Category"
         },
         {
           "description": "How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.",
@@ -7732,12 +7709,12 @@
         {
           "description": "The items lying in the level for Lara to take.",
           "name": "pickups",
-          "type": "Category"
+          "type": "stats.Category"
         },
         {
           "description": "The level's secrets. Which ones Lara holds is `secret_list`.",
           "name": "secrets",
-          "type": "Category"
+          "type": "stats.Category"
         }
       ],
       "fields": [
@@ -7788,9 +7765,8 @@
           "name": "give_secret",
           "params": [
             {
-              "description": "The secret's number, counted from one.",
-              "name": "num",
-              "type": "integer"
+              "name": "secret_num",
+              "type": "stats.SecretNum"
             }
           ],
           "returns": {
@@ -7799,7 +7775,7 @@
           }
         },
         {
-          "description": "The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, counted from one, and `found` is whether Lara has it.",
+          "description": "The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, and `found` is whether Lara has it.",
           "examples": [
             "for _, secret in ipairs(trx.stats.secret_list()) do\n  trx.log.info(secret.num .. \": \" .. tostring(secret.found))\nend"
           ],
@@ -7814,9 +7790,8 @@
           "name": "take_secret",
           "params": [
             {
-              "description": "The secret's number, counted from one.",
-              "name": "num",
-              "type": "integer"
+              "name": "secret_num",
+              "type": "stats.SecretNum"
             }
           ],
           "returns": {

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2146,7 +2146,7 @@
     {
       "bulk": false,
       "count": 5,
-      "description": "The kind of trigger `item:trigger` fires, matching the trigger types a level editor offers. Most are forward triggers that differ only in what trips them in a level; from a script they behave alike, and `TRIGGER` is the one to reach for.",
+      "description": "The kind of trigger `trx.items.Item:trigger` fires, matching the trigger types a level editor offers. Most are forward triggers that differ only in what trips them in a level; from a script they behave alike, and `TRIGGER` is the one to reach for.",
       "path": "items.TriggerType",
       "values": [
         {
@@ -2545,7 +2545,7 @@
     {
       "bulk": false,
       "count": 3,
-      "description": "The values `room.flip_status` can take.",
+      "description": "The values `trx.rooms.Room.flip_status` can take.",
       "path": "rooms.FlipStatus",
       "values": [
         {
@@ -2713,7 +2713,7 @@
       }
     },
     {
-      "description": "Whether the timer is shown on screen. It stays visible after `stop`.",
+      "description": "Whether the timer is shown on screen. It stays visible after `trx.assault.stop`.",
       "params": [
         {
           "default": 1,
@@ -2898,7 +2898,7 @@
       }
     },
     {
-      "description": "What shape a setting has: how a value is entered and shown, beyond the type `get` reads back.",
+      "description": "What shape a setting has: how a value is entered and shown, beyond the type `trx.config.get` reads back.",
       "examples": [
         "for _, value in ipairs(trx.config.describe(\"visuals.shadow_type\").values) do\n  trx.log.info(value)\nend"
       ],
@@ -2949,7 +2949,7 @@
       }
     },
     {
-      "description": "Changes the player's setting, and keeps the change. Raises if the key is unknown or the value will not parse.\n\nThe old value is not kept anywhere: the new one becomes the active setting as if the player had chosen it, and is remembered across saves and relaunches. Prefer `override` for anything a level wants only while it is running.",
+      "description": "Changes the player's setting, and keeps the change. Raises if the key is unknown or the value will not parse.\n\nThe old value is not kept anywhere: the new one becomes the active setting as if the player had chosen it, and is remembered across saves and relaunches. Prefer `trx.config.override` for anything a level wants only while it is running.",
       "params": [
         {
           "description": "Dotted path.",
@@ -2971,7 +2971,7 @@
       "path": "config.set"
     },
     {
-      "description": "Puts a setting back to its default, and keeps the change, as `set` does.",
+      "description": "Puts a setting back to its default, and keeps the change, as `trx.config.set` does.",
       "params": [
         {
           "description": "Dotted path.",
@@ -2979,7 +2979,7 @@
           "type": "string"
         },
         {
-          "description": "As for `set`.",
+          "description": "As for `trx.config.set`.",
           "name": "force",
           "optional": true,
           "type": "boolean"
@@ -2987,12 +2987,12 @@
       ],
       "path": "config.reset",
       "returns": {
-        "description": "`false` when a script or the game flow is holding the setting (see `is_overridden`).",
+        "description": "`false` when a script or the game flow is holding the setting (see `trx.config.is_overridden`).",
         "type": "boolean"
       }
     },
     {
-      "description": "Changes a setting for as long as the script keeps the override, without touching the player's own value.\n\nThe player's value sits underneath and comes back on `restore`. Nothing is written to disk. Overrides stack, so one can be pushed over another; each `restore` lifts one off. A setting the game flow enforces cannot be overridden.",
+      "description": "Changes a setting for as long as the script keeps the override, without touching the player's own value.\n\nThe player's value sits underneath and comes back on `trx.config.restore`. Nothing is written to disk. Overrides stack, so one can be pushed over another; each `trx.config.restore` lifts one off. A setting the game flow enforces cannot be overridden.",
       "examples": [
         "trx.config.override(\"visuals.water_color\", \"0080ff\")\n-- ... and when the level is done with it:\ntrx.config.restore(\"visuals.water_color\")"
       ],
@@ -3003,7 +3003,7 @@
           "type": "string"
         },
         {
-          "description": "As for `set`.",
+          "description": "As for `trx.config.set`.",
           "name": "value",
           "type": "any"
         }
@@ -3234,7 +3234,7 @@
       }
     },
     {
-      "description": "Marks a cutscene as played or unplayed. Marking one as played keeps its\ntrigger from firing; unmarking one lets it run again.\n\nA trigger may name a number the game has no cutscene for - TR4 uses 32 to\nask for a full-motion video - and the engine remembers those the same way,\nso `on_cutscene_trigger` hears about each of them once. This is what clears\nthat memory, and it takes any number a trigger may carry, not only the ones\n`play` accepts.",
+      "description": "Marks a cutscene as played or unplayed. Marking one as played keeps its\ntrigger from firing; unmarking one lets it run again.\n\nA trigger may name a number the game has no cutscene for - TR4 uses 32 to\nask for a full-motion video - and the engine remembers those the same way,\nso `trx.events.on_cutscene_trigger` hears about each of them once. This is what clears\nthat memory, and it takes any number a trigger may carry, not only the ones\n`trx.cutscenes.play` accepts.",
       "examples": [
         "trx.cutscenes.set_played(7, true)"
       ],
@@ -3256,7 +3256,7 @@
       "path": "cutscenes.forget_played"
     },
     {
-      "description": "Places Lara where the next cutscene to end leaves her. A cutscene stands\nher at its own origin while it plays and puts her back where it found her\nafterwards; this says to put her somewhere else instead, as the original\ngame does for the scenes that carry her along.\n\nIt holds for one cutscene, whether named before `play` or while the scene\nruns, and is forgotten once she has been placed.",
+      "description": "Places Lara where the next cutscene to end leaves her. A cutscene stands\nher at its own origin while it plays and puts her back where it found her\nafterwards; this says to put her somewhere else instead, as the original\ngame does for the scenes that carry her along.\n\nIt holds for one cutscene, whether named before `trx.cutscenes.play` or while the scene\nruns, and is forgotten once she has been placed.",
       "examples": [
         "trx.events.on_cutscene_start(function(num)\n  if num == 12 then\n    trx.cutscenes.set_lara_return({ x = 38912, y = 2048, z = 51200 })\n  end\nend)"
       ],
@@ -3276,7 +3276,7 @@
       "path": "cutscenes.set_lara_return"
     },
     {
-      "description": "Happens as a level starts running, before its first frame is drawn. By then\nthe level file is loaded, its items are set up and any savegame state has\nbeen applied, so this is where a script sets object properties, declares\nallies, changes room state and plays sound effects. Every kind of level\nfires it: a played level, a cutscene and the attract demo alike. The title\nscreen has `on_title_start` instead.\n\nWhich level is starting is `trx.game.current_level`, whose `num` and `type`\nsay where it counts and what kind it is. A level script already knows both,\nwhich is why the handler is not handed them.",
+      "description": "Happens as a level starts running, before its first frame is drawn. By then\nthe level file is loaded, its items are set up and any savegame state has\nbeen applied, so this is where a script sets object properties, declares\nallies, changes room state and plays sound effects. Every kind of level\nfires it: a played level, a cutscene and the attract demo alike. The title\nscreen has `trx.events.on_title_start` instead.\n\nWhich level is starting is `trx.game.current_level`, whose `trx.game.Level.num` and `trx.game.Level.type`\nsay where it counts and what kind it is. A level script already knows both,\nwhich is why the handler is not handed them.",
       "examples": [
         "trx.events.on_game_start(function(is_save)\n  trx.log.info(trx.game.current_level.title .. \" is up\")\nend)"
       ],
@@ -3300,7 +3300,7 @@
       }
     },
     {
-      "description": "Happens when the title screen's scene starts playing behind the menu, once\nits level is loaded and its items are set up. The handler takes no\narguments. `on_game_start` does not fire for the title level.",
+      "description": "Happens when the title screen's scene starts playing behind the menu, once\nits level is loaded and its items are set up. The handler takes no\narguments. `trx.events.on_game_start` does not fire for the title level.",
       "examples": [
         "trx.events.on_title_start(function()\n  trx.log.info(\"the menu is up\")\nend)"
       ],
@@ -3404,7 +3404,7 @@
       }
     },
     {
-      "description": "Happens when an item changes rooms during play, which a cutscene or the attract demo is not. `trx.rooms.Room:on_enter` and `:on_exit` are this same event, narrowed to one room.",
+      "description": "Happens when an item changes rooms during play, which a cutscene or the attract demo is not. `trx.rooms.Room:on_enter` and `trx.rooms.Room:on_exit` are this same event, narrowed to one room.",
       "examples": [
         "trx.events.on_room_change(function(item, old_room_num, new_room_num)\n  trx.log.info(item.object_id .. \" moved to room \" .. new_room_num)\nend)"
       ],
@@ -3438,7 +3438,7 @@
       }
     },
     {
-      "description": "Happens every time a trigger is aimed at an item - a floor trigger in the level, the `/trigger` console command, or `item:trigger` from a script - of any kind, an antitrigger included. It is the raw trigger, not a state change: a floor pad fires it every frame Lara stands on it, and a partial trigger fires it too. A cutscene or the attract demo does not.\n\nThe handler runs after the trigger has been applied, so the item already reflects it, and changes the handler makes to the item are not overwritten.\n\n`trx.items.Item:on_trigger` is this same event, narrowed to one item.",
+      "description": "Happens every time a trigger is aimed at an item - a floor trigger in the level, the `/trigger` console command, or `trx.items.Item:trigger` from a script - of any kind, an antitrigger included. It is the raw trigger, not a state change: a floor pad fires it every frame Lara stands on it, and a partial trigger fires it too. A cutscene or the attract demo does not.\n\nThe handler runs after the trigger has been applied, so the item already reflects it, and changes the handler makes to the item are not overwritten.\n\n`trx.items.Item:on_trigger` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_trigger(function(item, trigger)\n  if trigger.type == trx.items.TriggerType.ANTITRIGGER then\n    trx.log.info(item.object_id .. \" was antitriggered\")\n  end\nend)"
       ],
@@ -3452,7 +3452,7 @@
               "type": "items.Item"
             },
             {
-              "description": "What the trigger carried: `type` (an `items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.",
+              "description": "What the trigger carried: `type` (a `trx.items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.",
               "name": "trigger",
               "type": "table"
             }
@@ -3539,7 +3539,7 @@
       }
     },
     {
-      "description": "Happens when an item starts being simulated during play - its control routine begins running each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a cheat. A trigger also fires `on_activate`, which this does not.\n\n`trx.items.Item:on_enter_sim` is this same event, narrowed to one item.",
+      "description": "Happens when an item starts being simulated during play - its control routine begins running each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a cheat. A trigger also fires `trx.events.on_activate`, which this does not.\n\n`trx.items.Item:on_enter_sim` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_enter_sim(function(item)\n  trx.log.info(item.object_id .. \" started running\")\nend)"
       ],
@@ -3587,7 +3587,7 @@
       }
     },
     {
-      "description": "Happens when an item is activated through the lifecycle front door during play - the path a level trigger takes. Switches, respawns and cheats start an item without it, firing only `on_enter_sim`; watch that one for a start of any cause.\n\n`trx.items.Item:on_activate` is this same event, narrowed to one item.",
+      "description": "Happens when an item is activated through the lifecycle front door during play - the path a level trigger takes. Switches, respawns and cheats start an item without it, firing only `trx.events.on_enter_sim`; watch that one for a start of any cause.\n\n`trx.items.Item:on_activate` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_activate(function(item)\n  trx.log.info(item.object_id .. \" was activated\")\nend)"
       ],
@@ -3707,7 +3707,7 @@
       }
     },
     {
-      "description": "Happens when an item takes damage, Lara included. It is the raw damage that\nfires, before the item's hit points are clamped, so a fatal blow reports the whole amount the\nattacker dealt. A death that does not go through damage - a script writing `hit_points`, or\n`destroy()` - does not report.\n\n`trx.items.Item:on_hit` is this same event, narrowed to one item.",
+      "description": "Happens when an item takes damage, Lara included. It is the raw damage that\nfires, before the item's hit points are clamped, so a fatal blow reports the whole amount the\nattacker dealt. A death that does not go through damage - a script writing\n`trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.\n\n`trx.items.Item:on_hit` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_hit(function(item, damage)\n  trx.log.info(item.object_id .. \" lost \" .. damage .. \" hit points\")\nend)"
       ],
@@ -3736,7 +3736,7 @@
       }
     },
     {
-      "description": "Happens when damage takes an item's hit points to zero, Lara included. It is the\nsame blow `on_hit` reports, which fires first. A death that does not go through damage - a script\nwriting `hit_points`, or `destroy()` - does not report.\n\nSome bosses fall and get back up: Willard is knocked out, Natla plays dead before her second\nstage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points\nto zero, so they report once per stage rather than once per boss, and the dragon reports once\nmore for the dagger that ends it.\n\n`trx.items.Item:on_kill` is this same event, narrowed to one item.",
+      "description": "Happens when damage takes an item's hit points to zero, Lara included. It is the\nsame blow `trx.events.on_hit` reports, which fires first. A death that does not go through damage\n- a script writing `trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.\n\nSome bosses fall and get back up: Willard is knocked out, Natla plays dead before her second\nstage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points\nto zero, so they report once per stage rather than once per boss, and the dragon reports once\nmore for the dagger that ends it.\n\n`trx.items.Item:on_kill` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_kill(function(item)\n  trx.log.info(item.object_id .. \" is down\")\nend)"
       ],
@@ -3850,7 +3850,7 @@
       }
     },
     {
-      "description": "Removes a previously attached handler, which stops firing immediately. `listener:detach()` does the same to one held in hand.",
+      "description": "Removes a previously attached handler, which stops firing immediately. `trx.events.Listener:detach` does the same to one held in hand.",
       "examples": [
         "local listener = trx.events.before_control(function()\n  -- handle control loop event\nend)\ntrx.events.detach(listener)"
       ],
@@ -4241,7 +4241,7 @@
       ],
       "path": "lua.eval_file",
       "returns": {
-        "description": "As in `eval_expr`.",
+        "description": "As in `trx.lua.eval_expr`.",
         "nullable": true,
         "type": "table"
       }
@@ -4507,7 +4507,7 @@
           "type": "vec3"
         },
         {
-          "description": "The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `room:floor_height`.",
+          "description": "The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `trx.rooms.Room:floor_height`.",
           "name": "room_num",
           "optional": true,
           "type": "rooms.Num"
@@ -4913,12 +4913,12 @@
       "order": 12
     },
     {
-      "description": "The names TRX knows things by.\n\nEach catalog is an enum of every object, sample, music track, Lara state, Lara animation or item action the engine has a name for. The names are the C ones with their prefix taken off - `O_WOLF` is `trx.catalog.objects.WOLF` - and a catalog answers to a name in any case, so `trx.catalog.objects.wolf` is the same constant.\n\nThe ids in a catalog are TRX's own, and they are the same in all four games. The number a builder reads off Tomb Editor is not: that is the slot the game's own files use. `to_slot` and `from_slot` convert between the two.",
+      "description": "The names TRX knows things by.\n\nEach catalog is an enum of every object, sample, music track, Lara state, Lara animation or item action the engine has a name for. The names are the C ones with their prefix taken off - `O_WOLF` is `trx.catalog.objects.WOLF` - and a catalog answers to a name in any case, so `trx.catalog.objects.wolf` is the same constant.\n\nThe ids in a catalog are TRX's own, and they are the same in all four games. The number a builder reads off Tomb Editor is not: that is the slot the game's own files use. `trx.catalog.to_slot` and `trx.catalog.from_slot` convert between the two.",
       "name": "catalog",
       "order": 8
     },
     {
-      "description": "Module for reading and changing engine settings.\n\nThese are the player's settings, not the level's. `set` writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants `override` instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.",
+      "description": "Module for reading and changing engine settings.\n\nThese are the player's settings, not the level's. `trx.config.set` writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants `trx.config.override` instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.",
       "name": "config",
       "order": 22
     },
@@ -5283,7 +5283,7 @@
       "writable": true
     },
     {
-      "description": "Whether Lara is still shedding droplets after a swim. `dry` clears it.",
+      "description": "Whether Lara is still shedding droplets after a swim. `trx.lara.dry` clears it.",
       "path": "lara.is_wet",
       "type": "boolean",
       "writable": false
@@ -5349,7 +5349,7 @@
       "writable": false
     },
     {
-      "description": "How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills to. Warmth only moves in a room carrying the `damaging` flag, such as the cold water of Antarctica.",
+      "description": "How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills to. Warmth only moves in a room carrying the `trx.rooms.Room.damaging` flag, such as the cold water of Antarctica.",
       "path": "rules.exposure.max",
       "type": "integer",
       "writable": true
@@ -5552,7 +5552,7 @@
       "handle": true,
       "methods": [
         {
-          "description": "Whether `give` would do anything in the level being played. The level has to\ncarry the inventory model, which is not the same as the pickup being in it: a\nlevel with no shotgun lying about still draws one in the ring, which is what\nlets a cheat hand one over.\n\nThis asks about the level being played whichever inventory it is called on.",
+          "description": "Whether `trx.inventory.Inventory:give` would do anything in the level being played. The level has to\ncarry the inventory model, which is not the same as the pickup being in it: a\nlevel with no shotgun lying about still draws one in the ring, which is what\nlets a cheat hand one over.\n\nThis asks about the level being played whichever inventory it is called on.",
           "name": "can_add",
           "params": [
             {
@@ -5637,7 +5637,7 @@
             }
           ],
           "returns": {
-            "description": "How many went in. 0 from Lara's means the level does not carry the icon for it - see `can_add`.",
+            "description": "How many went in. 0 from Lara's means the level does not carry the icon for it - see `trx.inventory.Inventory:can_add`.",
             "type": "integer"
           }
         },
@@ -5670,7 +5670,7 @@
           }
         },
         {
-          "description": "Which inventory icon a pickup is drawn as, whether or not there is any of it.\n\nSeveral pickups share one icon - the scion whether or not Lara holds it, a\nwaterskin at each fill level - so this is what tells two spellings of one thing\nfrom two things. It answers with an object id rather than an entry; `entry` is\nwhat hands back the entry itself.",
+          "description": "Which inventory icon a pickup is drawn as, whether or not there is any of it.\n\nSeveral pickups share one icon - the scion whether or not Lara holds it, a\nwaterskin at each fill level - so this is what tells two spellings of one thing\nfrom two things. It answers with an object id rather than an entry; `trx.inventory.Inventory:entry` is\nwhat hands back the entry itself.",
           "name": "icon_of",
           "params": [
             {
@@ -5735,7 +5735,7 @@
           }
         },
         {
-          "description": "Takes things back out, stopping when there are none left.\n\nThis is not the exact opposite of `give`: a box of ammunition is rounds rather\nthan an entry of its own, so taking one back takes the rounds a box is worth.",
+          "description": "Takes things back out, stopping when there are none left.\n\nThis is not the exact opposite of `trx.inventory.Inventory:give`: a box of ammunition is rounds rather\nthan an entry of its own, so taking one back takes the rounds a box is worth.",
           "name": "take",
           "params": [
             {
@@ -5763,7 +5763,7 @@
       "description": "An item, also known as a moveable.",
       "extensions": [
         {
-          "description": "The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around `pos` before `rot` turns it, and they change as the item animates.",
+          "description": "The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around `trx.items.Item.pos` before `trx.items.Item.rot` turns it, and they change as the item animates.",
           "name": "bounds",
           "type": "table"
         },
@@ -5824,7 +5824,7 @@
           "writable": true
         },
         {
-          "description": "Current hit points. Raising this above the maximum also raises `properties.max_hit_points`.",
+          "description": "Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of `trx.items.Item.properties`.",
           "name": "hit_points",
           "type": "integer",
           "writable": true
@@ -5878,7 +5878,7 @@
           "writable": true
         },
         {
-          "description": "Whether the item's control routine runs each frame. Call `activate()` to start it.",
+          "description": "Whether the item's control routine runs each frame. Call `trx.items.Item:activate` to start it.",
           "name": "is_simulated",
           "type": "boolean",
           "writable": false
@@ -5890,7 +5890,7 @@
           "writable": false
         },
         {
-          "description": "Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.\n\nIt is a verdict on `trigger_mask`, `timer` and `is_reversed` together, not a field of its own.",
+          "description": "Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.\n\nIt is a verdict on `trx.items.Item.trigger_mask`, `trx.items.Item.timer` and `trx.items.Item.is_reversed` together, not a field of its own.",
           "name": "is_triggered",
           "type": "boolean",
           "writable": false
@@ -5902,7 +5902,7 @@
           "writable": true
         },
         {
-          "description": "Maximum hit points. Set `properties.max_hit_points` to change it.",
+          "description": "Maximum hit points. Set the `max_hit_points` entry of `trx.items.Item.properties` to change it.",
           "name": "max_hit_points",
           "type": "integer",
           "writable": false
@@ -5932,13 +5932,13 @@
           "writable": false
         },
         {
-          "description": "World position. Updating this also updates `room` and `room_num`.",
+          "description": "World position. Updating this also updates `trx.items.Item.room` and `trx.items.Item.room_num`.",
           "name": "pos",
           "type": "vec3",
           "writable": true
         },
         {
-          "description": "The room containing this item. Set `pos` to move the item between rooms.",
+          "description": "The room containing this item. Set `trx.items.Item.pos` to move the item between rooms.",
           "name": "room_num",
           "type": "rooms.Num",
           "writable": false
@@ -5956,7 +5956,7 @@
           "writable": true
         },
         {
-          "description": "How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - `trigger()` takes its timer in seconds instead.",
+          "description": "How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - `trx.items.Item:trigger` takes its timer in seconds instead.",
           "name": "timer",
           "type": "integer",
           "writable": true
@@ -5987,7 +5987,7 @@
           "name": "activate"
         },
         {
-          "description": "Stops the item: its control routine no longer runs, and a creature loses its AI and stands down. The item stays where it is and keeps its hit points, so this is not a way of getting rid of it - use `destroy()` for that.\n\nA trigger can still bring it back, and so can `activate()`.",
+          "description": "Stops the item: its control routine no longer runs, and a creature loses its AI and stands down. The item stays where it is and keeps its hit points, so this is not a way of getting rid of it - use `trx.items.Item:destroy` for that.\n\nA trigger can still bring it back, and so can `trx.items.Item:activate`.",
           "name": "deactivate"
         },
         {
@@ -5995,7 +5995,7 @@
           "name": "destroy"
         },
         {
-          "description": "Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; `destroy()` simply removes any item from the game.",
+          "description": "Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; `trx.items.Item:destroy` simply removes any item from the game.",
           "name": "die",
           "params": [
             {
@@ -6389,7 +6389,7 @@
           ]
         },
         {
-          "description": "Bursts the item's meshes into flying debris, the visual `die(true)` produces, on its own. It does not kill or remove the item.",
+          "description": "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with `explode`, on its own. It does not kill or remove the item.",
           "name": "shatter",
           "params": [
             {
@@ -6402,7 +6402,7 @@
           ]
         },
         {
-          "description": "Hurts the item the way a weapon does, and reports through `on_hit`, and\n`on_kill` where the blow takes the last hit point. Writing `hit_points` reports neither. The kill\ncounts as the environment's rather than Lara's.",
+          "description": "Hurts the item the way a weapon does, and reports through `trx.events.on_hit`,\nand `trx.events.on_kill` where the blow takes the last hit point. Writing\n`trx.items.Item.hit_points` reports neither. The kill counts as the\nenvironment's rather than Lara's.",
           "examples": [
             "local lara = trx.lara.item\nlara:take_damage(lara.hit_points)"
           ],
@@ -6416,7 +6416,7 @@
           ]
         },
         {
-          "description": "Fires a trigger at the item, exactly as a floor trigger in the level would: sets the code bits, and once they are all set, starts the item running.\n\nThis is the one to reach for on anything a level would trigger - a door, a switch, an alarm - because those read their trigger before they act, and merely `activate()`-ing one leaves it running but doing nothing. Pass `type = trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.",
+          "description": "Fires a trigger at the item, exactly as a floor trigger in the level would: sets the code bits, and once they are all set, starts the item running.\n\nThis is the one to reach for on anything a level would trigger - a door, a switch, an alarm - because those read their trigger before they act, and merely activating one leaves it running but doing nothing. Pass `type = trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.",
           "examples": [
             "trx.items[12]:trigger()",
             "trx.items[12]:trigger({ timer = 3, one_shot = true })",
@@ -6425,7 +6425,7 @@
           "name": "trigger",
           "params": [
             {
-              "description": "`type`: which `items.TriggerType` to fire; a plain `TRIGGER` by default.\n\n`mask`: which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.\n\n`timer`: how long it should keep the item going, in seconds. `0`, the default, means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.\n\n`one_shot`: never let it fire again.",
+              "description": "`type`: which `trx.items.TriggerType` to fire; a plain `TRIGGER` by default.\n\n`mask`: which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.\n\n`timer`: how long it should keep the item going, in seconds. `0`, the default, means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.\n\n`one_shot`: never let it fire again.",
               "name": "opts",
               "optional": true,
               "type": "table"
@@ -6437,7 +6437,7 @@
       "path": "items.Item"
     },
     {
-      "description": "A `trx.query.Query` over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `of_object` is how a name reaches them.",
+      "description": "A `trx.query.Query` over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `trx.items.ItemQuery:of_object` is how a name reaches them.",
       "extensions": [],
       "fields": [],
       "handle": false,
@@ -6504,7 +6504,7 @@
           }
         },
         {
-          "description": "The item stands within a radius of a point. As with `in_box`, the item's position is the whole of the test.",
+          "description": "The item stands within a radius of a point. As with `trx.items.ItemQuery:in_box`, the item's position is the whole of the test.",
           "name": "in_sphere",
           "params": [
             {
@@ -6612,7 +6612,7 @@
           "writable": false
         },
         {
-          "description": "Warmth remaining in the cold, out of `trx.rules.exposure.max`. Only moves in a level whose rooms carry the `damaging` flag.",
+          "description": "Warmth remaining in the cold, out of `trx.rules.exposure.max`. Only moves in a level whose rooms carry the `trx.rooms.Room.damaging` flag.",
           "name": "exposure_bar",
           "type": "integer",
           "writable": true
@@ -6660,7 +6660,7 @@
           "writable": true
         },
         {
-          "description": "The poison reservoir that drains into `poison` over time. TR4 only.",
+          "description": "The poison reservoir that drains into `trx.lara.poison` over time. TR4 only.",
           "name": "poison_target",
           "type": "integer",
           "writable": true
@@ -6748,7 +6748,7 @@
       "path": "mod.Mod"
     },
     {
-      "description": "One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through `trx.music.streams`. A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check `is_valid()` first.",
+      "description": "One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through `trx.music.streams`. A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check `trx.music.Stream:is_valid` first.",
       "extensions": [],
       "fields": [
         {
@@ -6811,7 +6811,7 @@
       "path": "music.Stream"
     },
     {
-      "description": "A track the current level carries. Reach them through `trx.music.tracks`, or as `trx.music.current_track`. A handle to a track the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.",
+      "description": "A track the current level carries. Reach them through `trx.music.tracks`, or as `trx.music.current_track`. A handle to a track the loaded level does not carry goes stale, so `trx.music.Track:is_valid` answers whether it is still there.",
       "extensions": [],
       "fields": [
         {
@@ -6874,7 +6874,7 @@
           "type": "table"
         },
         {
-          "description": "The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
+          "description": "The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `trx.items.Item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
           "name": "properties",
           "type": "table"
         }
@@ -6938,14 +6938,14 @@
       "handle": true,
       "methods": [
         {
-          "description": "The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `object.default_names`.",
+          "description": "The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `trx.objects.Object.default_names`.",
           "name": "get_default_names",
           "returns": {
             "type": "table"
           }
         },
         {
-          "description": "Every name the object answers to, in the player's language. Prefer `object.names`.",
+          "description": "Every name the object answers to, in the player's language. Prefer `trx.objects.Object.names`.",
           "name": "get_names",
           "returns": {
             "type": "table"
@@ -6991,7 +6991,7 @@
       "path": "objects.Object"
     },
     {
-      "description": "A `trx.query.Query` over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see `trx.query.NamedQuery`.\n\nThe families do not cover `pickup` between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.",
+      "description": "A `trx.query.Query` over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see `trx.query.NamedQuery`.\n\nThe families do not cover `trx.objects.ObjectQuery:pickup` between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.",
       "extensions": [],
       "fields": [],
       "handle": false,
@@ -7238,7 +7238,7 @@
                   "type": "integer"
                 },
                 {
-                  "description": "The candidate itself, an `Object` or an `Item`.",
+                  "description": "The candidate itself, a `trx.objects.Object` or a `trx.items.Item`.",
                   "name": "handle",
                   "type": "any"
                 }
@@ -7269,13 +7269,13 @@
       "path": "query.Query"
     },
     {
-      "description": "A query over a domain whose things answer to names, which adds the name layer to everything a `Query` has. A domain without names offers none of it.",
+      "description": "A query over a domain whose things answer to names, which adds the name layer to everything a `trx.query.Query` has. A domain without names offers none of it.",
       "extensions": [],
       "fields": [],
       "handle": false,
       "methods": [
         {
-          "description": "The ids tied for the best `by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `by_name`, every matching id.",
+          "description": "The ids tied for the best `trx.query.NamedQuery:by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `trx.query.NamedQuery:by_name`, every matching id.",
           "name": "best",
           "returns": {
             "description": "A list of integers.",
@@ -7301,7 +7301,7 @@
           }
         },
         {
-          "description": "Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `pickup`.",
+          "description": "Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `trx.objects.ObjectQuery:pickup`.",
           "name": "names",
           "returns": {
             "description": "A list of names.",
@@ -7326,7 +7326,7 @@
           "type": "rooms.Room"
         },
         {
-          "description": "As `bounds`, but excluding the outer ring of sectors, which is solid wall.",
+          "description": "As `trx.rooms.Room.bounds`, but excluding the outer ring of sectors, which is solid wall.",
           "name": "internal_bounds",
           "type": "table"
         }
@@ -7509,7 +7509,7 @@
           }
         },
         {
-          "description": "The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what `at` already applies.",
+          "description": "The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what `trx.rooms.RoomQuery:at` already applies.",
           "examples": [
             "trx.rooms.query:reachable():underwater():count()"
           ],
@@ -7540,7 +7540,7 @@
       "path": "rooms.RoomQuery"
     },
     {
-      "description": "A sound sample the current level carries. Reach them through `trx.sound.samples`. A handle to a sample the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.",
+      "description": "A sound sample the current level carries. Reach them through `trx.sound.samples`. A handle to a sample the loaded level does not carry goes stale, so `trx.sound.Sample:is_valid` answers whether it is still there.",
       "extensions": [],
       "fields": [
         {
@@ -7609,7 +7609,7 @@
       "path": "sound.Sample"
     },
     {
-      "description": "One of the sound effects playing now. Reach them through `trx.sound.streams`. A handle to a voice that has fallen silent goes stale, so check `is_valid()` first.",
+      "description": "One of the sound effects playing now. Reach them through `trx.sound.streams`. A handle to a voice that has fallen silent goes stale, so check `trx.sound.Stream:is_valid` first.",
       "extensions": [],
       "fields": [
         {
@@ -7645,11 +7645,11 @@
       "path": "sound.Stream"
     },
     {
-      "description": "One thing a level is counted on, which is one row of the statistics screen. `raw` is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.",
+      "description": "One thing a level is counted on, which is one row of the statistics screen. `trx.stats.Category.raw` is `trx.stats.Category.max` plus `trx.stats.Category.unobtainable`: the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.",
       "extensions": [],
       "fields": [
         {
-          "description": "How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `give_secret` and `take_secret` are how they change.",
+          "description": "How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `trx.stats.give_secret` and `trx.stats.take_secret` are how they change.",
           "name": "count",
           "type": "integer",
           "writable": true
@@ -7697,12 +7697,12 @@
           "type": "stats.Category"
         },
         {
-          "description": "How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.",
+          "description": "How many of `trx.stats.Stats.kills.max` are allies. The statistics screen holds them against the player only once `trx.stats.Stats.allies_hurt`, so a screen written in Lua wants to do the same: `trx.stats.Stats.max_enemy_kills`, and these as well once she has turned on one.",
           "name": "max_ally_kills",
           "type": "integer"
         },
         {
-          "description": "How many of `kills.max` are enemies rather than allies.",
+          "description": "How many of `trx.stats.Stats.kills.max` are enemies rather than allies.",
           "name": "max_enemy_kills",
           "type": "integer"
         },
@@ -7712,7 +7712,7 @@
           "type": "stats.Category"
         },
         {
-          "description": "The level's secrets. Which ones Lara holds is `secret_list`.",
+          "description": "The level's secrets. Which ones Lara holds is `trx.stats.Stats.secret_list`.",
           "name": "secrets",
           "type": "stats.Category"
         }

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -8678,5 +8678,6 @@
       "operators": [],
       "path": "stats.Stats"
     }
-  ]
+  ],
+  "units": []
 }

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -20,7 +20,7 @@ Argument checking for the whole of `trx`.
   Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.
 
   Parameters:
-  - **`enabled`** (boolean). Whether to check.
+  - <a id="api.strict.enabled" name="api.strict.enabled"></a>**`enabled`** (boolean). Whether to check.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -10,13 +10,13 @@ order: 30
   src/lua/api/api.lua. Edit it there.
 -->
 
-## API registry module
+## <a id="api" name="api"></a>API registry module
 
 Argument checking for the whole of `trx`.
 
 ### Functions
 
-- <a name="api.strict"></a>[lua]`trx.api.strict(enabled)`  
+- <a id="api.strict" name="api.strict"></a>[lua]`trx.api.strict(enabled)`  
   Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.
 
   Parameters:
@@ -27,7 +27,7 @@ Argument checking for the whole of `trx`.
   trx.api.strict(true)
   ```
 
-- <a name="api.is_strict"></a>[lua]`trx.api.is_strict()`  
+- <a id="api.is_strict" name="api.is_strict"></a>[lua]`trx.api.is_strict()`  
   Whether argument checking is on.
 
   Returns: boolean. False as the game starts, and true once something turns it on.

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -16,18 +16,18 @@ Argument checking for the whole of `trx`.
 
 ### Functions
 
-- [lua]`trx.api.strict(enabled)`  
+- <a name="api.strict"></a>[lua]`trx.api.strict(enabled)`  
   Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.
 
   Parameters:
-  - **`enabled`** (boolean).
+  - **`enabled`** (boolean). Whether to check.
 
   Example:
   ```lua
   trx.api.strict(true)
   ```
 
-- [lua]`trx.api.is_strict()`  
+- <a name="api.is_strict"></a>[lua]`trx.api.is_strict()`  
   Whether argument checking is on.
 
-  Returns: boolean.
+  Returns: boolean. False as the game starts, and true once something turns it on.

--- a/docs/trx/lua/reference/ARGPARSE.md
+++ b/docs/trx/lua/reference/ARGPARSE.md
@@ -16,7 +16,7 @@ A small, declarative argument parser for console commands, in the shape of
 Python's argparse.
 
 A parser both reads a command's arguments and offers completions for them,
-from one declaration. Every command written with `trx.console.register` has
+from one declaration. Every command written with [`trx.console.register`](CONSOLE.md#console.register) has
 one; a command shapes it through the `args` function it hands over, and `run`
 then receives a table of parsed values. A command that shapes nothing takes no
 arguments, and is told so when given one.
@@ -70,11 +70,11 @@ A parser has these methods, each returning the parser so calls chain:
 
 A choice is either a bare string, where the key and value are the same, or a
 `{ key, value }` pair, where `key` is matched and shown and `value` is what
-`parse` gives back. Matching is forgiving, through `trx.strings.fuzzy_match`.
+`parse` gives back. Matching is forgiving, through [`trx.strings.fuzzy_match`](STRINGS.md#strings.fuzzy_match).
 
 ### Functions
 
-- [lua]`trx.argparse.new([spec])`  
+- <a name="argparse.new"></a>[lua]`trx.argparse.new([spec])`  
   Creates an argument parser. See the module description for the parser's methods.
 
   Parameters:

--- a/docs/trx/lua/reference/ARGPARSE.md
+++ b/docs/trx/lua/reference/ARGPARSE.md
@@ -10,7 +10,7 @@ order: 21
   src/lua/api/argparse.lua. Edit it there.
 -->
 
-## Argparse module
+## <a id="argparse" name="argparse"></a>Argparse module
 
 A small, declarative argument parser for console commands, in the shape of
 Python's argparse.
@@ -74,7 +74,7 @@ A choice is either a bare string, where the key and value are the same, or a
 
 ### Functions
 
-- <a name="argparse.new"></a>[lua]`trx.argparse.new([spec])`  
+- <a id="argparse.new" name="argparse.new"></a>[lua]`trx.argparse.new([spec])`  
   Creates an argument parser. See the module description for the parser's methods.
 
   Parameters:

--- a/docs/trx/lua/reference/ARGPARSE.md
+++ b/docs/trx/lua/reference/ARGPARSE.md
@@ -17,24 +17,17 @@ Python's argparse.
 
 A parser both reads a command's arguments and offers completions for them,
 from one declaration. Every command written with [`trx.console.register`](CONSOLE.md#console.register) has
-one; a command shapes it through the `args` function it hands over, and `run`
-then receives a table of parsed values. A command that shapes nothing takes no
-arguments, and is told so when given one.
+one; a command shapes it through the [`trx.console.register.spec.args`](CONSOLE.md#console.register.spec.args) function
+it hands over, and [`trx.console.register.spec.run`](CONSOLE.md#console.register.spec.run) then receives a table of
+parsed values. A command that shapes nothing takes no arguments, and is told so
+when given one.
 
 Every parser answers `-h` and `--help` on its own, printing what it accepts.
 
-How a positional reads a token is its `matcher`, one of:
-
-- `type` - coerce to `"integer"`, `"number"`, `"string"` or `"boolean"`.
-- `choices` - the allowed set: a list of values or a `function(parsed)`
-  returning one. The token must match one; the set is shown in errors and
-  completes.
-- `match` - a `function(token, parsed)` returning `value, ok`, for a shape of its own.
-
-These do not combine on one positional; a value that is a number *or* a name is
-two matchers, declared with `any_of`. Separately, `suggest` offers completions
-without restricting or being shown in errors - for a free value with a long
-list behind it, like a setting name.
+How a positional reads a token is its matcher: a type to coerce to, a set of
+choices, or a function of its own. These do not combine on one positional; a
+value that is a number *or* a name is two matchers, declared with
+[`trx.argparse.Parser:any_of`](#argparse.Parser.any_of).
 
 Positionals are read in order, and an optional one a token does not fit is
 passed over: the token goes to the next positional, and the one skipped stays
@@ -43,44 +36,140 @@ without - a verb before a value, a count before a name. Completion follows the
 same path, so a slot offers what every argument reachable from it takes. A
 token nothing takes is reported against the first argument that refused it.
 
-A parser has these methods, each returning the parser so calls chain:
-
-- `positional(name, opts)` - a positional with one matcher (`opts.type`,
-  `opts.choices` or `opts.match`). `opts.optional` lets it be left out;
-  `opts.greedy` reads the rest of the line as one token, so a value with spaces
-  in it still arrives whole; `opts.suggest` completes it; `opts.help` describes
-  it.
-- `any_of(name, alternatives, opts)` - a positional whose value is the first of
-  several matchers to take the token. Each alternative is a matcher table,
-  `{ type = ... }` or `{ choices = ... }`. Same `opts` as `positional`.
-- `rest(name, opts)` - the rest of the line from here on, verbatim as one
-  string, or nil when an optional one is absent. Always the last argument;
-  `opts.suggest` completes it.
-- `flag(name, opts)` - a boolean that may sit anywhere. `opts.short` and
-  `opts.long` are the spellings, e.g. `"-f"` and `"--force"`; `opts.help`
-  describes it.
-- `parse(args)` - reads the argument string, returning a table of values, or
-  `nil` and a structured error the console layer turns into localized text. A
-  value carried by a `{ key, value }` choice comes back as its `value`;
-  `-h`/`--help` comes back as `{ help = true }`.
-- `complete(text, caret)` - the candidate completions for the token the caret
-  sits in, and the byte offsets `start, end` of the run they replace (reaching
-  to the end of the line for a greedy argument).
-- `usage()` - a short description of what the command accepts.
-
 A choice is either a bare string, where the key and value are the same, or a
-`{ key, value }` pair, where `key` is matched and shown and `value` is what
-`parse` gives back. Matching is forgiving, through [`trx.strings.fuzzy_match`](STRINGS.md#strings.fuzzy_match).
+`{ key, value }` pair, where the key is matched and shown and the value is what
+[`trx.argparse.Parser:parse`](#argparse.Parser.parse) gives back. Matching is forgiving, through
+[`trx.strings.fuzzy_match`](STRINGS.md#strings.fuzzy_match).
+
+### Structures
+
+- <a id="argparse.Parser" name="argparse.Parser"></a>[lua]`trx.argparse.Parser`
+
+    An argument parser, built up a call at a time. Every method hands the parser back, so the calls chain.
+
+    Methods:
+
+    - <a id="argparse.Parser.any_of" name="argparse.Parser.any_of"></a>[lua]`parser:any_of(name, alternatives, [opts])`  
+      Adds a positional whose value is the first of several matchers to take the token, for an argument that is a number or a name.
+
+      Parameters:
+      - <a id="argparse.Parser.any_of.name" name="argparse.Parser.any_of.name"></a>**`name`** (string). What the parsed value is keyed by.
+      - <a id="argparse.Parser.any_of.alternatives" name="argparse.Parser.any_of.alternatives"></a>**`alternatives`** (table). The ways the token may read, tried in order.
+
+        Each entry:
+        - <a id="argparse.Parser.any_of.alternatives.type" name="argparse.Parser.any_of.alternatives.type"></a>**`type`** (string, optional). As for [`positional`](#argparse.Parser.positional).
+        - <a id="argparse.Parser.any_of.alternatives.choices" name="argparse.Parser.any_of.alternatives.choices"></a>**`choices`** (any, optional). As for [`positional`](#argparse.Parser.positional).
+        - <a id="argparse.Parser.any_of.alternatives.match" name="argparse.Parser.any_of.alternatives.match"></a>**`match`** (function, optional). As for [`positional`](#argparse.Parser.positional).
+        - <a id="argparse.Parser.any_of.alternatives.metavar" name="argparse.Parser.any_of.alternatives.metavar"></a>**`metavar`** (string, optional). Names this alternative, which earns it a line of its own in the help.
+        - <a id="argparse.Parser.any_of.alternatives.help" name="argparse.Parser.any_of.alternatives.help"></a>**`help`** (string, optional). What this alternative is for.
+      - <a id="argparse.Parser.any_of.opts" name="argparse.Parser.any_of.opts"></a>**`opts`** (table, optional). How the argument behaves.
+
+        Keys:
+        - <a id="argparse.Parser.any_of.opts.optional" name="argparse.Parser.any_of.opts.optional"></a>**`optional`** (boolean, optional). Lets the argument be left out.
+        - <a id="argparse.Parser.any_of.opts.greedy" name="argparse.Parser.any_of.opts.greedy"></a>**`greedy`** (boolean, optional). Reads the rest of the line as one token, so a value with spaces in it still arrives whole.
+        - <a id="argparse.Parser.any_of.opts.metavar" name="argparse.Parser.any_of.opts.metavar"></a>**`metavar`** (string, optional). What the argument is called in messages and in the synopsis. Its own name by default.
+        - <a id="argparse.Parser.any_of.opts.suggest" name="argparse.Parser.any_of.opts.suggest"></a>**`suggest`** (function, optional). Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.
+        - <a id="argparse.Parser.any_of.opts.help" name="argparse.Parser.any_of.opts.help"></a>**`help`** (string, optional). What the argument is for, shown in the help.
+
+      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+
+    - <a id="argparse.Parser.complete" name="argparse.Parser.complete"></a>[lua]`parser:complete([text], [caret])`  
+      The candidate completions for the token the caret sits in. Matching is against the text before the caret.
+
+      Parameters:
+      - <a id="argparse.Parser.complete.text" name="argparse.Parser.complete.text"></a>**`text`** (string, optional). The line so far.
+      - <a id="argparse.Parser.complete.caret" name="argparse.Parser.complete.caret"></a>**`caret`** (integer, optional). Where the caret sits, as a byte offset. The end of the line by default.
+
+      Returns:
+      - table. The candidates, best first.
+      - integer. Where the run they replace starts. The run is the token, or the whole tail a greedy argument swallows; in whitespace it is empty, at the caret.
+      - integer. Where that run ends.
+
+    - <a id="argparse.Parser.flag" name="argparse.Parser.flag"></a>[lua]`parser:flag(name, [opts])`  
+      Adds a boolean flag, which may sit anywhere in the line.
+
+      Parameters:
+      - <a id="argparse.Parser.flag.name" name="argparse.Parser.flag.name"></a>**`name`** (string). What the parsed value is keyed by. `help` is reserved.
+      - <a id="argparse.Parser.flag.opts" name="argparse.Parser.flag.opts"></a>**`opts`** (table, optional). How it is spelled and what it is for.
+
+        Keys:
+        - <a id="argparse.Parser.flag.opts.short" name="argparse.Parser.flag.opts.short"></a>**`short`** (string, optional). The short spelling, such as `"-f"`.
+        - <a id="argparse.Parser.flag.opts.long" name="argparse.Parser.flag.opts.long"></a>**`long`** (string, optional). The long spelling, such as `"--force"`.
+        - <a id="argparse.Parser.flag.opts.help" name="argparse.Parser.flag.opts.help"></a>**`help`** (string, optional). What the flag is for, shown in the help.
+
+      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+
+    - <a id="argparse.Parser.format_error" name="argparse.Parser.format_error"></a>[lua]`parser:format_error(err)`  
+      Turns what a refused line reported into a localized line naming what was wrong and what was expected.
+
+      Parameters:
+      - <a id="argparse.Parser.format_error.err" name="argparse.Parser.format_error.err"></a>**`err`** (table). What [`parse`](#argparse.Parser.parse) handed back.
+
+      Returns: string. The line, ready to print.
+
+    - <a id="argparse.Parser.parse" name="argparse.Parser.parse"></a>[lua]`parser:parse([args])`  
+      Reads an argument line. A value carried by a `{ key, value }` choice comes back as its value, and `-h`/`--help` comes back as `{ help = true }`.
+
+      Parameters:
+      - <a id="argparse.Parser.parse.args" name="argparse.Parser.parse.args"></a>**`args`** (string, optional). The line as the player typed it.
+
+      Returns:
+      - table or `nil`. The values, keyed by argument name, or `nil` where the line was refused.
+      - table or `nil`. What was wrong, for [`format_error`](#argparse.Parser.format_error) to put into words.
+
+    - <a id="argparse.Parser.positional" name="argparse.Parser.positional"></a>[lua]`parser:positional(name, [opts])`  
+      Adds a positional argument, read one way.
+
+      Parameters:
+      - <a id="argparse.Parser.positional.name" name="argparse.Parser.positional.name"></a>**`name`** (string). What the parsed value is keyed by.
+      - <a id="argparse.Parser.positional.opts" name="argparse.Parser.positional.opts"></a>**`opts`** (table, optional). How it reads its token, and how it behaves. It reads a token one way: name at most one of [`opts.type`](#argparse.Parser.positional.opts.type), [`opts.choices`](#argparse.Parser.positional.opts.choices) and [`opts.match`](#argparse.Parser.positional.opts.match), and use [`any_of`](#argparse.Parser.any_of) for several.
+
+        Keys:
+        - <a id="argparse.Parser.positional.opts.type" name="argparse.Parser.positional.opts.type"></a>**`type`** (string, optional). Coerce the token: `"integer"`, `"number"`, `"string"` or `"boolean"`.
+        - <a id="argparse.Parser.positional.opts.choices" name="argparse.Parser.positional.opts.choices"></a>**`choices`** (any, optional). The allowed set: a list of values, or a function of the values parsed so far returning one. The token must match one; the set is shown in errors and completes.
+        - <a id="argparse.Parser.positional.opts.match" name="argparse.Parser.positional.opts.match"></a>**`match`** (function, optional). A function of the token and the values parsed so far, returning the value and whether it took, for a shape of its own.
+        - <a id="argparse.Parser.positional.opts.optional" name="argparse.Parser.positional.opts.optional"></a>**`optional`** (boolean, optional). Lets the argument be left out.
+        - <a id="argparse.Parser.positional.opts.greedy" name="argparse.Parser.positional.opts.greedy"></a>**`greedy`** (boolean, optional). Reads the rest of the line as one token, so a value with spaces in it still arrives whole.
+        - <a id="argparse.Parser.positional.opts.metavar" name="argparse.Parser.positional.opts.metavar"></a>**`metavar`** (string, optional). What the argument is called in messages and in the synopsis. Its own name by default.
+        - <a id="argparse.Parser.positional.opts.suggest" name="argparse.Parser.positional.opts.suggest"></a>**`suggest`** (function, optional). Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.
+        - <a id="argparse.Parser.positional.opts.help" name="argparse.Parser.positional.opts.help"></a>**`help`** (string, optional). What the argument is for, shown in the help.
+
+      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+
+    - <a id="argparse.Parser.rest" name="argparse.Parser.rest"></a>[lua]`parser:rest(name, [opts])`  
+      Adds an argument taking the rest of the line from here on, verbatim as one string, or `nil` where an optional one is absent. Always the last argument.
+
+      Parameters:
+      - <a id="argparse.Parser.rest.name" name="argparse.Parser.rest.name"></a>**`name`** (string). What the parsed value is keyed by.
+      - <a id="argparse.Parser.rest.opts" name="argparse.Parser.rest.opts"></a>**`opts`** (table, optional). How the argument behaves.
+
+        Keys:
+        - <a id="argparse.Parser.rest.opts.optional" name="argparse.Parser.rest.opts.optional"></a>**`optional`** (boolean, optional). Lets the argument be left out.
+        - <a id="argparse.Parser.rest.opts.greedy" name="argparse.Parser.rest.opts.greedy"></a>**`greedy`** (boolean, optional). Reads the rest of the line as one token, so a value with spaces in it still arrives whole.
+        - <a id="argparse.Parser.rest.opts.metavar" name="argparse.Parser.rest.opts.metavar"></a>**`metavar`** (string, optional). What the argument is called in messages and in the synopsis. Its own name by default.
+        - <a id="argparse.Parser.rest.opts.suggest" name="argparse.Parser.rest.opts.suggest"></a>**`suggest`** (function, optional). Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.
+        - <a id="argparse.Parser.rest.opts.help" name="argparse.Parser.rest.opts.help"></a>**`help`** (string, optional). What the argument is for, shown in the help.
+
+      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+
+    - <a id="argparse.Parser.usage" name="argparse.Parser.usage"></a>[lua]`parser:usage()`  
+      A short description of what the command accepts.
+
+      Returns: string. The synopsis, and a line per argument.
 
 ### Functions
 
 - <a id="argparse.new" name="argparse.new"></a>[lua]`trx.argparse.new([spec])`  
-  Creates an argument parser. See the module description for the parser's methods.
+  Creates an argument parser.
 
   Parameters:
-  - **`spec`** (table, optional). `prog`: the command word, for messages. `description`: what the command does.
+  - <a id="argparse.new.spec" name="argparse.new.spec"></a>**`spec`** (table, optional). What the parser calls itself in messages.
 
-  Returns: table. A parser. Describe its arguments with `positional`, `any_of`, `rest` and `flag`, then read them with `parse` or offer completions with `complete`.
+    Keys:
+    - <a id="argparse.new.spec.prog" name="argparse.new.spec.prog"></a>**`prog`** (string, optional). The command word.
+    - <a id="argparse.new.spec.description" name="argparse.new.spec.description"></a>**`description`** (string, optional). What the command does.
+
+  Returns: [trx.argparse.Parser](#argparse.Parser). A parser, with no arguments declared on it yet.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -29,6 +29,12 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
     - `trx.assault.Track.COURSE` = `1`  
         Lara's assault course.
 
+### Structures
+
+- <a id="assault.RecordNum" name="assault.RecordNum"></a>[lua]`trx.assault.RecordNum`
+
+    Where a time sits in the table of best times, fastest first. Counted from 1.
+
 ### Functions
 
 - <a id="assault.stats" name="assault.stats"></a>[lua]`trx.assault.stats`  
@@ -38,48 +44,48 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Starts the timer and clears its state. Raises outside a gym level.
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.start.track" name="assault.start.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
 - <a id="assault.stop" name="assault.stop"></a>[lua]`trx.assault.stop([track])`  
   Stops the timer, leaving it on screen. Raises outside a gym level.
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.stop.track" name="assault.stop.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
 - <a id="assault.finish" name="assault.finish"></a>[lua]`trx.assault.finish([track])`  
   Stops the timer as completing the track does, rather than as an abort. Raises outside a gym level.
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.finish.track" name="assault.finish.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
 - <a id="assault.reset" name="assault.reset"></a>[lua]`trx.assault.reset([track])`  
   Stops the timer and clears its state. Raises outside a gym level.
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.reset.track" name="assault.reset.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
 - <a id="assault.is_running" name="assault.is_running"></a>[lua]`trx.assault.is_running([track])`  
   Whether the timer is counting. False outside a gym level.
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.is_running.track" name="assault.is_running.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-  Returns: boolean.
+  Returns: boolean. True from the start of a run until it is finished or stopped.
 
 - <a id="assault.is_visible" name="assault.is_visible"></a>[lua]`trx.assault.is_visible([track])`  
   Whether the timer is shown on screen. It stays visible after [`trx.assault.stop`](#assault.stop).
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.is_visible.track" name="assault.is_visible.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-  Returns: boolean.
+  Returns: boolean. True while the timer is drawn, counting or not.
 
 - <a id="assault.stats.add_record" name="assault.stats.add_record"></a>[lua]`trx.assault.stats.add_record(time, [track])`  
   Files a new record, inserting it in time order and bumping the attempt count.
 
   Parameters:
-  - **`time`** (number). Time in seconds. Must be greater than zero.
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.stats.add_record.time" name="assault.stats.add_record.time"></a>**`time`** (number). Time in seconds. Must be greater than zero.
+  - <a id="assault.stats.add_record.track" name="assault.stats.add_record.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean. `false` if the table is full and the time is slower than every record in it.
 
@@ -92,8 +98,8 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Removes a record, closing the gap behind it.
 
   Parameters:
-  - **`record_num`** (integer). Position in the table. Counted from 1.
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.stats.remove_record.record_num" name="assault.stats.remove_record.record_num"></a>**`record_num`** ([trx.assault.RecordNum](#assault.RecordNum)).
+  - <a id="assault.stats.remove_record.track" name="assault.stats.remove_record.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean. `false` if there is no record at that position.
 
@@ -101,9 +107,13 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   The records, fastest first.
 
   Parameters:
-  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
+  - <a id="assault.stats.list_records.track" name="assault.stats.list_records.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-  Returns: table. List of `{ time = seconds, attempt_num = which attempt it was }`.
+  Returns: table. The records.
+
+    Each entry:
+    - <a id="assault.stats.list_records.time" name="assault.stats.list_records.time"></a>**`time`** (number). The time, in seconds.
+    - <a id="assault.stats.list_records.attempt_num" name="assault.stats.list_records.attempt_num"></a>**`attempt_num`** (integer). Which attempt it was. Counted from 1.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -16,11 +16,11 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
 ### Properties
 
-- **`trx.assault.active_track`** (integer). The track Lara is currently running, or `nil` if none. Compare against `trx.assault.Track`. *(read-only)*
+- <a name="assault.active_track"></a>**`trx.assault.active_track`** ([trx.assault.Track](#assault.Track)). The track Lara is currently running, or `nil` if none. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.assault.Track`
+- <a name="assault.Track"></a>[lua]`trx.assault.Track`
 
     A timed gym track.
 
@@ -31,55 +31,55 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
 ### Functions
 
-- [lua]`trx.assault.stats`  
+- <a name="assault.stats"></a>[lua]`trx.assault.stats`  
   A track's record table, as shown on the stats screen. Each track keeps its own. The records are stored in the player's profile, so writing to them outlives the level, and they can be read outside a gym level.
 
-- [lua]`trx.assault.start([track])`  
+- <a name="assault.start"></a>[lua]`trx.assault.start([track])`  
   Starts the timer and clears its state. Raises outside a gym level.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- [lua]`trx.assault.stop([track])`  
+- <a name="assault.stop"></a>[lua]`trx.assault.stop([track])`  
   Stops the timer, leaving it on screen. Raises outside a gym level.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- [lua]`trx.assault.finish([track])`  
+- <a name="assault.finish"></a>[lua]`trx.assault.finish([track])`  
   Stops the timer as completing the track does, rather than as an abort. Raises outside a gym level.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- [lua]`trx.assault.reset([track])`  
+- <a name="assault.reset"></a>[lua]`trx.assault.reset([track])`  
   Stops the timer and clears its state. Raises outside a gym level.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- [lua]`trx.assault.is_running([track])`  
+- <a name="assault.is_running"></a>[lua]`trx.assault.is_running([track])`  
   Whether the timer is counting. False outside a gym level.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean.
 
-- [lua]`trx.assault.is_visible([track])`  
+- <a name="assault.is_visible"></a>[lua]`trx.assault.is_visible([track])`  
   Whether the timer is shown on screen. It stays visible after `stop`.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean.
 
-- [lua]`trx.assault.stats.add_record(time, [track])`  
+- <a name="assault.stats.add_record"></a>[lua]`trx.assault.stats.add_record(time, [track])`  
   Files a new record, inserting it in time order and bumping the attempt count.
 
   Parameters:
   - **`time`** (number). Time in seconds. Must be greater than zero.
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean. `false` if the table is full and the time is slower than every record in it.
 
@@ -88,22 +88,22 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   trx.assault.stats.add_record(30.0)
   ```
 
-- [lua]`trx.assault.stats.remove_record(record_id, [track])`  
+- <a name="assault.stats.remove_record"></a>[lua]`trx.assault.stats.remove_record(record_num, [track])`  
   Removes a record, closing the gap behind it.
 
   Parameters:
-  - **`record_id`** (integer). 1-based position in the table.
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`record_num`** (integer). Position in the table. Counted from 1.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean. `false` if there is no record at that position.
 
-- [lua]`trx.assault.stats.list_records([track])`  
+- <a name="assault.stats.list_records"></a>[lua]`trx.assault.stats.list_records([track])`  
   The records, fastest first.
 
   Parameters:
-  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+  - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-  Returns: table. List, counted from one, of `{ time = seconds, attempt_num = which attempt it was }`.
+  Returns: table. List of `{ time = seconds, attempt_num = which attempt it was }`.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -10,17 +10,17 @@ order: 16
   src/lua/api/assault.lua. Edit it there.
 -->
 
-## Assault course module
+## <a id="assault" name="assault"></a>Assault course module
 
 Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
 ### Properties
 
-- <a name="assault.active_track"></a>**`trx.assault.active_track`** ([trx.assault.Track](#assault.Track)). The track Lara is currently running, or `nil` if none. *(read-only)*
+- <a id="assault.active_track" name="assault.active_track"></a>**`trx.assault.active_track`** ([trx.assault.Track](#assault.Track)). The track Lara is currently running, or `nil` if none. *(read-only)*
 
 ### Enums
 
-- <a name="assault.Track"></a>[lua]`trx.assault.Track`
+- <a id="assault.Track" name="assault.Track"></a>[lua]`trx.assault.Track`
 
     A timed gym track.
 
@@ -31,34 +31,34 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
 ### Functions
 
-- <a name="assault.stats"></a>[lua]`trx.assault.stats`  
+- <a id="assault.stats" name="assault.stats"></a>[lua]`trx.assault.stats`  
   A track's record table, as shown on the stats screen. Each track keeps its own. The records are stored in the player's profile, so writing to them outlives the level, and they can be read outside a gym level.
 
-- <a name="assault.start"></a>[lua]`trx.assault.start([track])`  
+- <a id="assault.start" name="assault.start"></a>[lua]`trx.assault.start([track])`  
   Starts the timer and clears its state. Raises outside a gym level.
 
   Parameters:
   - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- <a name="assault.stop"></a>[lua]`trx.assault.stop([track])`  
+- <a id="assault.stop" name="assault.stop"></a>[lua]`trx.assault.stop([track])`  
   Stops the timer, leaving it on screen. Raises outside a gym level.
 
   Parameters:
   - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- <a name="assault.finish"></a>[lua]`trx.assault.finish([track])`  
+- <a id="assault.finish" name="assault.finish"></a>[lua]`trx.assault.finish([track])`  
   Stops the timer as completing the track does, rather than as an abort. Raises outside a gym level.
 
   Parameters:
   - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- <a name="assault.reset"></a>[lua]`trx.assault.reset([track])`  
+- <a id="assault.reset" name="assault.reset"></a>[lua]`trx.assault.reset([track])`  
   Stops the timer and clears its state. Raises outside a gym level.
 
   Parameters:
   - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-- <a name="assault.is_running"></a>[lua]`trx.assault.is_running([track])`  
+- <a id="assault.is_running" name="assault.is_running"></a>[lua]`trx.assault.is_running([track])`  
   Whether the timer is counting. False outside a gym level.
 
   Parameters:
@@ -66,15 +66,15 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
   Returns: boolean.
 
-- <a name="assault.is_visible"></a>[lua]`trx.assault.is_visible([track])`  
-  Whether the timer is shown on screen. It stays visible after `stop`.
+- <a id="assault.is_visible" name="assault.is_visible"></a>[lua]`trx.assault.is_visible([track])`  
+  Whether the timer is shown on screen. It stays visible after [`trx.assault.stop`](#assault.stop).
 
   Parameters:
   - **`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean.
 
-- <a name="assault.stats.add_record"></a>[lua]`trx.assault.stats.add_record(time, [track])`  
+- <a id="assault.stats.add_record" name="assault.stats.add_record"></a>[lua]`trx.assault.stats.add_record(time, [track])`  
   Files a new record, inserting it in time order and bumping the attempt count.
 
   Parameters:
@@ -88,7 +88,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   trx.assault.stats.add_record(30.0)
   ```
 
-- <a name="assault.stats.remove_record"></a>[lua]`trx.assault.stats.remove_record(record_num, [track])`  
+- <a id="assault.stats.remove_record" name="assault.stats.remove_record"></a>[lua]`trx.assault.stats.remove_record(record_num, [track])`  
   Removes a record, closing the gap behind it.
 
   Parameters:
@@ -97,7 +97,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
   Returns: boolean. `false` if there is no record at that position.
 
-- <a name="assault.stats.list_records"></a>[lua]`trx.assault.stats.list_records([track])`  
+- <a id="assault.stats.list_records" name="assault.stats.list_records"></a>[lua]`trx.assault.stats.list_records([track])`  
   The records, fastest first.
 
   Parameters:

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -84,7 +84,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Files a new record, inserting it in time order and bumping the attempt count.
 
   Parameters:
-  - <a id="assault.stats.add_record.time" name="assault.stats.add_record.time"></a>**`time`** (number). Time in seconds. Must be greater than zero.
+  - <a id="assault.stats.add_record.time" name="assault.stats.add_record.time"></a>**`time`** ([trx.game.Seconds](GAME.md#game.Seconds)). Must be greater than zero.
   - <a id="assault.stats.add_record.track" name="assault.stats.add_record.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
   Returns: boolean. `false` if the table is full and the time is slower than every record in it.
@@ -112,7 +112,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Returns: table. The records.
 
     Each entry:
-    - <a id="assault.stats.list_records.time" name="assault.stats.list_records.time"></a>**`time`** (number). The time, in seconds.
+    - <a id="assault.stats.list_records.time" name="assault.stats.list_records.time"></a>**`time`** ([trx.game.Seconds](GAME.md#game.Seconds)). The time it took.
     - <a id="assault.stats.list_records.attempt_num" name="assault.stats.list_records.attempt_num"></a>**`attempt_num`** (integer). Which attempt it was. Counted from 1.
 
   Example:

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -10,28 +10,28 @@ order: 12
   src/lua/api/camera.lua. Edit it there.
 -->
 
-## Camera module
+## <a id="camera" name="camera"></a>Camera module
 
 Module for inspecting the active camera state.
 
 ### Properties
 
-- <a name="camera.pos"></a>**`trx.camera.pos`** (vec3). Current camera position. *(read-only)*
-- <a name="camera.room_num"></a>**`trx.camera.room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is in, or `nil` if unknown. *(read-only)*
-- <a name="camera.room"></a>**`trx.camera.room`** ([trx.rooms.Room](ROOMS.md#rooms.Room)). The room the camera is in, or `nil` if unknown. *(read-only)*
-- <a name="camera.target_pos"></a>**`trx.camera.target_pos`** (vec3). Position the camera is looking at. *(read-only)*
-- <a name="camera.target_room_num"></a>**`trx.camera.target_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is looking at, or `nil` if unknown. *(read-only)*
-- <a name="camera.is_flyby_active"></a>**`trx.camera.is_flyby_active`** (boolean). Whether a flyby camera sequence is playing. *(read-only)*
+- <a id="camera.pos" name="camera.pos"></a>**`trx.camera.pos`** (vec3). Current camera position. *(read-only)*
+- <a id="camera.room_num" name="camera.room_num"></a>**`trx.camera.room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is in, or `nil` if unknown. *(read-only)*
+- <a id="camera.room" name="camera.room"></a>**`trx.camera.room`** ([trx.rooms.Room](ROOMS.md#rooms.Room)). The room the camera is in, or `nil` if unknown. *(read-only)*
+- <a id="camera.target_pos" name="camera.target_pos"></a>**`trx.camera.target_pos`** (vec3). Position the camera is looking at. *(read-only)*
+- <a id="camera.target_room_num" name="camera.target_room_num"></a>**`trx.camera.target_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is looking at, or `nil` if unknown. *(read-only)*
+- <a id="camera.is_flyby_active" name="camera.is_flyby_active"></a>**`trx.camera.is_flyby_active`** (boolean). Whether a flyby camera sequence is playing. *(read-only)*
 
 ### Structures
 
-- <a name="camera.SequenceNum"></a>[lua]`trx.camera.SequenceNum`
+- <a id="camera.SequenceNum" name="camera.SequenceNum"></a>[lua]`trx.camera.SequenceNum`
 
     Flyby sequence number, as the level numbers them. Counted from 0.
 
 ### Functions
 
-- <a name="camera.shake"></a>[lua]`trx.camera.shake(intensity)`  
+- <a id="camera.shake" name="camera.shake"></a>[lua]`trx.camera.shake(intensity)`  
   Shakes the camera by setting its bounce value. Positive values shake it upward, negative values downward.
 
   Parameters:
@@ -42,10 +42,10 @@ Module for inspecting the active camera state.
   trx.camera.shake(200)
   ```
 
-- <a name="camera.reset"></a>[lua]`trx.camera.reset()`  
+- <a id="camera.reset" name="camera.reset"></a>[lua]`trx.camera.reset()`  
   Resets the camera to Lara's current position.
 
-- <a name="camera.play_flyby"></a>[lua]`trx.camera.play_flyby(sequence_num)`  
+- <a id="camera.play_flyby" name="camera.play_flyby"></a>[lua]`trx.camera.play_flyby(sequence_num)`  
   Starts a flyby camera sequence. Does nothing if another one is already playing.
 
   Parameters:
@@ -58,5 +58,5 @@ Module for inspecting the active camera state.
   trx.camera.play_flyby(1)
   ```
 
-- <a name="camera.cancel_flyby"></a>[lua]`trx.camera.cancel_flyby()`  
+- <a id="camera.cancel_flyby" name="camera.cancel_flyby"></a>[lua]`trx.camera.cancel_flyby()`  
   Cancels the flyby camera sequence, if one is playing.

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -16,16 +16,22 @@ Module for inspecting the active camera state.
 
 ### Properties
 
-- **`trx.camera.pos`** (vec3). Current camera position. *(read-only)*
-- **`trx.camera.room_num`** (integer). 0-based number of the room the camera is in, or `nil` if unknown. *(read-only)*
-- **`trx.camera.room`** (Room). The `trx.rooms.Room` the camera is in, or `nil` if unknown. *(read-only)*
-- **`trx.camera.target_pos`** (vec3). Position the camera is looking at. *(read-only)*
-- **`trx.camera.target_room_num`** (integer). 0-based number of the room the camera is looking at, or `nil` if unknown. *(read-only)*
-- **`trx.camera.is_flyby_active`** (boolean). Whether a flyby camera sequence is playing. *(read-only)*
+- <a name="camera.pos"></a>**`trx.camera.pos`** (vec3). Current camera position. *(read-only)*
+- <a name="camera.room_num"></a>**`trx.camera.room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is in, or `nil` if unknown. *(read-only)*
+- <a name="camera.room"></a>**`trx.camera.room`** ([trx.rooms.Room](ROOMS.md#rooms.Room)). The room the camera is in, or `nil` if unknown. *(read-only)*
+- <a name="camera.target_pos"></a>**`trx.camera.target_pos`** (vec3). Position the camera is looking at. *(read-only)*
+- <a name="camera.target_room_num"></a>**`trx.camera.target_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is looking at, or `nil` if unknown. *(read-only)*
+- <a name="camera.is_flyby_active"></a>**`trx.camera.is_flyby_active`** (boolean). Whether a flyby camera sequence is playing. *(read-only)*
+
+### Structures
+
+- <a name="camera.SequenceNum"></a>[lua]`trx.camera.SequenceNum`
+
+    Flyby sequence number, as the level numbers them. Counted from 0.
 
 ### Functions
 
-- [lua]`trx.camera.shake(intensity)`  
+- <a name="camera.shake"></a>[lua]`trx.camera.shake(intensity)`  
   Shakes the camera by setting its bounce value. Positive values shake it upward, negative values downward.
 
   Parameters:
@@ -36,14 +42,14 @@ Module for inspecting the active camera state.
   trx.camera.shake(200)
   ```
 
-- [lua]`trx.camera.reset()`  
+- <a name="camera.reset"></a>[lua]`trx.camera.reset()`  
   Resets the camera to Lara's current position.
 
-- [lua]`trx.camera.play_flyby(sequence_num)`  
+- <a name="camera.play_flyby"></a>[lua]`trx.camera.play_flyby(sequence_num)`  
   Starts a flyby camera sequence. Does nothing if another one is already playing.
 
   Parameters:
-  - **`sequence_num`** (integer). 0-based sequence number.
+  - **`sequence_num`** ([trx.camera.SequenceNum](#camera.SequenceNum)).
 
   Returns: boolean. Whether the sequence took the camera.
 
@@ -52,5 +58,5 @@ Module for inspecting the active camera state.
   trx.camera.play_flyby(1)
   ```
 
-- [lua]`trx.camera.cancel_flyby()`  
+- <a name="camera.cancel_flyby"></a>[lua]`trx.camera.cancel_flyby()`  
   Cancels the flyby camera sequence, if one is playing.

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -35,7 +35,7 @@ Module for inspecting the active camera state.
   Shakes the camera by setting its bounce value. Positive values shake it upward, negative values downward.
 
   Parameters:
-  - **`intensity`** (integer). Bounce value.
+  - <a id="camera.shake.intensity" name="camera.shake.intensity"></a>**`intensity`** (integer). Bounce value.
 
   Example:
   ```lua
@@ -49,7 +49,7 @@ Module for inspecting the active camera state.
   Starts a flyby camera sequence. Does nothing if another one is already playing.
 
   Parameters:
-  - **`sequence_num`** ([trx.camera.SequenceNum](#camera.SequenceNum)).
+  - <a id="camera.play_flyby.sequence_num" name="camera.play_flyby.sequence_num"></a>**`sequence_num`** ([trx.camera.SequenceNum](#camera.SequenceNum)).
 
   Returns: boolean. Whether the sequence took the camera.
 

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -10,17 +10,17 @@ order: 8
   src/lua/api/catalog.lua. Edit it there.
 -->
 
-## Catalog module
+## <a id="catalog" name="catalog"></a>Catalog module
 
 The names TRX knows things by.
 
 Each catalog is an enum of every object, sample, music track, Lara state, Lara animation or item action the engine has a name for. The names are the C ones with their prefix taken off - `O_WOLF` is [`trx.catalog.objects.WOLF`](#catalog.objects) - and a catalog answers to a name in any case, so [`trx.catalog.objects.wolf`](#catalog.objects) is the same constant.
 
-The ids in a catalog are TRX's own, and they are the same in all four games. The number a builder reads off Tomb Editor is not: that is the slot the game's own files use. `to_slot` and `from_slot` convert between the two.
+The ids in a catalog are TRX's own, and they are the same in all four games. The number a builder reads off Tomb Editor is not: that is the slot the game's own files use. [`trx.catalog.to_slot`](#catalog.to_slot) and [`trx.catalog.from_slot`](#catalog.from_slot) convert between the two.
 
 ### Enums
 
-- <a name="catalog.Context"></a>[lua]`trx.catalog.Context`
+- <a id="catalog.Context" name="catalog.Context"></a>[lua]`trx.catalog.Context`
 
     Which catalog a slot belongs to.
 
@@ -37,7 +37,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
     - `trx.catalog.Context.ITEM_ACTIONS` = `5`  
         Item actions, which the flip effects trigger.
 
-- <a name="catalog.objects"></a>[lua]`trx.catalog.objects` - 806 names
+- <a id="catalog.objects" name="catalog.objects"></a>[lua]`trx.catalog.objects` - 806 names
 
     Every object TRX has a name for.
 
@@ -255,7 +255,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- <a name="catalog.samples"></a>[lua]`trx.catalog.samples` - 203 names
+- <a id="catalog.samples" name="catalog.samples"></a>[lua]`trx.catalog.samples` - 203 names
 
     Every sound sample TRX has a name for.
 
@@ -319,7 +319,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- <a name="catalog.music"></a>[lua]`trx.catalog.music` - 52 names
+- <a id="catalog.music" name="catalog.music"></a>[lua]`trx.catalog.music` - 52 names
 
     Every music track TRX has a name for.
 
@@ -349,7 +349,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- <a name="catalog.lara_states"></a>[lua]`trx.catalog.lara_states` - 132 names
+- <a id="catalog.lara_states" name="catalog.lara_states"></a>[lua]`trx.catalog.lara_states` - 132 names
 
     Every state Lara can be in.
 
@@ -391,7 +391,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- <a name="catalog.lara_anims"></a>[lua]`trx.catalog.lara_anims` - 467 names
+- <a id="catalog.lara_anims" name="catalog.lara_anims"></a>[lua]`trx.catalog.lara_anims` - 467 names
 
     Every animation Lara has.
 
@@ -565,7 +565,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- <a name="catalog.flip_effects"></a>[lua]`trx.catalog.flip_effects` - 71 names
+- <a id="catalog.flip_effects" name="catalog.flip_effects"></a>[lua]`trx.catalog.flip_effects` - 71 names
 
     Every item action a flip effect can trigger.
 
@@ -597,7 +597,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- <a name="catalog.weapons"></a>[lua]`trx.catalog.weapons` - 16 names
+- <a id="catalog.weapons" name="catalog.weapons"></a>[lua]`trx.catalog.weapons` - 16 names
 
     Every weapon Lara can hold.
 
@@ -617,7 +617,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
 ### Functions
 
-- <a name="catalog.to_slot"></a>[lua]`trx.catalog.to_slot(context, id)`  
+- <a id="catalog.to_slot" name="catalog.to_slot"></a>[lua]`trx.catalog.to_slot(context, id)`  
   Converts a TRX id into the slot this game's own files use for it - the number a builder reads off Tomb Editor.
 
   Parameters:
@@ -631,7 +631,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
   local slot = trx.catalog.to_slot(trx.catalog.Context.OBJECTS, trx.catalog.objects.WOLF)
   ```
 
-- <a name="catalog.from_slot"></a>[lua]`trx.catalog.from_slot(context, slot)`  
+- <a id="catalog.from_slot" name="catalog.from_slot"></a>[lua]`trx.catalog.from_slot(context, slot)`  
   Converts a slot from this game's own files into the TRX id for it.
 
   Parameters:

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -14,13 +14,13 @@ order: 8
 
 The names TRX knows things by.
 
-Each catalog is an enum of every object, sample, music track, Lara state, Lara animation or item action the engine has a name for. The names are the C ones with their prefix taken off - `O_WOLF` is `trx.catalog.objects.WOLF` - and a catalog answers to a name in any case, so `trx.catalog.objects.wolf` is the same constant.
+Each catalog is an enum of every object, sample, music track, Lara state, Lara animation or item action the engine has a name for. The names are the C ones with their prefix taken off - `O_WOLF` is [`trx.catalog.objects.WOLF`](#catalog.objects) - and a catalog answers to a name in any case, so [`trx.catalog.objects.wolf`](#catalog.objects) is the same constant.
 
 The ids in a catalog are TRX's own, and they are the same in all four games. The number a builder reads off Tomb Editor is not: that is the slot the game's own files use. `to_slot` and `from_slot` convert between the two.
 
 ### Enums
 
-- [lua]`trx.catalog.Context`
+- <a name="catalog.Context"></a>[lua]`trx.catalog.Context`
 
     Which catalog a slot belongs to.
 
@@ -37,7 +37,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
     - `trx.catalog.Context.ITEM_ACTIONS` = `5`  
         Item actions, which the flip effects trigger.
 
-- [lua]`trx.catalog.objects` - 806 names
+- <a name="catalog.objects"></a>[lua]`trx.catalog.objects` - 806 names
 
     Every object TRX has a name for.
 
@@ -255,7 +255,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- [lua]`trx.catalog.samples` - 203 names
+- <a name="catalog.samples"></a>[lua]`trx.catalog.samples` - 203 names
 
     Every sound sample TRX has a name for.
 
@@ -319,7 +319,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- [lua]`trx.catalog.music` - 52 names
+- <a name="catalog.music"></a>[lua]`trx.catalog.music` - 52 names
 
     Every music track TRX has a name for.
 
@@ -349,7 +349,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- [lua]`trx.catalog.lara_states` - 132 names
+- <a name="catalog.lara_states"></a>[lua]`trx.catalog.lara_states` - 132 names
 
     Every state Lara can be in.
 
@@ -391,7 +391,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- [lua]`trx.catalog.lara_anims` - 467 names
+- <a name="catalog.lara_anims"></a>[lua]`trx.catalog.lara_anims` - 467 names
 
     Every animation Lara has.
 
@@ -565,7 +565,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- [lua]`trx.catalog.flip_effects` - 71 names
+- <a name="catalog.flip_effects"></a>[lua]`trx.catalog.flip_effects` - 71 names
 
     Every item action a flip effect can trigger.
 
@@ -597,7 +597,7 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
-- [lua]`trx.catalog.weapons` - 16 names
+- <a name="catalog.weapons"></a>[lua]`trx.catalog.weapons` - 16 names
 
     Every weapon Lara can hold.
 
@@ -617,11 +617,11 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
 ### Functions
 
-- [lua]`trx.catalog.to_slot(context, id)`  
+- <a name="catalog.to_slot"></a>[lua]`trx.catalog.to_slot(context, id)`  
   Converts a TRX id into the slot this game's own files use for it - the number a builder reads off Tomb Editor.
 
   Parameters:
-  - **`context`** (integer). Which catalog. Compare against `trx.catalog.Context`.
+  - **`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
   - **`id`** (integer). The TRX id.
 
   Returns: integer or `nil`. `nil` if this game has no slot for it - not every game has every object.
@@ -631,11 +631,11 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
   local slot = trx.catalog.to_slot(trx.catalog.Context.OBJECTS, trx.catalog.objects.WOLF)
   ```
 
-- [lua]`trx.catalog.from_slot(context, slot)`  
+- <a name="catalog.from_slot"></a>[lua]`trx.catalog.from_slot(context, slot)`  
   Converts a slot from this game's own files into the TRX id for it.
 
   Parameters:
-  - **`context`** (integer). Which catalog. Compare against `trx.catalog.Context`.
+  - **`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
   - **`slot`** (integer). The game's own id.
 
   Returns: integer or `nil`. `nil` if this game has nothing in that slot.

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -615,16 +615,26 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
     </details>
 
+### Structures
+
+- <a id="catalog.Id" name="catalog.Id"></a>[lua]`trx.catalog.Id`
+
+    A TRX id, in the catalog the context names. It is the same number in every game TRX ships, which is what lets a script name a thing once.
+
+- <a id="catalog.Slot" name="catalog.Slot"></a>[lua]`trx.catalog.Slot`
+
+    A slot in this game's own files, which is the number a builder reads off Tomb Editor. It differs from game to game.
+
 ### Functions
 
 - <a id="catalog.to_slot" name="catalog.to_slot"></a>[lua]`trx.catalog.to_slot(context, id)`  
-  Converts a TRX id into the slot this game's own files use for it - the number a builder reads off Tomb Editor.
+  Converts a [`trx.catalog.Id`](#catalog.Id) into the [`trx.catalog.Slot`](#catalog.Slot) this game's own files use for it.
 
   Parameters:
-  - **`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
-  - **`id`** (integer). The TRX id.
+  - <a id="catalog.to_slot.context" name="catalog.to_slot.context"></a>**`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
+  - <a id="catalog.to_slot.id" name="catalog.to_slot.id"></a>**`id`** ([trx.catalog.Id](#catalog.Id)).
 
-  Returns: integer or `nil`. `nil` if this game has no slot for it - not every game has every object.
+  Returns: [trx.catalog.Slot](#catalog.Slot) or `nil`. `nil` if this game has no slot for it - not every game has every object.
 
   Example:
   ```lua
@@ -632,13 +642,13 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
   ```
 
 - <a id="catalog.from_slot" name="catalog.from_slot"></a>[lua]`trx.catalog.from_slot(context, slot)`  
-  Converts a slot from this game's own files into the TRX id for it.
+  Converts a [`trx.catalog.Slot`](#catalog.Slot) from this game's own files into the [`trx.catalog.Id`](#catalog.Id) for it.
 
   Parameters:
-  - **`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
-  - **`slot`** (integer). The game's own id.
+  - <a id="catalog.from_slot.context" name="catalog.from_slot.context"></a>**`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
+  - <a id="catalog.from_slot.slot" name="catalog.from_slot.slot"></a>**`slot`** ([trx.catalog.Slot](#catalog.Slot)).
 
-  Returns: integer or `nil`. `nil` if this game has nothing in that slot.
+  Returns: [trx.catalog.Id](#catalog.Id) or `nil`. `nil` if this game has nothing in that slot.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -10,15 +10,15 @@ order: 22
   src/lua/api/config.lua. Edit it there.
 -->
 
-## Config module
+## <a id="config" name="config"></a>Config module
 
 Module for reading and changing engine settings.
 
-These are the player's settings, not the level's. `set` writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants `override` instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.
+These are the player's settings, not the level's. [`trx.config.set`](#config.set) writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants [`trx.config.override`](#config.override) instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.
 
 ### Functions
 
-- <a name="config.get"></a>[lua]`trx.config.get(key)`  
+- <a id="config.get" name="config.get"></a>[lua]`trx.config.get(key)`  
   Reads a setting. The value comes back as the type the option is declared with, so a boolean option reads as a boolean. Colors and enums read as strings.
 
   Parameters:
@@ -33,8 +33,8 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   end
   ```
 
-- <a name="config.describe"></a>[lua]`trx.config.describe(key)`  
-  What shape a setting has: how a value is entered and shown, beyond the type `get` reads back.
+- <a id="config.describe" name="config.describe"></a>[lua]`trx.config.describe(key)`  
+  What shape a setting has: how a value is entered and shown, beyond the type [`trx.config.get`](#config.get) reads back.
 
   Parameters:
   - **`key`** (string). Dotted path.
@@ -48,7 +48,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   end
   ```
 
-- <a name="config.format_value"></a>[lua]`trx.config.format_value(key)`  
+- <a id="config.format_value" name="config.format_value"></a>[lua]`trx.config.format_value(key)`  
   The current value as the console prints it: `1` or `0` for a boolean, two decimals for a plain number, a 0-100 percentage where the option is one, and enum values with dashes for underscores.
 
   Parameters:
@@ -61,7 +61,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   trx.console.log(trx.config.format_value("visuals.fov"))
   ```
 
-- <a name="config.accepted_values"></a>[lua]`trx.config.accepted_values(key)`  
+- <a id="config.accepted_values" name="config.accepted_values"></a>[lua]`trx.config.accepted_values(key)`  
   What a setting accepts, as text for an error message: `on, off` for a boolean, a marker like `[integer]` for the number kinds, or the value names for the enum kinds, with dashes for underscores.
 
   Parameters:
@@ -69,33 +69,33 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: string or `nil`. `nil` for the kinds with nothing to list, such as a color.
 
-- <a name="config.set"></a>[lua]`trx.config.set(key, value, [force])`  
+- <a id="config.set" name="config.set"></a>[lua]`trx.config.set(key, value, [force])`  
   Changes the player's setting, and keeps the change. Raises if the key is unknown or the value will not parse.
 
-  The old value is not kept anywhere: the new one becomes the active setting as if the player had chosen it, and is remembered across saves and relaunches. Prefer `override` for anything a level wants only while it is running.
+  The old value is not kept anywhere: the new one becomes the active setting as if the player had chosen it, and is remembered across saves and relaunches. Prefer [`trx.config.override`](#config.override) for anything a level wants only while it is running.
 
   Parameters:
   - **`key`** (string). Dotted path.
   - **`value`** (any). A boolean, a number, or a string, matching the option's type. A color is a 6-digit hex string. An enum value is taken in either spelling: underscores or the dashes the console shows.
   - **`force`** (boolean, optional). Write through a setting the game flow enforces.
 
-- <a name="config.reset"></a>[lua]`trx.config.reset(key, [force])`  
-  Puts a setting back to its default, and keeps the change, as `set` does.
+- <a id="config.reset" name="config.reset"></a>[lua]`trx.config.reset(key, [force])`  
+  Puts a setting back to its default, and keeps the change, as [`trx.config.set`](#config.set) does.
 
   Parameters:
   - **`key`** (string). Dotted path.
-  - **`force`** (boolean, optional). As for `set`.
+  - **`force`** (boolean, optional). As for [`trx.config.set`](#config.set).
 
-  Returns: boolean. `false` when a script or the game flow is holding the setting (see `is_overridden`).
+  Returns: boolean. `false` when a script or the game flow is holding the setting (see [`trx.config.is_overridden`](#config.is_overridden)).
 
-- <a name="config.override"></a>[lua]`trx.config.override(key, value)`  
+- <a id="config.override" name="config.override"></a>[lua]`trx.config.override(key, value)`  
   Changes a setting for as long as the script keeps the override, without touching the player's own value.
 
-  The player's value sits underneath and comes back on `restore`. Nothing is written to disk. Overrides stack, so one can be pushed over another; each `restore` lifts one off. A setting the game flow enforces cannot be overridden.
+  The player's value sits underneath and comes back on [`trx.config.restore`](#config.restore). Nothing is written to disk. Overrides stack, so one can be pushed over another; each [`trx.config.restore`](#config.restore) lifts one off. A setting the game flow enforces cannot be overridden.
 
   Parameters:
   - **`key`** (string). Dotted path.
-  - **`value`** (any). As for `set`.
+  - **`value`** (any). As for [`trx.config.set`](#config.set).
 
   Example:
   ```lua
@@ -104,7 +104,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   trx.config.restore("visuals.water_color")
   ```
 
-- <a name="config.restore"></a>[lua]`trx.config.restore(key)`  
+- <a id="config.restore" name="config.restore"></a>[lua]`trx.config.restore(key)`  
   Lifts one override off a setting, putting back whatever was underneath it.
 
   Parameters:
@@ -112,7 +112,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: boolean. `false` if the setting was not overridden.
 
-- <a name="config.is_overridden"></a>[lua]`trx.config.is_overridden(key)`  
+- <a id="config.is_overridden" name="config.is_overridden"></a>[lua]`trx.config.is_overridden(key)`  
   Whether a script or the game flow is currently holding this setting away from the player's own value.
 
   Parameters:
@@ -120,7 +120,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: boolean.
 
-- <a name="config.list"></a>[lua]`trx.config.list()`  
+- <a id="config.list" name="config.list"></a>[lua]`trx.config.list()`  
   Every setting and its current value.
 
   Returns: table. Maps each option's key to its value.

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -22,7 +22,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   Reads a setting. The value comes back as the type the option is declared with, so a boolean option reads as a boolean. Colors and enums read as strings.
 
   Parameters:
-  - **`key`** (string). Dotted path, e.g. `visuals.water_color`.
+  - <a id="config.get.key" name="config.get.key"></a>**`key`** (string). Dotted path, e.g. `visuals.water_color`.
 
   Returns: any. Raises if no option has that key.
 
@@ -37,9 +37,14 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   What shape a setting has: how a value is entered and shown, beyond the type [`trx.config.get`](#config.get) reads back.
 
   Parameters:
-  - **`key`** (string). Dotted path.
+  - <a id="config.describe.key" name="config.describe.key"></a>**`key`** (string). Dotted path.
 
-  Returns: table. `kind` is one of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. `percent` marks a number stored 0-1 but entered and shown as a 0-100 percentage. For the enum kinds, `values` lists what the setting accepts.
+  Returns: table. What the setting is and how it is entered.
+
+    Keys:
+    - <a id="config.describe.kind" name="config.describe.kind"></a>**`kind`** (string). One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.
+    - <a id="config.describe.percent" name="config.describe.percent"></a>**`percent`** (boolean). Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
+    - <a id="config.describe.values" name="config.describe.values"></a>**`values`** (table). What the setting accepts, for the enum kinds. `nil` for the rest.
 
   Example:
   ```lua
@@ -52,9 +57,9 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   The current value as the console prints it: `1` or `0` for a boolean, two decimals for a plain number, a 0-100 percentage where the option is one, and enum values with dashes for underscores.
 
   Parameters:
-  - **`key`** (string). Dotted path.
+  - <a id="config.format_value.key" name="config.format_value.key"></a>**`key`** (string). Dotted path.
 
-  Returns: string.
+  Returns: string. The text, ready to print.
 
   Example:
   ```lua
@@ -65,7 +70,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   What a setting accepts, as text for an error message: `on, off` for a boolean, a marker like `[integer]` for the number kinds, or the value names for the enum kinds, with dashes for underscores.
 
   Parameters:
-  - **`key`** (string). Dotted path.
+  - <a id="config.accepted_values.key" name="config.accepted_values.key"></a>**`key`** (string). Dotted path.
 
   Returns: string or `nil`. `nil` for the kinds with nothing to list, such as a color.
 
@@ -75,16 +80,16 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   The old value is not kept anywhere: the new one becomes the active setting as if the player had chosen it, and is remembered across saves and relaunches. Prefer [`trx.config.override`](#config.override) for anything a level wants only while it is running.
 
   Parameters:
-  - **`key`** (string). Dotted path.
-  - **`value`** (any). A boolean, a number, or a string, matching the option's type. A color is a 6-digit hex string. An enum value is taken in either spelling: underscores or the dashes the console shows.
-  - **`force`** (boolean, optional). Write through a setting the game flow enforces.
+  - <a id="config.set.key" name="config.set.key"></a>**`key`** (string). Dotted path.
+  - <a id="config.set.value" name="config.set.value"></a>**`value`** (any). A boolean, a number, or a string, matching the option's type. A color is a 6-digit hex string. An enum value is taken in either spelling: underscores or the dashes the console shows.
+  - <a id="config.set.force" name="config.set.force"></a>**`force`** (boolean, optional). Write through a setting the game flow enforces.
 
 - <a id="config.reset" name="config.reset"></a>[lua]`trx.config.reset(key, [force])`  
   Puts a setting back to its default, and keeps the change, as [`trx.config.set`](#config.set) does.
 
   Parameters:
-  - **`key`** (string). Dotted path.
-  - **`force`** (boolean, optional). As for [`trx.config.set`](#config.set).
+  - <a id="config.reset.key" name="config.reset.key"></a>**`key`** (string). Dotted path.
+  - <a id="config.reset.force" name="config.reset.force"></a>**`force`** (boolean, optional). As for [`trx.config.set`](#config.set).
 
   Returns: boolean. `false` when a script or the game flow is holding the setting (see [`trx.config.is_overridden`](#config.is_overridden)).
 
@@ -94,8 +99,8 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   The player's value sits underneath and comes back on [`trx.config.restore`](#config.restore). Nothing is written to disk. Overrides stack, so one can be pushed over another; each [`trx.config.restore`](#config.restore) lifts one off. A setting the game flow enforces cannot be overridden.
 
   Parameters:
-  - **`key`** (string). Dotted path.
-  - **`value`** (any). As for [`trx.config.set`](#config.set).
+  - <a id="config.override.key" name="config.override.key"></a>**`key`** (string). Dotted path.
+  - <a id="config.override.value" name="config.override.value"></a>**`value`** (any). As for [`trx.config.set`](#config.set).
 
   Example:
   ```lua
@@ -108,7 +113,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   Lifts one override off a setting, putting back whatever was underneath it.
 
   Parameters:
-  - **`key`** (string). Dotted path.
+  - <a id="config.restore.key" name="config.restore.key"></a>**`key`** (string). Dotted path.
 
   Returns: boolean. `false` if the setting was not overridden.
 
@@ -116,9 +121,9 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   Whether a script or the game flow is currently holding this setting away from the player's own value.
 
   Parameters:
-  - **`key`** (string). Dotted path.
+  - <a id="config.is_overridden.key" name="config.is_overridden.key"></a>**`key`** (string). Dotted path.
 
-  Returns: boolean.
+  Returns: boolean. True while an override stands, and false once the last is lifted.
 
 - <a id="config.list" name="config.list"></a>[lua]`trx.config.list()`  
   Every setting and its current value.

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -18,7 +18,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
 ### Functions
 
-- [lua]`trx.config.get(key)`  
+- <a name="config.get"></a>[lua]`trx.config.get(key)`  
   Reads a setting. The value comes back as the type the option is declared with, so a boolean option reads as a boolean. Colors and enums read as strings.
 
   Parameters:
@@ -33,7 +33,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   end
   ```
 
-- [lua]`trx.config.describe(key)`  
+- <a name="config.describe"></a>[lua]`trx.config.describe(key)`  
   What shape a setting has: how a value is entered and shown, beyond the type `get` reads back.
 
   Parameters:
@@ -48,7 +48,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   end
   ```
 
-- [lua]`trx.config.format_value(key)`  
+- <a name="config.format_value"></a>[lua]`trx.config.format_value(key)`  
   The current value as the console prints it: `1` or `0` for a boolean, two decimals for a plain number, a 0-100 percentage where the option is one, and enum values with dashes for underscores.
 
   Parameters:
@@ -61,7 +61,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   trx.console.log(trx.config.format_value("visuals.fov"))
   ```
 
-- [lua]`trx.config.accepted_values(key)`  
+- <a name="config.accepted_values"></a>[lua]`trx.config.accepted_values(key)`  
   What a setting accepts, as text for an error message: `on, off` for a boolean, a marker like `[integer]` for the number kinds, or the value names for the enum kinds, with dashes for underscores.
 
   Parameters:
@@ -69,7 +69,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: string or `nil`. `nil` for the kinds with nothing to list, such as a color.
 
-- [lua]`trx.config.set(key, value, [force])`  
+- <a name="config.set"></a>[lua]`trx.config.set(key, value, [force])`  
   Changes the player's setting, and keeps the change. Raises if the key is unknown or the value will not parse.
 
   The old value is not kept anywhere: the new one becomes the active setting as if the player had chosen it, and is remembered across saves and relaunches. Prefer `override` for anything a level wants only while it is running.
@@ -79,7 +79,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   - **`value`** (any). A boolean, a number, or a string, matching the option's type. A color is a 6-digit hex string. An enum value is taken in either spelling: underscores or the dashes the console shows.
   - **`force`** (boolean, optional). Write through a setting the game flow enforces.
 
-- [lua]`trx.config.reset(key, [force])`  
+- <a name="config.reset"></a>[lua]`trx.config.reset(key, [force])`  
   Puts a setting back to its default, and keeps the change, as `set` does.
 
   Parameters:
@@ -88,7 +88,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: boolean. `false` when a script or the game flow is holding the setting (see `is_overridden`).
 
-- [lua]`trx.config.override(key, value)`  
+- <a name="config.override"></a>[lua]`trx.config.override(key, value)`  
   Changes a setting for as long as the script keeps the override, without touching the player's own value.
 
   The player's value sits underneath and comes back on `restore`. Nothing is written to disk. Overrides stack, so one can be pushed over another; each `restore` lifts one off. A setting the game flow enforces cannot be overridden.
@@ -104,7 +104,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
   trx.config.restore("visuals.water_color")
   ```
 
-- [lua]`trx.config.restore(key)`  
+- <a name="config.restore"></a>[lua]`trx.config.restore(key)`  
   Lifts one override off a setting, putting back whatever was underneath it.
 
   Parameters:
@@ -112,7 +112,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: boolean. `false` if the setting was not overridden.
 
-- [lua]`trx.config.is_overridden(key)`  
+- <a name="config.is_overridden"></a>[lua]`trx.config.is_overridden(key)`  
   Whether a script or the game flow is currently holding this setting away from the player's own value.
 
   Parameters:
@@ -120,7 +120,7 @@ These are the player's settings, not the level's. `set` writes to them and keeps
 
   Returns: boolean.
 
-- [lua]`trx.config.list()`  
+- <a name="config.list"></a>[lua]`trx.config.list()`  
   Every setting and its current value.
 
   Returns: table. Maps each option's key to its value.

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -14,11 +14,11 @@ order: 20
 
 Module for interacting with the developer console.
 
-`trx.console.log` writes to the console overlay in-game, where `trx.log` writes only to the terminal and the log file.
+[`trx.console.log`](#console.log) writes to the console overlay in-game, where [`trx.log`](LOG.md#log) writes only to the terminal and the log file.
 
 ### Enums
 
-- [lua]`trx.console.Result`
+- <a name="console.Result"></a>[lua]`trx.console.Result`
 
     How a console command went. What a command's `run` gives back.
 
@@ -33,7 +33,7 @@ Module for interacting with the developer console.
 
 ### Functions
 
-- [lua]`trx.console.log(message)`  
+- <a name="console.log"></a>[lua]`trx.console.log(message)`  
   Logs a line to the developer console. Calling the group itself logs at `INFO`. Takes any value: a table is pretty-printed, anything else coerced to a string.
 
   Parameters:
@@ -44,44 +44,44 @@ Module for interacting with the developer console.
   trx.console.log({ hp = 1000, pos = { x = 1 } })
   ```
 
-- [lua]`trx.console.log.generic(level, message)`  
+- <a name="console.log.generic"></a>[lua]`trx.console.log.generic(level, message)`  
   Logs at a level chosen at runtime.
 
   Parameters:
-  - **`level`** (integer). Compare against `trx.log.LogLevel`.
+  - **`level`** ([trx.log.LogLevel](LOG.md#log.LogLevel)).
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- [lua]`trx.console.log.info(message)`  
+- <a name="console.log.info"></a>[lua]`trx.console.log.info(message)`  
   Logs an informational message.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- [lua]`trx.console.log.warn(message)`  
+- <a name="console.log.warn"></a>[lua]`trx.console.log.warn(message)`  
   Logs a warning.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- [lua]`trx.console.log.warning(message)`  
-  Logs a warning. An alias of `trx.console.log.warn`.
+- <a name="console.log.warning"></a>[lua]`trx.console.log.warning(message)`  
+  Logs a warning. An alias of [`trx.console.log.warn`](#console.log.warn).
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- [lua]`trx.console.log.error(message)`  
+- <a name="console.log.error"></a>[lua]`trx.console.log.error(message)`  
   Logs an error.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- [lua]`trx.console.log.debug(message)`  
+- <a name="console.log.debug"></a>[lua]`trx.console.log.debug(message)`  
   Logs a debug message.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- [lua]`trx.console.eval(command, [opts])`  
+- <a name="console.eval"></a>[lua]`trx.console.eval(command, [opts])`  
   Runs a string as a developer console command. Raises if the command fails.
 
   Output is silenced by default and appears only in the terminal and the log file. Pass `{ verbose = true }` to show it in the console as a command typed by the player would.
@@ -95,12 +95,12 @@ Module for interacting with the developer console.
   trx.console.eval("play 1", { verbose = true })
   ```
 
-- [lua]`trx.console.register(spec)`  
+- <a name="console.register"></a>[lua]`trx.console.register(spec)`  
   Registers a console command written in Lua.
 
-  Every command has a `trx.argparse` parser. `args` is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits `args` takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.
+  Every command has a [`trx.argparse`](ARGPARSE.md#argparse) parser. `args` is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits `args` takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.
 
-  `run` receives the parsed values, a table keyed by argument name. What it gives back is a `trx.console.Result`, and returning nothing means `OK`. It may return a message after that, which is logged to the console - as an error, for any result but `OK`. A line the parser rejects is reported with what it expected, without reaching `run`.
+  `run` receives the parsed values, a table keyed by argument name. What it gives back is a [`trx.console.Result`](#console.Result), and returning nothing means `OK`. It may return a message after that, which is logged to the console - as an error, for any result but `OK`. A line the parser rejects is reported with what it expected, without reaching `run`.
 
   A command lives for the whole run, so it can only be registered from a global script. A level script raises if it calls this: it runs again every time its level is loaded.
 
@@ -121,16 +121,16 @@ Module for interacting with the developer console.
   })
   ```
 
-- [lua]`trx.console.clear()`  
+- <a name="console.clear"></a>[lua]`trx.console.clear()`  
   Clears the console.
 
-- [lua]`trx.console.commands()`  
+- <a name="console.commands"></a>[lua]`trx.console.commands()`  
   Every registered console command, in registration order. Each is `{ name, aliases, help }`: `name` is the word the player types, `aliases` the other words that reach it (a list, or absent), and `help` the text the console shows for `name --help` (absent when the command carries none). The help command is built on this.
 
   Returns: table. A list of `{ name, aliases, help }`.
 
-- [lua]`trx.console.command(name)`  
-  The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches. The same `{ name, aliases, help }` as an entry of `trx.console.commands`, or nil when nothing answers to the name.
+- <a name="console.command"></a>[lua]`trx.console.command(name)`  
+  The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches. The same `{ name, aliases, help }` as an entry of [`trx.console.commands`](#console.commands), or nil when nothing answers to the name.
 
   Parameters:
   - **`name`** (string). The word or alias to look up.

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -20,7 +20,7 @@ Module for interacting with the developer console.
 
 - <a id="console.Result" name="console.Result"></a>[lua]`trx.console.Result`
 
-    How a console command went. What a command's `run` gives back.
+    How a console command went. What a command's [`trx.console.register.spec.run`](#console.register.spec.run) gives back.
 
     - `trx.console.Result.OK` = `0`  
         It worked.
@@ -37,7 +37,7 @@ Module for interacting with the developer console.
   Logs a line to the developer console. Calling the group itself logs at `INFO`. Takes any value: a table is pretty-printed, anything else coerced to a string.
 
   Parameters:
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.message" name="console.log.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
   Example:
   ```lua
@@ -48,38 +48,38 @@ Module for interacting with the developer console.
   Logs at a level chosen at runtime.
 
   Parameters:
-  - **`level`** ([trx.log.LogLevel](LOG.md#log.LogLevel)).
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.generic.level" name="console.log.generic.level"></a>**`level`** ([trx.log.LogLevel](LOG.md#log.LogLevel)).
+  - <a id="console.log.generic.message" name="console.log.generic.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
 - <a id="console.log.info" name="console.log.info"></a>[lua]`trx.console.log.info(message)`  
   Logs an informational message.
 
   Parameters:
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.info.message" name="console.log.info.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
 - <a id="console.log.warn" name="console.log.warn"></a>[lua]`trx.console.log.warn(message)`  
   Logs a warning.
 
   Parameters:
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.warn.message" name="console.log.warn.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
 - <a id="console.log.warning" name="console.log.warning"></a>[lua]`trx.console.log.warning(message)`  
   Logs a warning. An alias of [`warn`](#console.log.warn).
 
   Parameters:
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.warning.message" name="console.log.warning.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
 - <a id="console.log.error" name="console.log.error"></a>[lua]`trx.console.log.error(message)`  
   Logs an error.
 
   Parameters:
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.error.message" name="console.log.error.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
 - <a id="console.log.debug" name="console.log.debug"></a>[lua]`trx.console.log.debug(message)`  
   Logs a debug message.
 
   Parameters:
-  - **`message`** (any). Any value; a table is pretty-printed.
+  - <a id="console.log.debug.message" name="console.log.debug.message"></a>**`message`** (any). Any value; a table is pretty-printed.
 
 - <a id="console.eval" name="console.eval"></a>[lua]`trx.console.eval(command, [opts])`  
   Runs a string as a developer console command. Raises if the command fails.
@@ -87,8 +87,11 @@ Module for interacting with the developer console.
   Output is silenced by default and appears only in the terminal and the log file. Pass `{ verbose = true }` to show it in the console as a command typed by the player would.
 
   Parameters:
-  - **`command`** (string). Command to run, as the player would type it.
-  - **`opts`** (table, optional). `verbose`: show the command's output.
+  - <a id="console.eval.command" name="console.eval.command"></a>**`command`** (string). Command to run, as the player would type it.
+  - <a id="console.eval.opts" name="console.eval.opts"></a>**`opts`** (table, optional). How to run it.
+
+    Keys:
+    - <a id="console.eval.opts.verbose" name="console.eval.opts.verbose"></a>**`verbose`** (boolean, optional). Show the command's output.
 
   Example:
   ```lua
@@ -98,14 +101,21 @@ Module for interacting with the developer console.
 - <a id="console.register" name="console.register"></a>[lua]`trx.console.register(spec)`  
   Registers a console command written in Lua.
 
-  Every command has a [`trx.argparse`](ARGPARSE.md#argparse) parser. `args` is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits `args` takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.
+  Every command has a [`trx.argparse`](ARGPARSE.md#argparse) parser. [`spec.args`](#console.register.spec.args) is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits [`spec.args`](#console.register.spec.args) takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.
 
-  `run` receives the parsed values, a table keyed by argument name. What it gives back is a [`trx.console.Result`](#console.Result), and returning nothing means `OK`. It may return a message after that, which is logged to the console - as an error, for any result but `OK`. A line the parser rejects is reported with what it expected, without reaching `run`.
+  [`spec.run`](#console.register.spec.run) receives the parsed values, a table keyed by argument name. What it gives back is a [`trx.console.Result`](#console.Result), and returning nothing means `OK`. It may return a message after that, which is logged to the console - as an error, for any result but `OK`. A line the parser rejects is reported with what it expected, without reaching [`spec.run`](#console.register.spec.run).
 
   A command lives for the whole run, so it can only be registered from a global script. A level script raises if it calls this: it runs again every time its level is loaded.
 
   Parameters:
-  - **`spec`** (table). `name`: the word the player types. `help`: a game string key for the help text, optional. `args`: a function that shapes the parser, optional. `run`: the function, called with the parsed arguments. `aliases`: other words that reach the same command, optional; they dispatch but stay out of the command listing, and the help for `name` shows them.
+  - <a id="console.register.spec" name="console.register.spec"></a>**`spec`** (table). The command.
+
+    Keys:
+    - <a id="console.register.spec.name" name="console.register.spec.name"></a>**`name`** (string). The word the player types.
+    - <a id="console.register.spec.help" name="console.register.spec.help"></a>**`help`** (string, optional). A game string key for the help text.
+    - <a id="console.register.spec.args" name="console.register.spec.args"></a>**`args`** (function, optional). Shapes the parser.
+    - <a id="console.register.spec.run" name="console.register.spec.run"></a>**`run`** (function). Called with the parsed arguments.
+    - <a id="console.register.spec.aliases" name="console.register.spec.aliases"></a>**`aliases`** (table, optional). Other words that reach the same command. They dispatch but stay out of the command listing, and the help for the command shows them.
 
   Example:
   ```lua
@@ -125,14 +135,19 @@ Module for interacting with the developer console.
   Clears the console.
 
 - <a id="console.commands" name="console.commands"></a>[lua]`trx.console.commands()`  
-  Every registered console command, in registration order. Each is `{ name, aliases, help }`: `name` is the word the player types, `aliases` the other words that reach it (a list, or absent), and `help` the text the console shows for `name --help` (absent when the command carries none). The help command is built on this.
+  Every registered console command, in registration order. The help command is built on this.
 
-  Returns: table. A list of `{ name, aliases, help }`.
+  Returns: table. The commands.
+
+    Each entry:
+    - <a id="console.commands.name" name="console.commands.name"></a>**`name`** (string). The word the player types.
+    - <a id="console.commands.aliases" name="console.commands.aliases"></a>**`aliases`** (table). The other words that reach it, or `nil` where it answers to one.
+    - <a id="console.commands.help" name="console.commands.help"></a>**`help`** (string). What the console shows for `--help`, or `nil` where the command carries none.
 
 - <a id="console.command" name="console.command"></a>[lua]`trx.console.command(name)`  
   The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches. The same `{ name, aliases, help }` as an entry of [`trx.console.commands`](#console.commands), or nil when nothing answers to the name.
 
   Parameters:
-  - **`name`** (string). The word or alias to look up.
+  - <a id="console.command.name" name="console.command.name"></a>**`name`** (string). The word or alias to look up.
 
   Returns: table. `{ name, aliases, help }`, or nil.

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -10,7 +10,7 @@ order: 20
   src/lua/api/console.lua. Edit it there.
 -->
 
-## Console module
+## <a id="console" name="console"></a>Console module
 
 Module for interacting with the developer console.
 
@@ -18,7 +18,7 @@ Module for interacting with the developer console.
 
 ### Enums
 
-- <a name="console.Result"></a>[lua]`trx.console.Result`
+- <a id="console.Result" name="console.Result"></a>[lua]`trx.console.Result`
 
     How a console command went. What a command's `run` gives back.
 
@@ -33,7 +33,7 @@ Module for interacting with the developer console.
 
 ### Functions
 
-- <a name="console.log"></a>[lua]`trx.console.log(message)`  
+- <a id="console.log" name="console.log"></a>[lua]`trx.console.log(message)`  
   Logs a line to the developer console. Calling the group itself logs at `INFO`. Takes any value: a table is pretty-printed, anything else coerced to a string.
 
   Parameters:
@@ -44,44 +44,44 @@ Module for interacting with the developer console.
   trx.console.log({ hp = 1000, pos = { x = 1 } })
   ```
 
-- <a name="console.log.generic"></a>[lua]`trx.console.log.generic(level, message)`  
+- <a id="console.log.generic" name="console.log.generic"></a>[lua]`trx.console.log.generic(level, message)`  
   Logs at a level chosen at runtime.
 
   Parameters:
   - **`level`** ([trx.log.LogLevel](LOG.md#log.LogLevel)).
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- <a name="console.log.info"></a>[lua]`trx.console.log.info(message)`  
+- <a id="console.log.info" name="console.log.info"></a>[lua]`trx.console.log.info(message)`  
   Logs an informational message.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- <a name="console.log.warn"></a>[lua]`trx.console.log.warn(message)`  
+- <a id="console.log.warn" name="console.log.warn"></a>[lua]`trx.console.log.warn(message)`  
   Logs a warning.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- <a name="console.log.warning"></a>[lua]`trx.console.log.warning(message)`  
-  Logs a warning. An alias of [`trx.console.log.warn`](#console.log.warn).
+- <a id="console.log.warning" name="console.log.warning"></a>[lua]`trx.console.log.warning(message)`  
+  Logs a warning. An alias of [`warn`](#console.log.warn).
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- <a name="console.log.error"></a>[lua]`trx.console.log.error(message)`  
+- <a id="console.log.error" name="console.log.error"></a>[lua]`trx.console.log.error(message)`  
   Logs an error.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- <a name="console.log.debug"></a>[lua]`trx.console.log.debug(message)`  
+- <a id="console.log.debug" name="console.log.debug"></a>[lua]`trx.console.log.debug(message)`  
   Logs a debug message.
 
   Parameters:
   - **`message`** (any). Any value; a table is pretty-printed.
 
-- <a name="console.eval"></a>[lua]`trx.console.eval(command, [opts])`  
+- <a id="console.eval" name="console.eval"></a>[lua]`trx.console.eval(command, [opts])`  
   Runs a string as a developer console command. Raises if the command fails.
 
   Output is silenced by default and appears only in the terminal and the log file. Pass `{ verbose = true }` to show it in the console as a command typed by the player would.
@@ -95,7 +95,7 @@ Module for interacting with the developer console.
   trx.console.eval("play 1", { verbose = true })
   ```
 
-- <a name="console.register"></a>[lua]`trx.console.register(spec)`  
+- <a id="console.register" name="console.register"></a>[lua]`trx.console.register(spec)`  
   Registers a console command written in Lua.
 
   Every command has a [`trx.argparse`](ARGPARSE.md#argparse) parser. `args` is an optional function that shapes it - it receives the parser and declares the arguments the command takes. A command that omits `args` takes none, and reports so when handed one. The console completes the arguments from the parser, and answers `-h`/`--help` from it.
@@ -121,15 +121,15 @@ Module for interacting with the developer console.
   })
   ```
 
-- <a name="console.clear"></a>[lua]`trx.console.clear()`  
+- <a id="console.clear" name="console.clear"></a>[lua]`trx.console.clear()`  
   Clears the console.
 
-- <a name="console.commands"></a>[lua]`trx.console.commands()`  
+- <a id="console.commands" name="console.commands"></a>[lua]`trx.console.commands()`  
   Every registered console command, in registration order. Each is `{ name, aliases, help }`: `name` is the word the player types, `aliases` the other words that reach it (a list, or absent), and `help` the text the console shows for `name --help` (absent when the command carries none). The help command is built on this.
 
   Returns: table. A list of `{ name, aliases, help }`.
 
-- <a name="console.command"></a>[lua]`trx.console.command(name)`  
+- <a id="console.command" name="console.command"></a>[lua]`trx.console.command(name)`  
   The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches. The same `{ name, aliases, help }` as an entry of [`trx.console.commands`](#console.commands), or nil when nothing answers to the name.
 
   Parameters:

--- a/docs/trx/lua/reference/CREATURES.md
+++ b/docs/trx/lua/reference/CREATURES.md
@@ -16,26 +16,26 @@ Module for controlling certain creature behavior.
 
 ### Properties
 
-- **`trx.creatures.hostile_allies`** (boolean). Whether Lara's allies are hostile towards her.
+- <a name="creatures.hostile_allies"></a>**`trx.creatures.hostile_allies`** (boolean). Whether Lara's allies are hostile towards her.
 
 ### Functions
 
-- [lua]`trx.creatures.add_ally(object_id)`  
+- <a name="creatures.add_ally"></a>[lua]`trx.creatures.add_ally(object_id)`  
   Marks an object as an ally of Lara. Every item of that type becomes an ally.
 
   Parameters:
-  - **`object_id`** (integer). Compare against `trx.catalog.objects`.
+  - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
 
   Example:
   ```lua
   trx.creatures.add_ally(trx.catalog.objects.monk_1)
   ```
 
-- [lua]`trx.creatures.add_ally_target(object_id)`  
+- <a name="creatures.add_ally_target"></a>[lua]`trx.creatures.add_ally_target(object_id)`  
   Marks an object as one that will fight any of Lara's allies. Every item of that type will target them.
 
   Parameters:
-  - **`object_id`** (integer). Compare against `trx.catalog.objects`.
+  - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CREATURES.md
+++ b/docs/trx/lua/reference/CREATURES.md
@@ -24,7 +24,7 @@ Module for controlling certain creature behavior.
   Marks an object as an ally of Lara. Every item of that type becomes an ally.
 
   Parameters:
-  - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - <a id="creatures.add_ally.object_id" name="creatures.add_ally.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
 
   Example:
   ```lua
@@ -35,7 +35,7 @@ Module for controlling certain creature behavior.
   Marks an object as one that will fight any of Lara's allies. Every item of that type will target them.
 
   Parameters:
-  - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - <a id="creatures.add_ally_target.object_id" name="creatures.add_ally_target.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CREATURES.md
+++ b/docs/trx/lua/reference/CREATURES.md
@@ -10,17 +10,17 @@ order: 11
   src/lua/api/creatures.lua. Edit it there.
 -->
 
-## Creatures module
+## <a id="creatures" name="creatures"></a>Creatures module
 
 Module for controlling certain creature behavior.
 
 ### Properties
 
-- <a name="creatures.hostile_allies"></a>**`trx.creatures.hostile_allies`** (boolean). Whether Lara's allies are hostile towards her.
+- <a id="creatures.hostile_allies" name="creatures.hostile_allies"></a>**`trx.creatures.hostile_allies`** (boolean). Whether Lara's allies are hostile towards her.
 
 ### Functions
 
-- <a name="creatures.add_ally"></a>[lua]`trx.creatures.add_ally(object_id)`  
+- <a id="creatures.add_ally" name="creatures.add_ally"></a>[lua]`trx.creatures.add_ally(object_id)`  
   Marks an object as an ally of Lara. Every item of that type becomes an ally.
 
   Parameters:
@@ -31,7 +31,7 @@ Module for controlling certain creature behavior.
   trx.creatures.add_ally(trx.catalog.objects.monk_1)
   ```
 
-- <a name="creatures.add_ally_target"></a>[lua]`trx.creatures.add_ally_target(object_id)`  
+- <a id="creatures.add_ally_target" name="creatures.add_ally_target"></a>[lua]`trx.creatures.add_ally_target(object_id)`  
   Marks an object as one that will fight any of Lara's allies. Every item of that type will target them.
 
   Parameters:

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -37,7 +37,7 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   Plays a cutscene, fading the scene out first. Does nothing if one is already playing or the game has no cutscene data.
 
   Parameters:
-  - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
+  - <a id="cutscenes.play.num" name="cutscenes.play.num"></a>**`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
 
   Example:
   ```lua
@@ -48,9 +48,9 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   Whether a cutscene trigger naming this number has already been answered.
 
   Parameters:
-  - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
+  - <a id="cutscenes.is_played.num" name="cutscenes.is_played.num"></a>**`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
 
-  Returns: boolean.
+  Returns: boolean. True once it has run, which is what keeps its trigger from firing again.
 
 - <a id="cutscenes.set_played" name="cutscenes.set_played"></a>[lua]`trx.cutscenes.set_played(num, played)`  
   Marks a cutscene as played or unplayed. Marking one as played keeps its
@@ -63,8 +63,8 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   [`trx.cutscenes.play`](#cutscenes.play) accepts.
 
   Parameters:
-  - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
-  - **`played`** (boolean). Whether it counts as played.
+  - <a id="cutscenes.set_played.num" name="cutscenes.set_played.num"></a>**`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
+  - <a id="cutscenes.set_played.played" name="cutscenes.set_played.played"></a>**`played`** (boolean). Whether it counts as played.
 
   Example:
   ```lua
@@ -84,8 +84,8 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   runs, and is forgotten once she has been placed.
 
   Parameters:
-  - **`pos`** (vec3). World position.
-  - **`rot`** (integer, optional). Facing angle, in the engine's own angle units. Defaults to `0`.
+  - <a id="cutscenes.set_lara_return.pos" name="cutscenes.set_lara_return.pos"></a>**`pos`** (vec3). World position.
+  - <a id="cutscenes.set_lara_return.rot" name="cutscenes.set_lara_return.rot"></a>**`rot`** (integer, optional). Facing angle, in the engine's own angle units. Defaults to `0`.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -10,7 +10,7 @@ order: 13
   src/lua/api/cutscenes.lua. Edit it there.
 -->
 
-## Cutscenes module
+## <a id="cutscenes" name="cutscenes"></a>Cutscenes module
 
 Module for TR4's in-game cutscenes, the animated scenes stored in
 `cutseq.pak` and started by a cutscene trigger. A cutscene plays once:
@@ -20,20 +20,20 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
 
 ### Properties
 
-- <a name="cutscenes.current"></a>**`trx.cutscenes.current`** ([trx.cutscenes.Num](#cutscenes.Num)). Number of the cutscene playing, or `nil` if none is. *(read-only)*
-- <a name="cutscenes.is_playing"></a>**`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
-- <a name="cutscenes.fov"></a>**`trx.cutscenes.fov`** (integer). Field of view a cutscene plays at, in the engine's own angle units. TR4 uses 11488, against 14560 for ordinary play.
-- <a name="cutscenes.letterbox"></a>**`trx.cutscenes.letterbox`** (number). Depth of each cinematic bar, as a fraction of the screen height. `0` removes them.
+- <a id="cutscenes.current" name="cutscenes.current"></a>**`trx.cutscenes.current`** ([trx.cutscenes.Num](#cutscenes.Num)). Number of the cutscene playing, or `nil` if none is. *(read-only)*
+- <a id="cutscenes.is_playing" name="cutscenes.is_playing"></a>**`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
+- <a id="cutscenes.fov" name="cutscenes.fov"></a>**`trx.cutscenes.fov`** (integer). Field of view a cutscene plays at, in the engine's own angle units. TR4 uses 11488, against 14560 for ordinary play.
+- <a id="cutscenes.letterbox" name="cutscenes.letterbox"></a>**`trx.cutscenes.letterbox`** (number). Depth of each cinematic bar, as a fraction of the screen height. `0` removes them.
 
 ### Structures
 
-- <a name="cutscenes.Num"></a>[lua]`trx.cutscenes.Num`
+- <a id="cutscenes.Num" name="cutscenes.Num"></a>[lua]`trx.cutscenes.Num`
 
     Cutscene number, as a cutscene trigger names it. Counted from 0.
 
 ### Functions
 
-- <a name="cutscenes.play"></a>[lua]`trx.cutscenes.play(num)`  
+- <a id="cutscenes.play" name="cutscenes.play"></a>[lua]`trx.cutscenes.play(num)`  
   Plays a cutscene, fading the scene out first. Does nothing if one is already playing or the game has no cutscene data.
 
   Parameters:
@@ -44,7 +44,7 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   trx.cutscenes.play(28)
   ```
 
-- <a name="cutscenes.is_played"></a>[lua]`trx.cutscenes.is_played(num)`  
+- <a id="cutscenes.is_played" name="cutscenes.is_played"></a>[lua]`trx.cutscenes.is_played(num)`  
   Whether a cutscene trigger naming this number has already been answered.
 
   Parameters:
@@ -52,15 +52,15 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
 
   Returns: boolean.
 
-- <a name="cutscenes.set_played"></a>[lua]`trx.cutscenes.set_played(num, played)`  
+- <a id="cutscenes.set_played" name="cutscenes.set_played"></a>[lua]`trx.cutscenes.set_played(num, played)`  
   Marks a cutscene as played or unplayed. Marking one as played keeps its
   trigger from firing; unmarking one lets it run again.
 
   A trigger may name a number the game has no cutscene for - TR4 uses 32 to
   ask for a full-motion video - and the engine remembers those the same way,
-  so `on_cutscene_trigger` hears about each of them once. This is what clears
+  so [`trx.events.on_cutscene_trigger`](EVENTS.md#events.on_cutscene_trigger) hears about each of them once. This is what clears
   that memory, and it takes any number a trigger may carry, not only the ones
-  `play` accepts.
+  [`trx.cutscenes.play`](#cutscenes.play) accepts.
 
   Parameters:
   - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
@@ -71,16 +71,16 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   trx.cutscenes.set_played(7, true)
   ```
 
-- <a name="cutscenes.forget_played"></a>[lua]`trx.cutscenes.forget_played()`  
+- <a id="cutscenes.forget_played" name="cutscenes.forget_played"></a>[lua]`trx.cutscenes.forget_played()`  
   Forgets every cutscene, so all of them may run again.
 
-- <a name="cutscenes.set_lara_return"></a>[lua]`trx.cutscenes.set_lara_return(pos, [rot])`  
+- <a id="cutscenes.set_lara_return" name="cutscenes.set_lara_return"></a>[lua]`trx.cutscenes.set_lara_return(pos, [rot])`  
   Places Lara where the next cutscene to end leaves her. A cutscene stands
   her at its own origin while it plays and puts her back where it found her
   afterwards; this says to put her somewhere else instead, as the original
   game does for the scenes that carry her along.
 
-  It holds for one cutscene, whether named before `play` or while the scene
+  It holds for one cutscene, whether named before [`trx.cutscenes.play`](#cutscenes.play) or while the scene
   runs, and is forgotten once she has been placed.
 
   Parameters:

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -16,37 +16,43 @@ Module for TR4's in-game cutscenes, the animated scenes stored in
 `cutseq.pak` and started by a cutscene trigger. A cutscene plays once:
 the engine remembers which ones have run, and a script may consult or
 rewrite that memory. The cutscene levels of TR1-TR3, which the game flow
-lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.
+lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.md#game.cutscenes).
 
 ### Properties
 
-- **`trx.cutscenes.current`** (integer). Number of the cutscene playing, or `nil` if none is. *(read-only)*
-- **`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
-- **`trx.cutscenes.fov`** (integer). Field of view a cutscene plays at, in the engine's own angle units. TR4 uses 11488, against 14560 for ordinary play.
-- **`trx.cutscenes.letterbox`** (number). Depth of each cinematic bar, as a fraction of the screen height. `0` removes them.
+- <a name="cutscenes.current"></a>**`trx.cutscenes.current`** ([trx.cutscenes.Num](#cutscenes.Num)). Number of the cutscene playing, or `nil` if none is. *(read-only)*
+- <a name="cutscenes.is_playing"></a>**`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
+- <a name="cutscenes.fov"></a>**`trx.cutscenes.fov`** (integer). Field of view a cutscene plays at, in the engine's own angle units. TR4 uses 11488, against 14560 for ordinary play.
+- <a name="cutscenes.letterbox"></a>**`trx.cutscenes.letterbox`** (number). Depth of each cinematic bar, as a fraction of the screen height. `0` removes them.
+
+### Structures
+
+- <a name="cutscenes.Num"></a>[lua]`trx.cutscenes.Num`
+
+    Cutscene number, as a cutscene trigger names it. Counted from 0.
 
 ### Functions
 
-- [lua]`trx.cutscenes.play(num)`  
+- <a name="cutscenes.play"></a>[lua]`trx.cutscenes.play(num)`  
   Plays a cutscene, fading the scene out first. Does nothing if one is already playing or the game has no cutscene data.
 
   Parameters:
-  - **`num`** (integer). Cutscene number.
+  - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
 
   Example:
   ```lua
   trx.cutscenes.play(28)
   ```
 
-- [lua]`trx.cutscenes.is_played(num)`  
+- <a name="cutscenes.is_played"></a>[lua]`trx.cutscenes.is_played(num)`  
   Whether a cutscene trigger naming this number has already been answered.
 
   Parameters:
-  - **`num`** (integer). Cutscene number.
+  - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
 
   Returns: boolean.
 
-- [lua]`trx.cutscenes.set_played(num, played)`  
+- <a name="cutscenes.set_played"></a>[lua]`trx.cutscenes.set_played(num, played)`  
   Marks a cutscene as played or unplayed. Marking one as played keeps its
   trigger from firing; unmarking one lets it run again.
 
@@ -57,7 +63,7 @@ lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.
   `play` accepts.
 
   Parameters:
-  - **`num`** (integer). Cutscene number.
+  - **`num`** ([trx.cutscenes.Num](#cutscenes.Num)).
   - **`played`** (boolean). Whether it counts as played.
 
   Example:
@@ -65,10 +71,10 @@ lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.
   trx.cutscenes.set_played(7, true)
   ```
 
-- [lua]`trx.cutscenes.forget_played()`  
+- <a name="cutscenes.forget_played"></a>[lua]`trx.cutscenes.forget_played()`  
   Forgets every cutscene, so all of them may run again.
 
-- [lua]`trx.cutscenes.set_lara_return(pos, [rot])`  
+- <a name="cutscenes.set_lara_return"></a>[lua]`trx.cutscenes.set_lara_return(pos, [rot])`  
   Places Lara where the next cutscene to end leaves her. A cutscene stands
   her at its own origin while it plays and puts her back where it found her
   afterwards; this says to put her somewhere else instead, as the original

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -22,7 +22,7 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
 
 - <a id="cutscenes.current" name="cutscenes.current"></a>**`trx.cutscenes.current`** ([trx.cutscenes.Num](#cutscenes.Num)). Number of the cutscene playing, or `nil` if none is. *(read-only)*
 - <a id="cutscenes.is_playing" name="cutscenes.is_playing"></a>**`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
-- <a id="cutscenes.fov" name="cutscenes.fov"></a>**`trx.cutscenes.fov`** (integer). Field of view a cutscene plays at, in the engine's own angle units. TR4 uses 11488, against 14560 for ordinary play.
+- <a id="cutscenes.fov" name="cutscenes.fov"></a>**`trx.cutscenes.fov`** ([trx.math.Angle](MATH.md#math.Angle)). Field of view a cutscene plays at. TR4 uses 11488, against 14560 for ordinary play.
 - <a id="cutscenes.letterbox" name="cutscenes.letterbox"></a>**`trx.cutscenes.letterbox`** (number). Depth of each cinematic bar, as a fraction of the screen height. `0` removes them.
 
 ### Structures
@@ -85,7 +85,7 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
 
   Parameters:
   - <a id="cutscenes.set_lara_return.pos" name="cutscenes.set_lara_return.pos"></a>**`pos`** (vec3). World position.
-  - <a id="cutscenes.set_lara_return.rot" name="cutscenes.set_lara_return.rot"></a>**`rot`** (integer, optional). Facing angle, in the engine's own angle units. Defaults to `0`.
+  - <a id="cutscenes.set_lara_return.rot" name="cutscenes.set_lara_return.rot"></a>**`rot`** ([trx.math.Angle](MATH.md#math.Angle), optional). Facing angle. Defaults to `0`.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -12,7 +12,7 @@ order: 1
 
 ## Events module
 
-Lua scripts can listen for game events by attaching a handler to one of the hooks below. Attaching returns a listener id, which `trx.events.detach` takes.
+Lua scripts can listen for game events by attaching a handler to one of the hooks below. Attaching returns a listener id, which [`trx.events.detach`](#events.detach) takes.
 
 A handler attached from a level script is detached automatically when the level ends; one attached from a global script lives for the whole session.
 
@@ -20,23 +20,23 @@ An event that carries a default the script may take over says so in its descript
 
 ### Structures
 
-- [lua]`trx.events.Listener`
+- <a name="events.Listener"></a>[lua]`trx.events.Listener`
 
     An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.
 
     Properties:
-    - **`id`**: integer. The number the engine keys the handler by. Two listeners of the same handler carry the same one; it is never handed out twice within a session. *(read-only)*
+    - <a name="events.Listener.id"></a>**`id`**: integer. The number the engine keys the handler by. Two listeners of the same handler carry the same one; it is never handed out twice within a session. *(read-only)*
 
     Methods:
 
-    - [lua]`listener:detach()`  
-      Stops the handler, which fires no more from here on. `trx.events.detach` does the same to a listener held elsewhere.
+    - <a name="events.Listener.detach"></a>[lua]`listener:detach()`  
+      Stops the handler, which fires no more from here on. [`trx.events.detach`](#events.detach) does the same to a listener held elsewhere.
 
       Returns: boolean. Whether the handler was still attached.
 
 ### Functions
 
-- [lua]`trx.events.on_game_start(callback)`  
+- <a name="events.on_game_start"></a>[lua]`trx.events.on_game_start(callback)`  
   Happens as a level starts running, before its first frame is drawn. By then
   the level file is loaded, its items are set up and any savegame state has
   been applied, so this is where a script sets object properties, declares
@@ -44,7 +44,7 @@ An event that carries a default the script may take over says so in its descript
   fires it: a played level, a cutscene and the attract demo alike. The title
   screen has `on_title_start` instead.
 
-  Which level is starting is `trx.game.current_level`, whose `num` and `type`
+  Which level is starting is [`trx.game.current_level`](GAME.md#game.current_level), whose `num` and `type`
   say where it counts and what kind it is. A level script already knows both,
   which is why the handler is not handed them.
 
@@ -53,7 +53,7 @@ An event that carries a default the script may take over says so in its descript
     Called with:
     - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh. A cutscene and a demo are never resumed, and always report false.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -62,7 +62,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_title_start(callback)`  
+- <a name="events.on_title_start"></a>[lua]`trx.events.on_title_start(callback)`  
   Happens when the title screen's scene starts playing behind the menu, once
   its level is loaded and its items are set up. The handler takes no
   arguments. `on_game_start` does not fire for the title level.
@@ -70,7 +70,7 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -79,15 +79,15 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_pickup(callback)`  
+- <a name="events.on_pickup"></a>[lua]`trx.events.on_pickup(callback)`  
   Happens just after Lara picks up an item.
 
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item_num`** (integer). 0-based item number, matching the numbers level editors show. The item that was picked up.
+    - **`item_num`** ([trx.items.Num](ITEMS.md#items.Num)). The item that was picked up.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -96,23 +96,23 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.before_control(callback)`  
+- <a name="events.before_control"></a>[lua]`trx.events.before_control(callback)`  
   Happens on every logical game frame, before the main game logic runs. The handler takes no arguments.
 
   Parameters:
   - **`callback`** (function).
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
-- [lua]`trx.events.after_control(callback)`  
+- <a name="events.after_control"></a>[lua]`trx.events.after_control(callback)`  
   Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.
 
   Parameters:
   - **`callback`** (function).
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
-- [lua]`trx.events.on_flip_effect(effect_num, callback)`  
+- <a name="events.on_flip_effect"></a>[lua]`trx.events.on_flip_effect(effect_num, callback)`  
   Claims a flip effect number and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick an unused effect number, and handle it here from the level's script.
 
   A claimed number belongs to the script for the rest of the level: its stock engine effect does not run, even if the handler is later detached. Unclaimed numbers are unaffected.
@@ -120,13 +120,13 @@ An event that carries a default the script may take over says so in its descript
   Unlike the other hooks, this happens at effect execution time, in the middle of a game frame.
 
   Parameters:
-  - **`effect_num`** (integer). The flip effect number to claim, as the level editor numbers them. This is not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` names.
+  - **`effect_num`** (integer). The flip effect number to claim, as the level editor numbers them. This is not the id space of [`trx.rooms.flip_effect`](ROOMS.md#rooms.flip_effect), which takes [`trx.catalog.flip_effects`](CATALOG.md#catalog.flip_effects) names. Counted from 0.
   - **`callback`** (function).
     Called with:
     - **`timer`** (integer). A floor trigger's timer field, free for the level to use as a parameter. 0 for an animation command, which carries no timer.
-    - **`item_num`** (integer). 0-based item number, matching the numbers level editors show. The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
+    - **`item_num`** ([trx.items.Num](ITEMS.md#items.Num)). The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -135,17 +135,17 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_room_change(callback)`  
+- <a name="events.on_room_change"></a>[lua]`trx.events.on_room_change(callback)`  
   Happens when an item changes rooms during play, which a cutscene or the attract demo is not. `trx.rooms.Room:on_enter` and `:on_exit` are this same event, narrowed to one room.
 
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that changed rooms.
-    - **`old_room_num`** (integer). 0-based room number, matching the numbers level editors show. -1 if it had none.
-    - **`new_room_num`** (integer). 0-based room number, matching the numbers level editors show. -1 if it left the world.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
+    - **`old_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). -1 if it had none.
+    - **`new_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). -1 if it left the world.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -154,7 +154,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_trigger(callback)`  
+- <a name="events.on_trigger"></a>[lua]`trx.events.on_trigger(callback)`  
   Happens every time a trigger is aimed at an item - a floor trigger in the level, the `/trigger` console command, or `item:trigger` from a script - of any kind, an antitrigger included. It is the raw trigger, not a state change: a floor pad fires it every frame Lara stands on it, and a partial trigger fires it too. A cutscene or the attract demo does not.
 
   The handler runs after the trigger has been applied, so the item already reflects it, and changes the handler makes to the item are not overwritten.
@@ -164,10 +164,10 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` the trigger was aimed at.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item the trigger was aimed at.
     - **`trigger`** (table). What the trigger carried: `type` (an `items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -178,7 +178,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_show(callback)`  
+- <a name="events.on_show"></a>[lua]`trx.events.on_show(callback)`  
   Happens when an item becomes visible during play - drawn and in the world, taking part in collision and targeting. It is the change that fires, not the state: an item already visible does not fire it again, and only a live level does, not a cutscene or the attract demo.
 
   `trx.items.Item:on_show` is this same event, narrowed to one item.
@@ -186,9 +186,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that became visible.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that became visible.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -197,7 +197,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_hide(callback)`  
+- <a name="events.on_hide"></a>[lua]`trx.events.on_hide(callback)`  
   Happens when an item becomes hidden during play - drawn and in the world, taking part in collision and targeting. It is the change that fires, not the state: an item already hidden does not fire it again, and only a live level does, not a cutscene or the attract demo.
 
   `trx.items.Item:on_hide` is this same event, narrowed to one item.
@@ -205,9 +205,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that became hidden.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that became hidden.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -216,7 +216,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_finish(callback)`  
+- <a name="events.on_finish"></a>[lua]`trx.events.on_finish(callback)`  
   Happens when an item finishes its run during play - a trap that has sprung, a switch thrown, a one-shot object spent. It is the change that fires, once, and only a live level does, not a cutscene or the attract demo.
 
   `trx.items.Item:on_finish` is this same event, narrowed to one item.
@@ -224,9 +224,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that finished.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that finished.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -235,7 +235,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_enter_sim(callback)`  
+- <a name="events.on_enter_sim"></a>[lua]`trx.events.on_enter_sim(callback)`  
   Happens when an item starts being simulated during play - its control routine begins running each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a cheat. A trigger also fires `on_activate`, which this does not.
 
   `trx.items.Item:on_enter_sim` is this same event, narrowed to one item.
@@ -243,9 +243,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that started being simulated.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that started being simulated.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -254,7 +254,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_leave_sim(callback)`  
+- <a name="events.on_leave_sim"></a>[lua]`trx.events.on_leave_sim(callback)`  
   Happens when an item stops being simulated during play - its control routine no longer runs. It keeps its place and its state; it merely stops.
 
   `trx.items.Item:on_leave_sim` is this same event, narrowed to one item.
@@ -262,9 +262,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that stopped being simulated.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that stopped being simulated.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -273,7 +273,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_activate(callback)`  
+- <a name="events.on_activate"></a>[lua]`trx.events.on_activate(callback)`  
   Happens when an item is activated through the lifecycle front door during play - the path a level trigger takes. Switches, respawns and cheats start an item without it, firing only `on_enter_sim`; watch that one for a start of any cause.
 
   `trx.items.Item:on_activate` is this same event, narrowed to one item.
@@ -281,9 +281,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that was activated.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was activated.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -292,7 +292,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_deactivate(callback)`  
+- <a name="events.on_deactivate"></a>[lua]`trx.events.on_deactivate(callback)`  
   Happens when a running item is deactivated through the lifecycle front door during play - the path an antitrigger takes. It fires only when the item was actually running.
 
   `trx.items.Item:on_deactivate` is this same event, narrowed to one item.
@@ -300,9 +300,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that was deactivated.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was deactivated.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -311,7 +311,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_destroy(callback)`  
+- <a name="events.on_destroy"></a>[lua]`trx.events.on_destroy(callback)`  
   Happens as an item is removed from the game during play - a creature cleared away, a pickup taken, an object that has run its course. The item can still be read from the handler, which runs before the removal completes, but a handle kept past the handler goes stale.
 
   `trx.items.Item:on_destroy` is this same event, narrowed to one item.
@@ -319,9 +319,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` being removed. Valid only for the duration of the handler.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item being removed. Valid only for the duration of the handler.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -330,7 +330,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_enter_world(callback)`  
+- <a name="events.on_enter_world"></a>[lua]`trx.events.on_enter_world(callback)`  
   Happens when an item enters the world during play - a runtime spawn, such as a creature an emitter releases or an item a script creates. The level's own items do not fire it as they load; only an arrival during a live level counts.
 
   `trx.items.Item:on_enter_world` is this same event, narrowed to one item.
@@ -338,9 +338,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that entered the world.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that entered the world.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -349,7 +349,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_leave_world(callback)`  
+- <a name="events.on_leave_world"></a>[lua]`trx.events.on_leave_world(callback)`  
   Happens when an item leaves the world during play - unlinked from its room, no longer drawn or collidable. It need not be destroyed; a destroyed item leaves the world on its way out, and fires this first.
 
   `trx.items.Item:on_leave_world` is this same event, narrowed to one item.
@@ -357,9 +357,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that left the world.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that left the world.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -368,7 +368,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_hit(callback)`  
+- <a name="events.on_hit"></a>[lua]`trx.events.on_hit(callback)`  
   Happens when an item takes damage, Lara included. It is the raw damage that
   fires, before the item's hit points are clamped, so a fatal blow reports the whole amount the
   attacker dealt. A death that does not go through damage - a script writing `hit_points`, or
@@ -379,10 +379,10 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that took the damage.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that took the damage.
     - **`damage`** (integer). Hit points taken, before clamping to zero.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -391,7 +391,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_kill(callback)`  
+- <a name="events.on_kill"></a>[lua]`trx.events.on_kill(callback)`  
   Happens when damage takes an item's hit points to zero, Lara included. It is the
   same blow `on_hit` reports, which fires first. A death that does not go through damage - a script
   writing `hit_points`, or `destroy()` - does not report.
@@ -406,9 +406,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item`** (Item). The `trx.items.Item` that was brought down.
+    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was brought down.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -417,7 +417,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_cutscene_trigger(callback)`  
+- <a name="events.on_cutscene_trigger"></a>[lua]`trx.events.on_cutscene_trigger(callback)`  
   Happens when a cutscene trigger fires, before the engine acts on it. A
   handler answers the trigger by returning true - having played a cutscene of
   its own, run something else, or decided nothing should run. If no handler
@@ -426,7 +426,7 @@ An event that carries a default the script may take over says so in its descript
   A trigger Lara stands on fires every frame, so this happens only for a
   cutscene that has not run yet and while none is playing. Asking counts as
   running it, whatever came of it, so the same handler is not asked again on
-  the next frame. Clear the mark with `trx.cutscenes.set_played` to hear
+  the next frame. Clear the mark with [`trx.cutscenes.set_played`](CUTSCENES.md#cutscenes.set_played) to hear
   about one again.
 
   The number a trigger names need not be one the game has a cutscene for -
@@ -436,9 +436,9 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`cutscene_num`** (integer). Number the trigger names.
+    - **`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)). The number the trigger names, which the game need not have a cutscene for.
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -456,25 +456,25 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_cutscene_start(callback)`  
+- <a name="events.on_cutscene_start"></a>[lua]`trx.events.on_cutscene_start(callback)`  
   Happens when a TR4 cutscene's first frame is about to show, after the fade out.
 
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`cutscene_num`** (integer). Number of the cutscene starting.
+    - **`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
-- [lua]`trx.events.on_cutscene_end(callback)`  
+- <a name="events.on_cutscene_end"></a>[lua]`trx.events.on_cutscene_end(callback)`  
   Happens once a TR4 cutscene has finished and the scene it interrupted is back. This is where a script decides what follows.
 
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`cutscene_num`** (integer). Number of the cutscene that ended.
+    - **`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -483,16 +483,16 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.on_flyby_end(callback)`  
+- <a name="events.on_flyby_end"></a>[lua]`trx.events.on_flyby_end(callback)`  
   Happens when a flyby sequence reaches its last camera and hands the view back.
   A sequence that a cutscene or the player interrupts does not fire it.
 
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`sequence_num`** (integer). Number of the flyby sequence that ended.
+    - **`sequence_num`** ([trx.camera.SequenceNum](CAMERA.md#camera.SequenceNum)).
 
-  Returns: events.Listener. The attached handler.
+  Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
   Example:
   ```lua
@@ -501,11 +501,11 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- [lua]`trx.events.detach(listener)`  
+- <a name="events.detach"></a>[lua]`trx.events.detach(listener)`  
   Removes a previously attached handler, which stops firing immediately. `listener:detach()` does the same to one held in hand.
 
   Parameters:
-  - **`listener`** (events.Listener).
+  - **`listener`** ([trx.events.Listener](#events.Listener)).
 
   Returns: boolean. Whether the handler was still attached. `false` means it had already been detached, or the level it belonged to has ended.
 

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -10,7 +10,7 @@ order: 1
   src/lua/api/events.lua. Edit it there.
 -->
 
-## Events module
+## <a id="events" name="events"></a>Events module
 
 Lua scripts can listen for game events by attaching a handler to one of the hooks below. Attaching returns a listener id, which [`trx.events.detach`](#events.detach) takes.
 
@@ -20,31 +20,31 @@ An event that carries a default the script may take over says so in its descript
 
 ### Structures
 
-- <a name="events.Listener"></a>[lua]`trx.events.Listener`
+- <a id="events.Listener" name="events.Listener"></a>[lua]`trx.events.Listener`
 
     An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.
 
     Properties:
-    - <a name="events.Listener.id"></a>**`id`**: integer. The number the engine keys the handler by. Two listeners of the same handler carry the same one; it is never handed out twice within a session. *(read-only)*
+    - <a id="events.Listener.id" name="events.Listener.id"></a>**`id`**: integer. The number the engine keys the handler by. Two listeners of the same handler carry the same one; it is never handed out twice within a session. *(read-only)*
 
     Methods:
 
-    - <a name="events.Listener.detach"></a>[lua]`listener:detach()`  
+    - <a id="events.Listener.detach" name="events.Listener.detach"></a>[lua]`listener:detach()`  
       Stops the handler, which fires no more from here on. [`trx.events.detach`](#events.detach) does the same to a listener held elsewhere.
 
       Returns: boolean. Whether the handler was still attached.
 
 ### Functions
 
-- <a name="events.on_game_start"></a>[lua]`trx.events.on_game_start(callback)`  
+- <a id="events.on_game_start" name="events.on_game_start"></a>[lua]`trx.events.on_game_start(callback)`  
   Happens as a level starts running, before its first frame is drawn. By then
   the level file is loaded, its items are set up and any savegame state has
   been applied, so this is where a script sets object properties, declares
   allies, changes room state and plays sound effects. Every kind of level
   fires it: a played level, a cutscene and the attract demo alike. The title
-  screen has `on_title_start` instead.
+  screen has [`trx.events.on_title_start`](#events.on_title_start) instead.
 
-  Which level is starting is [`trx.game.current_level`](GAME.md#game.current_level), whose `num` and `type`
+  Which level is starting is [`trx.game.current_level`](GAME.md#game.current_level), whose [`trx.game.Level.num`](GAME.md#game.Level.num) and [`trx.game.Level.type`](GAME.md#game.Level.type)
   say where it counts and what kind it is. A level script already knows both,
   which is why the handler is not handed them.
 
@@ -62,10 +62,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_title_start"></a>[lua]`trx.events.on_title_start(callback)`  
+- <a id="events.on_title_start" name="events.on_title_start"></a>[lua]`trx.events.on_title_start(callback)`  
   Happens when the title screen's scene starts playing behind the menu, once
   its level is loaded and its items are set up. The handler takes no
-  arguments. `on_game_start` does not fire for the title level.
+  arguments. [`trx.events.on_game_start`](#events.on_game_start) does not fire for the title level.
 
   Parameters:
   - **`callback`** (function).
@@ -79,7 +79,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_pickup"></a>[lua]`trx.events.on_pickup(callback)`  
+- <a id="events.on_pickup" name="events.on_pickup"></a>[lua]`trx.events.on_pickup(callback)`  
   Happens just after Lara picks up an item.
 
   Parameters:
@@ -96,7 +96,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.before_control"></a>[lua]`trx.events.before_control(callback)`  
+- <a id="events.before_control" name="events.before_control"></a>[lua]`trx.events.before_control(callback)`  
   Happens on every logical game frame, before the main game logic runs. The handler takes no arguments.
 
   Parameters:
@@ -104,7 +104,7 @@ An event that carries a default the script may take over says so in its descript
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
-- <a name="events.after_control"></a>[lua]`trx.events.after_control(callback)`  
+- <a id="events.after_control" name="events.after_control"></a>[lua]`trx.events.after_control(callback)`  
   Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.
 
   Parameters:
@@ -112,7 +112,7 @@ An event that carries a default the script may take over says so in its descript
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
-- <a name="events.on_flip_effect"></a>[lua]`trx.events.on_flip_effect(effect_num, callback)`  
+- <a id="events.on_flip_effect" name="events.on_flip_effect"></a>[lua]`trx.events.on_flip_effect(effect_num, callback)`  
   Claims a flip effect number and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick an unused effect number, and handle it here from the level's script.
 
   A claimed number belongs to the script for the rest of the level: its stock engine effect does not run, even if the handler is later detached. Unclaimed numbers are unaffected.
@@ -135,8 +135,8 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_room_change"></a>[lua]`trx.events.on_room_change(callback)`  
-  Happens when an item changes rooms during play, which a cutscene or the attract demo is not. `trx.rooms.Room:on_enter` and `:on_exit` are this same event, narrowed to one room.
+- <a id="events.on_room_change" name="events.on_room_change"></a>[lua]`trx.events.on_room_change(callback)`  
+  Happens when an item changes rooms during play, which a cutscene or the attract demo is not. [`trx.rooms.Room:on_enter`](ROOMS.md#rooms.Room.on_enter) and [`trx.rooms.Room:on_exit`](ROOMS.md#rooms.Room.on_exit) are this same event, narrowed to one room.
 
   Parameters:
   - **`callback`** (function).
@@ -154,18 +154,18 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_trigger"></a>[lua]`trx.events.on_trigger(callback)`  
-  Happens every time a trigger is aimed at an item - a floor trigger in the level, the `/trigger` console command, or `item:trigger` from a script - of any kind, an antitrigger included. It is the raw trigger, not a state change: a floor pad fires it every frame Lara stands on it, and a partial trigger fires it too. A cutscene or the attract demo does not.
+- <a id="events.on_trigger" name="events.on_trigger"></a>[lua]`trx.events.on_trigger(callback)`  
+  Happens every time a trigger is aimed at an item - a floor trigger in the level, the `/trigger` console command, or [`trx.items.Item:trigger`](ITEMS.md#items.Item.trigger) from a script - of any kind, an antitrigger included. It is the raw trigger, not a state change: a floor pad fires it every frame Lara stands on it, and a partial trigger fires it too. A cutscene or the attract demo does not.
 
   The handler runs after the trigger has been applied, so the item already reflects it, and changes the handler makes to the item are not overwritten.
 
-  `trx.items.Item:on_trigger` is this same event, narrowed to one item.
+  [`trx.items.Item:on_trigger`](ITEMS.md#items.Item.on_trigger) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
     Called with:
     - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item the trigger was aimed at.
-    - **`trigger`** (table). What the trigger carried: `type` (an `items.TriggerType`), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.
+    - **`trigger`** (table). What the trigger carried: `type` (a [`trx.items.TriggerType`](ITEMS.md#items.TriggerType)), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -178,10 +178,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_show"></a>[lua]`trx.events.on_show(callback)`  
+- <a id="events.on_show" name="events.on_show"></a>[lua]`trx.events.on_show(callback)`  
   Happens when an item becomes visible during play - drawn and in the world, taking part in collision and targeting. It is the change that fires, not the state: an item already visible does not fire it again, and only a live level does, not a cutscene or the attract demo.
 
-  `trx.items.Item:on_show` is this same event, narrowed to one item.
+  [`trx.items.Item:on_show`](ITEMS.md#items.Item.on_show) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -197,10 +197,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_hide"></a>[lua]`trx.events.on_hide(callback)`  
+- <a id="events.on_hide" name="events.on_hide"></a>[lua]`trx.events.on_hide(callback)`  
   Happens when an item becomes hidden during play - drawn and in the world, taking part in collision and targeting. It is the change that fires, not the state: an item already hidden does not fire it again, and only a live level does, not a cutscene or the attract demo.
 
-  `trx.items.Item:on_hide` is this same event, narrowed to one item.
+  [`trx.items.Item:on_hide`](ITEMS.md#items.Item.on_hide) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -216,10 +216,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_finish"></a>[lua]`trx.events.on_finish(callback)`  
+- <a id="events.on_finish" name="events.on_finish"></a>[lua]`trx.events.on_finish(callback)`  
   Happens when an item finishes its run during play - a trap that has sprung, a switch thrown, a one-shot object spent. It is the change that fires, once, and only a live level does, not a cutscene or the attract demo.
 
-  `trx.items.Item:on_finish` is this same event, narrowed to one item.
+  [`trx.items.Item:on_finish`](ITEMS.md#items.Item.on_finish) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -235,10 +235,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_enter_sim"></a>[lua]`trx.events.on_enter_sim(callback)`  
-  Happens when an item starts being simulated during play - its control routine begins running each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a cheat. A trigger also fires `on_activate`, which this does not.
+- <a id="events.on_enter_sim" name="events.on_enter_sim"></a>[lua]`trx.events.on_enter_sim(callback)`  
+  Happens when an item starts being simulated during play - its control routine begins running each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a cheat. A trigger also fires [`trx.events.on_activate`](#events.on_activate), which this does not.
 
-  `trx.items.Item:on_enter_sim` is this same event, narrowed to one item.
+  [`trx.items.Item:on_enter_sim`](ITEMS.md#items.Item.on_enter_sim) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -254,10 +254,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_leave_sim"></a>[lua]`trx.events.on_leave_sim(callback)`  
+- <a id="events.on_leave_sim" name="events.on_leave_sim"></a>[lua]`trx.events.on_leave_sim(callback)`  
   Happens when an item stops being simulated during play - its control routine no longer runs. It keeps its place and its state; it merely stops.
 
-  `trx.items.Item:on_leave_sim` is this same event, narrowed to one item.
+  [`trx.items.Item:on_leave_sim`](ITEMS.md#items.Item.on_leave_sim) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -273,10 +273,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_activate"></a>[lua]`trx.events.on_activate(callback)`  
-  Happens when an item is activated through the lifecycle front door during play - the path a level trigger takes. Switches, respawns and cheats start an item without it, firing only `on_enter_sim`; watch that one for a start of any cause.
+- <a id="events.on_activate" name="events.on_activate"></a>[lua]`trx.events.on_activate(callback)`  
+  Happens when an item is activated through the lifecycle front door during play - the path a level trigger takes. Switches, respawns and cheats start an item without it, firing only [`trx.events.on_enter_sim`](#events.on_enter_sim); watch that one for a start of any cause.
 
-  `trx.items.Item:on_activate` is this same event, narrowed to one item.
+  [`trx.items.Item:on_activate`](ITEMS.md#items.Item.on_activate) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -292,10 +292,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_deactivate"></a>[lua]`trx.events.on_deactivate(callback)`  
+- <a id="events.on_deactivate" name="events.on_deactivate"></a>[lua]`trx.events.on_deactivate(callback)`  
   Happens when a running item is deactivated through the lifecycle front door during play - the path an antitrigger takes. It fires only when the item was actually running.
 
-  `trx.items.Item:on_deactivate` is this same event, narrowed to one item.
+  [`trx.items.Item:on_deactivate`](ITEMS.md#items.Item.on_deactivate) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -311,10 +311,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_destroy"></a>[lua]`trx.events.on_destroy(callback)`  
+- <a id="events.on_destroy" name="events.on_destroy"></a>[lua]`trx.events.on_destroy(callback)`  
   Happens as an item is removed from the game during play - a creature cleared away, a pickup taken, an object that has run its course. The item can still be read from the handler, which runs before the removal completes, but a handle kept past the handler goes stale.
 
-  `trx.items.Item:on_destroy` is this same event, narrowed to one item.
+  [`trx.items.Item:on_destroy`](ITEMS.md#items.Item.on_destroy) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -330,10 +330,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_enter_world"></a>[lua]`trx.events.on_enter_world(callback)`  
+- <a id="events.on_enter_world" name="events.on_enter_world"></a>[lua]`trx.events.on_enter_world(callback)`  
   Happens when an item enters the world during play - a runtime spawn, such as a creature an emitter releases or an item a script creates. The level's own items do not fire it as they load; only an arrival during a live level counts.
 
-  `trx.items.Item:on_enter_world` is this same event, narrowed to one item.
+  [`trx.items.Item:on_enter_world`](ITEMS.md#items.Item.on_enter_world) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -349,10 +349,10 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_leave_world"></a>[lua]`trx.events.on_leave_world(callback)`  
+- <a id="events.on_leave_world" name="events.on_leave_world"></a>[lua]`trx.events.on_leave_world(callback)`  
   Happens when an item leaves the world during play - unlinked from its room, no longer drawn or collidable. It need not be destroyed; a destroyed item leaves the world on its way out, and fires this first.
 
-  `trx.items.Item:on_leave_world` is this same event, narrowed to one item.
+  [`trx.items.Item:on_leave_world`](ITEMS.md#items.Item.on_leave_world) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -368,13 +368,13 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_hit"></a>[lua]`trx.events.on_hit(callback)`  
+- <a id="events.on_hit" name="events.on_hit"></a>[lua]`trx.events.on_hit(callback)`  
   Happens when an item takes damage, Lara included. It is the raw damage that
   fires, before the item's hit points are clamped, so a fatal blow reports the whole amount the
-  attacker dealt. A death that does not go through damage - a script writing `hit_points`, or
-  `destroy()` - does not report.
+  attacker dealt. A death that does not go through damage - a script writing
+  [`trx.items.Item.hit_points`](ITEMS.md#items.Item.hit_points), or [`trx.items.Item:destroy`](ITEMS.md#items.Item.destroy) - does not report.
 
-  `trx.items.Item:on_hit` is this same event, narrowed to one item.
+  [`trx.items.Item:on_hit`](ITEMS.md#items.Item.on_hit) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -391,17 +391,17 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_kill"></a>[lua]`trx.events.on_kill(callback)`  
+- <a id="events.on_kill" name="events.on_kill"></a>[lua]`trx.events.on_kill(callback)`  
   Happens when damage takes an item's hit points to zero, Lara included. It is the
-  same blow `on_hit` reports, which fires first. A death that does not go through damage - a script
-  writing `hit_points`, or `destroy()` - does not report.
+  same blow [`trx.events.on_hit`](#events.on_hit) reports, which fires first. A death that does not go through damage
+  - a script writing [`trx.items.Item.hit_points`](ITEMS.md#items.Item.hit_points), or [`trx.items.Item:destroy`](ITEMS.md#items.Item.destroy) - does not report.
 
   Some bosses fall and get back up: Willard is knocked out, Natla plays dead before her second
   stage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points
   to zero, so they report once per stage rather than once per boss, and the dragon reports once
   more for the dagger that ends it.
 
-  `trx.items.Item:on_kill` is this same event, narrowed to one item.
+  [`trx.items.Item:on_kill`](ITEMS.md#items.Item.on_kill) is this same event, narrowed to one item.
 
   Parameters:
   - **`callback`** (function).
@@ -417,7 +417,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_cutscene_trigger"></a>[lua]`trx.events.on_cutscene_trigger(callback)`  
+- <a id="events.on_cutscene_trigger" name="events.on_cutscene_trigger"></a>[lua]`trx.events.on_cutscene_trigger(callback)`  
   Happens when a cutscene trigger fires, before the engine acts on it. A
   handler answers the trigger by returning true - having played a cutscene of
   its own, run something else, or decided nothing should run. If no handler
@@ -456,7 +456,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_cutscene_start"></a>[lua]`trx.events.on_cutscene_start(callback)`  
+- <a id="events.on_cutscene_start" name="events.on_cutscene_start"></a>[lua]`trx.events.on_cutscene_start(callback)`  
   Happens when a TR4 cutscene's first frame is about to show, after the fade out.
 
   Parameters:
@@ -466,7 +466,7 @@ An event that carries a default the script may take over says so in its descript
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
-- <a name="events.on_cutscene_end"></a>[lua]`trx.events.on_cutscene_end(callback)`  
+- <a id="events.on_cutscene_end" name="events.on_cutscene_end"></a>[lua]`trx.events.on_cutscene_end(callback)`  
   Happens once a TR4 cutscene has finished and the scene it interrupted is back. This is where a script decides what follows.
 
   Parameters:
@@ -483,7 +483,7 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.on_flyby_end"></a>[lua]`trx.events.on_flyby_end(callback)`  
+- <a id="events.on_flyby_end" name="events.on_flyby_end"></a>[lua]`trx.events.on_flyby_end(callback)`  
   Happens when a flyby sequence reaches its last camera and hands the view back.
   A sequence that a cutscene or the player interrupts does not fire it.
 
@@ -501,8 +501,8 @@ An event that carries a default the script may take over says so in its descript
   end)
   ```
 
-- <a name="events.detach"></a>[lua]`trx.events.detach(listener)`  
-  Removes a previously attached handler, which stops firing immediately. `listener:detach()` does the same to one held in hand.
+- <a id="events.detach" name="events.detach"></a>[lua]`trx.events.detach(listener)`  
+  Removes a previously attached handler, which stops firing immediately. [`trx.events.Listener:detach`](#events.Listener.detach) does the same to one held in hand.
 
   Parameters:
   - **`listener`** ([trx.events.Listener](#events.Listener)).

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -142,15 +142,15 @@ An event that carries a default the script may take over says so in its descript
   - **`callback`** (function).
     Called with:
     - **`item`** (Item). The `trx.items.Item` that changed rooms.
-    - **`old_room`** (integer). 0-based number of the room it left, or -1 if it had none.
-    - **`new_room`** (integer). 0-based number of the room it entered, or -1 if it left the world.
+    - **`old_room_num`** (integer). 0-based room number, matching the numbers level editors show. -1 if it had none.
+    - **`new_room_num`** (integer). 0-based room number, matching the numbers level editors show. -1 if it left the world.
 
   Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
-  trx.events.on_room_change(function(item, old_room, new_room)
-    trx.log.info(item.object_id .. " moved to room " .. new_room)
+  trx.events.on_room_change(function(item, old_room_num, new_room_num)
+    trx.log.info(item.object_id .. " moved to room " .. new_room_num)
   end)
   ```
 
@@ -436,15 +436,15 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`num`** (integer). Number the trigger names.
+    - **`cutscene_num`** (integer). Number the trigger names.
 
   Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
   -- only in the throne room; a flyby stands in for it elsewhere
-  trx.events.on_cutscene_trigger(function(num)
-    if num ~= 27 then
+  trx.events.on_cutscene_trigger(function(cutscene_num)
+    if cutscene_num ~= 27 then
       return false
     end
     if trx.lara.item.room_num == 55 then
@@ -462,7 +462,7 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`num`** (integer). Number of the cutscene starting.
+    - **`cutscene_num`** (integer). Number of the cutscene starting.
 
   Returns: events.Listener. The attached handler.
 
@@ -472,14 +472,14 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`num`** (integer). Number of the cutscene that ended.
+    - **`cutscene_num`** (integer). Number of the cutscene that ended.
 
   Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
-  trx.events.on_cutscene_end(function(num)
-    trx.log.info("cutscene " .. num .. " finished")
+  trx.events.on_cutscene_end(function(cutscene_num)
+    trx.log.info("cutscene " .. cutscene_num .. " finished")
   end)
   ```
 
@@ -490,14 +490,14 @@ An event that carries a default the script may take over says so in its descript
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`sequence`** (integer). Number of the sequence that ended.
+    - **`sequence_num`** (integer). Number of the flyby sequence that ended.
 
   Returns: events.Listener. The attached handler.
 
   Example:
   ```lua
-  trx.events.on_flyby_end(function(sequence)
-    trx.camera.play_flyby(sequence)
+  trx.events.on_flyby_end(function(sequence_num)
+    trx.camera.play_flyby(sequence_num)
   end)
   ```
 

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -20,6 +20,10 @@ An event that carries a default the script may take over says so in its descript
 
 ### Structures
 
+- <a id="events.FlipEffectNum" name="events.FlipEffectNum"></a>[lua]`trx.events.FlipEffectNum`
+
+    A flip effect number, as a level editor numbers them. Not the id space of [`trx.rooms.flip_effect`](ROOMS.md#rooms.flip_effect), which takes [`trx.catalog.flip_effects`](CATALOG.md#catalog.flip_effects) names. Counted from 0.
+
 - <a id="events.Listener" name="events.Listener"></a>[lua]`trx.events.Listener`
 
     An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.
@@ -49,9 +53,9 @@ An event that carries a default the script may take over says so in its descript
   which is why the handler is not handed them.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_game_start.callback" name="events.on_game_start.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh. A cutscene and a demo are never resumed, and always report false.
+    - <a id="events.on_game_start.is_save" name="events.on_game_start.is_save"></a>**`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh. A cutscene and a demo are never resumed, and always report false.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -68,7 +72,7 @@ An event that carries a default the script may take over says so in its descript
   arguments. [`trx.events.on_game_start`](#events.on_game_start) does not fire for the title level.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_title_start.callback" name="events.on_title_start.callback"></a>**`callback`** (function). What to run when it happens.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -83,9 +87,9 @@ An event that carries a default the script may take over says so in its descript
   Happens just after Lara picks up an item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_pickup.callback" name="events.on_pickup.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item_num`** ([trx.items.Num](ITEMS.md#items.Num)). The item that was picked up.
+    - <a id="events.on_pickup.item_num" name="events.on_pickup.item_num"></a>**`item_num`** ([trx.items.Num](ITEMS.md#items.Num)). The item that was picked up.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -100,7 +104,7 @@ An event that carries a default the script may take over says so in its descript
   Happens on every logical game frame, before the main game logic runs. The handler takes no arguments.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.before_control.callback" name="events.before_control.callback"></a>**`callback`** (function). What to run when it happens.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -108,23 +112,23 @@ An event that carries a default the script may take over says so in its descript
   Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.after_control.callback" name="events.after_control.callback"></a>**`callback`** (function). What to run when it happens.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
 - <a id="events.on_flip_effect" name="events.on_flip_effect"></a>[lua]`trx.events.on_flip_effect(effect_num, callback)`  
-  Claims a flip effect number and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick an unused effect number, and handle it here from the level's script.
+  Claims a [`trx.events.FlipEffectNum`](#events.FlipEffectNum) and happens whenever a level runs it, whether from a floor trigger or an animation command. Place an ordinary flipeffect trigger in a level editor - pad, heavy, switch and antitrigger all work - pick one nothing uses, and handle it here from the level's script.
 
   A claimed number belongs to the script for the rest of the level: its stock engine effect does not run, even if the handler is later detached. Unclaimed numbers are unaffected.
 
   Unlike the other hooks, this happens at effect execution time, in the middle of a game frame.
 
   Parameters:
-  - **`effect_num`** (integer). The flip effect number to claim, as the level editor numbers them. This is not the id space of [`trx.rooms.flip_effect`](ROOMS.md#rooms.flip_effect), which takes [`trx.catalog.flip_effects`](CATALOG.md#catalog.flip_effects) names. Counted from 0.
-  - **`callback`** (function).
+  - <a id="events.on_flip_effect.effect_num" name="events.on_flip_effect.effect_num"></a>**`effect_num`** ([trx.events.FlipEffectNum](#events.FlipEffectNum)). The one to claim.
+  - <a id="events.on_flip_effect.callback" name="events.on_flip_effect.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`timer`** (integer). A floor trigger's timer field, free for the level to use as a parameter. 0 for an animation command, which carries no timer.
-    - **`item_num`** ([trx.items.Num](ITEMS.md#items.Num)). The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
+    - <a id="events.on_flip_effect.timer" name="events.on_flip_effect.timer"></a>**`timer`** (integer). A floor trigger's timer field, free for the level to use as a parameter. 0 for an animation command, which carries no timer.
+    - <a id="events.on_flip_effect.item_num" name="events.on_flip_effect.item_num"></a>**`item_num`** ([trx.items.Num](ITEMS.md#items.Num)). The item that ran the effect: Lara for a pad trigger, the activating object for a heavy trigger, the animating item for an animation command.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -139,11 +143,11 @@ An event that carries a default the script may take over says so in its descript
   Happens when an item changes rooms during play, which a cutscene or the attract demo is not. [`trx.rooms.Room:on_enter`](ROOMS.md#rooms.Room.on_enter) and [`trx.rooms.Room:on_exit`](ROOMS.md#rooms.Room.on_exit) are this same event, narrowed to one room.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_room_change.callback" name="events.on_room_change.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
-    - **`old_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). -1 if it had none.
-    - **`new_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). -1 if it left the world.
+    - <a id="events.on_room_change.item" name="events.on_room_change.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
+    - <a id="events.on_room_change.old_room_num" name="events.on_room_change.old_room_num"></a>**`old_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). -1 if it had none.
+    - <a id="events.on_room_change.new_room_num" name="events.on_room_change.new_room_num"></a>**`new_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). -1 if it left the world.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -162,10 +166,10 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_trigger`](ITEMS.md#items.Item.on_trigger) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_trigger.callback" name="events.on_trigger.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item the trigger was aimed at.
-    - **`trigger`** (table). What the trigger carried: `type` (a [`trx.items.TriggerType`](ITEMS.md#items.TriggerType)), `mask` (the code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.
+    - <a id="events.on_trigger.item" name="events.on_trigger.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item the trigger was aimed at.
+    - <a id="events.on_trigger.trigger" name="events.on_trigger.trigger"></a>**`trigger`** ([trx.items.Trigger](ITEMS.md#items.Trigger)). What the trigger carried.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -184,9 +188,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_show`](ITEMS.md#items.Item.on_show) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_show.callback" name="events.on_show.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that became visible.
+    - <a id="events.on_show.item" name="events.on_show.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that became visible.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -203,9 +207,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_hide`](ITEMS.md#items.Item.on_hide) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_hide.callback" name="events.on_hide.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that became hidden.
+    - <a id="events.on_hide.item" name="events.on_hide.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that became hidden.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -222,9 +226,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_finish`](ITEMS.md#items.Item.on_finish) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_finish.callback" name="events.on_finish.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that finished.
+    - <a id="events.on_finish.item" name="events.on_finish.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that finished.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -241,9 +245,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_enter_sim`](ITEMS.md#items.Item.on_enter_sim) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_enter_sim.callback" name="events.on_enter_sim.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that started being simulated.
+    - <a id="events.on_enter_sim.item" name="events.on_enter_sim.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that started being simulated.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -260,9 +264,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_leave_sim`](ITEMS.md#items.Item.on_leave_sim) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_leave_sim.callback" name="events.on_leave_sim.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that stopped being simulated.
+    - <a id="events.on_leave_sim.item" name="events.on_leave_sim.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that stopped being simulated.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -279,9 +283,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_activate`](ITEMS.md#items.Item.on_activate) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_activate.callback" name="events.on_activate.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was activated.
+    - <a id="events.on_activate.item" name="events.on_activate.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was activated.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -298,9 +302,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_deactivate`](ITEMS.md#items.Item.on_deactivate) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_deactivate.callback" name="events.on_deactivate.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was deactivated.
+    - <a id="events.on_deactivate.item" name="events.on_deactivate.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was deactivated.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -317,9 +321,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_destroy`](ITEMS.md#items.Item.on_destroy) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_destroy.callback" name="events.on_destroy.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item being removed. Valid only for the duration of the handler.
+    - <a id="events.on_destroy.item" name="events.on_destroy.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item being removed. Valid only for the duration of the handler.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -336,9 +340,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_enter_world`](ITEMS.md#items.Item.on_enter_world) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_enter_world.callback" name="events.on_enter_world.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that entered the world.
+    - <a id="events.on_enter_world.item" name="events.on_enter_world.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that entered the world.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -355,9 +359,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_leave_world`](ITEMS.md#items.Item.on_leave_world) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_leave_world.callback" name="events.on_leave_world.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that left the world.
+    - <a id="events.on_leave_world.item" name="events.on_leave_world.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that left the world.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -377,10 +381,10 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_hit`](ITEMS.md#items.Item.on_hit) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_hit.callback" name="events.on_hit.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that took the damage.
-    - **`damage`** (integer). Hit points taken, before clamping to zero.
+    - <a id="events.on_hit.item" name="events.on_hit.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that took the damage.
+    - <a id="events.on_hit.damage" name="events.on_hit.damage"></a>**`damage`** (integer). Hit points taken, before clamping to zero.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -404,9 +408,9 @@ An event that carries a default the script may take over says so in its descript
   [`trx.items.Item:on_kill`](ITEMS.md#items.Item.on_kill) is this same event, narrowed to one item.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_kill.callback" name="events.on_kill.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was brought down.
+    - <a id="events.on_kill.item" name="events.on_kill.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that was brought down.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -434,9 +438,9 @@ An event that carries a default the script may take over says so in its descript
   the engine has nothing of its own to do about them.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_cutscene_trigger.callback" name="events.on_cutscene_trigger.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)). The number the trigger names, which the game need not have a cutscene for.
+    - <a id="events.on_cutscene_trigger.cutscene_num" name="events.on_cutscene_trigger.cutscene_num"></a>**`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)). The number the trigger names, which the game need not have a cutscene for.
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -460,9 +464,9 @@ An event that carries a default the script may take over says so in its descript
   Happens when a TR4 cutscene's first frame is about to show, after the fade out.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_cutscene_start.callback" name="events.on_cutscene_start.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
+    - <a id="events.on_cutscene_start.cutscene_num" name="events.on_cutscene_start.cutscene_num"></a>**`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -470,9 +474,9 @@ An event that carries a default the script may take over says so in its descript
   Happens once a TR4 cutscene has finished and the scene it interrupted is back. This is where a script decides what follows.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_cutscene_end.callback" name="events.on_cutscene_end.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
+    - <a id="events.on_cutscene_end.cutscene_num" name="events.on_cutscene_end.cutscene_num"></a>**`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -488,9 +492,9 @@ An event that carries a default the script may take over says so in its descript
   A sequence that a cutscene or the player interrupts does not fire it.
 
   Parameters:
-  - **`callback`** (function).
+  - <a id="events.on_flyby_end.callback" name="events.on_flyby_end.callback"></a>**`callback`** (function). What to run when it happens.
     Called with:
-    - **`sequence_num`** ([trx.camera.SequenceNum](CAMERA.md#camera.SequenceNum)).
+    - <a id="events.on_flyby_end.sequence_num" name="events.on_flyby_end.sequence_num"></a>**`sequence_num`** ([trx.camera.SequenceNum](CAMERA.md#camera.SequenceNum)).
 
   Returns: [trx.events.Listener](#events.Listener). The attached handler.
 
@@ -505,7 +509,7 @@ An event that carries a default the script may take over says so in its descript
   Removes a previously attached handler, which stops firing immediately. [`trx.events.Listener:detach`](#events.Listener.detach) does the same to one held in hand.
 
   Parameters:
-  - **`listener`** ([trx.events.Listener](#events.Listener)).
+  - <a id="events.detach.listener" name="events.detach.listener"></a>**`listener`** ([trx.events.Listener](#events.Listener)). What the hook handed back when the handler was attached.
 
   Returns: boolean. Whether the handler was still attached. `false` means it had already been detached, or the level it belonged to has ended.
 

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -65,6 +65,14 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Structures
 
+- <a id="game.LevelNum" name="game.LevelNum"></a>[lua]`trx.game.LevelNum`
+
+    The number a level goes by, which is what the player is shown and what a gameflow names. Not its place in a table: a level the game flow skips does not count, and a gym level has no number at all and reads 0. Counted from 1.
+
+- <a id="game.DemoNum" name="game.DemoNum"></a>[lua]`trx.game.DemoNum`
+
+    Where a demo sits in the table of demos. Counted from 1.
+
 - <a id="game.Level" name="game.Level"></a>[lua]`trx.game.Level`
 
     A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.
@@ -76,7 +84,7 @@ Module for the game flow: which levels there are, and which one is being played.
     Properties:
     - <a id="game.Level.lara_outfit" name="game.Level.lara_outfit"></a>**`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
     - <a id="game.Level.music_track" name="game.Level.music_track"></a>**`music_track`**: [trx.catalog.music](CATALOG.md#catalog.music). The track that plays when the level starts. *(read-only)*
-    - <a id="game.Level.num" name="game.Level.num"></a>**`num`**: integer. The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0. Counted from 1. *(read-only)*
+    - <a id="game.Level.num" name="game.Level.num"></a>**`num`**: [trx.game.LevelNum](#game.LevelNum). *(read-only)*
     - <a id="game.Level.path" name="game.Level.path"></a>**`path`**: string. Path to the level file. *(read-only)*
     - <a id="game.Level.script_path" name="game.Level.script_path"></a>**`script_path`**: string. Path to the Lua script that runs when the level loads, or `nil` if it has none. *(read-only)*
     - <a id="game.Level.title" name="game.Level.title"></a>**`title`**: string. The level's name, as shown to the player. *(read-only)*
@@ -97,8 +105,11 @@ Module for the game flow: which levels there are, and which one is being played.
   Starts a level from [`trx.game.levels`](#game.levels).
 
   Parameters:
-  - **`level_num`** (integer). Position in [`trx.game.levels`](#game.levels). Counted from 1.
-  - **`opts`** (table, optional). `select`: start the level as the level-select screen does, rebuilding Lara's inventory to what she would carry on reaching it. Without it the level continues from the one in progress.
+  - <a id="game.play_level.level_num" name="game.play_level.level_num"></a>**`level_num`** ([trx.game.LevelNum](#game.LevelNum)).
+  - <a id="game.play_level.opts" name="game.play_level.opts"></a>**`opts`** (table, optional). How to start it.
+
+    Keys:
+    - <a id="game.play_level.opts.select" name="game.play_level.opts.select"></a>**`select`** (boolean, optional). Start the level as the level-select screen does, rebuilding Lara's inventory to what she would carry on reaching it. Without it the level continues from the one in progress.
 
   Example:
   ```lua
@@ -109,13 +120,13 @@ Module for the game flow: which levels there are, and which one is being played.
   Plays a cutscene.
 
   Parameters:
-  - **`cutscene_num`** (integer). Position in [`trx.game.cutscenes`](#game.cutscenes). Counted from 1.
+  - <a id="game.play_cutscene.cutscene_num" name="game.play_cutscene.cutscene_num"></a>**`cutscene_num`** ([trx.cutscenes.Num](CUTSCENES.md#cutscenes.Num)).
 
 - <a id="game.play_demo" name="game.play_demo"></a>[lua]`trx.game.play_demo([demo_num])`  
   Plays a demo, and returns the one that started.
 
   Parameters:
-  - **`demo_num`** (integer, optional). Position in [`trx.game.demos`](#game.demos). Omit to play the next demo in rotation. Counted from 1.
+  - <a id="game.play_demo.demo_num" name="game.play_demo.demo_num"></a>**`demo_num`** ([trx.game.DemoNum](#game.DemoNum), optional). Omit to play the next demo in rotation.
 
   Returns:
   - [trx.game.Level](#game.Level) or `nil`. The demo that started, or `nil` if the game has no demos.
@@ -136,4 +147,4 @@ Module for the game flow: which levels there are, and which one is being played.
   Takes a screenshot. Without a path, writes one to the screenshots folder in the player's configured format; with a path, writes to that file.
 
   Parameters:
-  - **`path`** (string, optional). File to write to.
+  - <a id="game.screenshot.path" name="game.screenshot.path"></a>**`path`** (string, optional). File to write to.

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -10,26 +10,26 @@ order: 10
   src/lua/api/game.lua. Edit it there.
 -->
 
-## Game module
+## <a id="game" name="game"></a>Game module
 
 Module for the game flow: which levels there are, and which one is being played.
 
 ### Properties
 
-- <a name="game.levels"></a>**`trx.game.levels`** (table). The levels of the game, in order, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
-- <a name="game.cutscenes"></a>**`trx.game.cutscenes`** (table). The cutscene levels, as a list of [`trx.game.Level`](#game.Level) counted from one. TR4's in-game cutscenes are a different thing, and live in [`trx.cutscenes`](CUTSCENES.md#cutscenes). *(read-only)*
-- <a name="game.demos"></a>**`trx.game.demos`** (table). The demos, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
-- <a name="game.current_level"></a>**`trx.game.current_level`** ([trx.game.Level](#game.Level)). The level being played, or `nil` if none is. *(read-only)*
-- <a name="game.gym"></a>**`trx.game.gym`** ([trx.game.Level](#game.Level)). The gym level, or `nil` if this game has no gym. *(read-only)*
-- <a name="game.version"></a>**`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
-- <a name="game.trx_version"></a>**`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
-- <a name="game.is_loaded"></a>**`trx.game.is_loaded`** (boolean). Whether a level is loaded. *(read-only)*
-- <a name="game.is_playable"></a>**`trx.game.is_playable`** (boolean). Whether the game is loaded and taking input - not in a menu, and not in a cutscene. *(read-only)*
-- <a name="game.is_ngplus"></a>**`trx.game.is_ngplus`** (boolean). Whether this is a new game plus run, which is what the passport's bonus start sets. Lara keeps her weapons between levels and her ammunition does not run down. *(read-only)*
+- <a id="game.levels" name="game.levels"></a>**`trx.game.levels`** (table). The levels of the game, in order, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
+- <a id="game.cutscenes" name="game.cutscenes"></a>**`trx.game.cutscenes`** (table). The cutscene levels, as a list of [`trx.game.Level`](#game.Level) counted from one. TR4's in-game cutscenes are a different thing, and live in [`trx.cutscenes`](CUTSCENES.md#cutscenes). *(read-only)*
+- <a id="game.demos" name="game.demos"></a>**`trx.game.demos`** (table). The demos, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
+- <a id="game.current_level" name="game.current_level"></a>**`trx.game.current_level`** ([trx.game.Level](#game.Level)). The level being played, or `nil` if none is. *(read-only)*
+- <a id="game.gym" name="game.gym"></a>**`trx.game.gym`** ([trx.game.Level](#game.Level)). The gym level, or `nil` if this game has no gym. *(read-only)*
+- <a id="game.version" name="game.version"></a>**`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
+- <a id="game.trx_version" name="game.trx_version"></a>**`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
+- <a id="game.is_loaded" name="game.is_loaded"></a>**`trx.game.is_loaded`** (boolean). Whether a level is loaded. *(read-only)*
+- <a id="game.is_playable" name="game.is_playable"></a>**`trx.game.is_playable`** (boolean). Whether the game is loaded and taking input - not in a menu, and not in a cutscene. *(read-only)*
+- <a id="game.is_ngplus" name="game.is_ngplus"></a>**`trx.game.is_ngplus`** (boolean). Whether this is a new game plus run, which is what the passport's bonus start sets. Lara keeps her weapons between levels and her ammunition does not run down. *(read-only)*
 
 ### Enums
 
-- <a name="game.LevelTable"></a>[lua]`trx.game.LevelTable`
+- <a id="game.LevelTable" name="game.LevelTable"></a>[lua]`trx.game.LevelTable`
 
     One of the lists of levels the game flow declares.
 
@@ -42,7 +42,7 @@ Module for the game flow: which levels there are, and which one is being played.
     - `trx.game.LevelTable.DEMOS` = `3`  
         The demos that play when the title screen is left alone.
 
-- <a name="game.LevelType"></a>[lua]`trx.game.LevelType`
+- <a id="game.LevelType" name="game.LevelType"></a>[lua]`trx.game.LevelType`
 
     What kind of level it is.
 
@@ -65,7 +65,7 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Structures
 
-- <a name="game.Level"></a>[lua]`trx.game.Level`
+- <a id="game.Level" name="game.Level"></a>[lua]`trx.game.Level`
 
     A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.
 
@@ -74,26 +74,26 @@ Module for the game flow: which levels there are, and which one is being played.
     unrelated one.
 
     Properties:
-    - <a name="game.Level.lara_outfit"></a>**`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
-    - <a name="game.Level.music_track"></a>**`music_track`**: [trx.catalog.music](CATALOG.md#catalog.music). The track that plays when the level starts. *(read-only)*
-    - <a name="game.Level.num"></a>**`num`**: integer. The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0. Counted from 1. *(read-only)*
-    - <a name="game.Level.path"></a>**`path`**: string. Path to the level file. *(read-only)*
-    - <a name="game.Level.script_path"></a>**`script_path`**: string. Path to the Lua script that runs when the level loads, or `nil` if it has none. *(read-only)*
-    - <a name="game.Level.title"></a>**`title`**: string. The level's name, as shown to the player. *(read-only)*
-    - <a name="game.Level.type"></a>**`type`**: [trx.game.LevelType](#game.LevelType). What kind of level it is. *(read-only)*
-    - <a name="game.Level.unobtainable_ally_kills"></a>**`unobtainable_ally_kills`**: integer. Ally kills the stats screen must not hold against the player. *(read-only)*
-    - <a name="game.Level.unobtainable_kills"></a>**`unobtainable_kills`**: integer. Kills the stats screen must not hold against the player. *(read-only)*
-    - <a name="game.Level.unobtainable_pickups"></a>**`unobtainable_pickups`**: integer. Pickups the stats screen must not hold against the player, because they cannot be got. *(read-only)*
-    - <a name="game.Level.unobtainable_secrets"></a>**`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
-    - <a name="game.Level.water_particles"></a>**`water_particles`**: boolean. Whether water particles are visible in the level's water. *(read-only)*
+    - <a id="game.Level.lara_outfit" name="game.Level.lara_outfit"></a>**`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
+    - <a id="game.Level.music_track" name="game.Level.music_track"></a>**`music_track`**: [trx.catalog.music](CATALOG.md#catalog.music). The track that plays when the level starts. *(read-only)*
+    - <a id="game.Level.num" name="game.Level.num"></a>**`num`**: integer. The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0. Counted from 1. *(read-only)*
+    - <a id="game.Level.path" name="game.Level.path"></a>**`path`**: string. Path to the level file. *(read-only)*
+    - <a id="game.Level.script_path" name="game.Level.script_path"></a>**`script_path`**: string. Path to the Lua script that runs when the level loads, or `nil` if it has none. *(read-only)*
+    - <a id="game.Level.title" name="game.Level.title"></a>**`title`**: string. The level's name, as shown to the player. *(read-only)*
+    - <a id="game.Level.type" name="game.Level.type"></a>**`type`**: [trx.game.LevelType](#game.LevelType). What kind of level it is. *(read-only)*
+    - <a id="game.Level.unobtainable_ally_kills" name="game.Level.unobtainable_ally_kills"></a>**`unobtainable_ally_kills`**: integer. Ally kills the stats screen must not hold against the player. *(read-only)*
+    - <a id="game.Level.unobtainable_kills" name="game.Level.unobtainable_kills"></a>**`unobtainable_kills`**: integer. Kills the stats screen must not hold against the player. *(read-only)*
+    - <a id="game.Level.unobtainable_pickups" name="game.Level.unobtainable_pickups"></a>**`unobtainable_pickups`**: integer. Pickups the stats screen must not hold against the player, because they cannot be got. *(read-only)*
+    - <a id="game.Level.unobtainable_secrets" name="game.Level.unobtainable_secrets"></a>**`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
+    - <a id="game.Level.water_particles" name="game.Level.water_particles"></a>**`water_particles`**: boolean. Whether water particles are visible in the level's water. *(read-only)*
 
     Computed properties (derived, not stored on the object):
-    - <a name="game.Level.inventory"></a>**`inventory`**: [trx.inventory.Inventory](INVENTORY.md#inventory.Inventory). What the level keeps for Lara's return, or `nil` for a level that keeps nothing: the title screen and the cutscenes. It is what she will arrive there with rather than what she is carrying now, which is `trx.inventory` itself.
-    - <a name="game.Level.stats"></a>**`stats`**: [trx.stats.Stats](STATS.md#stats.Stats). What the level keeps count of, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.
+    - <a id="game.Level.inventory" name="game.Level.inventory"></a>**`inventory`**: [trx.inventory.Inventory](INVENTORY.md#inventory.Inventory). What the level keeps for Lara's return, or `nil` for a level that keeps nothing: the title screen and the cutscenes. It is what she will arrive there with rather than what she is carrying now, which is [`trx.inventory`](INVENTORY.md#inventory) itself.
+    - <a id="game.Level.stats" name="game.Level.stats"></a>**`stats`**: [trx.stats.Stats](STATS.md#stats.Stats). What the level keeps count of, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also [`trx.stats`](STATS.md#stats) itself.
 
 ### Functions
 
-- <a name="game.play_level"></a>[lua]`trx.game.play_level(level_num, [opts])`  
+- <a id="game.play_level" name="game.play_level"></a>[lua]`trx.game.play_level(level_num, [opts])`  
   Starts a level from [`trx.game.levels`](#game.levels).
 
   Parameters:
@@ -105,13 +105,13 @@ Module for the game flow: which levels there are, and which one is being played.
   trx.game.play_level(1)
   ```
 
-- <a name="game.play_cutscene"></a>[lua]`trx.game.play_cutscene(cutscene_num)`  
+- <a id="game.play_cutscene" name="game.play_cutscene"></a>[lua]`trx.game.play_cutscene(cutscene_num)`  
   Plays a cutscene.
 
   Parameters:
   - **`cutscene_num`** (integer). Position in [`trx.game.cutscenes`](#game.cutscenes). Counted from 1.
 
-- <a name="game.play_demo"></a>[lua]`trx.game.play_demo([demo_num])`  
+- <a id="game.play_demo" name="game.play_demo"></a>[lua]`trx.game.play_demo([demo_num])`  
   Plays a demo, and returns the one that started.
 
   Parameters:
@@ -120,19 +120,19 @@ Module for the game flow: which levels there are, and which one is being played.
   Returns:
   - [trx.game.Level](#game.Level) or `nil`. The demo that started, or `nil` if the game has no demos.
 
-- <a name="game.play_gym"></a>[lua]`trx.game.play_gym()`  
+- <a id="game.play_gym" name="game.play_gym"></a>[lua]`trx.game.play_gym()`  
   Starts the gym. Raises if this game has no gym.
 
-- <a name="game.end_level"></a>[lua]`trx.game.end_level()`  
+- <a id="game.end_level" name="game.end_level"></a>[lua]`trx.game.end_level()`  
   Ends the current level, as though Lara had reached its exit.
 
-- <a name="game.exit_to_title"></a>[lua]`trx.game.exit_to_title()`  
+- <a id="game.exit_to_title" name="game.exit_to_title"></a>[lua]`trx.game.exit_to_title()`  
   Leaves the current game and returns to the title screen.
 
-- <a name="game.exit_game"></a>[lua]`trx.game.exit_game()`  
+- <a id="game.exit_game" name="game.exit_game"></a>[lua]`trx.game.exit_game()`  
   Closes the game.
 
-- <a name="game.screenshot"></a>[lua]`trx.game.screenshot([path])`  
+- <a id="game.screenshot" name="game.screenshot"></a>[lua]`trx.game.screenshot([path])`  
   Takes a screenshot. Without a path, writes one to the screenshots folder in the player's configured format; with a path, writes to that file.
 
   Parameters:

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -93,11 +93,11 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Functions
 
-- [lua]`trx.game.play_level(num, [opts])`  
+- [lua]`trx.game.play_level(level_num, [opts])`  
   Starts a level from `trx.game.levels`.
 
   Parameters:
-  - **`num`** (integer). 1-based position in `trx.game.levels`.
+  - **`level_num`** (integer). 1-based position in `trx.game.levels`.
   - **`opts`** (table, optional). `select`: start the level as the level-select screen does, rebuilding Lara's inventory to what she would carry on reaching it. Without it the level continues from the one in progress.
 
   Example:
@@ -105,17 +105,17 @@ Module for the game flow: which levels there are, and which one is being played.
   trx.game.play_level(1)
   ```
 
-- [lua]`trx.game.play_cutscene(num)`  
+- [lua]`trx.game.play_cutscene(cutscene_num)`  
   Plays a cutscene.
 
   Parameters:
-  - **`num`** (integer). 1-based position in `trx.game.cutscenes`.
+  - **`cutscene_num`** (integer). 1-based position in `trx.game.cutscenes`.
 
-- [lua]`trx.game.play_demo([num])`  
+- [lua]`trx.game.play_demo([demo_num])`  
   Plays a demo, and returns the one that started.
 
   Parameters:
-  - **`num`** (integer, optional). 1-based position in `trx.game.demos`. Omit to play the next demo in rotation.
+  - **`demo_num`** (integer, optional). 1-based position in `trx.game.demos`. Omit to play the next demo in rotation.
 
   Returns:
   - Level or `nil`. The demo that started, or `nil` if the game has no demos.

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -73,6 +73,15 @@ Module for the game flow: which levels there are, and which one is being played.
 
     Where a demo sits in the table of demos. Counted from 1.
 
+- <a id="game.Frames" name="game.Frames"></a>[lua]`trx.game.Frames` (integer)
+
+    A length of time counted in the frames the engine runs the world at, which
+    is what the engine measures its own timers in.
+
+- <a id="game.Seconds" name="game.Seconds"></a>[lua]`trx.game.Seconds` (number)
+
+    A length of time in seconds, as a player would read it off a clock.
+
 - <a id="game.Level" name="game.Level"></a>[lua]`trx.game.Level`
 
     A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -16,20 +16,20 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Properties
 
-- **`trx.game.levels`** (table). The levels of the game, in order, as a list of `trx.game.Level` counted from one. *(read-only)*
-- **`trx.game.cutscenes`** (table). The cutscene levels, as a list of `trx.game.Level` counted from one. TR4's in-game cutscenes are a different thing, and live in `trx.cutscenes`. *(read-only)*
-- **`trx.game.demos`** (table). The demos, as a list of `trx.game.Level` counted from one. *(read-only)*
-- **`trx.game.current_level`** (Level). The level being played, or `nil` if none is. *(read-only)*
-- **`trx.game.gym`** (Level). The gym level, or `nil` if this game has no gym. *(read-only)*
-- **`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
-- **`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
-- **`trx.game.is_loaded`** (boolean). Whether a level is loaded. *(read-only)*
-- **`trx.game.is_playable`** (boolean). Whether the game is loaded and taking input - not in a menu, and not in a cutscene. *(read-only)*
-- **`trx.game.is_ngplus`** (boolean). Whether this is a new game plus run, which is what the passport's bonus start sets. Lara keeps her weapons between levels and her ammunition does not run down. *(read-only)*
+- <a name="game.levels"></a>**`trx.game.levels`** (table). The levels of the game, in order, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
+- <a name="game.cutscenes"></a>**`trx.game.cutscenes`** (table). The cutscene levels, as a list of [`trx.game.Level`](#game.Level) counted from one. TR4's in-game cutscenes are a different thing, and live in [`trx.cutscenes`](CUTSCENES.md#cutscenes). *(read-only)*
+- <a name="game.demos"></a>**`trx.game.demos`** (table). The demos, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
+- <a name="game.current_level"></a>**`trx.game.current_level`** ([trx.game.Level](#game.Level)). The level being played, or `nil` if none is. *(read-only)*
+- <a name="game.gym"></a>**`trx.game.gym`** ([trx.game.Level](#game.Level)). The gym level, or `nil` if this game has no gym. *(read-only)*
+- <a name="game.version"></a>**`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
+- <a name="game.trx_version"></a>**`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
+- <a name="game.is_loaded"></a>**`trx.game.is_loaded`** (boolean). Whether a level is loaded. *(read-only)*
+- <a name="game.is_playable"></a>**`trx.game.is_playable`** (boolean). Whether the game is loaded and taking input - not in a menu, and not in a cutscene. *(read-only)*
+- <a name="game.is_ngplus"></a>**`trx.game.is_ngplus`** (boolean). Whether this is a new game plus run, which is what the passport's bonus start sets. Lara keeps her weapons between levels and her ammunition does not run down. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.game.LevelTable`
+- <a name="game.LevelTable"></a>[lua]`trx.game.LevelTable`
 
     One of the lists of levels the game flow declares.
 
@@ -42,7 +42,7 @@ Module for the game flow: which levels there are, and which one is being played.
     - `trx.game.LevelTable.DEMOS` = `3`  
         The demos that play when the title screen is left alone.
 
-- [lua]`trx.game.LevelType`
+- <a name="game.LevelType"></a>[lua]`trx.game.LevelType`
 
     What kind of level it is.
 
@@ -65,7 +65,7 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Structures
 
-- [lua]`trx.game.Level`
+- <a name="game.Level"></a>[lua]`trx.game.Level`
 
     A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.
 
@@ -74,30 +74,30 @@ Module for the game flow: which levels there are, and which one is being played.
     unrelated one.
 
     Properties:
-    - **`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
-    - **`music_track`**: integer. The track that plays when the level starts. Compare against `trx.catalog.music`. *(read-only)*
-    - **`num`**: integer. The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0. *(read-only)*
-    - **`path`**: string. Path to the level file. *(read-only)*
-    - **`script_path`**: string. Path to the Lua script that runs when the level loads, or `nil` if it has none. *(read-only)*
-    - **`title`**: string. The level's name, as shown to the player. *(read-only)*
-    - **`type`**: integer. What kind of level it is. Compare against `trx.game.LevelType`. *(read-only)*
-    - **`unobtainable_ally_kills`**: integer. Ally kills the stats screen must not hold against the player. *(read-only)*
-    - **`unobtainable_kills`**: integer. Kills the stats screen must not hold against the player. *(read-only)*
-    - **`unobtainable_pickups`**: integer. Pickups the stats screen must not hold against the player, because they cannot be got. *(read-only)*
-    - **`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
-    - **`water_particles`**: boolean. Whether water particles are visible in the level's water. *(read-only)*
+    - <a name="game.Level.lara_outfit"></a>**`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
+    - <a name="game.Level.music_track"></a>**`music_track`**: [trx.catalog.music](CATALOG.md#catalog.music). The track that plays when the level starts. *(read-only)*
+    - <a name="game.Level.num"></a>**`num`**: integer. The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0. Counted from 1. *(read-only)*
+    - <a name="game.Level.path"></a>**`path`**: string. Path to the level file. *(read-only)*
+    - <a name="game.Level.script_path"></a>**`script_path`**: string. Path to the Lua script that runs when the level loads, or `nil` if it has none. *(read-only)*
+    - <a name="game.Level.title"></a>**`title`**: string. The level's name, as shown to the player. *(read-only)*
+    - <a name="game.Level.type"></a>**`type`**: [trx.game.LevelType](#game.LevelType). What kind of level it is. *(read-only)*
+    - <a name="game.Level.unobtainable_ally_kills"></a>**`unobtainable_ally_kills`**: integer. Ally kills the stats screen must not hold against the player. *(read-only)*
+    - <a name="game.Level.unobtainable_kills"></a>**`unobtainable_kills`**: integer. Kills the stats screen must not hold against the player. *(read-only)*
+    - <a name="game.Level.unobtainable_pickups"></a>**`unobtainable_pickups`**: integer. Pickups the stats screen must not hold against the player, because they cannot be got. *(read-only)*
+    - <a name="game.Level.unobtainable_secrets"></a>**`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
+    - <a name="game.Level.water_particles"></a>**`water_particles`**: boolean. Whether water particles are visible in the level's water. *(read-only)*
 
     Computed properties (derived, not stored on the object):
-    - **`inventory`**: Inventory. What the level keeps for Lara's return, as a `trx.inventory.Inventory`, or `nil` for a level that keeps nothing: the title screen and the cutscenes. It is what she will arrive there with rather than what she is carrying now, which is `trx.inventory` itself.
-    - **`stats`**: Stats. What the level keeps count of, as a `trx.stats.Stats`, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.
+    - <a name="game.Level.inventory"></a>**`inventory`**: [trx.inventory.Inventory](INVENTORY.md#inventory.Inventory). What the level keeps for Lara's return, or `nil` for a level that keeps nothing: the title screen and the cutscenes. It is what she will arrive there with rather than what she is carrying now, which is `trx.inventory` itself.
+    - <a name="game.Level.stats"></a>**`stats`**: [trx.stats.Stats](STATS.md#stats.Stats). What the level keeps count of, or `nil` for a level that counts nothing: the title screen and the cutscenes. The level being played is also `trx.stats` itself.
 
 ### Functions
 
-- [lua]`trx.game.play_level(level_num, [opts])`  
-  Starts a level from `trx.game.levels`.
+- <a name="game.play_level"></a>[lua]`trx.game.play_level(level_num, [opts])`  
+  Starts a level from [`trx.game.levels`](#game.levels).
 
   Parameters:
-  - **`level_num`** (integer). 1-based position in `trx.game.levels`.
+  - **`level_num`** (integer). Position in [`trx.game.levels`](#game.levels). Counted from 1.
   - **`opts`** (table, optional). `select`: start the level as the level-select screen does, rebuilding Lara's inventory to what she would carry on reaching it. Without it the level continues from the one in progress.
 
   Example:
@@ -105,34 +105,34 @@ Module for the game flow: which levels there are, and which one is being played.
   trx.game.play_level(1)
   ```
 
-- [lua]`trx.game.play_cutscene(cutscene_num)`  
+- <a name="game.play_cutscene"></a>[lua]`trx.game.play_cutscene(cutscene_num)`  
   Plays a cutscene.
 
   Parameters:
-  - **`cutscene_num`** (integer). 1-based position in `trx.game.cutscenes`.
+  - **`cutscene_num`** (integer). Position in [`trx.game.cutscenes`](#game.cutscenes). Counted from 1.
 
-- [lua]`trx.game.play_demo([demo_num])`  
+- <a name="game.play_demo"></a>[lua]`trx.game.play_demo([demo_num])`  
   Plays a demo, and returns the one that started.
 
   Parameters:
-  - **`demo_num`** (integer, optional). 1-based position in `trx.game.demos`. Omit to play the next demo in rotation.
+  - **`demo_num`** (integer, optional). Position in [`trx.game.demos`](#game.demos). Omit to play the next demo in rotation. Counted from 1.
 
   Returns:
-  - Level or `nil`. The demo that started, or `nil` if the game has no demos.
+  - [trx.game.Level](#game.Level) or `nil`. The demo that started, or `nil` if the game has no demos.
 
-- [lua]`trx.game.play_gym()`  
+- <a name="game.play_gym"></a>[lua]`trx.game.play_gym()`  
   Starts the gym. Raises if this game has no gym.
 
-- [lua]`trx.game.end_level()`  
+- <a name="game.end_level"></a>[lua]`trx.game.end_level()`  
   Ends the current level, as though Lara had reached its exit.
 
-- [lua]`trx.game.exit_to_title()`  
+- <a name="game.exit_to_title"></a>[lua]`trx.game.exit_to_title()`  
   Leaves the current game and returns to the title screen.
 
-- [lua]`trx.game.exit_game()`  
+- <a name="game.exit_game"></a>[lua]`trx.game.exit_game()`  
   Closes the game.
 
-- [lua]`trx.game.screenshot([path])`  
+- <a name="game.screenshot"></a>[lua]`trx.game.screenshot([path])`  
   Takes a screenshot. Without a path, writes one to the screenshots folder in the player's configured format; with a path, writes to that file.
 
   Parameters:

--- a/docs/trx/lua/reference/INVENTORY.md
+++ b/docs/trx/lua/reference/INVENTORY.md
@@ -75,7 +75,7 @@ end
 
     Methods:
 
-    - [lua]`inventory:can_add(object)`  
+    - [lua]`inventory:can_add(object_id)`  
       Whether `give` would do anything in the level being played. The level has to
       carry the inventory model, which is not the same as the pickup being in it: a
       level with no shotgun lying about still draws one in the ring, which is what
@@ -84,19 +84,19 @@ end
       This asks about the level being played whichever inventory it is called on.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
 
       Returns: boolean.
 
-    - [lua]`inventory:count(object)`  
+    - [lua]`inventory:count(object_id)`  
       How many of something is in it. A box of ammunition counts what its rounds come to.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
 
       Returns: integer.
 
-    - [lua]`inventory:entry(object)`  
+    - [lua]`inventory:entry(object_id)`  
       The entry something is drawn as, or `nil` where there is none of it.
 
       Several pickups share one entry - the scion whether or not she holds it, a
@@ -104,15 +104,15 @@ end
       drawn as.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
 
       Returns: Entry or `nil`.
 
-    - [lua]`inventory:entry_at(n)`  
+    - [lua]`inventory:entry_at(entry_num)`  
       The entry at a position, counted from one in the order they are drawn, or `nil` past the end.
 
       Parameters:
-      - **`n`** (integer). 1-based position.
+      - **`entry_num`** (integer). 1-based position.
 
       Returns: Entry or `nil`.
 
@@ -121,13 +121,13 @@ end
 
       Returns: integer.
 
-    - [lua]`inventory:give(object, [count])`  
+    - [lua]`inventory:give(object_id, [count])`  
       Puts a pickup in. Lara's inventory takes it as walking over it would, so a
       weapon arrives with the rounds a pickup carries and a flare box with its
       flares; a level's simply gains it.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
       - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many went in. 0 from Lara's means the level does not carry the icon for it - see `can_add`.
@@ -137,11 +137,11 @@ end
       trx.inventory:give(trx.catalog.objects.uzi_item, 2)
       ```
 
-    - [lua]`inventory:has(object)`  
+    - [lua]`inventory:has(object_id)`  
       Whether there is any of it at all.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
 
       Returns: boolean.
 
@@ -153,7 +153,7 @@ end
 
       Returns: boolean.
 
-    - [lua]`inventory:icon_of(object)`  
+    - [lua]`inventory:icon_of(object_id)`  
       Which inventory icon a pickup is drawn as, whether or not there is any of it.
 
       Several pickups share one icon - the scion whether or not Lara holds it, a
@@ -162,15 +162,15 @@ end
       what hands back the entry itself.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
 
       Returns: integer or `nil`. The icon's object id, or `nil` for a pickup that has none. Compare against `trx.catalog.objects`.
 
-    - [lua]`inventory:set_count(object, count)`  
+    - [lua]`inventory:set_count(object_id, count)`  
       Sets how many of it there are. Zero takes it away.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
       - **`count`** (integer). How many. Below 0 raises.
 
     - [lua]`inventory:set_shots(weapon, count)`  
@@ -193,14 +193,14 @@ end
 
       Returns: integer.
 
-    - [lua]`inventory:take(object, [count])`  
+    - [lua]`inventory:take(object_id, [count])`  
       Takes things back out, stopping when there are none left.
 
       This is not the exact opposite of `give`: a box of ammunition is rounds rather
       than an entry of its own, so taking one back takes the rounds a box is worth.
 
       Parameters:
-      - **`object`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
       - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many came out.

--- a/docs/trx/lua/reference/INVENTORY.md
+++ b/docs/trx/lua/reference/INVENTORY.md
@@ -16,7 +16,7 @@ What Lara is carrying, and what goes into it.
 
 The module is the inventory she holds now, so `trx.inventory:count(object)`
 asks about her. Any level's is reached the same way through
-`trx.game.Level.inventory`, which is what it will hand her when she arrives
+[`trx.game.Level.inventory`](GAME.md#game.Level.inventory), which is what it will hand her when she arrives
 there rather than what she has this second.
 
 Every function takes either the pickup lying in the world or the inventory icon
@@ -25,9 +25,9 @@ has.
 
 ### Indexing
 
-Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries count from one, in the order they are drawn, and are built one at a time as they are asked for. `pairs()` walks them.
+Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries are keyed by the order they are drawn in, and are built one at a time as they are asked for. `pairs()` walks them.
 
-- **`trx.inventory[key]`** (Entry or `nil`). 1-based position.
+- <a name="inventory[]"></a>**`trx.inventory[key]`** ([trx.inventory.Entry](#inventory.Entry) or `nil`). Position in the ring. Counted from 1.
 - **`#trx.inventory`** (integer). How many there are.
 
 Example:
@@ -39,7 +39,7 @@ end
 
 ### Structures
 
-- [lua]`trx.inventory.Entry`
+- <a name="inventory.Entry"></a>[lua]`trx.inventory.Entry`
 
     One kind of thing an inventory holds, and how many of it.
 
@@ -52,15 +52,15 @@ end
     unrelated one.
 
     Properties:
-    - **`count`**: integer. How many of it there are. Writing 0 takes it away.
-    - **`object`**: integer. The inventory icon this entry is drawn as. Compare against `trx.catalog.objects`. *(read-only)*
+    - <a name="inventory.Entry.count"></a>**`count`**: integer. How many of it there are. Writing 0 takes it away.
+    - <a name="inventory.Entry.object"></a>**`object`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The inventory icon this entry is drawn as. *(read-only)*
 
-- [lua]`trx.inventory.Inventory`
+- <a name="inventory.Inventory"></a>[lua]`trx.inventory.Inventory`
 
     An inventory: what is in it, and how much ammunition goes with it.
 
-    `trx.inventory` is the one Lara is carrying. A level's, reached as
-    `trx.game.Level.inventory`, is what she will arrive there with, and holds only
+    [`trx.inventory`](#inventory) is the one Lara is carrying. A level's, reached as
+    [`trx.game.Level.inventory`](GAME.md#game.Level.inventory), is what she will arrive there with, and holds only
     what travels between levels - a key or a puzzle piece belongs to the level it
     was found in.
 
@@ -75,7 +75,7 @@ end
 
     Methods:
 
-    - [lua]`inventory:can_add(object_id)`  
+    - <a name="inventory.Inventory.can_add"></a>[lua]`inventory:can_add(object_id)`  
       Whether `give` would do anything in the level being played. The level has to
       carry the inventory model, which is not the same as the pickup being in it: a
       level with no shotgun lying about still draws one in the ring, which is what
@@ -84,19 +84,19 @@ end
       This asks about the level being played whichever inventory it is called on.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
       Returns: boolean.
 
-    - [lua]`inventory:count(object_id)`  
+    - <a name="inventory.Inventory.count"></a>[lua]`inventory:count(object_id)`  
       How many of something is in it. A box of ammunition counts what its rounds come to.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
       Returns: integer.
 
-    - [lua]`inventory:entry(object_id)`  
+    - <a name="inventory.Inventory.entry"></a>[lua]`inventory:entry(object_id)`  
       The entry something is drawn as, or `nil` where there is none of it.
 
       Several pickups share one entry - the scion whether or not she holds it, a
@@ -104,30 +104,30 @@ end
       drawn as.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
-      Returns: Entry or `nil`.
+      Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`.
 
-    - [lua]`inventory:entry_at(entry_num)`  
-      The entry at a position, counted from one in the order they are drawn, or `nil` past the end.
+    - <a name="inventory.Inventory.entry_at"></a>[lua]`inventory:entry_at(entry_num)`  
+      The entry at a position in the order they are drawn, or `nil` past the end.
 
       Parameters:
-      - **`entry_num`** (integer). 1-based position.
+      - **`entry_num`** (integer). Position in the ring. Counted from 1.
 
-      Returns: Entry or `nil`.
+      Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`.
 
-    - [lua]`inventory:entry_count()`  
+    - <a name="inventory.Inventory.entry_count"></a>[lua]`inventory:entry_count()`  
       How many entries there are. `#trx.inventory` is the same number for the one Lara carries.
 
       Returns: integer.
 
-    - [lua]`inventory:give(object_id, [count])`  
+    - <a name="inventory.Inventory.give"></a>[lua]`inventory:give(object_id, [count])`  
       Puts a pickup in. Lara's inventory takes it as walking over it would, so a
       weapon arrives with the rounds a pickup carries and a flare box with its
       flares; a level's simply gains it.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
       - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many went in. 0 from Lara's means the level does not carry the icon for it - see `can_add`.
@@ -137,23 +137,23 @@ end
       trx.inventory:give(trx.catalog.objects.uzi_item, 2)
       ```
 
-    - [lua]`inventory:has(object_id)`  
+    - <a name="inventory.Inventory.has"></a>[lua]`inventory:has(object_id)`  
       Whether there is any of it at all.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
       Returns: boolean.
 
-    - [lua]`inventory:has_weapon(weapon)`  
+    - <a name="inventory.Inventory.has_weapon"></a>[lua]`inventory:has_weapon(weapon)`  
       Whether the weapon itself is in it, which is not the same as having ammunition for it.
 
       Parameters:
-      - **`weapon`** (integer). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is. Compare against `trx.catalog.weapons`.
+      - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
       Returns: boolean.
 
-    - [lua]`inventory:icon_of(object_id)`  
+    - <a name="inventory.Inventory.icon_of"></a>[lua]`inventory:icon_of(object_id)`  
       Which inventory icon a pickup is drawn as, whether or not there is any of it.
 
       Several pickups share one icon - the scion whether or not Lara holds it, a
@@ -162,22 +162,22 @@ end
       what hands back the entry itself.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
-      Returns: integer or `nil`. The icon's object id, or `nil` for a pickup that has none. Compare against `trx.catalog.objects`.
+      Returns: [trx.catalog.objects](CATALOG.md#catalog.objects) or `nil`. The icon's object id, or `nil` for a pickup that has none.
 
-    - [lua]`inventory:set_count(object_id, count)`  
+    - <a name="inventory.Inventory.set_count"></a>[lua]`inventory:set_count(object_id, count)`  
       Sets how many of it there are. Zero takes it away.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
       - **`count`** (integer). How many. Below 0 raises.
 
-    - [lua]`inventory:set_shots(weapon, count)`  
+    - <a name="inventory.Inventory.set_shots"></a>[lua]`inventory:set_shots(weapon, count)`  
       Sets how many shots there are for it.
 
       Parameters:
-      - **`weapon`** (integer). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is. Compare against `trx.catalog.weapons`.
+      - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
       - **`count`** (integer). Shots. Below 0 raises.
 
       Example:
@@ -185,22 +185,22 @@ end
       trx.inventory:set_shots(trx.catalog.weapons.UZIS, 2000)
       ```
 
-    - [lua]`inventory:shots(weapon)`  
+    - <a name="inventory.Inventory.shots"></a>[lua]`inventory:shots(weapon)`  
       How many shots there are for the weapon. A shot is one pull of the trigger, which is what the counter shows the player; the shotgun spends six rounds on each.
 
       Parameters:
-      - **`weapon`** (integer). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is. Compare against `trx.catalog.weapons`.
+      - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
       Returns: integer.
 
-    - [lua]`inventory:take(object_id, [count])`  
+    - <a name="inventory.Inventory.take"></a>[lua]`inventory:take(object_id, [count])`  
       Takes things back out, stopping when there are none left.
 
       This is not the exact opposite of `give`: a box of ammunition is rounds rather
       than an entry of its own, so taking one back takes the rounds a box is worth.
 
       Parameters:
-      - **`object_id`** (integer). The pickup, or the inventory icon it goes into. Compare against `trx.catalog.objects`.
+      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
       - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many came out.

--- a/docs/trx/lua/reference/INVENTORY.md
+++ b/docs/trx/lua/reference/INVENTORY.md
@@ -27,7 +27,7 @@ has.
 
 Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries are keyed by the order they are drawn in, and are built one at a time as they are asked for. `pairs()` walks them.
 
-- <a id="inventory[]" name="inventory[]"></a>**`trx.inventory[key]`** ([trx.inventory.Entry](#inventory.Entry) or `nil`). Position in the ring. Counted from 1.
+- <a id="inventory[]" name="inventory[]"></a>**`trx.inventory[key]`** ([trx.inventory.Entry](#inventory.Entry) or `nil`).
 - **`#trx.inventory`** (integer). How many there are.
 
 Example:
@@ -38,6 +38,10 @@ end
 ```
 
 ### Structures
+
+- <a id="inventory.EntryNum" name="inventory.EntryNum"></a>[lua]`trx.inventory.EntryNum`
+
+    Where an entry sits in the ring, in the order they are drawn. Counted from 1.
 
 - <a id="inventory.Entry" name="inventory.Entry"></a>[lua]`trx.inventory.Entry`
 
@@ -84,17 +88,17 @@ end
       This asks about the level being played whichever inventory it is called on.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.can_add.object_id" name="inventory.Inventory.can_add.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
-      Returns: boolean.
+      Returns: boolean. True where the level carries the model to draw it with.
 
     - <a id="inventory.Inventory.count" name="inventory.Inventory.count"></a>[lua]`inventory:count(object_id)`  
       How many of something is in it. A box of ammunition counts what its rounds come to.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.count.object_id" name="inventory.Inventory.count.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
-      Returns: integer.
+      Returns: integer. 0 where there is none.
 
     - <a id="inventory.Inventory.entry" name="inventory.Inventory.entry"></a>[lua]`inventory:entry(object_id)`  
       The entry something is drawn as, or `nil` where there is none of it.
@@ -104,22 +108,22 @@ end
       drawn as.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.entry.object_id" name="inventory.Inventory.entry.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
-      Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`.
+      Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`. The entry, or `nil` where there is none of it.
 
     - <a id="inventory.Inventory.entry_at" name="inventory.Inventory.entry_at"></a>[lua]`inventory:entry_at(entry_num)`  
       The entry at a position in the order they are drawn, or `nil` past the end.
 
       Parameters:
-      - **`entry_num`** (integer). Position in the ring. Counted from 1.
+      - <a id="inventory.Inventory.entry_at.entry_num" name="inventory.Inventory.entry_at.entry_num"></a>**`entry_num`** ([trx.inventory.EntryNum](#inventory.EntryNum)).
 
-      Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`.
+      Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`. The entry, or `nil` past the last one.
 
     - <a id="inventory.Inventory.entry_count" name="inventory.Inventory.entry_count"></a>[lua]`inventory:entry_count()`  
       How many entries there are. `#trx.inventory` is the same number for the one Lara carries.
 
-      Returns: integer.
+      Returns: integer. Kinds of thing, not counts.
 
     - <a id="inventory.Inventory.give" name="inventory.Inventory.give"></a>[lua]`inventory:give(object_id, [count])`  
       Puts a pickup in. Lara's inventory takes it as walking over it would, so a
@@ -127,8 +131,8 @@ end
       flares; a level's simply gains it.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
-      - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
+      - <a id="inventory.Inventory.give.object_id" name="inventory.Inventory.give.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.give.count" name="inventory.Inventory.give.count"></a>**`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many went in. 0 from Lara's means the level does not carry the icon for it - see [`can_add`](#inventory.Inventory.can_add).
 
@@ -141,17 +145,17 @@ end
       Whether there is any of it at all.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.has.object_id" name="inventory.Inventory.has.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
-      Returns: boolean.
+      Returns: boolean. True for any count above 0.
 
     - <a id="inventory.Inventory.has_weapon" name="inventory.Inventory.has_weapon"></a>[lua]`inventory:has_weapon(weapon)`  
       Whether the weapon itself is in it, which is not the same as having ammunition for it.
 
       Parameters:
-      - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
+      - <a id="inventory.Inventory.has_weapon.weapon" name="inventory.Inventory.has_weapon.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
-      Returns: boolean.
+      Returns: boolean. True where the weapon itself is in it.
 
     - <a id="inventory.Inventory.icon_of" name="inventory.Inventory.icon_of"></a>[lua]`inventory:icon_of(object_id)`  
       Which inventory icon a pickup is drawn as, whether or not there is any of it.
@@ -162,7 +166,7 @@ end
       what hands back the entry itself.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.icon_of.object_id" name="inventory.Inventory.icon_of.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
 
       Returns: [trx.catalog.objects](CATALOG.md#catalog.objects) or `nil`. The icon's object id, or `nil` for a pickup that has none.
 
@@ -170,15 +174,15 @@ end
       Sets how many of it there are. Zero takes it away.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
-      - **`count`** (integer). How many. Below 0 raises.
+      - <a id="inventory.Inventory.set_count.object_id" name="inventory.Inventory.set_count.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.set_count.count" name="inventory.Inventory.set_count.count"></a>**`count`** (integer). How many. Below 0 raises.
 
     - <a id="inventory.Inventory.set_shots" name="inventory.Inventory.set_shots"></a>[lua]`inventory:set_shots(weapon, count)`  
       Sets how many shots there are for it.
 
       Parameters:
-      - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
-      - **`count`** (integer). Shots. Below 0 raises.
+      - <a id="inventory.Inventory.set_shots.weapon" name="inventory.Inventory.set_shots.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
+      - <a id="inventory.Inventory.set_shots.count" name="inventory.Inventory.set_shots.count"></a>**`count`** (integer). Shots. Below 0 raises.
 
       Example:
       ```lua
@@ -189,9 +193,9 @@ end
       How many shots there are for the weapon. A shot is one pull of the trigger, which is what the counter shows the player; the shotgun spends six rounds on each.
 
       Parameters:
-      - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
+      - <a id="inventory.Inventory.shots.weapon" name="inventory.Inventory.shots.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
-      Returns: integer.
+      Returns: integer. 0 where she carries no ammunition for it.
 
     - <a id="inventory.Inventory.take" name="inventory.Inventory.take"></a>[lua]`inventory:take(object_id, [count])`  
       Takes things back out, stopping when there are none left.
@@ -200,7 +204,7 @@ end
       than an entry of its own, so taking one back takes the rounds a box is worth.
 
       Parameters:
-      - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
-      - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
+      - <a id="inventory.Inventory.take.object_id" name="inventory.Inventory.take.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
+      - <a id="inventory.Inventory.take.count" name="inventory.Inventory.take.count"></a>**`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many came out.

--- a/docs/trx/lua/reference/INVENTORY.md
+++ b/docs/trx/lua/reference/INVENTORY.md
@@ -10,7 +10,7 @@ order: 4
   src/lua/api/inventory.lua. Edit it there.
 -->
 
-## Inventory module
+## <a id="inventory" name="inventory"></a>Inventory module
 
 What Lara is carrying, and what goes into it.
 
@@ -27,7 +27,7 @@ has.
 
 Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries are keyed by the order they are drawn in, and are built one at a time as they are asked for. `pairs()` walks them.
 
-- <a name="inventory[]"></a>**`trx.inventory[key]`** ([trx.inventory.Entry](#inventory.Entry) or `nil`). Position in the ring. Counted from 1.
+- <a id="inventory[]" name="inventory[]"></a>**`trx.inventory[key]`** ([trx.inventory.Entry](#inventory.Entry) or `nil`). Position in the ring. Counted from 1.
 - **`#trx.inventory`** (integer). How many there are.
 
 Example:
@@ -39,7 +39,7 @@ end
 
 ### Structures
 
-- <a name="inventory.Entry"></a>[lua]`trx.inventory.Entry`
+- <a id="inventory.Entry" name="inventory.Entry"></a>[lua]`trx.inventory.Entry`
 
     One kind of thing an inventory holds, and how many of it.
 
@@ -52,10 +52,10 @@ end
     unrelated one.
 
     Properties:
-    - <a name="inventory.Entry.count"></a>**`count`**: integer. How many of it there are. Writing 0 takes it away.
-    - <a name="inventory.Entry.object"></a>**`object`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The inventory icon this entry is drawn as. *(read-only)*
+    - <a id="inventory.Entry.count" name="inventory.Entry.count"></a>**`count`**: integer. How many of it there are. Writing 0 takes it away.
+    - <a id="inventory.Entry.object" name="inventory.Entry.object"></a>**`object`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The inventory icon this entry is drawn as. *(read-only)*
 
-- <a name="inventory.Inventory"></a>[lua]`trx.inventory.Inventory`
+- <a id="inventory.Inventory" name="inventory.Inventory"></a>[lua]`trx.inventory.Inventory`
 
     An inventory: what is in it, and how much ammunition goes with it.
 
@@ -75,8 +75,8 @@ end
 
     Methods:
 
-    - <a name="inventory.Inventory.can_add"></a>[lua]`inventory:can_add(object_id)`  
-      Whether `give` would do anything in the level being played. The level has to
+    - <a id="inventory.Inventory.can_add" name="inventory.Inventory.can_add"></a>[lua]`inventory:can_add(object_id)`  
+      Whether [`give`](#inventory.Inventory.give) would do anything in the level being played. The level has to
       carry the inventory model, which is not the same as the pickup being in it: a
       level with no shotgun lying about still draws one in the ring, which is what
       lets a cheat hand one over.
@@ -88,7 +88,7 @@ end
 
       Returns: boolean.
 
-    - <a name="inventory.Inventory.count"></a>[lua]`inventory:count(object_id)`  
+    - <a id="inventory.Inventory.count" name="inventory.Inventory.count"></a>[lua]`inventory:count(object_id)`  
       How many of something is in it. A box of ammunition counts what its rounds come to.
 
       Parameters:
@@ -96,7 +96,7 @@ end
 
       Returns: integer.
 
-    - <a name="inventory.Inventory.entry"></a>[lua]`inventory:entry(object_id)`  
+    - <a id="inventory.Inventory.entry" name="inventory.Inventory.entry"></a>[lua]`inventory:entry(object_id)`  
       The entry something is drawn as, or `nil` where there is none of it.
 
       Several pickups share one entry - the scion whether or not she holds it, a
@@ -108,7 +108,7 @@ end
 
       Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`.
 
-    - <a name="inventory.Inventory.entry_at"></a>[lua]`inventory:entry_at(entry_num)`  
+    - <a id="inventory.Inventory.entry_at" name="inventory.Inventory.entry_at"></a>[lua]`inventory:entry_at(entry_num)`  
       The entry at a position in the order they are drawn, or `nil` past the end.
 
       Parameters:
@@ -116,12 +116,12 @@ end
 
       Returns: [trx.inventory.Entry](#inventory.Entry) or `nil`.
 
-    - <a name="inventory.Inventory.entry_count"></a>[lua]`inventory:entry_count()`  
+    - <a id="inventory.Inventory.entry_count" name="inventory.Inventory.entry_count"></a>[lua]`inventory:entry_count()`  
       How many entries there are. `#trx.inventory` is the same number for the one Lara carries.
 
       Returns: integer.
 
-    - <a name="inventory.Inventory.give"></a>[lua]`inventory:give(object_id, [count])`  
+    - <a id="inventory.Inventory.give" name="inventory.Inventory.give"></a>[lua]`inventory:give(object_id, [count])`  
       Puts a pickup in. Lara's inventory takes it as walking over it would, so a
       weapon arrives with the rounds a pickup carries and a flare box with its
       flares; a level's simply gains it.
@@ -130,14 +130,14 @@ end
       - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
       - **`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
-      Returns: integer. How many went in. 0 from Lara's means the level does not carry the icon for it - see `can_add`.
+      Returns: integer. How many went in. 0 from Lara's means the level does not carry the icon for it - see [`can_add`](#inventory.Inventory.can_add).
 
       Example:
       ```lua
       trx.inventory:give(trx.catalog.objects.uzi_item, 2)
       ```
 
-    - <a name="inventory.Inventory.has"></a>[lua]`inventory:has(object_id)`  
+    - <a id="inventory.Inventory.has" name="inventory.Inventory.has"></a>[lua]`inventory:has(object_id)`  
       Whether there is any of it at all.
 
       Parameters:
@@ -145,7 +145,7 @@ end
 
       Returns: boolean.
 
-    - <a name="inventory.Inventory.has_weapon"></a>[lua]`inventory:has_weapon(weapon)`  
+    - <a id="inventory.Inventory.has_weapon" name="inventory.Inventory.has_weapon"></a>[lua]`inventory:has_weapon(weapon)`  
       Whether the weapon itself is in it, which is not the same as having ammunition for it.
 
       Parameters:
@@ -153,12 +153,12 @@ end
 
       Returns: boolean.
 
-    - <a name="inventory.Inventory.icon_of"></a>[lua]`inventory:icon_of(object_id)`  
+    - <a id="inventory.Inventory.icon_of" name="inventory.Inventory.icon_of"></a>[lua]`inventory:icon_of(object_id)`  
       Which inventory icon a pickup is drawn as, whether or not there is any of it.
 
       Several pickups share one icon - the scion whether or not Lara holds it, a
       waterskin at each fill level - so this is what tells two spellings of one thing
-      from two things. It answers with an object id rather than an entry; `entry` is
+      from two things. It answers with an object id rather than an entry; [`entry`](#inventory.Inventory.entry) is
       what hands back the entry itself.
 
       Parameters:
@@ -166,14 +166,14 @@ end
 
       Returns: [trx.catalog.objects](CATALOG.md#catalog.objects) or `nil`. The icon's object id, or `nil` for a pickup that has none.
 
-    - <a name="inventory.Inventory.set_count"></a>[lua]`inventory:set_count(object_id, count)`  
+    - <a id="inventory.Inventory.set_count" name="inventory.Inventory.set_count"></a>[lua]`inventory:set_count(object_id, count)`  
       Sets how many of it there are. Zero takes it away.
 
       Parameters:
       - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The pickup, or the inventory icon it goes into.
       - **`count`** (integer). How many. Below 0 raises.
 
-    - <a name="inventory.Inventory.set_shots"></a>[lua]`inventory:set_shots(weapon, count)`  
+    - <a id="inventory.Inventory.set_shots" name="inventory.Inventory.set_shots"></a>[lua]`inventory:set_shots(weapon, count)`  
       Sets how many shots there are for it.
 
       Parameters:
@@ -185,7 +185,7 @@ end
       trx.inventory:set_shots(trx.catalog.weapons.UZIS, 2000)
       ```
 
-    - <a name="inventory.Inventory.shots"></a>[lua]`inventory:shots(weapon)`  
+    - <a id="inventory.Inventory.shots" name="inventory.Inventory.shots"></a>[lua]`inventory:shots(weapon)`  
       How many shots there are for the weapon. A shot is one pull of the trigger, which is what the counter shows the player; the shotgun spends six rounds on each.
 
       Parameters:
@@ -193,10 +193,10 @@ end
 
       Returns: integer.
 
-    - <a name="inventory.Inventory.take"></a>[lua]`inventory:take(object_id, [count])`  
+    - <a id="inventory.Inventory.take" name="inventory.Inventory.take"></a>[lua]`inventory:take(object_id, [count])`  
       Takes things back out, stopping when there are none left.
 
-      This is not the exact opposite of `give`: a box of ammunition is rounds rather
+      This is not the exact opposite of [`give`](#inventory.Inventory.give): a box of ammunition is rounds rather
       than an entry of its own, so taking one back takes the rounds a box is worth.
 
       Parameters:

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -18,7 +18,7 @@ Module for controlling all moveables.
 
 Indexing the module reaches an item, and `#trx.items` is how many the level has. `pairs()` walks them in order, keyed by the item number.
 
-- **`trx.items[key]`** (Item or `nil`). 0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.
+- <a name="items[]"></a>**`trx.items[key]`** ([trx.items.Item](#items.Item) or `nil`). An item's unique name reaches it as well.
 - **`#trx.items`** (integer). How many there are.
 
 Example:
@@ -30,11 +30,11 @@ end
 
 ### Properties
 
-- **`trx.items.query`** (ItemQuery). The identity query over every item in the level. Narrow it and read it - see `trx.items.ItemQuery`. *(read-only)*
+- <a name="items.query"></a>**`trx.items.query`** ([trx.items.ItemQuery](#items.ItemQuery)). The identity query over every item in the level. Narrow it and read it. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.items.PickupMode`
+- <a name="items.PickupMode"></a>[lua]`trx.items.PickupMode`
 
     The values the `pickup_mode` item property can take. It selects the animation Lara plays when collecting the item.
 
@@ -49,7 +49,7 @@ end
     - `trx.items.PickupMode.CROWBAR` = `4`  
         Pried off the wall using a crowbar.
 
-- [lua]`trx.items.SwitchMode`
+- <a name="items.SwitchMode"></a>[lua]`trx.items.SwitchMode`
 
     The values the `switch_mode` item property can take. It selects the animation Lara plays when interacting with the item.
 
@@ -62,7 +62,7 @@ end
     - `trx.items.SwitchMode.SHOVE` = `3`  
         A single-use button that requires a shove to activate.
 
-- [lua]`trx.items.TriggerType`
+- <a name="items.TriggerType"></a>[lua]`trx.items.TriggerType`
 
     The kind of trigger `item:trigger` fires, matching the trigger types a level editor offers. Most are forward triggers that differ only in what trips them in a level; from a script they behave alike, and `TRIGGER` is the one to reach for.
 
@@ -79,7 +79,11 @@ end
 
 ### Structures
 
-- [lua]`trx.items.Item`
+- <a name="items.Num"></a>[lua]`trx.items.Num`
+
+    Item number, matching the numbers level editors show. Counted from 0.
+
+- <a name="items.Item"></a>[lua]`trx.items.Item`
 
     An item, also known as a moveable.
 
@@ -88,69 +92,69 @@ end
     unrelated one.
 
     Properties:
-    - **`anim_num`**: integer. The animation's number within the object, counted from 0.
-    - **`anim_state`**: integer. Current animation state.
-    - **`collidable`**: boolean. Whether Lara can collide with this item.
-    - **`fall_speed`**: integer. Vertical speed.
-    - **`frame_num`**: integer. The frame's number within the animation, counted from 0. Negative values count back from the end.
-    - **`goal_anim_state`**: integer. Animation state the item is transitioning towards.
-    - **`gravity`**: boolean. Whether gravity applies to this item.
-    - **`hit_points`**: integer. Current hit points. Raising this above the maximum also raises `properties.max_hit_points`.
-    - **`is_alive`**: boolean. Whether the item is a living creature with hit points remaining. *(read-only)*
-    - **`is_finished`**: boolean. Whether the item has finished its run - a creature that died, or a one-shot trigger that fired. It stays in the level but no longer acts.
-    - **`is_hostile`**: boolean. Whether this item is a creature currently hostile to Lara. *(read-only)*
-    - **`is_in_play`**: boolean. Whether the item is live: simulated, visible and not finished - the state a targetable enemy is in. A read-only composite of the axes. *(read-only)*
-    - **`is_killed`**: boolean. Whether the item has already been killed. *(read-only)*
-    - **`is_one_shot`**: boolean. Whether the item's trigger has been spent and will never fire again.
-    - **`is_present`**: boolean. Whether the item is in the world at all: linked in its room, so drawn and collidable in principle. Managed by the engine. *(read-only)*
-    - **`is_reversed`**: boolean. Whether the item's trigger is inverted, so it runs until triggered rather than once triggered. This is how a level ships something already on.
-    - **`is_simulated`**: boolean. Whether the item's control routine runs each frame. Call `activate()` to start it. *(read-only)*
-    - **`is_targetable`**: boolean. Whether Lara's auto-aim can lock onto the item right now. *(read-only)*
-    - **`is_triggered`**: boolean. Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.
+    - <a name="items.Item.anim_num"></a>**`anim_num`**: integer. The animation's number within the object. Counted from 0.
+    - <a name="items.Item.anim_state"></a>**`anim_state`**: integer. Current animation state.
+    - <a name="items.Item.collidable"></a>**`collidable`**: boolean. Whether Lara can collide with this item.
+    - <a name="items.Item.fall_speed"></a>**`fall_speed`**: integer. Vertical speed.
+    - <a name="items.Item.frame_num"></a>**`frame_num`**: integer. The frame's number within the animation. Negative values count back from the end. Counted from 0.
+    - <a name="items.Item.goal_anim_state"></a>**`goal_anim_state`**: integer. Animation state the item is transitioning towards.
+    - <a name="items.Item.gravity"></a>**`gravity`**: boolean. Whether gravity applies to this item.
+    - <a name="items.Item.hit_points"></a>**`hit_points`**: integer. Current hit points. Raising this above the maximum also raises `properties.max_hit_points`.
+    - <a name="items.Item.is_alive"></a>**`is_alive`**: boolean. Whether the item is a living creature with hit points remaining. *(read-only)*
+    - <a name="items.Item.is_finished"></a>**`is_finished`**: boolean. Whether the item has finished its run - a creature that died, or a one-shot trigger that fired. It stays in the level but no longer acts.
+    - <a name="items.Item.is_hostile"></a>**`is_hostile`**: boolean. Whether this item is a creature currently hostile to Lara. *(read-only)*
+    - <a name="items.Item.is_in_play"></a>**`is_in_play`**: boolean. Whether the item is live: simulated, visible and not finished - the state a targetable enemy is in. A read-only composite of the axes. *(read-only)*
+    - <a name="items.Item.is_killed"></a>**`is_killed`**: boolean. Whether the item has already been killed. *(read-only)*
+    - <a name="items.Item.is_one_shot"></a>**`is_one_shot`**: boolean. Whether the item's trigger has been spent and will never fire again.
+    - <a name="items.Item.is_present"></a>**`is_present`**: boolean. Whether the item is in the world at all: linked in its room, so drawn and collidable in principle. Managed by the engine. *(read-only)*
+    - <a name="items.Item.is_reversed"></a>**`is_reversed`**: boolean. Whether the item's trigger is inverted, so it runs until triggered rather than once triggered. This is how a level ships something already on.
+    - <a name="items.Item.is_simulated"></a>**`is_simulated`**: boolean. Whether the item's control routine runs each frame. Call `activate()` to start it. *(read-only)*
+    - <a name="items.Item.is_targetable"></a>**`is_targetable`**: boolean. Whether Lara's auto-aim can lock onto the item right now. *(read-only)*
+    - <a name="items.Item.is_triggered"></a>**`is_triggered`**: boolean. Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.
 
       It is a verdict on `trigger_mask`, `timer` and `is_reversed` together, not a field of its own. *(read-only)*
-    - **`is_visible`**: boolean. Whether the item is drawn. It can be present in the world but not visible, like an ambush enemy waiting to appear.
-    - **`max_hit_points`**: integer. Maximum hit points. Set `properties.max_hit_points` to change it. *(read-only)*
-    - **`mesh_bits`**: integer. Bitmask of which of the item's meshes are drawn.
-    - **`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
-    - **`num`**: integer. 0-based item number, matching the numbers level editors show. An item handed over by a query can say where it lives. *(read-only)*
-    - **`object_id`**: integer. The item's object type. Compare against `trx.catalog.objects`. *(read-only)*
-    - **`pos`**: vec3. World position. Updating this also updates `room` and `room_num`.
-    - **`room_num`**: integer. 0-based number of the room containing this item. Set `pos` to move the item between rooms. *(read-only)*
-    - **`rot`**: vec3. Orientation, in the units `trx.math` counts angles in. An angle counts in cycles, so one past the end of the turn wraps round to name the same direction rather than raising: adding a half turn to a rotation always works.
-    - **`speed`**: integer. Forward speed.
-    - **`timer`**: integer. How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - `trigger()` takes its timer in seconds instead.
-    - **`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
-    - **`trigger_mask`**: integer. The five code bits, counted the way a level editor counts them: `1` to `31`. The trigger only says go once every bit is set, which is how a level makes several triggers agree before anything happens. A lone trigger carries all of them.
-    - **`was_hit`**: boolean. Whether the item was hit during the current frame. *(read-only)*
+    - <a name="items.Item.is_visible"></a>**`is_visible`**: boolean. Whether the item is drawn. It can be present in the world but not visible, like an ambush enemy waiting to appear.
+    - <a name="items.Item.max_hit_points"></a>**`max_hit_points`**: integer. Maximum hit points. Set `properties.max_hit_points` to change it. *(read-only)*
+    - <a name="items.Item.mesh_bits"></a>**`mesh_bits`**: integer. Bitmask of which of the item's meshes are drawn.
+    - <a name="items.Item.name"></a>**`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
+    - <a name="items.Item.num"></a>**`num`**: [trx.items.Num](#items.Num). An item handed over by a query can say where it lives. *(read-only)*
+    - <a name="items.Item.object_id"></a>**`object_id`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The item's object type. *(read-only)*
+    - <a name="items.Item.pos"></a>**`pos`**: vec3. World position. Updating this also updates `room` and `room_num`.
+    - <a name="items.Item.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room containing this item. Set `pos` to move the item between rooms. *(read-only)*
+    - <a name="items.Item.rot"></a>**`rot`**: vec3. Orientation, in the units [`trx.math`](MATH.md#math) counts angles in. An angle counts in cycles, so one past the end of the turn wraps round to name the same direction rather than raising: adding a half turn to a rotation always works.
+    - <a name="items.Item.speed"></a>**`speed`**: integer. Forward speed.
+    - <a name="items.Item.timer"></a>**`timer`**: integer. How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - `trigger()` takes its timer in seconds instead.
+    - <a name="items.Item.touch_bits"></a>**`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
+    - <a name="items.Item.trigger_mask"></a>**`trigger_mask`**: integer. The five code bits, counted the way a level editor counts them: `1` to `31`. The trigger only says go once every bit is set, which is how a level makes several triggers agree before anything happens. A lone trigger carries all of them.
+    - <a name="items.Item.was_hit"></a>**`was_hit`**: boolean. Whether the item was hit during the current frame. *(read-only)*
 
     Computed properties (derived, not stored on the object):
-    - **`bounds`**: table. The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around `pos` before `rot` turns it, and they change as the item animates.
-    - **`properties`**: table. Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
-    - **`room`**: Room. The `trx.rooms.Room` containing this item.
+    - <a name="items.Item.bounds"></a>**`bounds`**: table. The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around `pos` before `rot` turns it, and they change as the item animates.
+    - <a name="items.Item.properties"></a>**`properties`**: table. Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
+    - <a name="items.Item.room"></a>**`room`**: [trx.rooms.Room](ROOMS.md#rooms.Room). The room containing this item.
 
     Methods:
 
-    - [lua]`item:activate()`  
+    - <a name="items.Item.activate"></a>[lua]`item:activate()`  
       Brings the item to life, exactly as tripping a trigger on it would: its control routine starts running, and a creature also gets its AI, without which it would stand there and ignore Lara.
 
       Objects with no control routine cannot be activated, and an item that is already active is left alone.
 
-    - [lua]`item:deactivate()`  
+    - <a name="items.Item.deactivate"></a>[lua]`item:deactivate()`  
       Stops the item: its control routine no longer runs, and a creature loses its AI and stands down. The item stays where it is and keeps its hit points, so this is not a way of getting rid of it - use `destroy()` for that.
 
       A trigger can still bring it back, and so can `activate()`.
 
-    - [lua]`item:destroy()`  
+    - <a name="items.Item.destroy"></a>[lua]`item:destroy()`  
       Removes the item from the game. Any other handle to it becomes stale.
 
-    - [lua]`item:die([explode])`  
+    - <a name="items.Item.die"></a>[lua]`item:die([explode])`  
       Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; `destroy()` simply removes any item from the game.
 
       Parameters:
-      - **`explode`** (boolean, optional, default `False`). Whether to burst the meshes as it dies.
+      - **`explode`** (boolean, optional, default `false`). Whether to burst the meshes as it dies.
 
-    - [lua]`item:distance_to(pos)`  
+    - <a name="items.Item.distance_to"></a>[lua]`item:distance_to(pos)`  
       Distance from this item to a world position.
 
       Parameters:
@@ -158,7 +162,7 @@ end
 
       Returns: integer.
 
-    - [lua]`item:get_property(name)`  
+    - <a name="items.Item.get_property"></a>[lua]`item:get_property(name)`  
       Reads an object property, falling back to the object's default. Prefer `item.properties.<name>`.
 
       Parameters:
@@ -166,12 +170,12 @@ end
 
       Returns: any or `nil`.
 
-    - [lua]`item:get_property_names()`  
+    - <a name="items.Item.get_property_names"></a>[lua]`item:get_property_names()`  
       Names of every property this item's object declares.
 
       Returns: table.
 
-    - [lua]`item:is_valid()`  
+    - <a name="items.Item.is_valid"></a>[lua]`item:is_valid()`  
       Whether the handle still refers to a live item. Reading or writing a field on a stale handle raises an error rather than silently operating on an unrelated item, so check this for a handle held across time.
 
       Returns: boolean.
@@ -186,15 +190,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_activate(callback)`  
-      Happens when this item is activated through the lifecycle front door during play. `trx.events.on_activate`, narrowed to this item.
+    - <a name="items.Item.on_activate"></a>[lua]`item:on_activate(callback)`  
+      Happens when this item is activated through the lifecycle front door during play. [`trx.events.on_activate`](EVENTS.md#events.on_activate), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -203,15 +207,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_deactivate(callback)`  
-      Happens when this item is deactivated through the lifecycle front door during play. `trx.events.on_deactivate`, narrowed to this item.
+    - <a name="items.Item.on_deactivate"></a>[lua]`item:on_deactivate(callback)`  
+      Happens when this item is deactivated through the lifecycle front door during play. [`trx.events.on_deactivate`](EVENTS.md#events.on_deactivate), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -220,15 +224,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_destroy(callback)`  
-      Happens as this item is removed from the game during play. It can still be read from the handler, but not after. `trx.events.on_destroy`, narrowed to this item.
+    - <a name="items.Item.on_destroy"></a>[lua]`item:on_destroy(callback)`  
+      Happens as this item is removed from the game during play. It can still be read from the handler, but not after. [`trx.events.on_destroy`](EVENTS.md#events.on_destroy), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -237,15 +241,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_enter_sim(callback)`  
-      Happens when this item starts being simulated during play. `trx.events.on_enter_sim`, narrowed to this item.
+    - <a name="items.Item.on_enter_sim"></a>[lua]`item:on_enter_sim(callback)`  
+      Happens when this item starts being simulated during play. [`trx.events.on_enter_sim`](EVENTS.md#events.on_enter_sim), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -254,15 +258,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_enter_world(callback)`  
-      Happens when this item enters the world during play, such as a runtime spawn. `trx.events.on_enter_world`, narrowed to this item.
+    - <a name="items.Item.on_enter_world"></a>[lua]`item:on_enter_world(callback)`  
+      Happens when this item enters the world during play, such as a runtime spawn. [`trx.events.on_enter_world`](EVENTS.md#events.on_enter_world), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -271,15 +275,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_finish(callback)`  
-      Happens when this item finishes its run during play. `trx.events.on_finish`, narrowed to this item.
+    - <a name="items.Item.on_finish"></a>[lua]`item:on_finish(callback)`  
+      Happens when this item finishes its run during play. [`trx.events.on_finish`](EVENTS.md#events.on_finish), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -288,15 +292,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_hide(callback)`  
-      Happens when this item becomes hidden during play. `trx.events.on_hide`, narrowed to this item.
+    - <a name="items.Item.on_hide"></a>[lua]`item:on_hide(callback)`  
+      Happens when this item becomes hidden during play. [`trx.events.on_hide`](EVENTS.md#events.on_hide), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -305,16 +309,16 @@ end
       end)
       ```
 
-    - [lua]`item:on_hit(callback)`  
-      Happens when this item takes damage. `trx.events.on_hit`, narrowed to this item.
+    - <a name="items.Item.on_hit"></a>[lua]`item:on_hit(callback)`  
+      Happens when this item takes damage. [`trx.events.on_hit`](EVENTS.md#events.on_hit), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
         - **`damage`** (integer). Hit points taken, before clamping to zero.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -323,15 +327,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_kill(callback)`  
-      Happens when damage takes this item's hit points to zero. `trx.events.on_kill`, narrowed to this item.
+    - <a name="items.Item.on_kill"></a>[lua]`item:on_kill(callback)`  
+      Happens when damage takes this item's hit points to zero. [`trx.events.on_kill`](EVENTS.md#events.on_kill), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -340,15 +344,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_leave_sim(callback)`  
-      Happens when this item stops being simulated during play. `trx.events.on_leave_sim`, narrowed to this item.
+    - <a name="items.Item.on_leave_sim"></a>[lua]`item:on_leave_sim(callback)`  
+      Happens when this item stops being simulated during play. [`trx.events.on_leave_sim`](EVENTS.md#events.on_leave_sim), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -357,15 +361,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_leave_world(callback)`  
-      Happens when this item leaves the world during play. `trx.events.on_leave_world`, narrowed to this item.
+    - <a name="items.Item.on_leave_world"></a>[lua]`item:on_leave_world(callback)`  
+      Happens when this item leaves the world during play. [`trx.events.on_leave_world`](EVENTS.md#events.on_leave_world), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -374,15 +378,15 @@ end
       end)
       ```
 
-    - [lua]`item:on_show(callback)`  
-      Happens when this item becomes visible during play. `trx.events.on_show`, narrowed to this item.
+    - <a name="items.Item.on_show"></a>[lua]`item:on_show(callback)`  
+      Happens when this item becomes visible during play. [`trx.events.on_show`](EVENTS.md#events.on_show), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -391,16 +395,16 @@ end
       end)
       ```
 
-    - [lua]`item:on_trigger(callback)`  
-      Happens every time a trigger is aimed at this item, of any kind. `trx.events.on_trigger`, narrowed to this item.
+    - <a name="items.Item.on_trigger"></a>[lua]`item:on_trigger(callback)`  
+      Happens every time a trigger is aimed at this item, of any kind. [`trx.events.on_trigger`](EVENTS.md#events.on_trigger), narrowed to this item.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). This item.
-        - **`trigger`** (table). What the trigger carried: `type`, `mask`, `timer` and `one_shot`. See `trx.events.on_trigger`.
+        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - **`trigger`** (table). What the trigger carried: `type`, `mask`, `timer` and `one_shot`.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -409,20 +413,20 @@ end
       end)
       ```
 
-    - [lua]`item:set_property(name, value)`  
+    - <a name="items.Item.set_property"></a>[lua]`item:set_property(name, value)`  
       Overrides an object property for this item. Prefer `item.properties.<name> = ...`.
 
       Parameters:
       - **`name`** (string).
       - **`value`** (any).
 
-    - [lua]`item:shatter([damage])`  
+    - <a name="items.Item.shatter"></a>[lua]`item:shatter([damage])`  
       Bursts the item's meshes into flying debris, the visual `die(true)` produces, on its own. It does not kill or remove the item.
 
       Parameters:
       - **`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
 
-    - [lua]`item:take_damage(damage)`  
+    - <a name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
       Hurts the item the way a weapon does, and reports through `on_hit`, and
       `on_kill` where the blow takes the last hit point. Writing `hit_points` reports neither. The kill
       counts as the environment's rather than Lara's.
@@ -436,7 +440,7 @@ end
       lara:take_damage(lara.hit_points)
       ```
 
-    - [lua]`item:trigger([opts])`  
+    - <a name="items.Item.trigger"></a>[lua]`item:trigger([opts])`  
       Fires a trigger at the item, exactly as a floor trigger in the level would: sets the code bits, and once they are all set, starts the item running.
 
       This is the one to reach for on anything a level would trigger - a door, a switch, an alarm - because those read their trigger before they act, and merely `activate()`-ing one leaves it running but doing nothing. Pass `type = trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.
@@ -465,23 +469,23 @@ end
       trx.items[12]:trigger({ type = trx.items.TriggerType.ANTITRIGGER })
       ```
 
-- [lua]`trx.items.ItemQuery`
+- <a name="items.ItemQuery"></a>[lua]`trx.items.ItemQuery`
 
-    A `trx.query.Query` over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `of_object` is how a name reaches them.
+    A [`trx.query.Query`](QUERY.md#query.Query) over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `of_object` is how a name reaches them.
 
     Methods:
 
-    - [lua]`itemquery:alive()`  
+    - <a name="items.ItemQuery.alive"></a>[lua]`itemquery:alive()`  
       The item still has hit points.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:finished()`  
+    - <a name="items.ItemQuery.finished"></a>[lua]`itemquery:finished()`  
       The item has run its course.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:in_box(min, max)`  
+    - <a name="items.ItemQuery.in_box"></a>[lua]`itemquery:in_box(min, max)`  
       The item stands inside a world-space box. The corners may come in any order.
 
       An item is tested by its position, the point it stands at, rather than by the box it fills. Position is all this asks after, so the rest of the query says what else the item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are in the world as well.
@@ -490,7 +494,7 @@ end
       - **`min`** (vec3). One corner of the box.
       - **`max`** (vec3). The opposite corner.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
       Example:
       ```lua
@@ -500,70 +504,70 @@ end
         :matches()
       ```
 
-    - [lua]`itemquery:in_play()`  
+    - <a name="items.ItemQuery.in_play"></a>[lua]`itemquery:in_play()`  
       The item is part of the game rather than set aside.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:in_room(room_num)`  
+    - <a name="items.ItemQuery.in_room"></a>[lua]`itemquery:in_room(room_num)`  
       The item is in the given room.
 
       Parameters:
-      - **`room_num`** (integer). 0-based room number, matching the numbers level editors show.
+      - **`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)).
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:in_sphere(centre, radius)`  
+    - <a name="items.ItemQuery.in_sphere"></a>[lua]`itemquery:in_sphere(centre, radius)`  
       The item stands within a radius of a point. As with `in_box`, the item's position is the whole of the test.
 
       Parameters:
       - **`centre`** (vec3). Middle of the sphere.
       - **`radius`** (integer). How far out it reaches. One sector is 1024.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:of_object(key)`  
+    - <a name="items.ItemQuery.of_object"></a>[lua]`itemquery:of_object(key)`  
       The item is of the given object, named the way a player would name it or by its id.
 
       Parameters:
-      - **`key`** (any). Object id, or a name `trx.objects.query` resolves.
+      - **`key`** (any). Object id, or a name [`trx.objects.query`](OBJECTS.md#objects.query) resolves.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
       Example:
       ```lua
       trx.items.query:of_object("wolf"):simulated():matches()
       ```
 
-    - [lua]`itemquery:present()`  
+    - <a name="items.ItemQuery.present"></a>[lua]`itemquery:present()`  
       The item is in the world, whether or not anything is simulating it.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:simulated()`  
+    - <a name="items.ItemQuery.simulated"></a>[lua]`itemquery:simulated()`  
       The item is being simulated: its control routine runs every frame.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:targetable()`  
+    - <a name="items.ItemQuery.targetable"></a>[lua]`itemquery:targetable()`  
       Lara's guns can lock onto the item.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`itemquery:visible()`  
+    - <a name="items.ItemQuery.visible"></a>[lua]`itemquery:visible()`  
       The item is drawn.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
 ### Functions
 
-- [lua]`trx.items.get(key)`  
+- <a name="items.get"></a>[lua]`trx.items.get(key)`  
   Retrieves an item by number or by name.
 
   Parameters:
-  - **`key`** (any). 0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.
+  - **`key`** ([trx.items.Num](#items.Num)). An item's unique name reaches it as well.
 
-  Returns: Item or `nil`.
+  Returns: [trx.items.Item](#items.Item) or `nil`.
 
   Example:
   ```lua
@@ -572,16 +576,16 @@ end
   local lara = trx.items["lara"]
   ```
 
-- [lua]`trx.items.spawn(object_id, pos, [angle_y], [opts])`  
+- <a name="items.spawn"></a>[lua]`trx.items.spawn(object_id, pos, [angle_y], [opts])`  
   Creates a new item of the given object type at the given position.
 
   Parameters:
-  - **`object_id`** (integer). Object type to spawn. Compare against `trx.catalog.objects`.
+  - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object type to spawn.
   - **`pos`** (vec3). World position. Must lie inside the level.
   - **`angle_y`** (integer, optional, default `0`). Facing angle.
   - **`opts`** (table, optional). `activate`: bring the item to life, enabling AI for creatures.
 
-  Returns: Item or `nil`. `nil` if the item pool is exhausted.
+  Returns: [trx.items.Item](#items.Item) or `nil`. `nil` if the item pool is exhausted.
 
   Example:
   ```lua
@@ -589,7 +593,7 @@ end
     trx.catalog.objects.wolf, trx.lara.item.pos, 0, { activate = true })
   ```
 
-- [lua]`trx.items.count()`  
+- <a name="items.count"></a>[lua]`trx.items.count()`  
   Returns the total number of allocated items. Same as `#trx.items`.
 
   Returns: integer.

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -79,9 +79,31 @@ end
 
 ### Structures
 
+- <a id="items.AnimNum" name="items.AnimNum"></a>[lua]`trx.items.AnimNum`
+
+    The animation's number within the object an item is of. Counted from 0.
+
+- <a id="items.FrameNum" name="items.FrameNum"></a>[lua]`trx.items.FrameNum`
+
+    The frame's number within the animation it belongs to. Counted from 0.
+
+- <a id="items.AnimState" name="items.AnimState"></a>[lua]`trx.items.AnimState`
+
+    An animation state, as the object's own animations number them. What a state means is the object's business: the numbers of a wolf are not the numbers of a door. Counted from 0.
+
 - <a id="items.Num" name="items.Num"></a>[lua]`trx.items.Num`
 
     Item number, matching the numbers level editors show. Counted from 0.
+
+- <a id="items.Trigger" name="items.Trigger"></a>[lua]`trx.items.Trigger`
+
+    What a trigger carried when it fired.
+
+    Properties:
+    - <a id="items.Trigger.mask" name="items.Trigger.mask"></a>**`mask`**: integer. The code bits it set, `1` to `31`.
+    - <a id="items.Trigger.one_shot" name="items.Trigger.one_shot"></a>**`one_shot`**: boolean. Whether it fires only the once.
+    - <a id="items.Trigger.timer" name="items.Trigger.timer"></a>**`timer`**: number. How long it keeps the item going, in seconds.
+    - <a id="items.Trigger.type" name="items.Trigger.type"></a>**`type`**: [trx.items.TriggerType](#items.TriggerType). The kind of trigger it was.
 
 - <a id="items.Item" name="items.Item"></a>[lua]`trx.items.Item`
 
@@ -92,12 +114,12 @@ end
     unrelated one.
 
     Properties:
-    - <a id="items.Item.anim_num" name="items.Item.anim_num"></a>**`anim_num`**: integer. The animation's number within the object. Counted from 0.
-    - <a id="items.Item.anim_state" name="items.Item.anim_state"></a>**`anim_state`**: integer. Current animation state.
+    - <a id="items.Item.anim_num" name="items.Item.anim_num"></a>**`anim_num`**: [trx.items.AnimNum](#items.AnimNum).
+    - <a id="items.Item.anim_state" name="items.Item.anim_state"></a>**`anim_state`**: [trx.items.AnimState](#items.AnimState). The state the item is in.
     - <a id="items.Item.collidable" name="items.Item.collidable"></a>**`collidable`**: boolean. Whether Lara can collide with this item.
     - <a id="items.Item.fall_speed" name="items.Item.fall_speed"></a>**`fall_speed`**: integer. Vertical speed.
-    - <a id="items.Item.frame_num" name="items.Item.frame_num"></a>**`frame_num`**: integer. The frame's number within the animation. Negative values count back from the end. Counted from 0.
-    - <a id="items.Item.goal_anim_state" name="items.Item.goal_anim_state"></a>**`goal_anim_state`**: integer. Animation state the item is transitioning towards.
+    - <a id="items.Item.frame_num" name="items.Item.frame_num"></a>**`frame_num`**: [trx.items.FrameNum](#items.FrameNum). Negative values count back from the end.
+    - <a id="items.Item.goal_anim_state" name="items.Item.goal_anim_state"></a>**`goal_anim_state`**: [trx.items.AnimState](#items.AnimState). The state the item is transitioning towards.
     - <a id="items.Item.gravity" name="items.Item.gravity"></a>**`gravity`**: boolean. Whether gravity applies to this item.
     - <a id="items.Item.hit_points" name="items.Item.hit_points"></a>**`hit_points`**: integer. Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of [`properties`](#items.Item.properties).
     - <a id="items.Item.is_alive" name="items.Item.is_alive"></a>**`is_alive`**: boolean. Whether the item is a living creature with hit points remaining. *(read-only)*
@@ -129,7 +151,7 @@ end
     - <a id="items.Item.was_hit" name="items.Item.was_hit"></a>**`was_hit`**: boolean. Whether the item was hit during the current frame. *(read-only)*
 
     Computed properties (derived, not stored on the object):
-    - <a id="items.Item.bounds" name="items.Item.bounds"></a>**`bounds`**: table. The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around [`pos`](#items.Item.pos) before [`rot`](#items.Item.rot) turns it, and they change as the item animates.
+    - <a id="items.Item.bounds" name="items.Item.bounds"></a>**`bounds`**: [trx.math.Box](MATH.md#math.Box). The item's bounding box for the frame it is on. The numbers are in the item's own frame, so they say how far the model reaches around [`pos`](#items.Item.pos) before [`rot`](#items.Item.rot) turns it, and they change as the item animates.
     - <a id="items.Item.properties" name="items.Item.properties"></a>**`properties`**: table. Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
     - <a id="items.Item.room" name="items.Item.room"></a>**`room`**: [trx.rooms.Room](ROOMS.md#rooms.Room). The room containing this item.
 
@@ -149,36 +171,36 @@ end
       Removes the item from the game. Any other handle to it becomes stale.
 
     - <a id="items.Item.die" name="items.Item.die"></a>[lua]`item:die([explode])`  
-      Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; [`destroy`](#items.Item.destroy) simply removes any item from the game.
+      Runs the object's creature death handling: the corpse stays, and [`explode`](#items.Item.die.explode) bursts its meshes as a rocket or grenade would. For creatures; [`destroy`](#items.Item.destroy) simply removes any item from the game.
 
       Parameters:
-      - **`explode`** (boolean, optional, default `false`). Whether to burst the meshes as it dies.
+      - <a id="items.Item.die.explode" name="items.Item.die.explode"></a>**`explode`** (boolean, optional, default `false`). Whether to burst the meshes as it dies.
 
     - <a id="items.Item.distance_to" name="items.Item.distance_to"></a>[lua]`item:distance_to(pos)`  
       Distance from this item to a world position.
 
       Parameters:
-      - **`pos`** (vec3). World position.
+      - <a id="items.Item.distance_to.pos" name="items.Item.distance_to.pos"></a>**`pos`** (vec3). World position.
 
-      Returns: integer.
+      Returns: integer. In world units, measured between the two positions.
 
     - <a id="items.Item.get_property" name="items.Item.get_property"></a>[lua]`item:get_property(name)`  
       Reads an object property, falling back to the object's default. Prefer `item.properties.<name>`.
 
       Parameters:
-      - **`name`** (string).
+      - <a id="items.Item.get_property.name" name="items.Item.get_property.name"></a>**`name`** (string). Which property, as the object declares it.
 
-      Returns: any or `nil`.
+      Returns: any or `nil`. The value, of whatever type the property is declared with.
 
     - <a id="items.Item.get_property_names" name="items.Item.get_property_names"></a>[lua]`item:get_property_names()`  
       Names of every property this item's object declares.
 
-      Returns: table.
+      Returns: table. The names, as a list of strings.
 
     - <a id="items.Item.is_valid" name="items.Item.is_valid"></a>[lua]`item:is_valid()`  
       Whether the handle still refers to a live item. Reading or writing a field on a stale handle raises an error rather than silently operating on an unrelated item, so check this for a handle held across time.
 
-      Returns: boolean.
+      Returns: boolean. False once the item it named is gone.
 
       Example:
       ```lua
@@ -194,9 +216,9 @@ end
       Happens when this item is activated through the lifecycle front door during play. [`trx.events.on_activate`](EVENTS.md#events.on_activate), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_activate.callback" name="items.Item.on_activate.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_activate.item" name="items.Item.on_activate.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -211,9 +233,9 @@ end
       Happens when this item is deactivated through the lifecycle front door during play. [`trx.events.on_deactivate`](EVENTS.md#events.on_deactivate), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_deactivate.callback" name="items.Item.on_deactivate.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_deactivate.item" name="items.Item.on_deactivate.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -228,9 +250,9 @@ end
       Happens as this item is removed from the game during play. It can still be read from the handler, but not after. [`trx.events.on_destroy`](EVENTS.md#events.on_destroy), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_destroy.callback" name="items.Item.on_destroy.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_destroy.item" name="items.Item.on_destroy.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -245,9 +267,9 @@ end
       Happens when this item starts being simulated during play. [`trx.events.on_enter_sim`](EVENTS.md#events.on_enter_sim), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_enter_sim.callback" name="items.Item.on_enter_sim.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_enter_sim.item" name="items.Item.on_enter_sim.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -262,9 +284,9 @@ end
       Happens when this item enters the world during play, such as a runtime spawn. [`trx.events.on_enter_world`](EVENTS.md#events.on_enter_world), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_enter_world.callback" name="items.Item.on_enter_world.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_enter_world.item" name="items.Item.on_enter_world.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -279,9 +301,9 @@ end
       Happens when this item finishes its run during play. [`trx.events.on_finish`](EVENTS.md#events.on_finish), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_finish.callback" name="items.Item.on_finish.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_finish.item" name="items.Item.on_finish.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -296,9 +318,9 @@ end
       Happens when this item becomes hidden during play. [`trx.events.on_hide`](EVENTS.md#events.on_hide), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_hide.callback" name="items.Item.on_hide.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_hide.item" name="items.Item.on_hide.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -313,10 +335,10 @@ end
       Happens when this item takes damage. [`trx.events.on_hit`](EVENTS.md#events.on_hit), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_hit.callback" name="items.Item.on_hit.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
-        - **`damage`** (integer). Hit points taken, before clamping to zero.
+        - <a id="items.Item.on_hit.item" name="items.Item.on_hit.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_hit.damage" name="items.Item.on_hit.damage"></a>**`damage`** (integer). Hit points taken, before clamping to zero.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -331,9 +353,9 @@ end
       Happens when damage takes this item's hit points to zero. [`trx.events.on_kill`](EVENTS.md#events.on_kill), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_kill.callback" name="items.Item.on_kill.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_kill.item" name="items.Item.on_kill.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -348,9 +370,9 @@ end
       Happens when this item stops being simulated during play. [`trx.events.on_leave_sim`](EVENTS.md#events.on_leave_sim), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_leave_sim.callback" name="items.Item.on_leave_sim.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_leave_sim.item" name="items.Item.on_leave_sim.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -365,9 +387,9 @@ end
       Happens when this item leaves the world during play. [`trx.events.on_leave_world`](EVENTS.md#events.on_leave_world), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_leave_world.callback" name="items.Item.on_leave_world.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_leave_world.item" name="items.Item.on_leave_world.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -382,9 +404,9 @@ end
       Happens when this item becomes visible during play. [`trx.events.on_show`](EVENTS.md#events.on_show), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_show.callback" name="items.Item.on_show.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_show.item" name="items.Item.on_show.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -399,10 +421,10 @@ end
       Happens every time a trigger is aimed at this item, of any kind. [`trx.events.on_trigger`](EVENTS.md#events.on_trigger), narrowed to this item.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="items.Item.on_trigger.callback" name="items.Item.on_trigger.callback"></a>**`callback`** (function). What to run when it happens to this item.
         Called with:
-        - **`item`** ([trx.items.Item](#items.Item)). This item.
-        - **`trigger`** (table). What the trigger carried: `type`, `mask`, `timer` and `one_shot`.
+        - <a id="items.Item.on_trigger.item" name="items.Item.on_trigger.item"></a>**`item`** ([trx.items.Item](#items.Item)). This item.
+        - <a id="items.Item.on_trigger.trigger" name="items.Item.on_trigger.trigger"></a>**`trigger`** ([trx.items.Trigger](#items.Trigger)). What the trigger carried.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -417,14 +439,14 @@ end
       Overrides an object property for this item. Prefer `item.properties.<name> = ...`.
 
       Parameters:
-      - **`name`** (string).
-      - **`value`** (any).
+      - <a id="items.Item.set_property.name" name="items.Item.set_property.name"></a>**`name`** (string). Which property, as the object declares it.
+      - <a id="items.Item.set_property.value" name="items.Item.set_property.value"></a>**`value`** (any). What to write, of the type the property is declared with.
 
     - <a id="items.Item.shatter" name="items.Item.shatter"></a>[lua]`item:shatter([damage])`  
-      Bursts the item's meshes into flying debris, the visual [`die`](#items.Item.die) produces with `explode`, on its own. It does not kill or remove the item.
+      Bursts the item's meshes into flying debris, the visual [`die`](#items.Item.die) produces with [`die.explode`](#items.Item.die.explode), on its own. It does not kill or remove the item.
 
       Parameters:
-      - **`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
+      - <a id="items.Item.shatter.damage" name="items.Item.shatter.damage"></a>**`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
 
     - <a id="items.Item.take_damage" name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
       Hurts the item the way a weapon does, and reports through [`trx.events.on_hit`](EVENTS.md#events.on_hit),
@@ -433,7 +455,7 @@ end
       environment's rather than Lara's.
 
       Parameters:
-      - **`damage`** (integer). Hit points to take.
+      - <a id="items.Item.take_damage.damage" name="items.Item.take_damage.damage"></a>**`damage`** (integer). Hit points to take.
 
       Example:
       ```lua
@@ -447,13 +469,13 @@ end
       This is the one to reach for on anything a level would trigger - a door, a switch, an alarm - because those read their trigger before they act, and merely activating one leaves it running but doing nothing. Pass `type = trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.
 
       Parameters:
-      - **`opts`** (table, optional). `type`: which [`trx.items.TriggerType`](#items.TriggerType) to fire; a plain `TRIGGER` by default.
+      - <a id="items.Item.trigger.opts" name="items.Item.trigger.opts"></a>**`opts`** (table, optional). What the trigger carries.
 
-        `mask`: which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.
-
-        `timer`: how long it should keep the item going, in seconds. `0`, the default, means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.
-
-        `one_shot`: never let it fire again.
+        Keys:
+        - <a id="items.Item.trigger.opts.type" name="items.Item.trigger.opts.type"></a>**`type`** ([trx.items.TriggerType](#items.TriggerType), optional). A plain `TRIGGER` by default.
+        - <a id="items.Item.trigger.opts.mask" name="items.Item.trigger.opts.mask"></a>**`mask`** (integer, optional). Which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.
+        - <a id="items.Item.trigger.opts.timer" name="items.Item.trigger.opts.timer"></a>**`timer`** (number, optional, default `0`). How long it should keep the item going, in seconds. `0` means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.
+        - <a id="items.Item.trigger.opts.one_shot" name="items.Item.trigger.opts.one_shot"></a>**`one_shot`** (boolean, optional). Never let it fire again.
 
       Example:
       ```lua
@@ -492,8 +514,8 @@ end
       An item is tested by its position, the point it stands at, rather than by the box it fills. Position is all this asks after, so the rest of the query says what else the item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are in the world as well.
 
       Parameters:
-      - **`min`** (vec3). One corner of the box.
-      - **`max`** (vec3). The opposite corner.
+      - <a id="items.ItemQuery.in_box.min" name="items.ItemQuery.in_box.min"></a>**`min`** (vec3). One corner of the box.
+      - <a id="items.ItemQuery.in_box.max" name="items.ItemQuery.in_box.max"></a>**`max`** (vec3). The opposite corner.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -514,7 +536,7 @@ end
       The item is in the given room.
 
       Parameters:
-      - **`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)).
+      - <a id="items.ItemQuery.in_room.room_num" name="items.ItemQuery.in_room.room_num"></a>**`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)).
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -522,8 +544,8 @@ end
       The item stands within a radius of a point. As with [`in_box`](#items.ItemQuery.in_box), the item's position is the whole of the test.
 
       Parameters:
-      - **`centre`** (vec3). Middle of the sphere.
-      - **`radius`** (integer). How far out it reaches. One sector is 1024.
+      - <a id="items.ItemQuery.in_sphere.centre" name="items.ItemQuery.in_sphere.centre"></a>**`centre`** (vec3). Middle of the sphere.
+      - <a id="items.ItemQuery.in_sphere.radius" name="items.ItemQuery.in_sphere.radius"></a>**`radius`** (integer). How far out it reaches. One sector is 1024.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -531,7 +553,7 @@ end
       The item is of the given object, named the way a player would name it or by its id.
 
       Parameters:
-      - **`key`** (any). Object id, or a name [`trx.objects.query`](OBJECTS.md#objects.query) resolves.
+      - <a id="items.ItemQuery.of_object.key" name="items.ItemQuery.of_object.key"></a>**`key`** (any). Object id, or a name [`trx.objects.query`](OBJECTS.md#objects.query) resolves.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -566,9 +588,9 @@ end
   Retrieves an item by number or by name.
 
   Parameters:
-  - **`key`** ([trx.items.Num](#items.Num)). An item's unique name reaches it as well.
+  - <a id="items.get.key" name="items.get.key"></a>**`key`** ([trx.items.Num](#items.Num)). An item's unique name reaches it as well.
 
-  Returns: [trx.items.Item](#items.Item) or `nil`.
+  Returns: [trx.items.Item](#items.Item) or `nil`. The item, or `nil` where nothing answers to the key.
 
   Example:
   ```lua
@@ -581,10 +603,13 @@ end
   Creates a new item of the given object type at the given position.
 
   Parameters:
-  - **`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object type to spawn.
-  - **`pos`** (vec3). World position. Must lie inside the level.
-  - **`angle_y`** (integer, optional, default `0`). Facing angle.
-  - **`opts`** (table, optional). `activate`: bring the item to life, enabling AI for creatures.
+  - <a id="items.spawn.object_id" name="items.spawn.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object type to spawn.
+  - <a id="items.spawn.pos" name="items.spawn.pos"></a>**`pos`** (vec3). World position. Must lie inside the level.
+  - <a id="items.spawn.angle_y" name="items.spawn.angle_y"></a>**`angle_y`** (integer, optional, default `0`). Facing angle.
+  - <a id="items.spawn.opts" name="items.spawn.opts"></a>**`opts`** (table, optional). How to spawn it.
+
+    Keys:
+    - <a id="items.spawn.opts.activate" name="items.spawn.opts.activate"></a>**`activate`** (boolean, optional). Bring the item to life, enabling AI for creatures.
 
   Returns: [trx.items.Item](#items.Item) or `nil`. `nil` if the item pool is exhausted.
 
@@ -597,4 +622,4 @@ end
 - <a id="items.count" name="items.count"></a>[lua]`trx.items.count()`  
   Returns the total number of allocated items. Same as `#trx.items`.
 
-  Returns: integer.
+  Returns: integer. How many slots the level holds, live or not.

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -142,7 +142,7 @@ end
     - <a id="items.Item.object_id" name="items.Item.object_id"></a>**`object_id`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The item's object type. *(read-only)*
     - <a id="items.Item.pos" name="items.Item.pos"></a>**`pos`**: vec3. World position. Updating this also updates [`room`](#items.Item.room) and [`room_num`](#items.Item.room_num).
     - <a id="items.Item.room_num" name="items.Item.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room containing this item. Set [`pos`](#items.Item.pos) to move the item between rooms. *(read-only)*
-    - <a id="items.Item.rot" name="items.Item.rot"></a>**`rot`**: vec3. Orientation, in the units [`trx.math`](MATH.md#math) counts angles in. An angle counts in cycles, so one past the end of the turn wraps round to name the same direction rather than raising: adding a half turn to a rotation always works.
+    - <a id="items.Item.rot" name="items.Item.rot"></a>**`rot`**: vec3. Orientation. Each component is a [`trx.math.Angle`](MATH.md#math.Angle).
     - <a id="items.Item.speed" name="items.Item.speed"></a>**`speed`**: integer. Forward speed.
     - <a id="items.Item.timer" name="items.Item.timer"></a>**`timer`**: integer. How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - [`trigger`](#items.Item.trigger) takes its timer in seconds instead.
     - <a id="items.Item.touch_bits" name="items.Item.touch_bits"></a>**`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
@@ -181,7 +181,7 @@ end
       Parameters:
       - <a id="items.Item.distance_to.pos" name="items.Item.distance_to.pos"></a>**`pos`** (vec3). World position.
 
-      Returns: integer. In world units, measured between the two positions.
+      Returns: [trx.math.Distance](MATH.md#math.Distance). Measured between the two positions.
 
     - <a id="items.Item.get_property" name="items.Item.get_property"></a>[lua]`item:get_property(name)`  
       Reads an object property, falling back to the object's default. Prefer `item.properties.<name>`.
@@ -544,7 +544,7 @@ end
 
       Parameters:
       - <a id="items.ItemQuery.in_sphere.centre" name="items.ItemQuery.in_sphere.centre"></a>**`centre`** (vec3). Middle of the sphere.
-      - <a id="items.ItemQuery.in_sphere.radius" name="items.ItemQuery.in_sphere.radius"></a>**`radius`** (integer). How far out it reaches. One sector is 1024.
+      - <a id="items.ItemQuery.in_sphere.radius" name="items.ItemQuery.in_sphere.radius"></a>**`radius`** ([trx.math.Distance](MATH.md#math.Distance)). How far out it reaches.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -604,7 +604,7 @@ end
   Parameters:
   - <a id="items.spawn.object_id" name="items.spawn.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object type to spawn.
   - <a id="items.spawn.pos" name="items.spawn.pos"></a>**`pos`** (vec3). World position. Must lie inside the level.
-  - <a id="items.spawn.angle_y" name="items.spawn.angle_y"></a>**`angle_y`** (integer, optional, default `0`). Facing angle.
+  - <a id="items.spawn.angle_y" name="items.spawn.angle_y"></a>**`angle_y`** ([trx.math.Angle](MATH.md#math.Angle), optional, default `0`). Facing angle.
   - <a id="items.spawn.opts" name="items.spawn.opts"></a>**`opts`** (table, optional). How to spawn it.
 
     Keys:

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -133,7 +133,6 @@ end
     - <a id="items.Item.is_simulated" name="items.Item.is_simulated"></a>**`is_simulated`**: boolean. Whether the item's control routine runs each frame. Call [`activate`](#items.Item.activate) to start it. *(read-only)*
     - <a id="items.Item.is_targetable" name="items.Item.is_targetable"></a>**`is_targetable`**: boolean. Whether Lara's auto-aim can lock onto the item right now. *(read-only)*
     - <a id="items.Item.is_triggered" name="items.Item.is_triggered"></a>**`is_triggered`**: boolean. Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.
-
       It is a verdict on [`trigger_mask`](#items.Item.trigger_mask), [`timer`](#items.Item.timer) and [`is_reversed`](#items.Item.is_reversed) together, not a field of its own. *(read-only)*
     - <a id="items.Item.is_visible" name="items.Item.is_visible"></a>**`is_visible`**: boolean. Whether the item is drawn. It can be present in the world but not visible, like an ambush enemy waiting to appear.
     - <a id="items.Item.max_hit_points" name="items.Item.max_hit_points"></a>**`max_hit_points`**: integer. Maximum hit points. Set the `max_hit_points` entry of [`properties`](#items.Item.properties) to change it. *(read-only)*

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -10,7 +10,7 @@ order: 2
   src/lua/api/items.lua. Edit it there.
 -->
 
-## Items module
+## <a id="items" name="items"></a>Items module
 
 Module for controlling all moveables.
 
@@ -18,7 +18,7 @@ Module for controlling all moveables.
 
 Indexing the module reaches an item, and `#trx.items` is how many the level has. `pairs()` walks them in order, keyed by the item number.
 
-- <a name="items[]"></a>**`trx.items[key]`** ([trx.items.Item](#items.Item) or `nil`). An item's unique name reaches it as well.
+- <a id="items[]" name="items[]"></a>**`trx.items[key]`** ([trx.items.Item](#items.Item) or `nil`). An item's unique name reaches it as well.
 - **`#trx.items`** (integer). How many there are.
 
 Example:
@@ -30,11 +30,11 @@ end
 
 ### Properties
 
-- <a name="items.query"></a>**`trx.items.query`** ([trx.items.ItemQuery](#items.ItemQuery)). The identity query over every item in the level. Narrow it and read it. *(read-only)*
+- <a id="items.query" name="items.query"></a>**`trx.items.query`** ([trx.items.ItemQuery](#items.ItemQuery)). The identity query over every item in the level. Narrow it and read it. *(read-only)*
 
 ### Enums
 
-- <a name="items.PickupMode"></a>[lua]`trx.items.PickupMode`
+- <a id="items.PickupMode" name="items.PickupMode"></a>[lua]`trx.items.PickupMode`
 
     The values the `pickup_mode` item property can take. It selects the animation Lara plays when collecting the item.
 
@@ -49,7 +49,7 @@ end
     - `trx.items.PickupMode.CROWBAR` = `4`  
         Pried off the wall using a crowbar.
 
-- <a name="items.SwitchMode"></a>[lua]`trx.items.SwitchMode`
+- <a id="items.SwitchMode" name="items.SwitchMode"></a>[lua]`trx.items.SwitchMode`
 
     The values the `switch_mode` item property can take. It selects the animation Lara plays when interacting with the item.
 
@@ -62,9 +62,9 @@ end
     - `trx.items.SwitchMode.SHOVE` = `3`  
         A single-use button that requires a shove to activate.
 
-- <a name="items.TriggerType"></a>[lua]`trx.items.TriggerType`
+- <a id="items.TriggerType" name="items.TriggerType"></a>[lua]`trx.items.TriggerType`
 
-    The kind of trigger `item:trigger` fires, matching the trigger types a level editor offers. Most are forward triggers that differ only in what trips them in a level; from a script they behave alike, and `TRIGGER` is the one to reach for.
+    The kind of trigger [`trx.items.Item:trigger`](#items.Item.trigger) fires, matching the trigger types a level editor offers. Most are forward triggers that differ only in what trips them in a level; from a script they behave alike, and `TRIGGER` is the one to reach for.
 
     - `trx.items.TriggerType.TRIGGER` = `0`  
         A plain trigger: sets the code bits and, once they are all set, starts the item.
@@ -79,11 +79,11 @@ end
 
 ### Structures
 
-- <a name="items.Num"></a>[lua]`trx.items.Num`
+- <a id="items.Num" name="items.Num"></a>[lua]`trx.items.Num`
 
     Item number, matching the numbers level editors show. Counted from 0.
 
-- <a name="items.Item"></a>[lua]`trx.items.Item`
+- <a id="items.Item" name="items.Item"></a>[lua]`trx.items.Item`
 
     An item, also known as a moveable.
 
@@ -92,69 +92,69 @@ end
     unrelated one.
 
     Properties:
-    - <a name="items.Item.anim_num"></a>**`anim_num`**: integer. The animation's number within the object. Counted from 0.
-    - <a name="items.Item.anim_state"></a>**`anim_state`**: integer. Current animation state.
-    - <a name="items.Item.collidable"></a>**`collidable`**: boolean. Whether Lara can collide with this item.
-    - <a name="items.Item.fall_speed"></a>**`fall_speed`**: integer. Vertical speed.
-    - <a name="items.Item.frame_num"></a>**`frame_num`**: integer. The frame's number within the animation. Negative values count back from the end. Counted from 0.
-    - <a name="items.Item.goal_anim_state"></a>**`goal_anim_state`**: integer. Animation state the item is transitioning towards.
-    - <a name="items.Item.gravity"></a>**`gravity`**: boolean. Whether gravity applies to this item.
-    - <a name="items.Item.hit_points"></a>**`hit_points`**: integer. Current hit points. Raising this above the maximum also raises `properties.max_hit_points`.
-    - <a name="items.Item.is_alive"></a>**`is_alive`**: boolean. Whether the item is a living creature with hit points remaining. *(read-only)*
-    - <a name="items.Item.is_finished"></a>**`is_finished`**: boolean. Whether the item has finished its run - a creature that died, or a one-shot trigger that fired. It stays in the level but no longer acts.
-    - <a name="items.Item.is_hostile"></a>**`is_hostile`**: boolean. Whether this item is a creature currently hostile to Lara. *(read-only)*
-    - <a name="items.Item.is_in_play"></a>**`is_in_play`**: boolean. Whether the item is live: simulated, visible and not finished - the state a targetable enemy is in. A read-only composite of the axes. *(read-only)*
-    - <a name="items.Item.is_killed"></a>**`is_killed`**: boolean. Whether the item has already been killed. *(read-only)*
-    - <a name="items.Item.is_one_shot"></a>**`is_one_shot`**: boolean. Whether the item's trigger has been spent and will never fire again.
-    - <a name="items.Item.is_present"></a>**`is_present`**: boolean. Whether the item is in the world at all: linked in its room, so drawn and collidable in principle. Managed by the engine. *(read-only)*
-    - <a name="items.Item.is_reversed"></a>**`is_reversed`**: boolean. Whether the item's trigger is inverted, so it runs until triggered rather than once triggered. This is how a level ships something already on.
-    - <a name="items.Item.is_simulated"></a>**`is_simulated`**: boolean. Whether the item's control routine runs each frame. Call `activate()` to start it. *(read-only)*
-    - <a name="items.Item.is_targetable"></a>**`is_targetable`**: boolean. Whether Lara's auto-aim can lock onto the item right now. *(read-only)*
-    - <a name="items.Item.is_triggered"></a>**`is_triggered`**: boolean. Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.
+    - <a id="items.Item.anim_num" name="items.Item.anim_num"></a>**`anim_num`**: integer. The animation's number within the object. Counted from 0.
+    - <a id="items.Item.anim_state" name="items.Item.anim_state"></a>**`anim_state`**: integer. Current animation state.
+    - <a id="items.Item.collidable" name="items.Item.collidable"></a>**`collidable`**: boolean. Whether Lara can collide with this item.
+    - <a id="items.Item.fall_speed" name="items.Item.fall_speed"></a>**`fall_speed`**: integer. Vertical speed.
+    - <a id="items.Item.frame_num" name="items.Item.frame_num"></a>**`frame_num`**: integer. The frame's number within the animation. Negative values count back from the end. Counted from 0.
+    - <a id="items.Item.goal_anim_state" name="items.Item.goal_anim_state"></a>**`goal_anim_state`**: integer. Animation state the item is transitioning towards.
+    - <a id="items.Item.gravity" name="items.Item.gravity"></a>**`gravity`**: boolean. Whether gravity applies to this item.
+    - <a id="items.Item.hit_points" name="items.Item.hit_points"></a>**`hit_points`**: integer. Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of [`properties`](#items.Item.properties).
+    - <a id="items.Item.is_alive" name="items.Item.is_alive"></a>**`is_alive`**: boolean. Whether the item is a living creature with hit points remaining. *(read-only)*
+    - <a id="items.Item.is_finished" name="items.Item.is_finished"></a>**`is_finished`**: boolean. Whether the item has finished its run - a creature that died, or a one-shot trigger that fired. It stays in the level but no longer acts.
+    - <a id="items.Item.is_hostile" name="items.Item.is_hostile"></a>**`is_hostile`**: boolean. Whether this item is a creature currently hostile to Lara. *(read-only)*
+    - <a id="items.Item.is_in_play" name="items.Item.is_in_play"></a>**`is_in_play`**: boolean. Whether the item is live: simulated, visible and not finished - the state a targetable enemy is in. A read-only composite of the axes. *(read-only)*
+    - <a id="items.Item.is_killed" name="items.Item.is_killed"></a>**`is_killed`**: boolean. Whether the item has already been killed. *(read-only)*
+    - <a id="items.Item.is_one_shot" name="items.Item.is_one_shot"></a>**`is_one_shot`**: boolean. Whether the item's trigger has been spent and will never fire again.
+    - <a id="items.Item.is_present" name="items.Item.is_present"></a>**`is_present`**: boolean. Whether the item is in the world at all: linked in its room, so drawn and collidable in principle. Managed by the engine. *(read-only)*
+    - <a id="items.Item.is_reversed" name="items.Item.is_reversed"></a>**`is_reversed`**: boolean. Whether the item's trigger is inverted, so it runs until triggered rather than once triggered. This is how a level ships something already on.
+    - <a id="items.Item.is_simulated" name="items.Item.is_simulated"></a>**`is_simulated`**: boolean. Whether the item's control routine runs each frame. Call [`activate`](#items.Item.activate) to start it. *(read-only)*
+    - <a id="items.Item.is_targetable" name="items.Item.is_targetable"></a>**`is_targetable`**: boolean. Whether Lara's auto-aim can lock onto the item right now. *(read-only)*
+    - <a id="items.Item.is_triggered" name="items.Item.is_triggered"></a>**`is_triggered`**: boolean. Whether the item's trigger currently says go. This is what a door, a switch or an alarm reads to decide whether to act; a creature ignores it and goes by whether it is running.
 
-      It is a verdict on `trigger_mask`, `timer` and `is_reversed` together, not a field of its own. *(read-only)*
-    - <a name="items.Item.is_visible"></a>**`is_visible`**: boolean. Whether the item is drawn. It can be present in the world but not visible, like an ambush enemy waiting to appear.
-    - <a name="items.Item.max_hit_points"></a>**`max_hit_points`**: integer. Maximum hit points. Set `properties.max_hit_points` to change it. *(read-only)*
-    - <a name="items.Item.mesh_bits"></a>**`mesh_bits`**: integer. Bitmask of which of the item's meshes are drawn.
-    - <a name="items.Item.name"></a>**`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
-    - <a name="items.Item.num"></a>**`num`**: [trx.items.Num](#items.Num). An item handed over by a query can say where it lives. *(read-only)*
-    - <a name="items.Item.object_id"></a>**`object_id`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The item's object type. *(read-only)*
-    - <a name="items.Item.pos"></a>**`pos`**: vec3. World position. Updating this also updates `room` and `room_num`.
-    - <a name="items.Item.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room containing this item. Set `pos` to move the item between rooms. *(read-only)*
-    - <a name="items.Item.rot"></a>**`rot`**: vec3. Orientation, in the units [`trx.math`](MATH.md#math) counts angles in. An angle counts in cycles, so one past the end of the turn wraps round to name the same direction rather than raising: adding a half turn to a rotation always works.
-    - <a name="items.Item.speed"></a>**`speed`**: integer. Forward speed.
-    - <a name="items.Item.timer"></a>**`timer`**: integer. How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - `trigger()` takes its timer in seconds instead.
-    - <a name="items.Item.touch_bits"></a>**`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
-    - <a name="items.Item.trigger_mask"></a>**`trigger_mask`**: integer. The five code bits, counted the way a level editor counts them: `1` to `31`. The trigger only says go once every bit is set, which is how a level makes several triggers agree before anything happens. A lone trigger carries all of them.
-    - <a name="items.Item.was_hit"></a>**`was_hit`**: boolean. Whether the item was hit during the current frame. *(read-only)*
+      It is a verdict on [`trigger_mask`](#items.Item.trigger_mask), [`timer`](#items.Item.timer) and [`is_reversed`](#items.Item.is_reversed) together, not a field of its own. *(read-only)*
+    - <a id="items.Item.is_visible" name="items.Item.is_visible"></a>**`is_visible`**: boolean. Whether the item is drawn. It can be present in the world but not visible, like an ambush enemy waiting to appear.
+    - <a id="items.Item.max_hit_points" name="items.Item.max_hit_points"></a>**`max_hit_points`**: integer. Maximum hit points. Set the `max_hit_points` entry of [`properties`](#items.Item.properties) to change it. *(read-only)*
+    - <a id="items.Item.mesh_bits" name="items.Item.mesh_bits"></a>**`mesh_bits`**: integer. Bitmask of which of the item's meshes are drawn.
+    - <a id="items.Item.name" name="items.Item.name"></a>**`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
+    - <a id="items.Item.num" name="items.Item.num"></a>**`num`**: [trx.items.Num](#items.Num). An item handed over by a query can say where it lives. *(read-only)*
+    - <a id="items.Item.object_id" name="items.Item.object_id"></a>**`object_id`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The item's object type. *(read-only)*
+    - <a id="items.Item.pos" name="items.Item.pos"></a>**`pos`**: vec3. World position. Updating this also updates [`room`](#items.Item.room) and [`room_num`](#items.Item.room_num).
+    - <a id="items.Item.room_num" name="items.Item.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room containing this item. Set [`pos`](#items.Item.pos) to move the item between rooms. *(read-only)*
+    - <a id="items.Item.rot" name="items.Item.rot"></a>**`rot`**: vec3. Orientation, in the units [`trx.math`](MATH.md#math) counts angles in. An angle counts in cycles, so one past the end of the turn wraps round to name the same direction rather than raising: adding a half turn to a rotation always works.
+    - <a id="items.Item.speed" name="items.Item.speed"></a>**`speed`**: integer. Forward speed.
+    - <a id="items.Item.timer" name="items.Item.timer"></a>**`timer`**: integer. How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - [`trigger`](#items.Item.trigger) takes its timer in seconds instead.
+    - <a id="items.Item.touch_bits" name="items.Item.touch_bits"></a>**`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
+    - <a id="items.Item.trigger_mask" name="items.Item.trigger_mask"></a>**`trigger_mask`**: integer. The five code bits, counted the way a level editor counts them: `1` to `31`. The trigger only says go once every bit is set, which is how a level makes several triggers agree before anything happens. A lone trigger carries all of them.
+    - <a id="items.Item.was_hit" name="items.Item.was_hit"></a>**`was_hit`**: boolean. Whether the item was hit during the current frame. *(read-only)*
 
     Computed properties (derived, not stored on the object):
-    - <a name="items.Item.bounds"></a>**`bounds`**: table. The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around `pos` before `rot` turns it, and they change as the item animates.
-    - <a name="items.Item.properties"></a>**`properties`**: table. Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
-    - <a name="items.Item.room"></a>**`room`**: [trx.rooms.Room](ROOMS.md#rooms.Room). The room containing this item.
+    - <a id="items.Item.bounds" name="items.Item.bounds"></a>**`bounds`**: table. The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far the model reaches around [`pos`](#items.Item.pos) before [`rot`](#items.Item.rot) turns it, and they change as the item animates.
+    - <a id="items.Item.properties" name="items.Item.properties"></a>**`properties`**: table. Typed, object-specific item properties. Writing here overrides the object's default for this item only; reads fall back to the object. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
+    - <a id="items.Item.room" name="items.Item.room"></a>**`room`**: [trx.rooms.Room](ROOMS.md#rooms.Room). The room containing this item.
 
     Methods:
 
-    - <a name="items.Item.activate"></a>[lua]`item:activate()`  
+    - <a id="items.Item.activate" name="items.Item.activate"></a>[lua]`item:activate()`  
       Brings the item to life, exactly as tripping a trigger on it would: its control routine starts running, and a creature also gets its AI, without which it would stand there and ignore Lara.
 
       Objects with no control routine cannot be activated, and an item that is already active is left alone.
 
-    - <a name="items.Item.deactivate"></a>[lua]`item:deactivate()`  
-      Stops the item: its control routine no longer runs, and a creature loses its AI and stands down. The item stays where it is and keeps its hit points, so this is not a way of getting rid of it - use `destroy()` for that.
+    - <a id="items.Item.deactivate" name="items.Item.deactivate"></a>[lua]`item:deactivate()`  
+      Stops the item: its control routine no longer runs, and a creature loses its AI and stands down. The item stays where it is and keeps its hit points, so this is not a way of getting rid of it - use [`destroy`](#items.Item.destroy) for that.
 
-      A trigger can still bring it back, and so can `activate()`.
+      A trigger can still bring it back, and so can [`activate`](#items.Item.activate).
 
-    - <a name="items.Item.destroy"></a>[lua]`item:destroy()`  
+    - <a id="items.Item.destroy" name="items.Item.destroy"></a>[lua]`item:destroy()`  
       Removes the item from the game. Any other handle to it becomes stale.
 
-    - <a name="items.Item.die"></a>[lua]`item:die([explode])`  
-      Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; `destroy()` simply removes any item from the game.
+    - <a id="items.Item.die" name="items.Item.die"></a>[lua]`item:die([explode])`  
+      Runs the object's creature death handling: the corpse stays, and `explode` bursts its meshes as a rocket or grenade would. For creatures; [`destroy`](#items.Item.destroy) simply removes any item from the game.
 
       Parameters:
       - **`explode`** (boolean, optional, default `false`). Whether to burst the meshes as it dies.
 
-    - <a name="items.Item.distance_to"></a>[lua]`item:distance_to(pos)`  
+    - <a id="items.Item.distance_to" name="items.Item.distance_to"></a>[lua]`item:distance_to(pos)`  
       Distance from this item to a world position.
 
       Parameters:
@@ -162,7 +162,7 @@ end
 
       Returns: integer.
 
-    - <a name="items.Item.get_property"></a>[lua]`item:get_property(name)`  
+    - <a id="items.Item.get_property" name="items.Item.get_property"></a>[lua]`item:get_property(name)`  
       Reads an object property, falling back to the object's default. Prefer `item.properties.<name>`.
 
       Parameters:
@@ -170,12 +170,12 @@ end
 
       Returns: any or `nil`.
 
-    - <a name="items.Item.get_property_names"></a>[lua]`item:get_property_names()`  
+    - <a id="items.Item.get_property_names" name="items.Item.get_property_names"></a>[lua]`item:get_property_names()`  
       Names of every property this item's object declares.
 
       Returns: table.
 
-    - <a name="items.Item.is_valid"></a>[lua]`item:is_valid()`  
+    - <a id="items.Item.is_valid" name="items.Item.is_valid"></a>[lua]`item:is_valid()`  
       Whether the handle still refers to a live item. Reading or writing a field on a stale handle raises an error rather than silently operating on an unrelated item, so check this for a handle held across time.
 
       Returns: boolean.
@@ -190,7 +190,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_activate"></a>[lua]`item:on_activate(callback)`  
+    - <a id="items.Item.on_activate" name="items.Item.on_activate"></a>[lua]`item:on_activate(callback)`  
       Happens when this item is activated through the lifecycle front door during play. [`trx.events.on_activate`](EVENTS.md#events.on_activate), narrowed to this item.
 
       Parameters:
@@ -207,7 +207,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_deactivate"></a>[lua]`item:on_deactivate(callback)`  
+    - <a id="items.Item.on_deactivate" name="items.Item.on_deactivate"></a>[lua]`item:on_deactivate(callback)`  
       Happens when this item is deactivated through the lifecycle front door during play. [`trx.events.on_deactivate`](EVENTS.md#events.on_deactivate), narrowed to this item.
 
       Parameters:
@@ -224,7 +224,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_destroy"></a>[lua]`item:on_destroy(callback)`  
+    - <a id="items.Item.on_destroy" name="items.Item.on_destroy"></a>[lua]`item:on_destroy(callback)`  
       Happens as this item is removed from the game during play. It can still be read from the handler, but not after. [`trx.events.on_destroy`](EVENTS.md#events.on_destroy), narrowed to this item.
 
       Parameters:
@@ -241,7 +241,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_enter_sim"></a>[lua]`item:on_enter_sim(callback)`  
+    - <a id="items.Item.on_enter_sim" name="items.Item.on_enter_sim"></a>[lua]`item:on_enter_sim(callback)`  
       Happens when this item starts being simulated during play. [`trx.events.on_enter_sim`](EVENTS.md#events.on_enter_sim), narrowed to this item.
 
       Parameters:
@@ -258,7 +258,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_enter_world"></a>[lua]`item:on_enter_world(callback)`  
+    - <a id="items.Item.on_enter_world" name="items.Item.on_enter_world"></a>[lua]`item:on_enter_world(callback)`  
       Happens when this item enters the world during play, such as a runtime spawn. [`trx.events.on_enter_world`](EVENTS.md#events.on_enter_world), narrowed to this item.
 
       Parameters:
@@ -275,7 +275,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_finish"></a>[lua]`item:on_finish(callback)`  
+    - <a id="items.Item.on_finish" name="items.Item.on_finish"></a>[lua]`item:on_finish(callback)`  
       Happens when this item finishes its run during play. [`trx.events.on_finish`](EVENTS.md#events.on_finish), narrowed to this item.
 
       Parameters:
@@ -292,7 +292,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_hide"></a>[lua]`item:on_hide(callback)`  
+    - <a id="items.Item.on_hide" name="items.Item.on_hide"></a>[lua]`item:on_hide(callback)`  
       Happens when this item becomes hidden during play. [`trx.events.on_hide`](EVENTS.md#events.on_hide), narrowed to this item.
 
       Parameters:
@@ -309,7 +309,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_hit"></a>[lua]`item:on_hit(callback)`  
+    - <a id="items.Item.on_hit" name="items.Item.on_hit"></a>[lua]`item:on_hit(callback)`  
       Happens when this item takes damage. [`trx.events.on_hit`](EVENTS.md#events.on_hit), narrowed to this item.
 
       Parameters:
@@ -327,7 +327,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_kill"></a>[lua]`item:on_kill(callback)`  
+    - <a id="items.Item.on_kill" name="items.Item.on_kill"></a>[lua]`item:on_kill(callback)`  
       Happens when damage takes this item's hit points to zero. [`trx.events.on_kill`](EVENTS.md#events.on_kill), narrowed to this item.
 
       Parameters:
@@ -344,7 +344,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_leave_sim"></a>[lua]`item:on_leave_sim(callback)`  
+    - <a id="items.Item.on_leave_sim" name="items.Item.on_leave_sim"></a>[lua]`item:on_leave_sim(callback)`  
       Happens when this item stops being simulated during play. [`trx.events.on_leave_sim`](EVENTS.md#events.on_leave_sim), narrowed to this item.
 
       Parameters:
@@ -361,7 +361,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_leave_world"></a>[lua]`item:on_leave_world(callback)`  
+    - <a id="items.Item.on_leave_world" name="items.Item.on_leave_world"></a>[lua]`item:on_leave_world(callback)`  
       Happens when this item leaves the world during play. [`trx.events.on_leave_world`](EVENTS.md#events.on_leave_world), narrowed to this item.
 
       Parameters:
@@ -378,7 +378,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_show"></a>[lua]`item:on_show(callback)`  
+    - <a id="items.Item.on_show" name="items.Item.on_show"></a>[lua]`item:on_show(callback)`  
       Happens when this item becomes visible during play. [`trx.events.on_show`](EVENTS.md#events.on_show), narrowed to this item.
 
       Parameters:
@@ -395,7 +395,7 @@ end
       end)
       ```
 
-    - <a name="items.Item.on_trigger"></a>[lua]`item:on_trigger(callback)`  
+    - <a id="items.Item.on_trigger" name="items.Item.on_trigger"></a>[lua]`item:on_trigger(callback)`  
       Happens every time a trigger is aimed at this item, of any kind. [`trx.events.on_trigger`](EVENTS.md#events.on_trigger), narrowed to this item.
 
       Parameters:
@@ -413,23 +413,24 @@ end
       end)
       ```
 
-    - <a name="items.Item.set_property"></a>[lua]`item:set_property(name, value)`  
+    - <a id="items.Item.set_property" name="items.Item.set_property"></a>[lua]`item:set_property(name, value)`  
       Overrides an object property for this item. Prefer `item.properties.<name> = ...`.
 
       Parameters:
       - **`name`** (string).
       - **`value`** (any).
 
-    - <a name="items.Item.shatter"></a>[lua]`item:shatter([damage])`  
-      Bursts the item's meshes into flying debris, the visual `die(true)` produces, on its own. It does not kill or remove the item.
+    - <a id="items.Item.shatter" name="items.Item.shatter"></a>[lua]`item:shatter([damage])`  
+      Bursts the item's meshes into flying debris, the visual [`die`](#items.Item.die) produces with `explode`, on its own. It does not kill or remove the item.
 
       Parameters:
       - **`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
 
-    - <a name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
-      Hurts the item the way a weapon does, and reports through `on_hit`, and
-      `on_kill` where the blow takes the last hit point. Writing `hit_points` reports neither. The kill
-      counts as the environment's rather than Lara's.
+    - <a id="items.Item.take_damage" name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
+      Hurts the item the way a weapon does, and reports through [`trx.events.on_hit`](EVENTS.md#events.on_hit),
+      and [`trx.events.on_kill`](EVENTS.md#events.on_kill) where the blow takes the last hit point. Writing
+      [`hit_points`](#items.Item.hit_points) reports neither. The kill counts as the
+      environment's rather than Lara's.
 
       Parameters:
       - **`damage`** (integer). Hit points to take.
@@ -440,13 +441,13 @@ end
       lara:take_damage(lara.hit_points)
       ```
 
-    - <a name="items.Item.trigger"></a>[lua]`item:trigger([opts])`  
+    - <a id="items.Item.trigger" name="items.Item.trigger"></a>[lua]`item:trigger([opts])`  
       Fires a trigger at the item, exactly as a floor trigger in the level would: sets the code bits, and once they are all set, starts the item running.
 
-      This is the one to reach for on anything a level would trigger - a door, a switch, an alarm - because those read their trigger before they act, and merely `activate()`-ing one leaves it running but doing nothing. Pass `type = trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.
+      This is the one to reach for on anything a level would trigger - a door, a switch, an alarm - because those read their trigger before they act, and merely activating one leaves it running but doing nothing. Pass `type = trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.
 
       Parameters:
-      - **`opts`** (table, optional). `type`: which `items.TriggerType` to fire; a plain `TRIGGER` by default.
+      - **`opts`** (table, optional). `type`: which [`trx.items.TriggerType`](#items.TriggerType) to fire; a plain `TRIGGER` by default.
 
         `mask`: which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.
 
@@ -469,23 +470,23 @@ end
       trx.items[12]:trigger({ type = trx.items.TriggerType.ANTITRIGGER })
       ```
 
-- <a name="items.ItemQuery"></a>[lua]`trx.items.ItemQuery`
+- <a id="items.ItemQuery" name="items.ItemQuery"></a>[lua]`trx.items.ItemQuery`
 
-    A [`trx.query.Query`](QUERY.md#query.Query) over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so `of_object` is how a name reaches them.
+    A [`trx.query.Query`](QUERY.md#query.Query) over the items a level holds, with the narrowings below on top of the ones every query has. Items answer to no names of their own, so [`of_object`](#items.ItemQuery.of_object) is how a name reaches them.
 
     Methods:
 
-    - <a name="items.ItemQuery.alive"></a>[lua]`itemquery:alive()`  
+    - <a id="items.ItemQuery.alive" name="items.ItemQuery.alive"></a>[lua]`itemquery:alive()`  
       The item still has hit points.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.finished"></a>[lua]`itemquery:finished()`  
+    - <a id="items.ItemQuery.finished" name="items.ItemQuery.finished"></a>[lua]`itemquery:finished()`  
       The item has run its course.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.in_box"></a>[lua]`itemquery:in_box(min, max)`  
+    - <a id="items.ItemQuery.in_box" name="items.ItemQuery.in_box"></a>[lua]`itemquery:in_box(min, max)`  
       The item stands inside a world-space box. The corners may come in any order.
 
       An item is tested by its position, the point it stands at, rather than by the box it fills. Position is all this asks after, so the rest of the query says what else the item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are in the world as well.
@@ -504,12 +505,12 @@ end
         :matches()
       ```
 
-    - <a name="items.ItemQuery.in_play"></a>[lua]`itemquery:in_play()`  
+    - <a id="items.ItemQuery.in_play" name="items.ItemQuery.in_play"></a>[lua]`itemquery:in_play()`  
       The item is part of the game rather than set aside.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.in_room"></a>[lua]`itemquery:in_room(room_num)`  
+    - <a id="items.ItemQuery.in_room" name="items.ItemQuery.in_room"></a>[lua]`itemquery:in_room(room_num)`  
       The item is in the given room.
 
       Parameters:
@@ -517,8 +518,8 @@ end
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.in_sphere"></a>[lua]`itemquery:in_sphere(centre, radius)`  
-      The item stands within a radius of a point. As with `in_box`, the item's position is the whole of the test.
+    - <a id="items.ItemQuery.in_sphere" name="items.ItemQuery.in_sphere"></a>[lua]`itemquery:in_sphere(centre, radius)`  
+      The item stands within a radius of a point. As with [`in_box`](#items.ItemQuery.in_box), the item's position is the whole of the test.
 
       Parameters:
       - **`centre`** (vec3). Middle of the sphere.
@@ -526,7 +527,7 @@ end
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.of_object"></a>[lua]`itemquery:of_object(key)`  
+    - <a id="items.ItemQuery.of_object" name="items.ItemQuery.of_object"></a>[lua]`itemquery:of_object(key)`  
       The item is of the given object, named the way a player would name it or by its id.
 
       Parameters:
@@ -539,29 +540,29 @@ end
       trx.items.query:of_object("wolf"):simulated():matches()
       ```
 
-    - <a name="items.ItemQuery.present"></a>[lua]`itemquery:present()`  
+    - <a id="items.ItemQuery.present" name="items.ItemQuery.present"></a>[lua]`itemquery:present()`  
       The item is in the world, whether or not anything is simulating it.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.simulated"></a>[lua]`itemquery:simulated()`  
+    - <a id="items.ItemQuery.simulated" name="items.ItemQuery.simulated"></a>[lua]`itemquery:simulated()`  
       The item is being simulated: its control routine runs every frame.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.targetable"></a>[lua]`itemquery:targetable()`  
+    - <a id="items.ItemQuery.targetable" name="items.ItemQuery.targetable"></a>[lua]`itemquery:targetable()`  
       Lara's guns can lock onto the item.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="items.ItemQuery.visible"></a>[lua]`itemquery:visible()`  
+    - <a id="items.ItemQuery.visible" name="items.ItemQuery.visible"></a>[lua]`itemquery:visible()`  
       The item is drawn.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
 ### Functions
 
-- <a name="items.get"></a>[lua]`trx.items.get(key)`  
+- <a id="items.get" name="items.get"></a>[lua]`trx.items.get(key)`  
   Retrieves an item by number or by name.
 
   Parameters:
@@ -576,7 +577,7 @@ end
   local lara = trx.items["lara"]
   ```
 
-- <a name="items.spawn"></a>[lua]`trx.items.spawn(object_id, pos, [angle_y], [opts])`  
+- <a id="items.spawn" name="items.spawn"></a>[lua]`trx.items.spawn(object_id, pos, [angle_y], [opts])`  
   Creates a new item of the given object type at the given position.
 
   Parameters:
@@ -593,7 +594,7 @@ end
     trx.catalog.objects.wolf, trx.lara.item.pos, 0, { activate = true })
   ```
 
-- <a name="items.count"></a>[lua]`trx.items.count()`  
+- <a id="items.count" name="items.count"></a>[lua]`trx.items.count()`  
   Returns the total number of allocated items. Same as `#trx.items`.
 
   Returns: integer.

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -102,7 +102,7 @@ end
     Properties:
     - <a id="items.Trigger.mask" name="items.Trigger.mask"></a>**`mask`**: integer. The code bits it set, `1` to `31`.
     - <a id="items.Trigger.one_shot" name="items.Trigger.one_shot"></a>**`one_shot`**: boolean. Whether it fires only the once.
-    - <a id="items.Trigger.timer" name="items.Trigger.timer"></a>**`timer`**: number. How long it keeps the item going, in seconds.
+    - <a id="items.Trigger.timer" name="items.Trigger.timer"></a>**`timer`**: [trx.game.Seconds](GAME.md#game.Seconds). How long it keeps the item going.
     - <a id="items.Trigger.type" name="items.Trigger.type"></a>**`type`**: [trx.items.TriggerType](#items.TriggerType). The kind of trigger it was.
 
 - <a id="items.Item" name="items.Item"></a>[lua]`trx.items.Item`
@@ -144,7 +144,7 @@ end
     - <a id="items.Item.room_num" name="items.Item.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room containing this item. Set [`pos`](#items.Item.pos) to move the item between rooms. *(read-only)*
     - <a id="items.Item.rot" name="items.Item.rot"></a>**`rot`**: vec3. Orientation. Each component is a [`trx.math.Angle`](MATH.md#math.Angle).
     - <a id="items.Item.speed" name="items.Item.speed"></a>**`speed`**: integer. Forward speed.
-    - <a id="items.Item.timer" name="items.Item.timer"></a>**`timer`**: integer. How long the item's trigger keeps it going, in game frames. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. This is the raw frame count - [`trigger`](#items.Item.trigger) takes its timer in seconds instead.
+    - <a id="items.Item.timer" name="items.Item.timer"></a>**`timer`**: [trx.game.Frames](GAME.md#game.Frames). How long the item's trigger keeps it going. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. [`trigger`](#items.Item.trigger) takes its own timer as a [`trx.game.Seconds`](GAME.md#game.Seconds).
     - <a id="items.Item.touch_bits" name="items.Item.touch_bits"></a>**`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
     - <a id="items.Item.trigger_mask" name="items.Item.trigger_mask"></a>**`trigger_mask`**: integer. The five code bits, counted the way a level editor counts them: `1` to `31`. The trigger only says go once every bit is set, which is how a level makes several triggers agree before anything happens. A lone trigger carries all of them.
     - <a id="items.Item.was_hit" name="items.Item.was_hit"></a>**`was_hit`**: boolean. Whether the item was hit during the current frame. *(read-only)*
@@ -473,7 +473,7 @@ end
         Keys:
         - <a id="items.Item.trigger.opts.type" name="items.Item.trigger.opts.type"></a>**`type`** ([trx.items.TriggerType](#items.TriggerType), optional). A plain `TRIGGER` by default.
         - <a id="items.Item.trigger.opts.mask" name="items.Item.trigger.opts.mask"></a>**`mask`** (integer, optional). Which of the five code bits to set, `1` to `31`, all of them by default. Pass fewer to act as one of several triggers a puzzle is waiting on.
-        - <a id="items.Item.trigger.opts.timer" name="items.Item.trigger.opts.timer"></a>**`timer`** (number, optional, default `0`). How long it should keep the item going, in seconds. `0` means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.
+        - <a id="items.Item.trigger.opts.timer" name="items.Item.trigger.opts.timer"></a>**`timer`** ([trx.game.Seconds](GAME.md#game.Seconds), optional, default `0`). How long it should keep the item going. `0` means until something takes the trigger back. A timer of exactly `1` is a single frame, not a second, matching the level format.
         - <a id="items.Item.trigger.opts.one_shot" name="items.Item.trigger.opts.one_shot"></a>**`one_shot`** (boolean, optional). Never let it fire again.
 
       Example:

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -16,9 +16,9 @@ Module for controlling all moveables.
 
 ### Indexing
 
-Indexing the module reaches an item, and `#trx.items` is how many the level has. Items count from zero, matching the item numbers level editors show. `pairs()` walks them in order, keyed by that number.
+Indexing the module reaches an item, and `#trx.items` is how many the level has. `pairs()` walks them in order, keyed by the item number.
 
-- **`trx.items[key]`** (Item or `nil`). 0-based index, or the item's unique name.
+- **`trx.items[key]`** (Item or `nil`). 0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.
 - **`#trx.items`** (integer). How many there are.
 
 Example:
@@ -88,15 +88,14 @@ end
     unrelated one.
 
     Properties:
-    - **`anim`**: integer. Object-relative animation number, 0-indexed.
+    - **`anim_num`**: integer. The animation's number within the object, counted from 0.
     - **`anim_state`**: integer. Current animation state.
     - **`collidable`**: boolean. Whether Lara can collide with this item.
     - **`fall_speed`**: integer. Vertical speed.
-    - **`frame`**: integer. Object-relative frame number, 0-indexed. Negative values count back from the end.
+    - **`frame_num`**: integer. The frame's number within the animation, counted from 0. Negative values count back from the end.
     - **`goal_anim_state`**: integer. Animation state the item is transitioning towards.
     - **`gravity`**: boolean. Whether gravity applies to this item.
     - **`hit_points`**: integer. Current hit points. Raising this above the maximum also raises `properties.max_hit_points`.
-    - **`index`**: integer. The index `trx.items[i]` takes, counted from 0. An item handed over by a query can say where it lives. *(read-only)*
     - **`is_alive`**: boolean. Whether the item is a living creature with hit points remaining. *(read-only)*
     - **`is_finished`**: boolean. Whether the item has finished its run - a creature that died, or a one-shot trigger that fired. It stays in the level but no longer acts.
     - **`is_hostile`**: boolean. Whether this item is a creature currently hostile to Lara. *(read-only)*
@@ -114,6 +113,7 @@ end
     - **`max_hit_points`**: integer. Maximum hit points. Set `properties.max_hit_points` to change it. *(read-only)*
     - **`mesh_bits`**: integer. Bitmask of which of the item's meshes are drawn.
     - **`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
+    - **`num`**: integer. 0-based item number, matching the numbers level editors show. An item handed over by a query can say where it lives. *(read-only)*
     - **`object_id`**: integer. The item's object type. Compare against `trx.catalog.objects`. *(read-only)*
     - **`pos`**: vec3. World position. Updating this also updates `room` and `room_num`.
     - **`room_num`**: integer. 0-based number of the room containing this item. Set `pos` to move the item between rooms. *(read-only)*
@@ -558,10 +558,10 @@ end
 ### Functions
 
 - [lua]`trx.items.get(key)`  
-  Retrieves an item by index or by name. Items count from zero, matching the item numbers level editors show.
+  Retrieves an item by number or by name.
 
   Parameters:
-  - **`key`** (any). 0-based index, or the item's unique name.
+  - **`key`** (any). 0-based item number, matching the numbers level editors show. An item's unique name reaches it as well.
 
   Returns: Item or `nil`.
 

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -156,8 +156,8 @@ Her position, room and hit points are not here: she is an item like any other an
 
     Properties:
     - <a id="lara.Lara.air_bar" name="lara.Lara.air_bar"></a>**`air_bar`**: integer. Air remaining underwater, out of 1800. Runs down while she is under.
-    - <a id="lara.Lara.death_timer" name="lara.Lara.death_timer"></a>**`death_timer`**: integer. Frames Lara has been dead for. *(read-only)*
-    - <a id="lara.Lara.dive_timer" name="lara.Lara.dive_timer"></a>**`dive_timer`**: integer. Frames Lara has been diving for. *(read-only)*
+    - <a id="lara.Lara.death_timer" name="lara.Lara.death_timer"></a>**`death_timer`**: [trx.game.Frames](GAME.md#game.Frames). How long Lara has been dead. *(read-only)*
+    - <a id="lara.Lara.dive_timer" name="lara.Lara.dive_timer"></a>**`dive_timer`**: [trx.game.Frames](GAME.md#game.Frames). How long Lara has been diving. *(read-only)*
     - <a id="lara.Lara.electric" name="lara.Lara.electric"></a>**`electric`**: integer. How badly Lara is being electrocuted, and 0 when she is not.
     - <a id="lara.Lara.equipped_gun" name="lara.Lara.equipped_gun"></a>**`equipped_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is holding. *(read-only)*
     - <a id="lara.Lara.exposure_bar" name="lara.Lara.exposure_bar"></a>**`exposure_bar`**: integer. Warmth remaining in the cold, out of [`trx.rules.exposure.max`](RULES.md#rules.exposure.max). Only moves in a level whose rooms carry the [`trx.rooms.Room.damaging`](ROOMS.md#rooms.Room.damaging) flag.
@@ -169,7 +169,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - <a id="lara.Lara.is_crouched" name="lara.Lara.is_crouched"></a>**`is_crouched`**: boolean. Whether Lara is crouching. *(read-only)*
     - <a id="lara.Lara.poison" name="lara.Lara.poison"></a>**`poison`**: integer. How poisoned Lara is, and 0 when she is not.
     - <a id="lara.Lara.poison_target" name="lara.Lara.poison_target"></a>**`poison_target`**: integer. The poison reservoir that drains into [`trx.lara.poison`](#lara.Lara.poison) over time. TR4 only.
-    - <a id="lara.Lara.pose_count" name="lara.Lara.pose_count"></a>**`pose_count`**: integer. Frames Lara has stood still for, which is what starts an idle animation. *(read-only)*
+    - <a id="lara.Lara.pose_count" name="lara.Lara.pose_count"></a>**`pose_count`**: [trx.game.Frames](GAME.md#game.Frames). How long Lara has stood still, which is what starts an idle animation. *(read-only)*
     - <a id="lara.Lara.requested_gun" name="lara.Lara.requested_gun"></a>**`requested_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is drawing, while she is drawing it. *(read-only)*
     - <a id="lara.Lara.sprint_timer" name="lara.Lara.sprint_timer"></a>**`sprint_timer`**: integer. Sprint left in her legs.
     - <a id="lara.Lara.water_status" name="lara.Lara.water_status"></a>**`water_status`**: [trx.lara.WaterState](#lara.WaterState). Where Lara is with respect to water. *(read-only)*

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -10,7 +10,7 @@ order: 3
   src/lua/api/lara.lua. Edit it there.
 -->
 
-## Lara module
+## <a id="lara" name="lara"></a>Lara module
 
 Module for reading and nudging Lara's own state.
 
@@ -18,17 +18,17 @@ Her position, room and hit points are not here: she is an item like any other an
 
 ### Properties
 
-- <a name="lara.item"></a>**`trx.lara.item`** ([trx.items.Item](ITEMS.md#items.Item)). Lara's own item, or `nil` outside a level. Her position, room and hit points are read and written there. *(read-only)*
-- <a name="lara.target"></a>**`trx.lara.target`** ([trx.items.Item](ITEMS.md#items.Item)). The item Lara's guns are locked onto, or `nil` if she has none. *(read-only)*
-- <a name="lara.outfit"></a>**`trx.lara.outfit`** (string). The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.
-- <a name="lara.holsters_visible"></a>**`trx.lara.holsters_visible`** (boolean). Whether Lara's holsters are drawn on her hips.
-- <a name="lara.is_flying"></a>**`trx.lara.is_flying`** (boolean). Whether Lara is in the fly-mode cheat. Setting it enters or leaves fly mode.
-- <a name="lara.is_wet"></a>**`trx.lara.is_wet`** (boolean). Whether Lara is still shedding droplets after a swim. `dry` clears it. *(read-only)*
-- <a name="lara.has_pistol_weapon"></a>**`trx.lara.has_pistol_weapon`** (boolean). Whether Lara is carrying a pistol-class weapon, which is what decides whether she has holsters to show at all. *(read-only)*
+- <a id="lara.item" name="lara.item"></a>**`trx.lara.item`** ([trx.items.Item](ITEMS.md#items.Item)). Lara's own item, or `nil` outside a level. Her position, room and hit points are read and written there. *(read-only)*
+- <a id="lara.target" name="lara.target"></a>**`trx.lara.target`** ([trx.items.Item](ITEMS.md#items.Item)). The item Lara's guns are locked onto, or `nil` if she has none. *(read-only)*
+- <a id="lara.outfit" name="lara.outfit"></a>**`trx.lara.outfit`** (string). The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.
+- <a id="lara.holsters_visible" name="lara.holsters_visible"></a>**`trx.lara.holsters_visible`** (boolean). Whether Lara's holsters are drawn on her hips.
+- <a id="lara.is_flying" name="lara.is_flying"></a>**`trx.lara.is_flying`** (boolean). Whether Lara is in the fly-mode cheat. Setting it enters or leaves fly mode.
+- <a id="lara.is_wet" name="lara.is_wet"></a>**`trx.lara.is_wet`** (boolean). Whether Lara is still shedding droplets after a swim. [`trx.lara.dry`](#lara.dry) clears it. *(read-only)*
+- <a id="lara.has_pistol_weapon" name="lara.has_pistol_weapon"></a>**`trx.lara.has_pistol_weapon`** (boolean). Whether Lara is carrying a pistol-class weapon, which is what decides whether she has holsters to show at all. *(read-only)*
 
 ### Enums
 
-- <a name="lara.Mesh"></a>[lua]`trx.lara.Mesh`
+- <a id="lara.Mesh" name="lara.Mesh"></a>[lua]`trx.lara.Mesh`
 
     One of the fifteen meshes Lara is built from.
 
@@ -63,7 +63,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - `trx.lara.Mesh.HEAD` = `14`  
         Head.
 
-- <a name="lara.ExtraMesh"></a>[lua]`trx.lara.ExtraMesh`
+- <a id="lara.ExtraMesh" name="lara.ExtraMesh"></a>[lua]`trx.lara.ExtraMesh`
 
     A mesh Lara can carry on top of one of her own - the dagger in Home Sweet Home, the oar in a boat.
 
@@ -112,7 +112,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - `trx.lara.ExtraMesh.WATERSKIN` = `21`  
         Waterskin.
 
-- <a name="lara.WaterState"></a>[lua]`trx.lara.WaterState`
+- <a id="lara.WaterState" name="lara.WaterState"></a>[lua]`trx.lara.WaterState`
 
     Where Lara is with respect to water.
 
@@ -127,7 +127,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - `trx.lara.WaterState.WADE` = `4`  
         Wading, feet still on the floor.
 
-- <a name="lara.GunState"></a>[lua]`trx.lara.GunState`
+- <a id="lara.GunState" name="lara.GunState"></a>[lua]`trx.lara.GunState`
 
     What Lara's hands are doing.
 
@@ -146,7 +146,7 @@ Her position, room and hit points are not here: she is an item like any other an
 
 ### Structures
 
-- <a name="lara.Lara"></a>[lua]`trx.lara.Lara`
+- <a id="lara.Lara" name="lara.Lara"></a>[lua]`trx.lara.Lara`
 
     Lara's own state, reachable straight off [`trx.lara`](#lara).
 
@@ -155,28 +155,28 @@ Her position, room and hit points are not here: she is an item like any other an
     unrelated one.
 
     Properties:
-    - <a name="lara.Lara.air_bar"></a>**`air_bar`**: integer. Air remaining underwater, out of 1800. Runs down while she is under.
-    - <a name="lara.Lara.death_timer"></a>**`death_timer`**: integer. Frames Lara has been dead for. *(read-only)*
-    - <a name="lara.Lara.dive_timer"></a>**`dive_timer`**: integer. Frames Lara has been diving for. *(read-only)*
-    - <a name="lara.Lara.electric"></a>**`electric`**: integer. How badly Lara is being electrocuted, and 0 when she is not.
-    - <a name="lara.Lara.equipped_gun"></a>**`equipped_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is holding. *(read-only)*
-    - <a name="lara.Lara.exposure_bar"></a>**`exposure_bar`**: integer. Warmth remaining in the cold, out of [`trx.rules.exposure.max`](RULES.md#rules.exposure.max). Only moves in a level whose rooms carry the `damaging` flag.
-    - <a name="lara.Lara.extra_anim"></a>**`extra_anim`**: boolean. Whether a scripted animation is driving Lara rather than her own state machine. *(read-only)*
-    - <a name="lara.Lara.gun_status"></a>**`gun_status`**: [trx.lara.GunState](#lara.GunState). What Lara's hands are doing. *(read-only)*
-    - <a name="lara.Lara.hit_direction"></a>**`hit_direction`**: integer. Which way the last hit came from, or -1 if she has not been hit. *(read-only)*
-    - <a name="lara.Lara.is_burning"></a>**`is_burning`**: boolean. Whether Lara is on fire. Setting it lights her or puts her out.
-    - <a name="lara.Lara.is_climbing"></a>**`is_climbing`**: boolean. Whether Lara is on a climbable wall. *(read-only)*
-    - <a name="lara.Lara.is_crouched"></a>**`is_crouched`**: boolean. Whether Lara is crouching. *(read-only)*
-    - <a name="lara.Lara.poison"></a>**`poison`**: integer. How poisoned Lara is, and 0 when she is not.
-    - <a name="lara.Lara.poison_target"></a>**`poison_target`**: integer. The poison reservoir that drains into `poison` over time. TR4 only.
-    - <a name="lara.Lara.pose_count"></a>**`pose_count`**: integer. Frames Lara has stood still for, which is what starts an idle animation. *(read-only)*
-    - <a name="lara.Lara.requested_gun"></a>**`requested_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is drawing, while she is drawing it. *(read-only)*
-    - <a name="lara.Lara.sprint_timer"></a>**`sprint_timer`**: integer. Sprint left in her legs.
-    - <a name="lara.Lara.water_status"></a>**`water_status`**: [trx.lara.WaterState](#lara.WaterState). Where Lara is with respect to water. *(read-only)*
+    - <a id="lara.Lara.air_bar" name="lara.Lara.air_bar"></a>**`air_bar`**: integer. Air remaining underwater, out of 1800. Runs down while she is under.
+    - <a id="lara.Lara.death_timer" name="lara.Lara.death_timer"></a>**`death_timer`**: integer. Frames Lara has been dead for. *(read-only)*
+    - <a id="lara.Lara.dive_timer" name="lara.Lara.dive_timer"></a>**`dive_timer`**: integer. Frames Lara has been diving for. *(read-only)*
+    - <a id="lara.Lara.electric" name="lara.Lara.electric"></a>**`electric`**: integer. How badly Lara is being electrocuted, and 0 when she is not.
+    - <a id="lara.Lara.equipped_gun" name="lara.Lara.equipped_gun"></a>**`equipped_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is holding. *(read-only)*
+    - <a id="lara.Lara.exposure_bar" name="lara.Lara.exposure_bar"></a>**`exposure_bar`**: integer. Warmth remaining in the cold, out of [`trx.rules.exposure.max`](RULES.md#rules.exposure.max). Only moves in a level whose rooms carry the [`trx.rooms.Room.damaging`](ROOMS.md#rooms.Room.damaging) flag.
+    - <a id="lara.Lara.extra_anim" name="lara.Lara.extra_anim"></a>**`extra_anim`**: boolean. Whether a scripted animation is driving Lara rather than her own state machine. *(read-only)*
+    - <a id="lara.Lara.gun_status" name="lara.Lara.gun_status"></a>**`gun_status`**: [trx.lara.GunState](#lara.GunState). What Lara's hands are doing. *(read-only)*
+    - <a id="lara.Lara.hit_direction" name="lara.Lara.hit_direction"></a>**`hit_direction`**: integer. Which way the last hit came from, or -1 if she has not been hit. *(read-only)*
+    - <a id="lara.Lara.is_burning" name="lara.Lara.is_burning"></a>**`is_burning`**: boolean. Whether Lara is on fire. Setting it lights her or puts her out.
+    - <a id="lara.Lara.is_climbing" name="lara.Lara.is_climbing"></a>**`is_climbing`**: boolean. Whether Lara is on a climbable wall. *(read-only)*
+    - <a id="lara.Lara.is_crouched" name="lara.Lara.is_crouched"></a>**`is_crouched`**: boolean. Whether Lara is crouching. *(read-only)*
+    - <a id="lara.Lara.poison" name="lara.Lara.poison"></a>**`poison`**: integer. How poisoned Lara is, and 0 when she is not.
+    - <a id="lara.Lara.poison_target" name="lara.Lara.poison_target"></a>**`poison_target`**: integer. The poison reservoir that drains into [`trx.lara.poison`](#lara.Lara.poison) over time. TR4 only.
+    - <a id="lara.Lara.pose_count" name="lara.Lara.pose_count"></a>**`pose_count`**: integer. Frames Lara has stood still for, which is what starts an idle animation. *(read-only)*
+    - <a id="lara.Lara.requested_gun" name="lara.Lara.requested_gun"></a>**`requested_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is drawing, while she is drawing it. *(read-only)*
+    - <a id="lara.Lara.sprint_timer" name="lara.Lara.sprint_timer"></a>**`sprint_timer`**: integer. Sprint left in her legs.
+    - <a id="lara.Lara.water_status" name="lara.Lara.water_status"></a>**`water_status`**: [trx.lara.WaterState](#lara.WaterState). Where Lara is with respect to water. *(read-only)*
 
 ### Functions
 
-- <a name="lara.set_extra_equipment"></a>[lua]`trx.lara.set_extra_equipment(mesh, extra_mesh)`  
+- <a id="lara.set_extra_equipment" name="lara.set_extra_equipment"></a>[lua]`trx.lara.set_extra_equipment(mesh, extra_mesh)`  
   Hangs an extra mesh on one of Lara's own, replacing whatever is there.
 
   Parameters:
@@ -188,7 +188,7 @@ Her position, room and hit points are not here: she is an item like any other an
   trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)
   ```
 
-- <a name="lara.teleport"></a>[lua]`trx.lara.teleport(pos, [room_num])`  
+- <a id="lara.teleport" name="lara.teleport"></a>[lua]`trx.lara.teleport(pos, [room_num])`  
   Moves Lara to a world position, putting her down on the floor there. She is taken off any vehicle, her weapons are put away and the camera follows her over.
 
   The position is nudged into valid room geometry, so a spot inside a wall lands her beside it rather than in it. Somewhere with no floor within reach moves nothing.
@@ -204,16 +204,16 @@ Her position, room and hit points are not here: she is an item like any other an
   trx.lara.teleport(trx.items.query:of_object("wolf"):first().pos)
   ```
 
-- <a name="lara.cure_poison"></a>[lua]`trx.lara.cure_poison()`  
+- <a id="lara.cure_poison" name="lara.cure_poison"></a>[lua]`trx.lara.cure_poison()`  
   Cures Lara's poisoning. Not the same as writing `0` to `poison`: the poison has a target as well as a current value, and clearing only the value lets it climb back.
 
-- <a name="lara.extinguish"></a>[lua]`trx.lara.extinguish()`  
+- <a id="lara.extinguish" name="lara.extinguish"></a>[lua]`trx.lara.extinguish()`  
   Puts Lara's fire out, and stops her being electrocuted with it.
 
-- <a name="lara.dry"></a>[lua]`trx.lara.dry()`  
+- <a id="lara.dry" name="lara.dry"></a>[lua]`trx.lara.dry()`  
   Dries Lara off, clearing the wetness that sheds droplets after she leaves water.
 
-- <a name="lara.clear_equipment"></a>[lua]`trx.lara.clear_equipment(mesh)`  
+- <a id="lara.clear_equipment" name="lara.clear_equipment"></a>[lua]`trx.lara.clear_equipment(mesh)`  
   Takes the extra mesh back off, leaving Lara's own.
 
   Parameters:

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -14,21 +14,21 @@ order: 3
 
 Module for reading and nudging Lara's own state.
 
-Her position, room and hit points are not here: she is an item like any other and they live on it, as `trx.lara.item`.
+Her position, room and hit points are not here: she is an item like any other and they live on it, as [`trx.lara.item`](#lara.item).
 
 ### Properties
 
-- **`trx.lara.item`** (Item). Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit points are read and written there. *(read-only)*
-- **`trx.lara.target`** (Item). The item Lara's guns are locked onto, or `nil` if she has none. *(read-only)*
-- **`trx.lara.outfit`** (string). The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.
-- **`trx.lara.holsters_visible`** (boolean). Whether Lara's holsters are drawn on her hips.
-- **`trx.lara.is_flying`** (boolean). Whether Lara is in the fly-mode cheat. Setting it enters or leaves fly mode.
-- **`trx.lara.is_wet`** (boolean). Whether Lara is still shedding droplets after a swim. `dry` clears it. *(read-only)*
-- **`trx.lara.has_pistol_weapon`** (boolean). Whether Lara is carrying a pistol-class weapon, which is what decides whether she has holsters to show at all. *(read-only)*
+- <a name="lara.item"></a>**`trx.lara.item`** ([trx.items.Item](ITEMS.md#items.Item)). Lara's own item, or `nil` outside a level. Her position, room and hit points are read and written there. *(read-only)*
+- <a name="lara.target"></a>**`trx.lara.target`** ([trx.items.Item](ITEMS.md#items.Item)). The item Lara's guns are locked onto, or `nil` if she has none. *(read-only)*
+- <a name="lara.outfit"></a>**`trx.lara.outfit`** (string). The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.
+- <a name="lara.holsters_visible"></a>**`trx.lara.holsters_visible`** (boolean). Whether Lara's holsters are drawn on her hips.
+- <a name="lara.is_flying"></a>**`trx.lara.is_flying`** (boolean). Whether Lara is in the fly-mode cheat. Setting it enters or leaves fly mode.
+- <a name="lara.is_wet"></a>**`trx.lara.is_wet`** (boolean). Whether Lara is still shedding droplets after a swim. `dry` clears it. *(read-only)*
+- <a name="lara.has_pistol_weapon"></a>**`trx.lara.has_pistol_weapon`** (boolean). Whether Lara is carrying a pistol-class weapon, which is what decides whether she has holsters to show at all. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.lara.Mesh`
+- <a name="lara.Mesh"></a>[lua]`trx.lara.Mesh`
 
     One of the fifteen meshes Lara is built from.
 
@@ -63,7 +63,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - `trx.lara.Mesh.HEAD` = `14`  
         Head.
 
-- [lua]`trx.lara.ExtraMesh`
+- <a name="lara.ExtraMesh"></a>[lua]`trx.lara.ExtraMesh`
 
     A mesh Lara can carry on top of one of her own - the dagger in Home Sweet Home, the oar in a boat.
 
@@ -112,7 +112,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - `trx.lara.ExtraMesh.WATERSKIN` = `21`  
         Waterskin.
 
-- [lua]`trx.lara.WaterState`
+- <a name="lara.WaterState"></a>[lua]`trx.lara.WaterState`
 
     Where Lara is with respect to water.
 
@@ -127,7 +127,7 @@ Her position, room and hit points are not here: she is an item like any other an
     - `trx.lara.WaterState.WADE` = `4`  
         Wading, feet still on the floor.
 
-- [lua]`trx.lara.GunState`
+- <a name="lara.GunState"></a>[lua]`trx.lara.GunState`
 
     What Lara's hands are doing.
 
@@ -146,56 +146,56 @@ Her position, room and hit points are not here: she is an item like any other an
 
 ### Structures
 
-- [lua]`trx.lara.Lara`
+- <a name="lara.Lara"></a>[lua]`trx.lara.Lara`
 
-    Lara's own state, reachable straight off `trx.lara`.
+    Lara's own state, reachable straight off [`trx.lara`](#lara).
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - **`air_bar`**: integer. Air remaining underwater, out of 1800. Runs down while she is under.
-    - **`death_timer`**: integer. Frames Lara has been dead for. *(read-only)*
-    - **`dive_timer`**: integer. Frames Lara has been diving for. *(read-only)*
-    - **`electric`**: integer. How badly Lara is being electrocuted, and 0 when she is not.
-    - **`equipped_gun`**: integer. The weapon Lara is holding. Compare against `trx.catalog.weapons`. *(read-only)*
-    - **`exposure_bar`**: integer. Warmth remaining in the cold, out of `trx.rules.exposure.max`. Only moves in a level whose rooms carry the `damaging` flag.
-    - **`extra_anim`**: boolean. Whether a scripted animation is driving Lara rather than her own state machine. *(read-only)*
-    - **`gun_status`**: integer. What Lara's hands are doing. Compare against `trx.lara.GunState`. *(read-only)*
-    - **`hit_direction`**: integer. Which way the last hit came from, or -1 if she has not been hit. *(read-only)*
-    - **`is_burning`**: boolean. Whether Lara is on fire. Setting it lights her or puts her out.
-    - **`is_climbing`**: boolean. Whether Lara is on a climbable wall. *(read-only)*
-    - **`is_crouched`**: boolean. Whether Lara is crouching. *(read-only)*
-    - **`poison`**: integer. How poisoned Lara is, and 0 when she is not.
-    - **`poison_target`**: integer. The poison reservoir that drains into `poison` over time. TR4 only.
-    - **`pose_count`**: integer. Frames Lara has stood still for, which is what starts an idle animation. *(read-only)*
-    - **`requested_gun`**: integer. The weapon Lara is drawing, while she is drawing it. Compare against `trx.catalog.weapons`. *(read-only)*
-    - **`sprint_timer`**: integer. Sprint left in her legs.
-    - **`water_status`**: integer. Where Lara is with respect to water. Compare against `trx.lara.WaterState`. *(read-only)*
+    - <a name="lara.Lara.air_bar"></a>**`air_bar`**: integer. Air remaining underwater, out of 1800. Runs down while she is under.
+    - <a name="lara.Lara.death_timer"></a>**`death_timer`**: integer. Frames Lara has been dead for. *(read-only)*
+    - <a name="lara.Lara.dive_timer"></a>**`dive_timer`**: integer. Frames Lara has been diving for. *(read-only)*
+    - <a name="lara.Lara.electric"></a>**`electric`**: integer. How badly Lara is being electrocuted, and 0 when she is not.
+    - <a name="lara.Lara.equipped_gun"></a>**`equipped_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is holding. *(read-only)*
+    - <a name="lara.Lara.exposure_bar"></a>**`exposure_bar`**: integer. Warmth remaining in the cold, out of [`trx.rules.exposure.max`](RULES.md#rules.exposure.max). Only moves in a level whose rooms carry the `damaging` flag.
+    - <a name="lara.Lara.extra_anim"></a>**`extra_anim`**: boolean. Whether a scripted animation is driving Lara rather than her own state machine. *(read-only)*
+    - <a name="lara.Lara.gun_status"></a>**`gun_status`**: [trx.lara.GunState](#lara.GunState). What Lara's hands are doing. *(read-only)*
+    - <a name="lara.Lara.hit_direction"></a>**`hit_direction`**: integer. Which way the last hit came from, or -1 if she has not been hit. *(read-only)*
+    - <a name="lara.Lara.is_burning"></a>**`is_burning`**: boolean. Whether Lara is on fire. Setting it lights her or puts her out.
+    - <a name="lara.Lara.is_climbing"></a>**`is_climbing`**: boolean. Whether Lara is on a climbable wall. *(read-only)*
+    - <a name="lara.Lara.is_crouched"></a>**`is_crouched`**: boolean. Whether Lara is crouching. *(read-only)*
+    - <a name="lara.Lara.poison"></a>**`poison`**: integer. How poisoned Lara is, and 0 when she is not.
+    - <a name="lara.Lara.poison_target"></a>**`poison_target`**: integer. The poison reservoir that drains into `poison` over time. TR4 only.
+    - <a name="lara.Lara.pose_count"></a>**`pose_count`**: integer. Frames Lara has stood still for, which is what starts an idle animation. *(read-only)*
+    - <a name="lara.Lara.requested_gun"></a>**`requested_gun`**: [trx.catalog.weapons](CATALOG.md#catalog.weapons). The weapon Lara is drawing, while she is drawing it. *(read-only)*
+    - <a name="lara.Lara.sprint_timer"></a>**`sprint_timer`**: integer. Sprint left in her legs.
+    - <a name="lara.Lara.water_status"></a>**`water_status`**: [trx.lara.WaterState](#lara.WaterState). Where Lara is with respect to water. *(read-only)*
 
 ### Functions
 
-- [lua]`trx.lara.set_extra_equipment(mesh, extra_mesh)`  
+- <a name="lara.set_extra_equipment"></a>[lua]`trx.lara.set_extra_equipment(mesh, extra_mesh)`  
   Hangs an extra mesh on one of Lara's own, replacing whatever is there.
 
   Parameters:
-  - **`mesh`** (integer). Which of Lara's meshes. Compare against `trx.lara.Mesh`.
-  - **`extra_mesh`** (integer). The mesh to hang on it. Compare against `trx.lara.ExtraMesh`.
+  - **`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.
+  - **`extra_mesh`** ([trx.lara.ExtraMesh](#lara.ExtraMesh)). The mesh to hang on it.
 
   Example:
   ```lua
   trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)
   ```
 
-- [lua]`trx.lara.teleport(pos, [room_num])`  
+- <a name="lara.teleport"></a>[lua]`trx.lara.teleport(pos, [room_num])`  
   Moves Lara to a world position, putting her down on the floor there. She is taken off any vehicle, her weapons are put away and the camera follows her over.
 
   The position is nudged into valid room geometry, so a spot inside a wall lands her beside it rather than in it. Somewhere with no floor within reach moves nothing.
 
   Parameters:
   - **`pos`** (vec3). World position.
-  - **`room_num`** (integer, optional). 0-based room to look in. Without it, the room is found from the position.
+  - **`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num), optional). Without it, the room is found from the position.
 
   Returns: boolean. Whether she was moved.
 
@@ -204,17 +204,17 @@ Her position, room and hit points are not here: she is an item like any other an
   trx.lara.teleport(trx.items.query:of_object("wolf"):first().pos)
   ```
 
-- [lua]`trx.lara.cure_poison()`  
+- <a name="lara.cure_poison"></a>[lua]`trx.lara.cure_poison()`  
   Cures Lara's poisoning. Not the same as writing `0` to `poison`: the poison has a target as well as a current value, and clearing only the value lets it climb back.
 
-- [lua]`trx.lara.extinguish()`  
+- <a name="lara.extinguish"></a>[lua]`trx.lara.extinguish()`  
   Puts Lara's fire out, and stops her being electrocuted with it.
 
-- [lua]`trx.lara.dry()`  
+- <a name="lara.dry"></a>[lua]`trx.lara.dry()`  
   Dries Lara off, clearing the wetness that sheds droplets after she leaves water.
 
-- [lua]`trx.lara.clear_equipment(mesh)`  
+- <a name="lara.clear_equipment"></a>[lua]`trx.lara.clear_equipment(mesh)`  
   Takes the extra mesh back off, leaving Lara's own.
 
   Parameters:
-  - **`mesh`** (integer). Which of Lara's meshes. Compare against `trx.lara.Mesh`.
+  - **`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -180,8 +180,8 @@ Her position, room and hit points are not here: she is an item like any other an
   Hangs an extra mesh on one of Lara's own, replacing whatever is there.
 
   Parameters:
-  - **`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.
-  - **`extra_mesh`** ([trx.lara.ExtraMesh](#lara.ExtraMesh)). The mesh to hang on it.
+  - <a id="lara.set_extra_equipment.mesh" name="lara.set_extra_equipment.mesh"></a>**`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.
+  - <a id="lara.set_extra_equipment.extra_mesh" name="lara.set_extra_equipment.extra_mesh"></a>**`extra_mesh`** ([trx.lara.ExtraMesh](#lara.ExtraMesh)). The mesh to hang on it.
 
   Example:
   ```lua
@@ -194,8 +194,8 @@ Her position, room and hit points are not here: she is an item like any other an
   The position is nudged into valid room geometry, so a spot inside a wall lands her beside it rather than in it. Somewhere with no floor within reach moves nothing.
 
   Parameters:
-  - **`pos`** (vec3). World position.
-  - **`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num), optional). Without it, the room is found from the position.
+  - <a id="lara.teleport.pos" name="lara.teleport.pos"></a>**`pos`** (vec3). World position.
+  - <a id="lara.teleport.room_num" name="lara.teleport.room_num"></a>**`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num), optional). Without it, the room is found from the position.
 
   Returns: boolean. Whether she was moved.
 
@@ -205,7 +205,7 @@ Her position, room and hit points are not here: she is an item like any other an
   ```
 
 - <a id="lara.cure_poison" name="lara.cure_poison"></a>[lua]`trx.lara.cure_poison()`  
-  Cures Lara's poisoning. Not the same as writing `0` to `poison`: the poison has a target as well as a current value, and clearing only the value lets it climb back.
+  Cures Lara's poisoning. Not the same as writing `0` to [`trx.lara.poison`](#lara.Lara.poison): the poison has a target as well as a current value, and clearing only the value lets it climb back.
 
 - <a id="lara.extinguish" name="lara.extinguish"></a>[lua]`trx.lara.extinguish()`  
   Puts Lara's fire out, and stops her being electrocuted with it.
@@ -217,4 +217,4 @@ Her position, room and hit points are not here: she is an item like any other an
   Takes the extra mesh back off, leaving Lara's own.
 
   Parameters:
-  - **`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.
+  - <a id="lara.clear_equipment.mesh" name="lara.clear_equipment.mesh"></a>**`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.

--- a/docs/trx/lua/reference/LOCALE.md
+++ b/docs/trx/lua/reference/LOCALE.md
@@ -25,7 +25,7 @@ The text the player reads, in the player's own language.
   declaration keep the text they already carry.
 
   Parameters:
-  - **`strings`** (table). Keys to their English text.
+  - <a id="locale.declare.strings" name="locale.declare.strings"></a>**`strings`** (table). Keys to their English text.
 
   Example:
   ```lua
@@ -39,7 +39,7 @@ The text the player reads, in the player's own language.
   The text behind a game string key.
 
   Parameters:
-  - **`key`** (string). The key, e.g. `general/misc/off`.
+  - <a id="locale.get.key" name="locale.get.key"></a>**`key`** (string). The key, e.g. `general/misc/off`.
 
   Returns: string. The key itself if nothing is behind it, so a typo shows up on screen rather than as a nil further down.
 
@@ -52,8 +52,8 @@ The text the player reads, in the player's own language.
   The text behind a key with its placeholders filled in.
 
   Parameters:
-  - **`key`** (string). The key.
-  - **`...`** (any). What to fill the placeholders with.
+  - <a id="locale.format.key" name="locale.format.key"></a>**`key`** (string). The key.
+  - <a id="locale.format...." name="locale.format...."></a>**`...`** (any). What to fill the placeholders with.
 
   Returns: string. The text with the arguments in it. A translation whose placeholders do not line up with the arguments comes back unformatted, with a warning in the log: a player is better served by text they can read than by a script that stops.
 

--- a/docs/trx/lua/reference/LOCALE.md
+++ b/docs/trx/lua/reference/LOCALE.md
@@ -16,7 +16,7 @@ The text the player reads, in the player's own language.
 
 ### Functions
 
-- [lua]`trx.locale.declare(strings)`  
+- <a name="locale.declare"></a>[lua]`trx.locale.declare(strings)`  
   Declares game string keys and the text behind them.
 
   A key belongs with the script that shows it, so a command carries its own
@@ -35,7 +35,7 @@ The text the player reads, in the player's own language.
   })
   ```
 
-- [lua]`trx.locale.get(key)`  
+- <a name="locale.get"></a>[lua]`trx.locale.get(key)`  
   The text behind a game string key.
 
   Parameters:
@@ -48,7 +48,7 @@ The text the player reads, in the player's own language.
   trx.console.log(trx.locale.get("general/misc/off"))
   ```
 
-- [lua]`trx.locale.format(key, ...)`  
+- <a name="locale.format"></a>[lua]`trx.locale.format(key, ...)`  
   The text behind a key with its placeholders filled in.
 
   Parameters:
@@ -62,7 +62,7 @@ The text the player reads, in the player's own language.
   trx.console.log(trx.locale.format("general/misc/pagination_nav", 1, 5))
   ```
 
-- [lua]`trx.locale.reload()`  
+- <a name="locale.reload"></a>[lua]`trx.locale.reload()`  
   Reloads the current language's text from disk.
 
   Returns: boolean. Whether the reload succeeded.

--- a/docs/trx/lua/reference/LOCALE.md
+++ b/docs/trx/lua/reference/LOCALE.md
@@ -10,13 +10,13 @@ order: 19
   src/lua/api/locale.lua. Edit it there.
 -->
 
-## Locale module
+## <a id="locale" name="locale"></a>Locale module
 
 The text the player reads, in the player's own language.
 
 ### Functions
 
-- <a name="locale.declare"></a>[lua]`trx.locale.declare(strings)`  
+- <a id="locale.declare" name="locale.declare"></a>[lua]`trx.locale.declare(strings)`  
   Declares game string keys and the text behind them.
 
   A key belongs with the script that shows it, so a command carries its own
@@ -35,7 +35,7 @@ The text the player reads, in the player's own language.
   })
   ```
 
-- <a name="locale.get"></a>[lua]`trx.locale.get(key)`  
+- <a id="locale.get" name="locale.get"></a>[lua]`trx.locale.get(key)`  
   The text behind a game string key.
 
   Parameters:
@@ -48,7 +48,7 @@ The text the player reads, in the player's own language.
   trx.console.log(trx.locale.get("general/misc/off"))
   ```
 
-- <a name="locale.format"></a>[lua]`trx.locale.format(key, ...)`  
+- <a id="locale.format" name="locale.format"></a>[lua]`trx.locale.format(key, ...)`  
   The text behind a key with its placeholders filled in.
 
   Parameters:
@@ -62,7 +62,7 @@ The text the player reads, in the player's own language.
   trx.console.log(trx.locale.format("general/misc/pagination_nav", 1, 5))
   ```
 
-- <a name="locale.reload"></a>[lua]`trx.locale.reload()`  
+- <a id="locale.reload" name="locale.reload"></a>[lua]`trx.locale.reload()`  
   Reloads the current language's text from disk.
 
   Returns: boolean. Whether the reload succeeded.

--- a/docs/trx/lua/reference/LOG.md
+++ b/docs/trx/lua/reference/LOG.md
@@ -16,9 +16,9 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
 
 ### Enums
 
-- [lua]`trx.log.LogLevel`
+- <a name="log.LogLevel"></a>[lua]`trx.log.LogLevel`
 
-    Severity of a log message. Pass one to `trx.log.generic`.
+    Severity of a log message. Pass one to [`trx.log.generic`](#log.generic).
 
     - `trx.log.LogLevel.DEBUG` = `0`  
         Diagnostic detail, of interest while writing a script.
@@ -31,11 +31,11 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
 
 ### Functions
 
-- [lua]`trx.log.generic(level, message)`  
+- <a name="log.generic"></a>[lua]`trx.log.generic(level, message)`  
   Logs a message at a level chosen at runtime, for when the level is computed rather than written literally.
 
   Parameters:
-  - **`level`** (integer). Compare against `trx.log.LogLevel`.
+  - **`level`** ([trx.log.LogLevel](#log.LogLevel)).
   - **`message`** (string).
 
   Example:
@@ -44,7 +44,7 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   trx.log.generic(level, "finished")
   ```
 
-- [lua]`trx.log.info(message)`  
+- <a name="log.info"></a>[lua]`trx.log.info(message)`  
   Logs an informational message.
 
   Parameters:
@@ -55,25 +55,25 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   trx.log.info("hello from lua")
   ```
 
-- [lua]`trx.log.warn(message)`  
+- <a name="log.warn"></a>[lua]`trx.log.warn(message)`  
   Logs a warning.
 
   Parameters:
   - **`message`** (string).
 
-- [lua]`trx.log.warning(message)`  
-  Logs a warning. An alias of `trx.log.warn`.
+- <a name="log.warning"></a>[lua]`trx.log.warning(message)`  
+  Logs a warning. An alias of [`trx.log.warn`](#log.warn).
 
   Parameters:
   - **`message`** (string).
 
-- [lua]`trx.log.error(message)`  
+- <a name="log.error"></a>[lua]`trx.log.error(message)`  
   Logs an error.
 
   Parameters:
   - **`message`** (string).
 
-- [lua]`trx.log.debug(message)`  
+- <a name="log.debug"></a>[lua]`trx.log.debug(message)`  
   Logs a debug message.
 
   Parameters:

--- a/docs/trx/lua/reference/LOG.md
+++ b/docs/trx/lua/reference/LOG.md
@@ -10,13 +10,13 @@ order: 26
   src/lua/api/log.lua. Edit it there.
 -->
 
-## Logging module
+## <a id="log" name="log"></a>Logging module
 
 Logs a message to the terminal and to `TRX.log` in the installation directory. Each call records the Lua script's filename, function name and line number.
 
 ### Enums
 
-- <a name="log.LogLevel"></a>[lua]`trx.log.LogLevel`
+- <a id="log.LogLevel" name="log.LogLevel"></a>[lua]`trx.log.LogLevel`
 
     Severity of a log message. Pass one to [`trx.log.generic`](#log.generic).
 
@@ -31,7 +31,7 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
 
 ### Functions
 
-- <a name="log.generic"></a>[lua]`trx.log.generic(level, message)`  
+- <a id="log.generic" name="log.generic"></a>[lua]`trx.log.generic(level, message)`  
   Logs a message at a level chosen at runtime, for when the level is computed rather than written literally.
 
   Parameters:
@@ -44,7 +44,7 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   trx.log.generic(level, "finished")
   ```
 
-- <a name="log.info"></a>[lua]`trx.log.info(message)`  
+- <a id="log.info" name="log.info"></a>[lua]`trx.log.info(message)`  
   Logs an informational message.
 
   Parameters:
@@ -55,25 +55,25 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   trx.log.info("hello from lua")
   ```
 
-- <a name="log.warn"></a>[lua]`trx.log.warn(message)`  
+- <a id="log.warn" name="log.warn"></a>[lua]`trx.log.warn(message)`  
   Logs a warning.
 
   Parameters:
   - **`message`** (string).
 
-- <a name="log.warning"></a>[lua]`trx.log.warning(message)`  
+- <a id="log.warning" name="log.warning"></a>[lua]`trx.log.warning(message)`  
   Logs a warning. An alias of [`trx.log.warn`](#log.warn).
 
   Parameters:
   - **`message`** (string).
 
-- <a name="log.error"></a>[lua]`trx.log.error(message)`  
+- <a id="log.error" name="log.error"></a>[lua]`trx.log.error(message)`  
   Logs an error.
 
   Parameters:
   - **`message`** (string).
 
-- <a name="log.debug"></a>[lua]`trx.log.debug(message)`  
+- <a id="log.debug" name="log.debug"></a>[lua]`trx.log.debug(message)`  
   Logs a debug message.
 
   Parameters:

--- a/docs/trx/lua/reference/LOG.md
+++ b/docs/trx/lua/reference/LOG.md
@@ -12,7 +12,7 @@ order: 26
 
 ## <a id="log" name="log"></a>Logging module
 
-Logs a message to the terminal and to `TRX.log` in the installation directory.  Each call records the Lua script's filename, function name and line number.
+Logs a message to the terminal and to `TRX.log` in the installation directory. Each call records the Lua script's filename, function name and line number.
 
 ### Enums
 

--- a/docs/trx/lua/reference/LOG.md
+++ b/docs/trx/lua/reference/LOG.md
@@ -12,7 +12,7 @@ order: 26
 
 ## <a id="log" name="log"></a>Logging module
 
-Logs a message to the terminal and to `TRX.log` in the installation directory. Each call records the Lua script's filename, function name and line number.
+Logs a message to the terminal and to `TRX.log` in the installation directory.  Each call records the Lua script's filename, function name and line number.
 
 ### Enums
 
@@ -35,8 +35,8 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   Logs a message at a level chosen at runtime, for when the level is computed rather than written literally.
 
   Parameters:
-  - **`level`** ([trx.log.LogLevel](#log.LogLevel)).
-  - **`message`** (string).
+  - <a id="log.generic.level" name="log.generic.level"></a>**`level`** ([trx.log.LogLevel](#log.LogLevel)).
+  - <a id="log.generic.message" name="log.generic.message"></a>**`message`** (string). The line to log.
 
   Example:
   ```lua
@@ -48,7 +48,7 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   Logs an informational message.
 
   Parameters:
-  - **`message`** (string).
+  - <a id="log.info.message" name="log.info.message"></a>**`message`** (string). The line to log.
 
   Example:
   ```lua
@@ -59,22 +59,22 @@ Logs a message to the terminal and to `TRX.log` in the installation directory. E
   Logs a warning.
 
   Parameters:
-  - **`message`** (string).
+  - <a id="log.warn.message" name="log.warn.message"></a>**`message`** (string). The line to log.
 
 - <a id="log.warning" name="log.warning"></a>[lua]`trx.log.warning(message)`  
   Logs a warning. An alias of [`trx.log.warn`](#log.warn).
 
   Parameters:
-  - **`message`** (string).
+  - <a id="log.warning.message" name="log.warning.message"></a>**`message`** (string). The line to log.
 
 - <a id="log.error" name="log.error"></a>[lua]`trx.log.error(message)`  
   Logs an error.
 
   Parameters:
-  - **`message`** (string).
+  - <a id="log.error.message" name="log.error.message"></a>**`message`** (string). The line to log.
 
 - <a id="log.debug" name="log.debug"></a>[lua]`trx.log.debug(message)`  
   Logs a debug message.
 
   Parameters:
-  - **`message`** (string).
+  - <a id="log.debug.message" name="log.debug.message"></a>**`message`** (string). The line to log.

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -20,9 +20,13 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   Evaluates a string of Lua code, as the `/lua` console command does.
 
   Parameters:
-  - **`code`** (string). The code.
+  - <a id="lua.eval_expr.code" name="lua.eval_expr.code"></a>**`code`** (string). The code.
 
-  Returns: table or `nil`. `nil` when the code ran to completion. Otherwise a table with `kind` (`"syntax"` or `"runtime"`) and `message`, the error text. A failure comes back as a value rather than raising, so the caller decides what it means.
+  Returns: table or `nil`. `nil` when the code ran to completion, and what went wrong otherwise. A failure comes back as a value rather than raising, so the caller decides what it means.
+
+    Keys:
+    - <a id="lua.eval_expr.kind" name="lua.eval_expr.kind"></a>**`kind`** (string). Either `"syntax"` or `"runtime"`.
+    - <a id="lua.eval_expr.message" name="lua.eval_expr.message"></a>**`message`** (string). The error text.
 
   Example:
   ```lua
@@ -33,7 +37,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   Runs a Lua file, the way a level script is run. A file that cannot be read reports as a `"runtime"` failure.
 
   Parameters:
-  - **`path`** (string). Path of the file.
+  - <a id="lua.eval_file.path" name="lua.eval_file.path"></a>**`path`** (string). Path of the file.
 
   Returns: table or `nil`. As in [`trx.lua.eval_expr`](#lua.eval_expr).
 

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -10,13 +10,13 @@ order: 29
   src/lua/api/lua.lua. Edit it there.
 -->
 
-## Lua module
+## <a id="lua" name="lua"></a>Lua module
 
 Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the same state as every other script.
 
 ### Functions
 
-- <a name="lua.eval_expr"></a>[lua]`trx.lua.eval_expr(code)`  
+- <a id="lua.eval_expr" name="lua.eval_expr"></a>[lua]`trx.lua.eval_expr(code)`  
   Evaluates a string of Lua code, as the `/lua` console command does.
 
   Parameters:
@@ -29,13 +29,13 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   trx.lua.eval_expr("trx.console.log('hello')")
   ```
 
-- <a name="lua.eval_file"></a>[lua]`trx.lua.eval_file(path)`  
+- <a id="lua.eval_file" name="lua.eval_file"></a>[lua]`trx.lua.eval_file(path)`  
   Runs a Lua file, the way a level script is run. A file that cannot be read reports as a `"runtime"` failure.
 
   Parameters:
   - **`path`** (string). Path of the file.
 
-  Returns: table or `nil`. As in `eval_expr`.
+  Returns: table or `nil`. As in [`trx.lua.eval_expr`](#lua.eval_expr).
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -16,7 +16,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
 
 ### Functions
 
-- [lua]`trx.lua.eval_expr(code)`  
+- <a name="lua.eval_expr"></a>[lua]`trx.lua.eval_expr(code)`  
   Evaluates a string of Lua code, as the `/lua` console command does.
 
   Parameters:
@@ -29,7 +29,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   trx.lua.eval_expr("trx.console.log('hello')")
   ```
 
-- [lua]`trx.lua.eval_file(path)`  
+- <a name="lua.eval_file"></a>[lua]`trx.lua.eval_file(path)`  
   Runs a Lua file, the way a level script is run. A file that cannot be read reports as a `"runtime"` failure.
 
   Parameters:

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -18,21 +18,21 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 
 ### Constants
 
-- [lua]`trx.math.DEG_1` = `182`  
+- <a name="math.DEG_1"></a>[lua]`trx.math.DEG_1` = `182`  
   One degree in TRX units. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.
 
-- [lua]`trx.math.DEG_45` = `8192`  
+- <a name="math.DEG_45"></a>[lua]`trx.math.DEG_45` = `8192`  
   A 45-degree turn, in TRX units.
 
-- [lua]`trx.math.DEG_90` = `16384`  
+- <a name="math.DEG_90"></a>[lua]`trx.math.DEG_90` = `16384`  
   A quarter turn, in TRX units. A full turn is four of these, and wraps to zero.
 
-- [lua]`trx.math.WALL_L` = `1024`  
+- <a name="math.WALL_L"></a>[lua]`trx.math.WALL_L` = `1024`  
   The size of one sector in world units. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.
 
 ### Functions
 
-- [lua]`trx.math.sin(angle)`  
+- <a name="math.sin"></a>[lua]`trx.math.sin(angle)`  
   Sine of an angle.
 
   Parameters:
@@ -40,7 +40,7 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 
   Returns: number. A value in [-1, 1].
 
-- [lua]`trx.math.cos(angle)`  
+- <a name="math.cos"></a>[lua]`trx.math.cos(angle)`  
   Cosine of an angle.
 
   Parameters:
@@ -48,7 +48,7 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 
   Returns: number. A value in [-1, 1].
 
-- [lua]`trx.math.atan(z, x)`  
+- <a name="math.atan"></a>[lua]`trx.math.atan(z, x)`  
   Angle of the vector (x, z), in TRX units.
 
   Parameters:

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -10,7 +10,7 @@ order: 27
   src/lua/api/math.lua. Edit it there.
 -->
 
-## Math module
+## <a id="math" name="math"></a>Math module
 
 Fixed-point trigonometry, matching the engine's own tables.
 
@@ -18,21 +18,21 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 
 ### Constants
 
-- <a name="math.DEG_1"></a>[lua]`trx.math.DEG_1` = `182`  
+- <a id="math.DEG_1" name="math.DEG_1"></a>[lua]`trx.math.DEG_1` = `182`  
   One degree in TRX units. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.
 
-- <a name="math.DEG_45"></a>[lua]`trx.math.DEG_45` = `8192`  
+- <a id="math.DEG_45" name="math.DEG_45"></a>[lua]`trx.math.DEG_45` = `8192`  
   A 45-degree turn, in TRX units.
 
-- <a name="math.DEG_90"></a>[lua]`trx.math.DEG_90` = `16384`  
+- <a id="math.DEG_90" name="math.DEG_90"></a>[lua]`trx.math.DEG_90` = `16384`  
   A quarter turn, in TRX units. A full turn is four of these, and wraps to zero.
 
-- <a name="math.WALL_L"></a>[lua]`trx.math.WALL_L` = `1024`  
+- <a id="math.WALL_L" name="math.WALL_L"></a>[lua]`trx.math.WALL_L` = `1024`  
   The size of one sector in world units. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.
 
 ### Functions
 
-- <a name="math.sin"></a>[lua]`trx.math.sin(angle)`  
+- <a id="math.sin" name="math.sin"></a>[lua]`trx.math.sin(angle)`  
   Sine of an angle.
 
   Parameters:
@@ -40,7 +40,7 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 
   Returns: number. A value in [-1, 1].
 
-- <a name="math.cos"></a>[lua]`trx.math.cos(angle)`  
+- <a id="math.cos" name="math.cos"></a>[lua]`trx.math.cos(angle)`  
   Cosine of an angle.
 
   Parameters:
@@ -48,7 +48,7 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 
   Returns: number. A value in [-1, 1].
 
-- <a name="math.atan"></a>[lua]`trx.math.atan(z, x)`  
+- <a id="math.atan" name="math.atan"></a>[lua]`trx.math.atan(z, x)`  
   Angle of the vector (x, z), in TRX units.
 
   Parameters:

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -12,37 +12,47 @@ order: 27
 
 ## <a id="math" name="math"></a>Math module
 
-Fixed-point trigonometry, matching the engine's own tables.
-
-TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would.
+Fixed-point trigonometry, matching the engine's own tables. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would. [`trx.math.Angle`](#math.Angle) says what an angle is here.
 
 ### Constants
 
-- <a id="math.DEG_1" name="math.DEG_1"></a>[lua]`trx.math.DEG_1` = `182`  
-  One degree in TRX units. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.
+- <a id="math.DEG_1" name="math.DEG_1"></a>[lua]`trx.math.DEG_1` = `182` ([trx.math.Angle](#math.Angle))  
+  One degree. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.
 
-- <a id="math.DEG_45" name="math.DEG_45"></a>[lua]`trx.math.DEG_45` = `8192`  
-  A 45-degree turn, in TRX units.
+- <a id="math.DEG_45" name="math.DEG_45"></a>[lua]`trx.math.DEG_45` = `8192` ([trx.math.Angle](#math.Angle))  
+  A 45-degree turn.
 
-- <a id="math.DEG_90" name="math.DEG_90"></a>[lua]`trx.math.DEG_90` = `16384`  
-  A quarter turn, in TRX units. A full turn is four of these, and wraps to zero.
+- <a id="math.DEG_90" name="math.DEG_90"></a>[lua]`trx.math.DEG_90` = `16384` ([trx.math.Angle](#math.Angle))  
+  A quarter turn. A full turn is four of these.
 
-- <a id="math.WALL_L" name="math.WALL_L"></a>[lua]`trx.math.WALL_L` = `1024`  
-  The size of one sector in world units. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.
+- <a id="math.WALL_L" name="math.WALL_L"></a>[lua]`trx.math.WALL_L` = `1024` ([trx.math.Distance](#math.Distance))  
+  The size of one sector. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.
 
 ### Structures
 
+- <a id="math.Angle" name="math.Angle"></a>[lua]`trx.math.Angle` (integer)
+
+    An angle in the engine's own units, where 65536 is a full turn rather than
+    2 pi. An angle counts in cycles, so one past the end of a turn wraps round
+    to name the same direction: adding a half turn to a rotation always works.
+    [`trx.math.DEG_1`](#math.DEG_1) converts from degrees.
+
+- <a id="math.Distance" name="math.Distance"></a>[lua]`trx.math.Distance` (integer)
+
+    A length in the units the engine measures the world in, where one sector is
+    [`trx.math.WALL_L`](#math.WALL_L). Y grows downwards, so a greater Y is further down.
+
 - <a id="math.Box" name="math.Box"></a>[lua]`trx.math.Box`
 
-    An axis-aligned box, in the units the engine measures the world in. Whether it is placed in world coordinates or in something's own frame is for whatever hands it over to say.
+    An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.
 
     Properties:
-    - <a id="math.Box.max_x" name="math.Box.max_x"></a>**`max_x`**: integer. East edge.
-    - <a id="math.Box.max_y" name="math.Box.max_y"></a>**`max_y`**: integer. Bottom edge.
-    - <a id="math.Box.max_z" name="math.Box.max_z"></a>**`max_z`**: integer. South edge.
-    - <a id="math.Box.min_x" name="math.Box.min_x"></a>**`min_x`**: integer. West edge.
-    - <a id="math.Box.min_y" name="math.Box.min_y"></a>**`min_y`**: integer. Top edge. Y grows downwards.
-    - <a id="math.Box.min_z" name="math.Box.min_z"></a>**`min_z`**: integer. North edge.
+    - <a id="math.Box.max_x" name="math.Box.max_x"></a>**`max_x`**: [trx.math.Distance](#math.Distance). East edge.
+    - <a id="math.Box.max_y" name="math.Box.max_y"></a>**`max_y`**: [trx.math.Distance](#math.Distance). Bottom edge.
+    - <a id="math.Box.max_z" name="math.Box.max_z"></a>**`max_z`**: [trx.math.Distance](#math.Distance). South edge.
+    - <a id="math.Box.min_x" name="math.Box.min_x"></a>**`min_x`**: [trx.math.Distance](#math.Distance). West edge.
+    - <a id="math.Box.min_y" name="math.Box.min_y"></a>**`min_y`**: [trx.math.Distance](#math.Distance). Top edge.
+    - <a id="math.Box.min_z" name="math.Box.min_z"></a>**`min_z`**: [trx.math.Distance](#math.Distance). North edge.
 
 ### Functions
 
@@ -50,7 +60,7 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
   Sine of an angle.
 
   Parameters:
-  - <a id="math.sin.angle" name="math.sin.angle"></a>**`angle`** (integer). Angle in TRX units.
+  - <a id="math.sin.angle" name="math.sin.angle"></a>**`angle`** ([trx.math.Angle](#math.Angle)).
 
   Returns: number. A value in [-1, 1].
 
@@ -58,18 +68,18 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
   Cosine of an angle.
 
   Parameters:
-  - <a id="math.cos.angle" name="math.cos.angle"></a>**`angle`** (integer). Angle in TRX units.
+  - <a id="math.cos.angle" name="math.cos.angle"></a>**`angle`** ([trx.math.Angle](#math.Angle)).
 
   Returns: number. A value in [-1, 1].
 
 - <a id="math.atan" name="math.atan"></a>[lua]`trx.math.atan(z, x)`  
-  Angle of the vector (x, z), in TRX units.
+  Angle of the vector (x, z).
 
   Parameters:
-  - <a id="math.atan.z" name="math.atan.z"></a>**`z`** (integer). How far the vector reaches north.
-  - <a id="math.atan.x" name="math.atan.x"></a>**`x`** (integer). How far it reaches east.
+  - <a id="math.atan.z" name="math.atan.z"></a>**`z`** ([trx.math.Distance](#math.Distance)). How far the vector reaches north.
+  - <a id="math.atan.x" name="math.atan.x"></a>**`x`** ([trx.math.Distance](#math.Distance)). How far it reaches east.
 
-  Returns: integer. In TRX units.
+  Returns: [trx.math.Angle](#math.Angle).
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -30,13 +30,27 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
 - <a id="math.WALL_L" name="math.WALL_L"></a>[lua]`trx.math.WALL_L` = `1024`  
   The size of one sector in world units. Level geometry is laid out on this grid, so it is the step to take to move an item a sector over.
 
+### Structures
+
+- <a id="math.Box" name="math.Box"></a>[lua]`trx.math.Box`
+
+    An axis-aligned box, in the units the engine measures the world in. Whether it is placed in world coordinates or in something's own frame is for whatever hands it over to say.
+
+    Properties:
+    - <a id="math.Box.max_x" name="math.Box.max_x"></a>**`max_x`**: integer. East edge.
+    - <a id="math.Box.max_y" name="math.Box.max_y"></a>**`max_y`**: integer. Bottom edge.
+    - <a id="math.Box.max_z" name="math.Box.max_z"></a>**`max_z`**: integer. South edge.
+    - <a id="math.Box.min_x" name="math.Box.min_x"></a>**`min_x`**: integer. West edge.
+    - <a id="math.Box.min_y" name="math.Box.min_y"></a>**`min_y`**: integer. Top edge. Y grows downwards.
+    - <a id="math.Box.min_z" name="math.Box.min_z"></a>**`min_z`**: integer. North edge.
+
 ### Functions
 
 - <a id="math.sin" name="math.sin"></a>[lua]`trx.math.sin(angle)`  
   Sine of an angle.
 
   Parameters:
-  - **`angle`** (integer). Angle in TRX units.
+  - <a id="math.sin.angle" name="math.sin.angle"></a>**`angle`** (integer). Angle in TRX units.
 
   Returns: number. A value in [-1, 1].
 
@@ -44,7 +58,7 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
   Cosine of an angle.
 
   Parameters:
-  - **`angle`** (integer). Angle in TRX units.
+  - <a id="math.cos.angle" name="math.cos.angle"></a>**`angle`** (integer). Angle in TRX units.
 
   Returns: number. A value in [-1, 1].
 
@@ -52,10 +66,10 @@ TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these
   Angle of the vector (x, z), in TRX units.
 
   Parameters:
-  - **`z`** (integer).
-  - **`x`** (integer).
+  - <a id="math.atan.z" name="math.atan.z"></a>**`z`** (integer). How far the vector reaches north.
+  - <a id="math.atan.x" name="math.atan.x"></a>**`x`** (integer). How far it reaches east.
 
-  Returns: integer.
+  Returns: integer. In TRX units.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/MOD.md
+++ b/docs/trx/lua/reference/MOD.md
@@ -10,18 +10,18 @@ order: 25
   src/lua/api/mod.lua. Edit it there.
 -->
 
-## Mod module
+## <a id="mod" name="mod"></a>Mod module
 
 The mods the game was built with, and which one is loaded.
 
 ### Properties
 
-- <a name="mod.list"></a>**`trx.mod.list`** (table). The mods the game was built with, as a list of [`trx.mod.Mod`](#mod.Mod) counted from one. *(read-only)*
-- <a name="mod.current"></a>**`trx.mod.current`** ([trx.mod.Mod](#mod.Mod)). The loaded mod. *(read-only)*
+- <a id="mod.list" name="mod.list"></a>**`trx.mod.list`** (table). The mods the game was built with, as a list of [`trx.mod.Mod`](#mod.Mod) counted from one. *(read-only)*
+- <a id="mod.current" name="mod.current"></a>**`trx.mod.current`** ([trx.mod.Mod](#mod.Mod)). The loaded mod. *(read-only)*
 
 ### Enums
 
-- <a name="mod.Type"></a>[lua]`trx.mod.Type`
+- <a id="mod.Type" name="mod.Type"></a>[lua]`trx.mod.Type`
 
     What kind of mod it is.
 
@@ -38,7 +38,7 @@ The mods the game was built with, and which one is loaded.
 
 ### Structures
 
-- <a name="mod.Mod"></a>[lua]`trx.mod.Mod`
+- <a id="mod.Mod" name="mod.Mod"></a>[lua]`trx.mod.Mod`
 
     A mod the game can run. Everything on it is read-only.
 
@@ -47,17 +47,17 @@ The mods the game was built with, and which one is loaded.
     unrelated one.
 
     Properties:
-    - <a name="mod.Mod.base_mod"></a>**`base_mod`**: string. The mod this one builds on, or `nil` if it stands alone. *(read-only)*
-    - <a name="mod.Mod.engine_version"></a>**`engine_version`**: integer. Which Tomb Raider the mod runs on. *(read-only)*
-    - <a name="mod.Mod.is_available"></a>**`is_available`**: boolean. Whether the mod's files are present. *(read-only)*
-    - <a name="mod.Mod.is_valid"></a>**`is_valid`**: boolean. Whether the mod can be loaded. *(read-only)*
-    - <a name="mod.Mod.name"></a>**`name`**: string. The mod's identifier, as [`trx.mod.switch`](#mod.switch) takes it. *(read-only)*
-    - <a name="mod.Mod.title"></a>**`title`**: string. The mod's name, as shown to the player. *(read-only)*
-    - <a name="mod.Mod.type"></a>**`type`**: [trx.mod.Type](#mod.Type). What kind of mod it is. *(read-only)*
+    - <a id="mod.Mod.base_mod" name="mod.Mod.base_mod"></a>**`base_mod`**: string. The mod this one builds on, or `nil` if it stands alone. *(read-only)*
+    - <a id="mod.Mod.engine_version" name="mod.Mod.engine_version"></a>**`engine_version`**: integer. Which Tomb Raider the mod runs on. *(read-only)*
+    - <a id="mod.Mod.is_available" name="mod.Mod.is_available"></a>**`is_available`**: boolean. Whether the mod's files are present. *(read-only)*
+    - <a id="mod.Mod.is_valid" name="mod.Mod.is_valid"></a>**`is_valid`**: boolean. Whether the mod can be loaded. *(read-only)*
+    - <a id="mod.Mod.name" name="mod.Mod.name"></a>**`name`**: string. The mod's identifier, as [`trx.mod.switch`](#mod.switch) takes it. *(read-only)*
+    - <a id="mod.Mod.title" name="mod.Mod.title"></a>**`title`**: string. The mod's name, as shown to the player. *(read-only)*
+    - <a id="mod.Mod.type" name="mod.Mod.type"></a>**`type`**: [trx.mod.Type](#mod.Type). What kind of mod it is. *(read-only)*
 
 ### Functions
 
-- <a name="mod.switch"></a>[lua]`trx.mod.switch(mod)`  
+- <a id="mod.switch" name="mod.switch"></a>[lua]`trx.mod.switch(mod)`  
   Restarts the game into another mod. The switch happens once the game flow picks it up, not on the call.
 
   Parameters:

--- a/docs/trx/lua/reference/MOD.md
+++ b/docs/trx/lua/reference/MOD.md
@@ -61,7 +61,7 @@ The mods the game was built with, and which one is loaded.
   Restarts the game into another mod. The switch happens once the game flow picks it up, not on the call.
 
   Parameters:
-  - **`mod`** (any). A [`trx.mod.Mod`](#mod.Mod) or a mod name.
+  - <a id="mod.switch.mod" name="mod.switch.mod"></a>**`mod`** (any). A [`trx.mod.Mod`](#mod.Mod) or a mod name.
 
   Returns:
   - boolean. Whether the mod can be switched to. `false` leaves the game where it is.

--- a/docs/trx/lua/reference/MOD.md
+++ b/docs/trx/lua/reference/MOD.md
@@ -16,12 +16,12 @@ The mods the game was built with, and which one is loaded.
 
 ### Properties
 
-- **`trx.mod.list`** (table). The mods the game was built with, as a list of `trx.mod.Mod` counted from one. *(read-only)*
-- **`trx.mod.current`** (Mod). The loaded mod, as a `trx.mod.Mod`. *(read-only)*
+- <a name="mod.list"></a>**`trx.mod.list`** (table). The mods the game was built with, as a list of [`trx.mod.Mod`](#mod.Mod) counted from one. *(read-only)*
+- <a name="mod.current"></a>**`trx.mod.current`** ([trx.mod.Mod](#mod.Mod)). The loaded mod. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.mod.Type`
+- <a name="mod.Type"></a>[lua]`trx.mod.Type`
 
     What kind of mod it is.
 
@@ -38,7 +38,7 @@ The mods the game was built with, and which one is loaded.
 
 ### Structures
 
-- [lua]`trx.mod.Mod`
+- <a name="mod.Mod"></a>[lua]`trx.mod.Mod`
 
     A mod the game can run. Everything on it is read-only.
 
@@ -47,21 +47,21 @@ The mods the game was built with, and which one is loaded.
     unrelated one.
 
     Properties:
-    - **`base_mod`**: string. The mod this one builds on, or `nil` if it stands alone. *(read-only)*
-    - **`engine_version`**: integer. Which Tomb Raider the mod runs on. *(read-only)*
-    - **`is_available`**: boolean. Whether the mod's files are present. *(read-only)*
-    - **`is_valid`**: boolean. Whether the mod can be loaded. *(read-only)*
-    - **`name`**: string. The mod's identifier, as `trx.mod.switch` takes it. *(read-only)*
-    - **`title`**: string. The mod's name, as shown to the player. *(read-only)*
-    - **`type`**: integer. What kind of mod it is. Compare against `trx.mod.Type`. *(read-only)*
+    - <a name="mod.Mod.base_mod"></a>**`base_mod`**: string. The mod this one builds on, or `nil` if it stands alone. *(read-only)*
+    - <a name="mod.Mod.engine_version"></a>**`engine_version`**: integer. Which Tomb Raider the mod runs on. *(read-only)*
+    - <a name="mod.Mod.is_available"></a>**`is_available`**: boolean. Whether the mod's files are present. *(read-only)*
+    - <a name="mod.Mod.is_valid"></a>**`is_valid`**: boolean. Whether the mod can be loaded. *(read-only)*
+    - <a name="mod.Mod.name"></a>**`name`**: string. The mod's identifier, as [`trx.mod.switch`](#mod.switch) takes it. *(read-only)*
+    - <a name="mod.Mod.title"></a>**`title`**: string. The mod's name, as shown to the player. *(read-only)*
+    - <a name="mod.Mod.type"></a>**`type`**: [trx.mod.Type](#mod.Type). What kind of mod it is. *(read-only)*
 
 ### Functions
 
-- [lua]`trx.mod.switch(mod)`  
+- <a name="mod.switch"></a>[lua]`trx.mod.switch(mod)`  
   Restarts the game into another mod. The switch happens once the game flow picks it up, not on the call.
 
   Parameters:
-  - **`mod`** (any). A `trx.mod.Mod` or a mod name.
+  - **`mod`** (any). A [`trx.mod.Mod`](#mod.Mod) or a mod name.
 
   Returns:
   - boolean. Whether the mod can be switched to. `false` leaves the game where it is.

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -25,7 +25,7 @@ Module for playing and controlling the soundtrack.
 
 - <a id="music.PlayMode" name="music.PlayMode"></a>[lua]`trx.music.PlayMode`
 
-    How a track is played. Pass one as `opts.mode` to [`trx.music.play`](#music.play).
+    How a track is played. Pass one as [`trx.music.play.opts.mode`](#music.play.opts.mode).
 
     - `trx.music.PlayMode.ONCE` = `0`  
         Plays the track once. When it finishes, any active looped track resumes from its start.
@@ -40,6 +40,10 @@ Module for playing and controlling the soundtrack.
 
 ### Structures
 
+- <a id="music.TrackNum" name="music.TrackNum"></a>[lua]`trx.music.TrackNum`
+
+    Track number, in the numbering the loaded level carries. Not a [`trx.catalog.music`](CATALOG.md#catalog.music) name, which is the soundtrack's own.
+
 - <a id="music.Stream" name="music.Stream"></a>[lua]`trx.music.Stream`
 
     One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through [`trx.music.streams`](#music.streams). A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check [`is_valid`](#music.Stream.is_valid) first.
@@ -51,14 +55,14 @@ Module for playing and controlling the soundtrack.
     Properties:
     - <a id="music.Stream.mode" name="music.Stream.mode"></a>**`mode`**: [trx.music.PlayMode](#music.PlayMode). How the track is playing. *(read-only)*
     - <a id="music.Stream.timestamp" name="music.Stream.timestamp"></a>**`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
-    - <a id="music.Stream.track_num" name="music.Stream.track_num"></a>**`track_num`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
+    - <a id="music.Stream.track_num" name="music.Stream.track_num"></a>**`track_num`**: [trx.music.TrackNum](#music.TrackNum). The track this stream is playing. *(read-only)*
 
     Methods:
 
     - <a id="music.Stream.is_valid" name="music.Stream.is_valid"></a>[lua]`stream:is_valid()`  
       Whether the slot is still playing. A stream that has finished, or been stopped, leaves its handle stale.
 
-      Returns: boolean.
+      Returns: boolean. False once the slot has gone quiet.
 
     - <a id="music.Stream.pause" name="music.Stream.pause"></a>[lua]`stream:pause()`  
       Pauses this stream.
@@ -67,7 +71,7 @@ Module for playing and controlling the soundtrack.
       Seeks this stream to a timestamp.
 
       Parameters:
-      - **`timestamp`** (number). Where to seek to, in seconds.
+      - <a id="music.Stream.seek.timestamp" name="music.Stream.seek.timestamp"></a>**`timestamp`** (number). Where to seek to, in seconds.
 
       Returns: boolean. Whether the seek took.
 
@@ -86,14 +90,14 @@ Module for playing and controlling the soundtrack.
     unrelated one.
 
     Properties:
-    - <a id="music.Track.num" name="music.Track.num"></a>**`num`**: integer. The number the level gives this track. *(read-only)*
+    - <a id="music.Track.num" name="music.Track.num"></a>**`num`**: [trx.music.TrackNum](#music.TrackNum). *(read-only)*
 
     Methods:
 
     - <a id="music.Track.is_valid" name="music.Track.is_valid"></a>[lua]`track:is_valid()`  
       Whether the loaded level still carries this track.
 
-      Returns: boolean.
+      Returns: boolean. False once a level change has replaced the tracks.
 
     - <a id="music.Track.path" name="music.Track.path"></a>[lua]`track:path()`  
       Resolves the track's file path.
@@ -104,7 +108,10 @@ Module for playing and controlling the soundtrack.
       Plays this track.
 
       Parameters:
-      - **`opts`** (table, optional). `mode`: a [`trx.music.PlayMode`](#music.PlayMode). Defaults to `ONCE`.
+      - <a id="music.Track.play.opts" name="music.Track.play.opts"></a>**`opts`** (table, optional). How to play it.
+
+        Keys:
+        - <a id="music.Track.play.opts.mode" name="music.Track.play.opts.mode"></a>**`mode`** ([trx.music.PlayMode](#music.PlayMode), optional). Plays once by default.
 
       Returns: [trx.music.Stream](#music.Stream) or `nil`. The stream it started, or `nil` if none did.
 
@@ -114,8 +121,11 @@ Module for playing and controlling the soundtrack.
   Plays a track by catalog id, mapping it to the level's own track. A game that does not carry the track plays nothing.
 
   Parameters:
-  - **`id`** ([trx.catalog.music](CATALOG.md#catalog.music)). Track to play. To reach a track by the level's own slot, play it through a handle: `trx.music.tracks[slot]:play()`.
-  - **`opts`** (table, optional). `mode`: a [`trx.music.PlayMode`](#music.PlayMode). Defaults to `ONCE`.
+  - <a id="music.play.id" name="music.play.id"></a>**`id`** ([trx.catalog.music](CATALOG.md#catalog.music)). Track to play. To reach a track by the level's own slot, play it through a handle: `trx.music.tracks[slot]:play()`.
+  - <a id="music.play.opts" name="music.play.opts"></a>**`opts`** (table, optional). How to play it.
+
+    Keys:
+    - <a id="music.play.opts.mode" name="music.play.opts.mode"></a>**`mode`** ([trx.music.PlayMode](#music.PlayMode), optional). Plays once by default.
 
   Returns: [trx.music.Stream](#music.Stream) or `nil`. The stream it started, or `nil` if none did.
 

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -10,20 +10,20 @@ order: 18
   src/lua/api/music.lua. Edit it there.
 -->
 
-## Music module
+## <a id="music" name="music"></a>Music module
 
 Module for playing and controlling the soundtrack.
 
 ### Properties
 
-- <a name="music.streams"></a>**`trx.music.streams`** (table). The soundtrack's streams as [`trx.music.Stream`](#music.Stream) handles: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
-- <a name="music.tracks"></a>**`trx.music.tracks`** (table). The tracks the current level carries, as [`trx.music.Track`](#music.Track) handles keyed by id: `trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
-- <a name="music.current_track"></a>**`trx.music.current_track`** ([trx.music.Track](#music.Track)). The track playing now, or `nil` when nothing plays. *(read-only)*
-- <a name="music.looped_track"></a>**`trx.music.looped_track`** ([trx.music.Track](#music.Track)). The ambient track that resumes once the current one-shot finishes, or `nil` when none is set. *(read-only)*
+- <a id="music.streams" name="music.streams"></a>**`trx.music.streams`** (table). The soundtrack's streams as [`trx.music.Stream`](#music.Stream) handles: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
+- <a id="music.tracks" name="music.tracks"></a>**`trx.music.tracks`** (table). The tracks the current level carries, as [`trx.music.Track`](#music.Track) handles keyed by id: `trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
+- <a id="music.current_track" name="music.current_track"></a>**`trx.music.current_track`** ([trx.music.Track](#music.Track)). The track playing now, or `nil` when nothing plays. *(read-only)*
+- <a id="music.looped_track" name="music.looped_track"></a>**`trx.music.looped_track`** ([trx.music.Track](#music.Track)). The ambient track that resumes once the current one-shot finishes, or `nil` when none is set. *(read-only)*
 
 ### Enums
 
-- <a name="music.PlayMode"></a>[lua]`trx.music.PlayMode`
+- <a id="music.PlayMode" name="music.PlayMode"></a>[lua]`trx.music.PlayMode`
 
     How a track is played. Pass one as `opts.mode` to [`trx.music.play`](#music.play).
 
@@ -40,30 +40,30 @@ Module for playing and controlling the soundtrack.
 
 ### Structures
 
-- <a name="music.Stream"></a>[lua]`trx.music.Stream`
+- <a id="music.Stream" name="music.Stream"></a>[lua]`trx.music.Stream`
 
-    One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through [`trx.music.streams`](#music.streams). A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check `is_valid()` first.
+    One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through [`trx.music.streams`](#music.streams). A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check [`is_valid`](#music.Stream.is_valid) first.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - <a name="music.Stream.mode"></a>**`mode`**: [trx.music.PlayMode](#music.PlayMode). How the track is playing. *(read-only)*
-    - <a name="music.Stream.timestamp"></a>**`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
-    - <a name="music.Stream.track_num"></a>**`track_num`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
+    - <a id="music.Stream.mode" name="music.Stream.mode"></a>**`mode`**: [trx.music.PlayMode](#music.PlayMode). How the track is playing. *(read-only)*
+    - <a id="music.Stream.timestamp" name="music.Stream.timestamp"></a>**`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
+    - <a id="music.Stream.track_num" name="music.Stream.track_num"></a>**`track_num`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
 
     Methods:
 
-    - <a name="music.Stream.is_valid"></a>[lua]`stream:is_valid()`  
+    - <a id="music.Stream.is_valid" name="music.Stream.is_valid"></a>[lua]`stream:is_valid()`  
       Whether the slot is still playing. A stream that has finished, or been stopped, leaves its handle stale.
 
       Returns: boolean.
 
-    - <a name="music.Stream.pause"></a>[lua]`stream:pause()`  
+    - <a id="music.Stream.pause" name="music.Stream.pause"></a>[lua]`stream:pause()`  
       Pauses this stream.
 
-    - <a name="music.Stream.seek"></a>[lua]`stream:seek(timestamp)`  
+    - <a id="music.Stream.seek" name="music.Stream.seek"></a>[lua]`stream:seek(timestamp)`  
       Seeks this stream to a timestamp.
 
       Parameters:
@@ -71,36 +71,36 @@ Module for playing and controlling the soundtrack.
 
       Returns: boolean. Whether the seek took.
 
-    - <a name="music.Stream.stop"></a>[lua]`stream:stop()`  
+    - <a id="music.Stream.stop" name="music.Stream.stop"></a>[lua]`stream:stop()`  
       Stops this stream. Stopping the main stream lets a deferred ambient loop resume; an overlay just ends.
 
-    - <a name="music.Stream.unpause"></a>[lua]`stream:unpause()`  
+    - <a id="music.Stream.unpause" name="music.Stream.unpause"></a>[lua]`stream:unpause()`  
       Resumes this stream.
 
-- <a name="music.Track"></a>[lua]`trx.music.Track`
+- <a id="music.Track" name="music.Track"></a>[lua]`trx.music.Track`
 
-    A track the current level carries. Reach them through [`trx.music.tracks`](#music.tracks), or as [`trx.music.current_track`](#music.current_track). A handle to a track the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.
+    A track the current level carries. Reach them through [`trx.music.tracks`](#music.tracks), or as [`trx.music.current_track`](#music.current_track). A handle to a track the loaded level does not carry goes stale, so [`is_valid`](#music.Track.is_valid) answers whether it is still there.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - <a name="music.Track.num"></a>**`num`**: integer. The number the level gives this track. *(read-only)*
+    - <a id="music.Track.num" name="music.Track.num"></a>**`num`**: integer. The number the level gives this track. *(read-only)*
 
     Methods:
 
-    - <a name="music.Track.is_valid"></a>[lua]`track:is_valid()`  
+    - <a id="music.Track.is_valid" name="music.Track.is_valid"></a>[lua]`track:is_valid()`  
       Whether the loaded level still carries this track.
 
       Returns: boolean.
 
-    - <a name="music.Track.path"></a>[lua]`track:path()`  
+    - <a id="music.Track.path" name="music.Track.path"></a>[lua]`track:path()`  
       Resolves the track's file path.
 
       Returns: string or `nil`. `nil` when there is no file, e.g. a CD-audio soundtrack.
 
-    - <a name="music.Track.play"></a>[lua]`track:play([opts])`  
+    - <a id="music.Track.play" name="music.Track.play"></a>[lua]`track:play([opts])`  
       Plays this track.
 
       Parameters:
@@ -110,7 +110,7 @@ Module for playing and controlling the soundtrack.
 
 ### Functions
 
-- <a name="music.play"></a>[lua]`trx.music.play(id, [opts])`  
+- <a id="music.play" name="music.play"></a>[lua]`trx.music.play(id, [opts])`  
   Plays a track by catalog id, mapping it to the level's own track. A game that does not carry the track plays nothing.
 
   Parameters:
@@ -125,11 +125,11 @@ Module for playing and controlling the soundtrack.
   trx.music.play(trx.catalog.music.SECRET, { mode = trx.music.PlayMode.LOOP })
   ```
 
-- <a name="music.pause"></a>[lua]`trx.music.pause()`  
+- <a id="music.pause" name="music.pause"></a>[lua]`trx.music.pause()`  
   Pauses the music.
 
-- <a name="music.unpause"></a>[lua]`trx.music.unpause()`  
+- <a id="music.unpause" name="music.unpause"></a>[lua]`trx.music.unpause()`  
   Resumes paused music.
 
-- <a name="music.stop"></a>[lua]`trx.music.stop()`  
+- <a id="music.stop" name="music.stop"></a>[lua]`trx.music.stop()`  
   Stops all music.

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -51,7 +51,7 @@ Module for playing and controlling the soundtrack.
     Properties:
     - **`mode`**: integer. How the track is playing. Compare against `trx.music.PlayMode`. *(read-only)*
     - **`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
-    - **`track_id`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
+    - **`track_num`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
 
     Methods:
 
@@ -86,7 +86,7 @@ Module for playing and controlling the soundtrack.
     unrelated one.
 
     Properties:
-    - **`id`**: integer. The track's id, in the level's own numbering. *(read-only)*
+    - **`num`**: integer. The number the level gives this track. *(read-only)*
 
     Methods:
 

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -54,7 +54,7 @@ Module for playing and controlling the soundtrack.
 
     Properties:
     - <a id="music.Stream.mode" name="music.Stream.mode"></a>**`mode`**: [trx.music.PlayMode](#music.PlayMode). How the track is playing. *(read-only)*
-    - <a id="music.Stream.timestamp" name="music.Stream.timestamp"></a>**`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
+    - <a id="music.Stream.timestamp" name="music.Stream.timestamp"></a>**`timestamp`**: [trx.game.Seconds](GAME.md#game.Seconds). How far into the track the stream is. *(read-only)*
     - <a id="music.Stream.track_num" name="music.Stream.track_num"></a>**`track_num`**: [trx.music.TrackNum](#music.TrackNum). The track this stream is playing. *(read-only)*
 
     Methods:
@@ -71,7 +71,7 @@ Module for playing and controlling the soundtrack.
       Seeks this stream to a timestamp.
 
       Parameters:
-      - <a id="music.Stream.seek.timestamp" name="music.Stream.seek.timestamp"></a>**`timestamp`** (number). Where to seek to, in seconds.
+      - <a id="music.Stream.seek.timestamp" name="music.Stream.seek.timestamp"></a>**`timestamp`** ([trx.game.Seconds](GAME.md#game.Seconds)). Where to seek to.
 
       Returns: boolean. Whether the seek took.
 

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -16,16 +16,16 @@ Module for playing and controlling the soundtrack.
 
 ### Properties
 
-- **`trx.music.streams`** (table). The soundtrack's streams as `trx.music.Stream` handles: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
-- **`trx.music.tracks`** (table). The tracks the current level carries, as `trx.music.Track` handles keyed by id: `trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
-- **`trx.music.current_track`** (Track). The track playing now, as a `trx.music.Track`, or `nil` when nothing plays. *(read-only)*
-- **`trx.music.looped_track`** (Track). The ambient track that resumes once the current one-shot finishes, as a `trx.music.Track`, or `nil` when none is set. *(read-only)*
+- <a name="music.streams"></a>**`trx.music.streams`** (table). The soundtrack's streams as [`trx.music.Stream`](#music.Stream) handles: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
+- <a name="music.tracks"></a>**`trx.music.tracks`** (table). The tracks the current level carries, as [`trx.music.Track`](#music.Track) handles keyed by id: `trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
+- <a name="music.current_track"></a>**`trx.music.current_track`** ([trx.music.Track](#music.Track)). The track playing now, or `nil` when nothing plays. *(read-only)*
+- <a name="music.looped_track"></a>**`trx.music.looped_track`** ([trx.music.Track](#music.Track)). The ambient track that resumes once the current one-shot finishes, or `nil` when none is set. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.music.PlayMode`
+- <a name="music.PlayMode"></a>[lua]`trx.music.PlayMode`
 
-    How a track is played. Pass one as `opts.mode` to `trx.music.play`.
+    How a track is played. Pass one as `opts.mode` to [`trx.music.play`](#music.play).
 
     - `trx.music.PlayMode.ONCE` = `0`  
         Plays the track once. When it finishes, any active looped track resumes from its start.
@@ -40,30 +40,30 @@ Module for playing and controlling the soundtrack.
 
 ### Structures
 
-- [lua]`trx.music.Stream`
+- <a name="music.Stream"></a>[lua]`trx.music.Stream`
 
-    One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through `trx.music.streams`. A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check `is_valid()` first.
+    One of the soundtrack's playing streams: the main stream, or an overlay. Reach them through [`trx.music.streams`](#music.streams). A handle to a slot that is not playing goes stale, so reading a field or calling a method on it raises; check `is_valid()` first.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - **`mode`**: integer. How the track is playing. Compare against `trx.music.PlayMode`. *(read-only)*
-    - **`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
-    - **`track_num`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
+    - <a name="music.Stream.mode"></a>**`mode`**: [trx.music.PlayMode](#music.PlayMode). How the track is playing. *(read-only)*
+    - <a name="music.Stream.timestamp"></a>**`timestamp`**: number. How far into the track the stream is, in seconds. *(read-only)*
+    - <a name="music.Stream.track_num"></a>**`track_num`**: integer. The track this stream is playing, in the level's own numbering. *(read-only)*
 
     Methods:
 
-    - [lua]`stream:is_valid()`  
+    - <a name="music.Stream.is_valid"></a>[lua]`stream:is_valid()`  
       Whether the slot is still playing. A stream that has finished, or been stopped, leaves its handle stale.
 
       Returns: boolean.
 
-    - [lua]`stream:pause()`  
+    - <a name="music.Stream.pause"></a>[lua]`stream:pause()`  
       Pauses this stream.
 
-    - [lua]`stream:seek(timestamp)`  
+    - <a name="music.Stream.seek"></a>[lua]`stream:seek(timestamp)`  
       Seeks this stream to a timestamp.
 
       Parameters:
@@ -71,53 +71,53 @@ Module for playing and controlling the soundtrack.
 
       Returns: boolean. Whether the seek took.
 
-    - [lua]`stream:stop()`  
+    - <a name="music.Stream.stop"></a>[lua]`stream:stop()`  
       Stops this stream. Stopping the main stream lets a deferred ambient loop resume; an overlay just ends.
 
-    - [lua]`stream:unpause()`  
+    - <a name="music.Stream.unpause"></a>[lua]`stream:unpause()`  
       Resumes this stream.
 
-- [lua]`trx.music.Track`
+- <a name="music.Track"></a>[lua]`trx.music.Track`
 
-    A track the current level carries. Reach them through `trx.music.tracks`, or as `trx.music.current_track`. A handle to a track the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.
+    A track the current level carries. Reach them through [`trx.music.tracks`](#music.tracks), or as [`trx.music.current_track`](#music.current_track). A handle to a track the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - **`num`**: integer. The number the level gives this track. *(read-only)*
+    - <a name="music.Track.num"></a>**`num`**: integer. The number the level gives this track. *(read-only)*
 
     Methods:
 
-    - [lua]`track:is_valid()`  
+    - <a name="music.Track.is_valid"></a>[lua]`track:is_valid()`  
       Whether the loaded level still carries this track.
 
       Returns: boolean.
 
-    - [lua]`track:path()`  
+    - <a name="music.Track.path"></a>[lua]`track:path()`  
       Resolves the track's file path.
 
       Returns: string or `nil`. `nil` when there is no file, e.g. a CD-audio soundtrack.
 
-    - [lua]`track:play([opts])`  
+    - <a name="music.Track.play"></a>[lua]`track:play([opts])`  
       Plays this track.
 
       Parameters:
-      - **`opts`** (table, optional). `mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.
+      - **`opts`** (table, optional). `mode`: a [`trx.music.PlayMode`](#music.PlayMode). Defaults to `ONCE`.
 
-      Returns: music.Stream or `nil`. The stream it started, or `nil` if none did.
+      Returns: [trx.music.Stream](#music.Stream) or `nil`. The stream it started, or `nil` if none did.
 
 ### Functions
 
-- [lua]`trx.music.play(id, [opts])`  
+- <a name="music.play"></a>[lua]`trx.music.play(id, [opts])`  
   Plays a track by catalog id, mapping it to the level's own track. A game that does not carry the track plays nothing.
 
   Parameters:
-  - **`id`** (integer). Track to play. To reach a track by the level's own slot, play it through a handle: `trx.music.tracks[slot]:play()`. Compare against `trx.catalog.music`.
-  - **`opts`** (table, optional). `mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.
+  - **`id`** ([trx.catalog.music](CATALOG.md#catalog.music)). Track to play. To reach a track by the level's own slot, play it through a handle: `trx.music.tracks[slot]:play()`.
+  - **`opts`** (table, optional). `mode`: a [`trx.music.PlayMode`](#music.PlayMode). Defaults to `ONCE`.
 
-  Returns: music.Stream or `nil`. The stream it started, or `nil` if none did.
+  Returns: [trx.music.Stream](#music.Stream) or `nil`. The stream it started, or `nil` if none did.
 
   Example:
   ```lua
@@ -125,11 +125,11 @@ Module for playing and controlling the soundtrack.
   trx.music.play(trx.catalog.music.SECRET, { mode = trx.music.PlayMode.LOOP })
   ```
 
-- [lua]`trx.music.pause()`  
+- <a name="music.pause"></a>[lua]`trx.music.pause()`  
   Pauses the music.
 
-- [lua]`trx.music.unpause()`  
+- <a name="music.unpause"></a>[lua]`trx.music.unpause()`  
   Resumes paused music.
 
-- [lua]`trx.music.stop()`  
+- <a name="music.stop"></a>[lua]`trx.music.stop()`  
   Stops all music.

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -14,13 +14,13 @@ order: 7
 
 Module for the object definitions a level is built from.
 
-An object is the pattern every item of that type is cut from: a wolf's radius, not this wolf's. Per-item state lives on the item - see `trx.items`.
+An object is the pattern every item of that type is cut from: a wolf's radius, not this wolf's. Per-item state lives on the item - see [`trx.items`](ITEMS.md#items).
 
 ### Indexing
 
-Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf. Keyed by object id or catalog name, not by position.
+Indexing the module reaches an object definition, so [`trx.objects.wolf`](#objects) is the wolf. Keyed by object id or catalog name, not by position.
 
-- **`trx.objects[key]`** (Object or `nil`). Object id, or its catalog name.
+- <a name="objects[]"></a>**`trx.objects[key]`** ([trx.objects.Object](#objects.Object) or `nil`). Object id, or its catalog name.
 
 Example:
 ```lua
@@ -29,11 +29,11 @@ trx.objects.wolf.properties.max_hit_points = 30
 
 ### Properties
 
-- **`trx.objects.query`** (ObjectQuery). The identity query over every object definition. Narrow it and read it - see `trx.objects.ObjectQuery`. *(read-only)*
+- <a name="objects.query"></a>**`trx.objects.query`** ([trx.objects.ObjectQuery](#objects.ObjectQuery)). The identity query over every object definition. Narrow it and read it. *(read-only)*
 
 ### Structures
 
-- [lua]`trx.objects.Object`
+- <a name="objects.Object"></a>[lua]`trx.objects.Object`
 
     An object definition.
 
@@ -42,34 +42,34 @@ trx.objects.wolf.properties.max_hit_points = 30
     unrelated one.
 
     Properties:
-    - **`anim_count`**: integer. How many animations it has. *(read-only)*
-    - **`is_intelligent`**: boolean. Whether the object thinks - a creature rather than a door. *(read-only)*
-    - **`loaded`**: boolean. Whether the current level has this object at all. An object it never loaded still has a definition; this is how a script tells. *(read-only)*
-    - **`mesh_count`**: integer. How many meshes the object is built from. *(read-only)*
-    - **`pivot_length`**: integer. How far in front of itself the object turns about.
-    - **`radius`**: integer. Collision radius.
-    - **`semi_transparent`**: boolean. Whether the object is drawn see-through.
-    - **`shadow_size`**: integer. Size of the blob shadow drawn under it, and 0 for none.
-    - **`smartness`**: integer. How readily a creature of this type finds its way to Lara.
+    - <a name="objects.Object.anim_count"></a>**`anim_count`**: integer. How many animations it has. *(read-only)*
+    - <a name="objects.Object.is_intelligent"></a>**`is_intelligent`**: boolean. Whether the object thinks - a creature rather than a door. *(read-only)*
+    - <a name="objects.Object.loaded"></a>**`loaded`**: boolean. Whether the current level has this object at all. An object it never loaded still has a definition; this is how a script tells. *(read-only)*
+    - <a name="objects.Object.mesh_count"></a>**`mesh_count`**: integer. How many meshes the object is built from. *(read-only)*
+    - <a name="objects.Object.pivot_length"></a>**`pivot_length`**: integer. How far in front of itself the object turns about.
+    - <a name="objects.Object.radius"></a>**`radius`**: integer. Collision radius.
+    - <a name="objects.Object.semi_transparent"></a>**`semi_transparent`**: boolean. Whether the object is drawn see-through.
+    - <a name="objects.Object.shadow_size"></a>**`shadow_size`**: integer. Size of the blob shadow drawn under it, and 0 for none.
+    - <a name="objects.Object.smartness"></a>**`smartness`**: integer. How readily a creature of this type finds its way to Lara.
 
     Computed properties (derived, not stored on the object):
-    - **`default_names`**: table. The compile-time English names. A lookup falls back on these when the player's language has no name to match, which is the case before a language file is loaded at all.
-    - **`names`**: table. Every name the object answers to, in the player's language. An object has more than one: a large medipack is also a `medipack` and a `big medi`.
-    - **`properties`**: table. The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
+    - <a name="objects.Object.default_names"></a>**`default_names`**: table. The compile-time English names. A lookup falls back on these when the player's language has no name to match, which is the case before a language file is loaded at all.
+    - <a name="objects.Object.names"></a>**`names`**: table. Every name the object answers to, in the player's language. An object has more than one: a large medipack is also a `medipack` and a `big medi`.
+    - <a name="objects.Object.properties"></a>**`properties`**: table. The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
 
     Methods:
 
-    - [lua]`object:get_default_names()`  
+    - <a name="objects.Object.get_default_names"></a>[lua]`object:get_default_names()`  
       The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `object.default_names`.
 
       Returns: table.
 
-    - [lua]`object:get_names()`  
+    - <a name="objects.Object.get_names"></a>[lua]`object:get_names()`  
       Every name the object answers to, in the player's language. Prefer `object.names`.
 
       Returns: table.
 
-    - [lua]`object:get_property(name)`  
+    - <a name="objects.Object.get_property"></a>[lua]`object:get_property(name)`  
       Reads one of the object's properties. Prefer `object.properties.<name>`.
 
       Parameters:
@@ -77,150 +77,150 @@ trx.objects.wolf.properties.max_hit_points = 30
 
       Returns: any or `nil`.
 
-    - [lua]`object:get_property_names()`  
+    - <a name="objects.Object.get_property_names"></a>[lua]`object:get_property_names()`  
       Names of every property this object declares.
 
       Returns: table.
 
-    - [lua]`object:set_property(name, value)`  
+    - <a name="objects.Object.set_property"></a>[lua]`object:set_property(name, value)`  
       Writes one of the object's properties. Prefer `object.properties.<name> = ...`.
 
       Parameters:
       - **`name`** (string).
       - **`value`** (any).
 
-- [lua]`trx.objects.ObjectQuery`
+- <a name="objects.ObjectQuery"></a>[lua]`trx.objects.ObjectQuery`
 
-    A `trx.query.Query` over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see `trx.query.NamedQuery`.
+    A [`trx.query.Query`](QUERY.md#query.Query) over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see [`trx.query.NamedQuery`](QUERY.md#query.NamedQuery).
 
     The families do not cover `pickup` between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.
 
     Methods:
 
-    - [lua]`objectquery:ammo()`  
+    - <a name="objects.ObjectQuery.ammo"></a>[lua]`objectquery:ammo()`  
       Clips for a weapon.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:animation()`  
+    - <a name="objects.ObjectQuery.animation"></a>[lua]`objectquery:animation()`  
       An animation an object borrows rather than a thing of its own.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:collectible()`  
+    - <a name="objects.ObjectQuery.collectible"></a>[lua]`objectquery:collectible()`  
       A collectible, by the slot it fills.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:creature()`  
+    - <a name="objects.ObjectQuery.creature"></a>[lua]`objectquery:creature()`  
       The object is a creature.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:door()`  
+    - <a name="objects.ObjectQuery.door"></a>[lua]`objectquery:door()`  
       A door.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:enemy()`  
+    - <a name="objects.ObjectQuery.enemy"></a>[lua]`objectquery:enemy()`  
       A creature that fights Lara rather than for her.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:examine()`  
+    - <a name="objects.ObjectQuery.examine"></a>[lua]`objectquery:examine()`  
       An examine item, by the slot it fills.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:gun()`  
+    - <a name="objects.ObjectQuery.gun"></a>[lua]`objectquery:gun()`  
       A weapon.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:inventory_item()`  
+    - <a name="objects.ObjectQuery.inventory_item"></a>[lua]`objectquery:inventory_item()`  
       An icon in the inventory rather than a thing in the world.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:key()`  
+    - <a name="objects.ObjectQuery.key"></a>[lua]`objectquery:key()`  
       A key, by the slot it fills.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:loaded()`  
+    - <a name="objects.ObjectQuery.loaded"></a>[lua]`objectquery:loaded()`  
       The level loaded the object, so items of it exist.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:loyal()`  
+    - <a name="objects.ObjectQuery.loyal"></a>[lua]`objectquery:loyal()`  
       One of Lara's own: the butler, and Lara herself.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:null_object()`  
+    - <a name="objects.ObjectQuery.null_object"></a>[lua]`objectquery:null_object()`  
       A placeholder that is never drawn.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:pickup()`  
+    - <a name="objects.ObjectQuery.pickup"></a>[lua]`objectquery:pickup()`  
       Something Lara can pick up.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:pushable()`  
+    - <a name="objects.ObjectQuery.pushable"></a>[lua]`objectquery:pushable()`  
       A block Lara pushes and pulls.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:puzzle()`  
+    - <a name="objects.ObjectQuery.puzzle"></a>[lua]`objectquery:puzzle()`  
       A puzzle item, by the slot it fills.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:quest()`  
+    - <a name="objects.ObjectQuery.quest"></a>[lua]`objectquery:quest()`  
       A quest item, by the slot it fills. This is what carries the scion.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:receptacle()`  
+    - <a name="objects.ObjectQuery.receptacle"></a>[lua]`objectquery:receptacle()`  
       A slot a puzzle item goes into.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:secret()`  
+    - <a name="objects.ObjectQuery.secret"></a>[lua]`objectquery:secret()`  
       The trinket a secret trigger sits under.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:spawnable()`  
+    - <a name="objects.ObjectQuery.spawnable"></a>[lua]`objectquery:spawnable()`  
       The object is a thing in the world at all, rather than an inventory icon, an animation, or a null placeholder.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:supply()`  
+    - <a name="objects.ObjectQuery.supply"></a>[lua]`objectquery:supply()`  
       A pickup Lara spends rather than keeps.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:switch()`  
+    - <a name="objects.ObjectQuery.switch"></a>[lua]`objectquery:switch()`  
       A switch Lara throws.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`objectquery:tool()`  
+    - <a name="objects.ObjectQuery.tool"></a>[lua]`objectquery:tool()`  
       A pickup named for itself rather than filling a numbered slot: the crowbar, the lasersight, the binoculars, the waterskins, the leadbar.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
 ### Functions
 
-- [lua]`trx.objects.get(key)`  
+- <a name="objects.get"></a>[lua]`trx.objects.get(key)`  
   Retrieves an object definition by id or by name.
 
   Parameters:
-  - **`key`** (any). Object id, or its catalog name: `trx.objects["wolf"]`. Compare against `trx.catalog.objects`.
+  - **`key`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object id, or its catalog name: `trx.objects["wolf"]`.
 
-  Returns: Object or `nil`. `nil` if no such object exists.
+  Returns: [trx.objects.Object](#objects.Object) or `nil`. `nil` if no such object exists.
 
   Example:
   ```lua
@@ -228,20 +228,20 @@ trx.objects.wolf.properties.max_hit_points = 30
   wolf.properties.max_hit_points = 30
   ```
 
-- [lua]`trx.objects.swap_mesh(object_id1, object_id2, [mesh_num1], [mesh_num2])`  
+- <a name="objects.swap_mesh"></a>[lua]`trx.objects.swap_mesh(object_id1, object_id2, [mesh_num1], [mesh_num2])`  
   Swaps meshes between two objects. With no mesh numbers, swaps all of them; with both, swaps just those two. One without the other raises.
 
   Parameters:
-  - **`object_id1`** (integer). Compare against `trx.catalog.objects`.
-  - **`object_id2`** (integer). Compare against `trx.catalog.objects`.
+  - **`object_id1`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - **`object_id2`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
   - **`mesh_num1`** (integer, optional). Mesh of the first.
   - **`mesh_num2`** (integer, optional). Mesh of the second.
 
-- [lua]`trx.objects.swap_sprite(object_id1, object_id2)`  
+- <a name="objects.swap_sprite"></a>[lua]`trx.objects.swap_sprite(object_id1, object_id2)`  
   Swaps the sprites of two objects, which is how a pickup looks when 3D pickups
   are turned off. Raises if either object is drawn from meshes rather than a
   sprite.
 
   Parameters:
-  - **`object_id1`** (integer). Compare against `trx.catalog.objects`.
-  - **`object_id2`** (integer). Compare against `trx.catalog.objects`.
+  - **`object_id1`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - **`object_id2`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -33,6 +33,10 @@ trx.objects.wolf.properties.max_hit_points = 30
 
 ### Structures
 
+- <a id="objects.MeshNum" name="objects.MeshNum"></a>[lua]`trx.objects.MeshNum`
+
+    The mesh's number within the object it belongs to. Counted from 0.
+
 - <a id="objects.Object" name="objects.Object"></a>[lua]`trx.objects.Object`
 
     An object definition.
@@ -62,32 +66,32 @@ trx.objects.wolf.properties.max_hit_points = 30
     - <a id="objects.Object.get_default_names" name="objects.Object.get_default_names"></a>[lua]`object:get_default_names()`  
       The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer [`default_names`](#objects.Object.default_names).
 
-      Returns: table.
+      Returns: table. The names, as a list of strings.
 
     - <a id="objects.Object.get_names" name="objects.Object.get_names"></a>[lua]`object:get_names()`  
       Every name the object answers to, in the player's language. Prefer [`names`](#objects.Object.names).
 
-      Returns: table.
+      Returns: table. The names, as a list of strings.
 
     - <a id="objects.Object.get_property" name="objects.Object.get_property"></a>[lua]`object:get_property(name)`  
       Reads one of the object's properties. Prefer `object.properties.<name>`.
 
       Parameters:
-      - **`name`** (string).
+      - <a id="objects.Object.get_property.name" name="objects.Object.get_property.name"></a>**`name`** (string). Which property, as the object declares it.
 
-      Returns: any or `nil`.
+      Returns: any or `nil`. The value, of whatever type the property is declared with.
 
     - <a id="objects.Object.get_property_names" name="objects.Object.get_property_names"></a>[lua]`object:get_property_names()`  
       Names of every property this object declares.
 
-      Returns: table.
+      Returns: table. The names, as a list of strings.
 
     - <a id="objects.Object.set_property" name="objects.Object.set_property"></a>[lua]`object:set_property(name, value)`  
       Writes one of the object's properties. Prefer `object.properties.<name> = ...`.
 
       Parameters:
-      - **`name`** (string).
-      - **`value`** (any).
+      - <a id="objects.Object.set_property.name" name="objects.Object.set_property.name"></a>**`name`** (string). Which property, as the object declares it.
+      - <a id="objects.Object.set_property.value" name="objects.Object.set_property.value"></a>**`value`** (any). What to write, of the type the property is declared with.
 
 - <a id="objects.ObjectQuery" name="objects.ObjectQuery"></a>[lua]`trx.objects.ObjectQuery`
 
@@ -218,7 +222,7 @@ trx.objects.wolf.properties.max_hit_points = 30
   Retrieves an object definition by id or by name.
 
   Parameters:
-  - **`key`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object id, or its catalog name: `trx.objects["wolf"]`.
+  - <a id="objects.get.key" name="objects.get.key"></a>**`key`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object id, or its catalog name: `trx.objects["wolf"]`.
 
   Returns: [trx.objects.Object](#objects.Object) or `nil`. `nil` if no such object exists.
 
@@ -232,10 +236,10 @@ trx.objects.wolf.properties.max_hit_points = 30
   Swaps meshes between two objects. With no mesh numbers, swaps all of them; with both, swaps just those two. One without the other raises.
 
   Parameters:
-  - **`object_id1`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
-  - **`object_id2`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
-  - **`mesh_num1`** (integer, optional). Mesh of the first.
-  - **`mesh_num2`** (integer, optional). Mesh of the second.
+  - <a id="objects.swap_mesh.object_id1" name="objects.swap_mesh.object_id1"></a>**`object_id1`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - <a id="objects.swap_mesh.object_id2" name="objects.swap_mesh.object_id2"></a>**`object_id2`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - <a id="objects.swap_mesh.mesh_num1" name="objects.swap_mesh.mesh_num1"></a>**`mesh_num1`** ([trx.objects.MeshNum](#objects.MeshNum), optional). Mesh of the first.
+  - <a id="objects.swap_mesh.mesh_num2" name="objects.swap_mesh.mesh_num2"></a>**`mesh_num2`** ([trx.objects.MeshNum](#objects.MeshNum), optional). Mesh of the second.
 
 - <a id="objects.swap_sprite" name="objects.swap_sprite"></a>[lua]`trx.objects.swap_sprite(object_id1, object_id2)`  
   Swaps the sprites of two objects, which is how a pickup looks when 3D pickups
@@ -243,5 +247,5 @@ trx.objects.wolf.properties.max_hit_points = 30
   sprite.
 
   Parameters:
-  - **`object_id1`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
-  - **`object_id2`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - <a id="objects.swap_sprite.object_id1" name="objects.swap_sprite.object_id1"></a>**`object_id1`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).
+  - <a id="objects.swap_sprite.object_id2" name="objects.swap_sprite.object_id2"></a>**`object_id2`** ([trx.catalog.objects](CATALOG.md#catalog.objects)).

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -10,7 +10,7 @@ order: 7
   src/lua/api/objects.lua. Edit it there.
 -->
 
-## Object module
+## <a id="objects" name="objects"></a>Object module
 
 Module for the object definitions a level is built from.
 
@@ -20,7 +20,7 @@ An object is the pattern every item of that type is cut from: a wolf's radius, n
 
 Indexing the module reaches an object definition, so [`trx.objects.wolf`](#objects) is the wolf. Keyed by object id or catalog name, not by position.
 
-- <a name="objects[]"></a>**`trx.objects[key]`** ([trx.objects.Object](#objects.Object) or `nil`). Object id, or its catalog name.
+- <a id="objects[]" name="objects[]"></a>**`trx.objects[key]`** ([trx.objects.Object](#objects.Object) or `nil`). Object id, or its catalog name.
 
 Example:
 ```lua
@@ -29,11 +29,11 @@ trx.objects.wolf.properties.max_hit_points = 30
 
 ### Properties
 
-- <a name="objects.query"></a>**`trx.objects.query`** ([trx.objects.ObjectQuery](#objects.ObjectQuery)). The identity query over every object definition. Narrow it and read it. *(read-only)*
+- <a id="objects.query" name="objects.query"></a>**`trx.objects.query`** ([trx.objects.ObjectQuery](#objects.ObjectQuery)). The identity query over every object definition. Narrow it and read it. *(read-only)*
 
 ### Structures
 
-- <a name="objects.Object"></a>[lua]`trx.objects.Object`
+- <a id="objects.Object" name="objects.Object"></a>[lua]`trx.objects.Object`
 
     An object definition.
 
@@ -42,34 +42,34 @@ trx.objects.wolf.properties.max_hit_points = 30
     unrelated one.
 
     Properties:
-    - <a name="objects.Object.anim_count"></a>**`anim_count`**: integer. How many animations it has. *(read-only)*
-    - <a name="objects.Object.is_intelligent"></a>**`is_intelligent`**: boolean. Whether the object thinks - a creature rather than a door. *(read-only)*
-    - <a name="objects.Object.loaded"></a>**`loaded`**: boolean. Whether the current level has this object at all. An object it never loaded still has a definition; this is how a script tells. *(read-only)*
-    - <a name="objects.Object.mesh_count"></a>**`mesh_count`**: integer. How many meshes the object is built from. *(read-only)*
-    - <a name="objects.Object.pivot_length"></a>**`pivot_length`**: integer. How far in front of itself the object turns about.
-    - <a name="objects.Object.radius"></a>**`radius`**: integer. Collision radius.
-    - <a name="objects.Object.semi_transparent"></a>**`semi_transparent`**: boolean. Whether the object is drawn see-through.
-    - <a name="objects.Object.shadow_size"></a>**`shadow_size`**: integer. Size of the blob shadow drawn under it, and 0 for none.
-    - <a name="objects.Object.smartness"></a>**`smartness`**: integer. How readily a creature of this type finds its way to Lara.
+    - <a id="objects.Object.anim_count" name="objects.Object.anim_count"></a>**`anim_count`**: integer. How many animations it has. *(read-only)*
+    - <a id="objects.Object.is_intelligent" name="objects.Object.is_intelligent"></a>**`is_intelligent`**: boolean. Whether the object thinks - a creature rather than a door. *(read-only)*
+    - <a id="objects.Object.loaded" name="objects.Object.loaded"></a>**`loaded`**: boolean. Whether the current level has this object at all. An object it never loaded still has a definition; this is how a script tells. *(read-only)*
+    - <a id="objects.Object.mesh_count" name="objects.Object.mesh_count"></a>**`mesh_count`**: integer. How many meshes the object is built from. *(read-only)*
+    - <a id="objects.Object.pivot_length" name="objects.Object.pivot_length"></a>**`pivot_length`**: integer. How far in front of itself the object turns about.
+    - <a id="objects.Object.radius" name="objects.Object.radius"></a>**`radius`**: integer. Collision radius.
+    - <a id="objects.Object.semi_transparent" name="objects.Object.semi_transparent"></a>**`semi_transparent`**: boolean. Whether the object is drawn see-through.
+    - <a id="objects.Object.shadow_size" name="objects.Object.shadow_size"></a>**`shadow_size`**: integer. Size of the blob shadow drawn under it, and 0 for none.
+    - <a id="objects.Object.smartness" name="objects.Object.smartness"></a>**`smartness`**: integer. How readily a creature of this type finds its way to Lara.
 
     Computed properties (derived, not stored on the object):
-    - <a name="objects.Object.default_names"></a>**`default_names`**: table. The compile-time English names. A lookup falls back on these when the player's language has no name to match, which is the case before a language file is loaded at all.
-    - <a name="objects.Object.names"></a>**`names`**: table. Every name the object answers to, in the player's language. An object has more than one: a large medipack is also a `medipack` and a `big medi`.
-    - <a name="objects.Object.properties"></a>**`properties`**: table. The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
+    - <a id="objects.Object.default_names" name="objects.Object.default_names"></a>**`default_names`**: table. The compile-time English names. A lookup falls back on these when the player's language has no name to match, which is the case before a language file is loaded at all.
+    - <a id="objects.Object.names" name="objects.Object.names"></a>**`names`**: table. Every name the object answers to, in the player's language. An object has more than one: a large medipack is also a `medipack` and a `big medi`.
+    - <a id="objects.Object.properties" name="objects.Object.properties"></a>**`properties`**: table. The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to [`trx.items.Item.properties`](ITEMS.md#items.Item.properties) to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
 
     Methods:
 
-    - <a name="objects.Object.get_default_names"></a>[lua]`object:get_default_names()`  
-      The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `object.default_names`.
+    - <a id="objects.Object.get_default_names" name="objects.Object.get_default_names"></a>[lua]`object:get_default_names()`  
+      The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer [`default_names`](#objects.Object.default_names).
 
       Returns: table.
 
-    - <a name="objects.Object.get_names"></a>[lua]`object:get_names()`  
-      Every name the object answers to, in the player's language. Prefer `object.names`.
+    - <a id="objects.Object.get_names" name="objects.Object.get_names"></a>[lua]`object:get_names()`  
+      Every name the object answers to, in the player's language. Prefer [`names`](#objects.Object.names).
 
       Returns: table.
 
-    - <a name="objects.Object.get_property"></a>[lua]`object:get_property(name)`  
+    - <a id="objects.Object.get_property" name="objects.Object.get_property"></a>[lua]`object:get_property(name)`  
       Reads one of the object's properties. Prefer `object.properties.<name>`.
 
       Parameters:
@@ -77,144 +77,144 @@ trx.objects.wolf.properties.max_hit_points = 30
 
       Returns: any or `nil`.
 
-    - <a name="objects.Object.get_property_names"></a>[lua]`object:get_property_names()`  
+    - <a id="objects.Object.get_property_names" name="objects.Object.get_property_names"></a>[lua]`object:get_property_names()`  
       Names of every property this object declares.
 
       Returns: table.
 
-    - <a name="objects.Object.set_property"></a>[lua]`object:set_property(name, value)`  
+    - <a id="objects.Object.set_property" name="objects.Object.set_property"></a>[lua]`object:set_property(name, value)`  
       Writes one of the object's properties. Prefer `object.properties.<name> = ...`.
 
       Parameters:
       - **`name`** (string).
       - **`value`** (any).
 
-- <a name="objects.ObjectQuery"></a>[lua]`trx.objects.ObjectQuery`
+- <a id="objects.ObjectQuery" name="objects.ObjectQuery"></a>[lua]`trx.objects.ObjectQuery`
 
     A [`trx.query.Query`](QUERY.md#query.Query) over every object the engine knows, with the narrowings below on top of the ones every query has. Objects answer to names, so it carries the name layer too - see [`trx.query.NamedQuery`](QUERY.md#query.NamedQuery).
 
-    The families do not cover `pickup` between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.
+    The families do not cover [`pickup`](#objects.ObjectQuery.pickup) between them: a second state of something Lara already carries, such as a part-full waterskin, is in none of them.
 
     Methods:
 
-    - <a name="objects.ObjectQuery.ammo"></a>[lua]`objectquery:ammo()`  
+    - <a id="objects.ObjectQuery.ammo" name="objects.ObjectQuery.ammo"></a>[lua]`objectquery:ammo()`  
       Clips for a weapon.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.animation"></a>[lua]`objectquery:animation()`  
+    - <a id="objects.ObjectQuery.animation" name="objects.ObjectQuery.animation"></a>[lua]`objectquery:animation()`  
       An animation an object borrows rather than a thing of its own.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.collectible"></a>[lua]`objectquery:collectible()`  
+    - <a id="objects.ObjectQuery.collectible" name="objects.ObjectQuery.collectible"></a>[lua]`objectquery:collectible()`  
       A collectible, by the slot it fills.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.creature"></a>[lua]`objectquery:creature()`  
+    - <a id="objects.ObjectQuery.creature" name="objects.ObjectQuery.creature"></a>[lua]`objectquery:creature()`  
       The object is a creature.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.door"></a>[lua]`objectquery:door()`  
+    - <a id="objects.ObjectQuery.door" name="objects.ObjectQuery.door"></a>[lua]`objectquery:door()`  
       A door.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.enemy"></a>[lua]`objectquery:enemy()`  
+    - <a id="objects.ObjectQuery.enemy" name="objects.ObjectQuery.enemy"></a>[lua]`objectquery:enemy()`  
       A creature that fights Lara rather than for her.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.examine"></a>[lua]`objectquery:examine()`  
+    - <a id="objects.ObjectQuery.examine" name="objects.ObjectQuery.examine"></a>[lua]`objectquery:examine()`  
       An examine item, by the slot it fills.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.gun"></a>[lua]`objectquery:gun()`  
+    - <a id="objects.ObjectQuery.gun" name="objects.ObjectQuery.gun"></a>[lua]`objectquery:gun()`  
       A weapon.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.inventory_item"></a>[lua]`objectquery:inventory_item()`  
+    - <a id="objects.ObjectQuery.inventory_item" name="objects.ObjectQuery.inventory_item"></a>[lua]`objectquery:inventory_item()`  
       An icon in the inventory rather than a thing in the world.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.key"></a>[lua]`objectquery:key()`  
+    - <a id="objects.ObjectQuery.key" name="objects.ObjectQuery.key"></a>[lua]`objectquery:key()`  
       A key, by the slot it fills.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.loaded"></a>[lua]`objectquery:loaded()`  
+    - <a id="objects.ObjectQuery.loaded" name="objects.ObjectQuery.loaded"></a>[lua]`objectquery:loaded()`  
       The level loaded the object, so items of it exist.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.loyal"></a>[lua]`objectquery:loyal()`  
+    - <a id="objects.ObjectQuery.loyal" name="objects.ObjectQuery.loyal"></a>[lua]`objectquery:loyal()`  
       One of Lara's own: the butler, and Lara herself.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.null_object"></a>[lua]`objectquery:null_object()`  
+    - <a id="objects.ObjectQuery.null_object" name="objects.ObjectQuery.null_object"></a>[lua]`objectquery:null_object()`  
       A placeholder that is never drawn.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.pickup"></a>[lua]`objectquery:pickup()`  
+    - <a id="objects.ObjectQuery.pickup" name="objects.ObjectQuery.pickup"></a>[lua]`objectquery:pickup()`  
       Something Lara can pick up.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.pushable"></a>[lua]`objectquery:pushable()`  
+    - <a id="objects.ObjectQuery.pushable" name="objects.ObjectQuery.pushable"></a>[lua]`objectquery:pushable()`  
       A block Lara pushes and pulls.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.puzzle"></a>[lua]`objectquery:puzzle()`  
+    - <a id="objects.ObjectQuery.puzzle" name="objects.ObjectQuery.puzzle"></a>[lua]`objectquery:puzzle()`  
       A puzzle item, by the slot it fills.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.quest"></a>[lua]`objectquery:quest()`  
+    - <a id="objects.ObjectQuery.quest" name="objects.ObjectQuery.quest"></a>[lua]`objectquery:quest()`  
       A quest item, by the slot it fills. This is what carries the scion.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.receptacle"></a>[lua]`objectquery:receptacle()`  
+    - <a id="objects.ObjectQuery.receptacle" name="objects.ObjectQuery.receptacle"></a>[lua]`objectquery:receptacle()`  
       A slot a puzzle item goes into.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.secret"></a>[lua]`objectquery:secret()`  
+    - <a id="objects.ObjectQuery.secret" name="objects.ObjectQuery.secret"></a>[lua]`objectquery:secret()`  
       The trinket a secret trigger sits under.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.spawnable"></a>[lua]`objectquery:spawnable()`  
+    - <a id="objects.ObjectQuery.spawnable" name="objects.ObjectQuery.spawnable"></a>[lua]`objectquery:spawnable()`  
       The object is a thing in the world at all, rather than an inventory icon, an animation, or a null placeholder.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.supply"></a>[lua]`objectquery:supply()`  
+    - <a id="objects.ObjectQuery.supply" name="objects.ObjectQuery.supply"></a>[lua]`objectquery:supply()`  
       A pickup Lara spends rather than keeps.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.switch"></a>[lua]`objectquery:switch()`  
+    - <a id="objects.ObjectQuery.switch" name="objects.ObjectQuery.switch"></a>[lua]`objectquery:switch()`  
       A switch Lara throws.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="objects.ObjectQuery.tool"></a>[lua]`objectquery:tool()`  
+    - <a id="objects.ObjectQuery.tool" name="objects.ObjectQuery.tool"></a>[lua]`objectquery:tool()`  
       A pickup named for itself rather than filling a numbered slot: the crowbar, the lasersight, the binoculars, the waterskins, the leadbar.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
 ### Functions
 
-- <a name="objects.get"></a>[lua]`trx.objects.get(key)`  
+- <a id="objects.get" name="objects.get"></a>[lua]`trx.objects.get(key)`  
   Retrieves an object definition by id or by name.
 
   Parameters:
@@ -228,7 +228,7 @@ trx.objects.wolf.properties.max_hit_points = 30
   wolf.properties.max_hit_points = 30
   ```
 
-- <a name="objects.swap_mesh"></a>[lua]`trx.objects.swap_mesh(object_id1, object_id2, [mesh_num1], [mesh_num2])`  
+- <a id="objects.swap_mesh" name="objects.swap_mesh"></a>[lua]`trx.objects.swap_mesh(object_id1, object_id2, [mesh_num1], [mesh_num2])`  
   Swaps meshes between two objects. With no mesh numbers, swaps all of them; with both, swaps just those two. One without the other raises.
 
   Parameters:
@@ -237,7 +237,7 @@ trx.objects.wolf.properties.max_hit_points = 30
   - **`mesh_num1`** (integer, optional). Mesh of the first.
   - **`mesh_num2`** (integer, optional). Mesh of the second.
 
-- <a name="objects.swap_sprite"></a>[lua]`trx.objects.swap_sprite(object_id1, object_id2)`  
+- <a id="objects.swap_sprite" name="objects.swap_sprite"></a>[lua]`trx.objects.swap_sprite(object_id1, object_id2)`  
   Swaps the sprites of two objects, which is how a pickup looks when 3D pickups
   are turned off. Raises if either object is drawn from meshes rather than a
   sprite.

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -10,7 +10,7 @@ order: 9
   src/lua/api/query.lua. Edit it there.
 -->
 
-## Query module
+## <a id="query" name="query"></a>Query module
 
 A composable filter over a domain of things - the objects a level is built
 from, or the items alive in it. [`trx.objects.query`](OBJECTS.md#objects.query) and [`trx.items.query`](ITEMS.md#items.query) are
@@ -26,7 +26,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
 ### Structures
 
-- <a name="query.Query"></a>[lua]`trx.query.Query`
+- <a id="query.Query" name="query.Query"></a>[lua]`trx.query.Query`
 
     A filter over a domain, read with one of the terminals below once it is narrow enough.
 
@@ -37,34 +37,34 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
     Methods:
 
-    - <a name="query.Query.count"></a>[lua]`query:count()`  
+    - <a id="query.Query.count" name="query.Query.count"></a>[lua]`query:count()`  
       How many candidates match.
 
       Returns: integer.
 
-    - <a name="query.Query.first"></a>[lua]`query:first()`  
+    - <a id="query.Query.first" name="query.Query.first"></a>[lua]`query:first()`  
       The first matching handle.
 
       Returns: any or `nil`. The handle, or `nil`.
 
-    - <a name="query.Query.ids"></a>[lua]`query:ids()`  
+    - <a id="query.Query.ids" name="query.Query.ids"></a>[lua]`query:ids()`  
       The matching ids. For objects these are object ids; for items, their numbers.
 
       Returns: table. A list of integers.
 
-    - <a name="query.Query.matches"></a>[lua]`query:matches()`  
+    - <a id="query.Query.matches" name="query.Query.matches"></a>[lua]`query:matches()`  
       The matching handles.
 
       Returns: table. A list of [`trx.objects.Object`](OBJECTS.md#objects.Object)s or [`trx.items.Item`](ITEMS.md#items.Item)s.
 
-    - <a name="query.Query.where"></a>[lua]`query:where(predicate)`  
+    - <a id="query.Query.where" name="query.Query.where"></a>[lua]`query:where(predicate)`  
       Narrows by a test of the caller's own, for what the domain does not name.
 
       Parameters:
       - **`predicate`** (function).
         Called with:
         - **`id`** (integer). The candidate's id.
-        - **`handle`** (any). The candidate itself, an `Object` or an `Item`.
+        - **`handle`** (any). The candidate itself, a [`trx.objects.Object`](OBJECTS.md#objects.Object) or a [`trx.items.Item`](ITEMS.md#items.Item).
 
       Returns: [trx.query.Query](#query.Query). The narrowed query.
 
@@ -75,18 +75,18 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
       end)
       ```
 
-- <a name="query.NamedQuery"></a>[lua]`trx.query.NamedQuery`
+- <a id="query.NamedQuery" name="query.NamedQuery"></a>[lua]`trx.query.NamedQuery`
 
-    A query over a domain whose things answer to names, which adds the name layer to everything a `Query` has. A domain without names offers none of it.
+    A query over a domain whose things answer to names, which adds the name layer to everything a [`trx.query.Query`](#query.Query) has. A domain without names offers none of it.
 
     Methods:
 
-    - <a name="query.NamedQuery.best"></a>[lua]`namedquery:best()`  
-      The ids tied for the best `by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `by_name`, every matching id.
+    - <a id="query.NamedQuery.best" name="query.NamedQuery.best"></a>[lua]`namedquery:best()`  
+      The ids tied for the best [`by_name`](#query.NamedQuery.by_name) score: one for a name only one thing answers to, the whole group for a group name. Without a [`by_name`](#query.NamedQuery.by_name), every matching id.
 
       Returns: table. A list of integers.
 
-    - <a name="query.NamedQuery.by_name"></a>[lua]`namedquery:by_name(name)`  
+    - <a id="query.NamedQuery.by_name" name="query.NamedQuery.by_name"></a>[lua]`namedquery:by_name(name)`  
       Ranks rather than filters: matches the way a player types a name, forgivingly, and orders what survives the rest of the query best first. Some of a domain's narrowings are also searchable groups, so their own name matches every member.
 
       Parameters:
@@ -99,14 +99,14 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
       trx.objects.query:spawnable():by_name("wolf"):ids()
       ```
 
-    - <a name="query.NamedQuery.names"></a>[lua]`namedquery:names()`  
-      Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `pickup`.
+    - <a id="query.NamedQuery.names" name="query.NamedQuery.names"></a>[lua]`namedquery:names()`  
+      Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no [`trx.objects.ObjectQuery:pickup`](OBJECTS.md#objects.ObjectQuery.pickup).
 
       Returns: table. A list of names.
 
 ### Functions
 
-- <a name="query.narrowing"></a>[lua]`trx.query.narrowing(make)`  
+- <a id="query.narrowing" name="query.narrowing"></a>[lua]`trx.query.narrowing(make)`  
   Builds a narrowing method for a domain's query type out of a predicate factory. [`trx.items`](ITEMS.md#items) and [`trx.objects`](OBJECTS.md#objects) declare their own filters with it.
 
   Parameters:
@@ -114,7 +114,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
   Returns: function. The method to declare as an `impl`.
 
-- <a name="query.new"></a>[lua]`trx.query.new(domain, class)`  
+- <a id="query.new" name="query.new"></a>[lua]`trx.query.new(domain, class)`  
   Builds the identity query over a domain, as an instance of that domain's query type. [`trx.objects`](OBJECTS.md#objects) and [`trx.items`](ITEMS.md#items) call this to make the query a script reaches through [`trx.objects.query`](OBJECTS.md#objects.query) and [`trx.items.query`](ITEMS.md#items.query).
 
   Parameters:

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -40,7 +40,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
     - <a id="query.Query.count" name="query.Query.count"></a>[lua]`query:count()`  
       How many candidates match.
 
-      Returns: integer.
+      Returns: integer. The count, without building the list.
 
     - <a id="query.Query.first" name="query.Query.first"></a>[lua]`query:first()`  
       The first matching handle.
@@ -61,10 +61,10 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
       Narrows by a test of the caller's own, for what the domain does not name.
 
       Parameters:
-      - **`predicate`** (function).
+      - <a id="query.Query.where.predicate" name="query.Query.where.predicate"></a>**`predicate`** (function). The test each candidate is put through.
         Called with:
-        - **`id`** (integer). The candidate's id.
-        - **`handle`** (any). The candidate itself, a [`trx.objects.Object`](OBJECTS.md#objects.Object) or a [`trx.items.Item`](ITEMS.md#items.Item).
+        - <a id="query.Query.where.id" name="query.Query.where.id"></a>**`id`** (integer). The candidate's id.
+        - <a id="query.Query.where.handle" name="query.Query.where.handle"></a>**`handle`** (any). The candidate itself, a [`trx.objects.Object`](OBJECTS.md#objects.Object) or a [`trx.items.Item`](ITEMS.md#items.Item).
 
       Returns: [trx.query.Query](#query.Query). The narrowed query.
 
@@ -90,7 +90,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
       Ranks rather than filters: matches the way a player types a name, forgivingly, and orders what survives the rest of the query best first. Some of a domain's narrowings are also searchable groups, so their own name matches every member.
 
       Parameters:
-      - **`name`** (string). What to look for.
+      - <a id="query.NamedQuery.by_name.name" name="query.NamedQuery.by_name.name"></a>**`name`** (string). What to look for.
 
       Returns: [trx.query.Query](#query.Query). The narrowed query.
 
@@ -110,7 +110,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
   Builds a narrowing method for a domain's query type out of a predicate factory. [`trx.items`](ITEMS.md#items) and [`trx.objects`](OBJECTS.md#objects) declare their own filters with it.
 
   Parameters:
-  - **`make`** (function). Called with the method's own arguments, returning a `predicate(id, handle)`.
+  - <a id="query.narrowing.make" name="query.narrowing.make"></a>**`make`** (function). Called with the method's own arguments, returning a `predicate(id, handle)`.
 
   Returns: function. The method to declare as an `impl`.
 
@@ -118,7 +118,14 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
   Builds the identity query over a domain, as an instance of that domain's query type. [`trx.objects`](OBJECTS.md#objects) and [`trx.items`](ITEMS.md#items) call this to make the query a script reaches through [`trx.objects.query`](OBJECTS.md#objects.query) and [`trx.items.query`](ITEMS.md#items.query).
 
   Parameters:
-  - **`domain`** (table). What the query runs against: `enumerate`, `id_of`, `searchable`, and an optional `names_of`/`default_names_of` name layer. See the module source.
-  - **`class`** (table). The query type the domain's narrowings were declared on.
+  - <a id="query.new.domain" name="query.new.domain"></a>**`domain`** (table). What the query runs against.
+
+    Keys:
+    - <a id="query.new.domain.enumerate" name="query.new.domain.enumerate"></a>**`enumerate`** (function). Every id the domain holds.
+    - <a id="query.new.domain.id_of" name="query.new.domain.id_of"></a>**`id_of`** (function). The id of a thing the domain hands out.
+    - <a id="query.new.domain.searchable" name="query.new.domain.searchable"></a>**`searchable`** (function). Whether an id is one a name may reach.
+    - <a id="query.new.domain.names_of" name="query.new.domain.names_of"></a>**`names_of`** (function, optional). The names an id answers to, for a domain that has them.
+    - <a id="query.new.domain.default_names_of" name="query.new.domain.default_names_of"></a>**`default_names_of`** (function, optional). The same names before a language file is loaded.
+  - <a id="query.new.class" name="query.new.class"></a>**`class`** (table). The query type the domain's narrowings were declared on.
 
   Returns: [trx.query.Query](#query.Query). The identity query, matching everything until narrowed.

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -13,7 +13,7 @@ order: 9
 ## Query module
 
 A composable filter over a domain of things - the objects a level is built
-from, or the items alive in it. `trx.objects.query` and `trx.items.query` are
+from, or the items alive in it. [`trx.objects.query`](OBJECTS.md#objects.query) and [`trx.items.query`](ITEMS.md#items.query) are
 each the identity query, matching everything; narrow one down, then read the
 result.
 
@@ -21,12 +21,12 @@ A query is immutable. Every method returns a fresh query, so a base can be kept
 and branched from without one narrowing leaking into another.
 
 Each domain adds narrowings of its own on top of the ones below - see
-`trx.items.ItemQuery` and `trx.objects.ObjectQuery` - and chained methods read
+[`trx.items.ItemQuery`](ITEMS.md#items.ItemQuery) and [`trx.objects.ObjectQuery`](OBJECTS.md#objects.ObjectQuery) - and chained methods read
 left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
 ### Structures
 
-- [lua]`trx.query.Query`
+- <a name="query.Query"></a>[lua]`trx.query.Query`
 
     A filter over a domain, read with one of the terminals below once it is narrow enough.
 
@@ -37,27 +37,27 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
 
     Methods:
 
-    - [lua]`query:count()`  
+    - <a name="query.Query.count"></a>[lua]`query:count()`  
       How many candidates match.
 
       Returns: integer.
 
-    - [lua]`query:first()`  
+    - <a name="query.Query.first"></a>[lua]`query:first()`  
       The first matching handle.
 
       Returns: any or `nil`. The handle, or `nil`.
 
-    - [lua]`query:ids()`  
+    - <a name="query.Query.ids"></a>[lua]`query:ids()`  
       The matching ids. For objects these are object ids; for items, their numbers.
 
       Returns: table. A list of integers.
 
-    - [lua]`query:matches()`  
+    - <a name="query.Query.matches"></a>[lua]`query:matches()`  
       The matching handles.
 
-      Returns: table. A list of `trx.objects.Object`s or `trx.items.Item`s.
+      Returns: table. A list of [`trx.objects.Object`](OBJECTS.md#objects.Object)s or [`trx.items.Item`](ITEMS.md#items.Item)s.
 
-    - [lua]`query:where(predicate)`  
+    - <a name="query.Query.where"></a>[lua]`query:where(predicate)`  
       Narrows by a test of the caller's own, for what the domain does not name.
 
       Parameters:
@@ -66,7 +66,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
         - **`id`** (integer). The candidate's id.
         - **`handle`** (any). The candidate itself, an `Object` or an `Item`.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](#query.Query). The narrowed query.
 
       Example:
       ```lua
@@ -75,50 +75,50 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
       end)
       ```
 
-- [lua]`trx.query.NamedQuery`
+- <a name="query.NamedQuery"></a>[lua]`trx.query.NamedQuery`
 
     A query over a domain whose things answer to names, which adds the name layer to everything a `Query` has. A domain without names offers none of it.
 
     Methods:
 
-    - [lua]`namedquery:best()`  
+    - <a name="query.NamedQuery.best"></a>[lua]`namedquery:best()`  
       The ids tied for the best `by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `by_name`, every matching id.
 
       Returns: table. A list of integers.
 
-    - [lua]`namedquery:by_name(name)`  
+    - <a name="query.NamedQuery.by_name"></a>[lua]`namedquery:by_name(name)`  
       Ranks rather than filters: matches the way a player types a name, forgivingly, and orders what survives the rest of the query best first. Some of a domain's narrowings are also searchable groups, so their own name matches every member.
 
       Parameters:
       - **`name`** (string). What to look for.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](#query.Query). The narrowed query.
 
       Example:
       ```lua
       trx.objects.query:spawnable():by_name("wolf"):ids()
       ```
 
-    - [lua]`namedquery:names()`  
+    - <a name="query.NamedQuery.names"></a>[lua]`namedquery:names()`  
       Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `pickup`.
 
       Returns: table. A list of names.
 
 ### Functions
 
-- [lua]`trx.query.narrowing(make)`  
-  Builds a narrowing method for a domain's query type out of a predicate factory. `trx.items` and `trx.objects` declare their own filters with it.
+- <a name="query.narrowing"></a>[lua]`trx.query.narrowing(make)`  
+  Builds a narrowing method for a domain's query type out of a predicate factory. [`trx.items`](ITEMS.md#items) and [`trx.objects`](OBJECTS.md#objects) declare their own filters with it.
 
   Parameters:
   - **`make`** (function). Called with the method's own arguments, returning a `predicate(id, handle)`.
 
   Returns: function. The method to declare as an `impl`.
 
-- [lua]`trx.query.new(domain, class)`  
-  Builds the identity query over a domain, as an instance of that domain's query type. `trx.objects` and `trx.items` call this to make the query a script reaches through `trx.objects.query` and `trx.items.query`.
+- <a name="query.new"></a>[lua]`trx.query.new(domain, class)`  
+  Builds the identity query over a domain, as an instance of that domain's query type. [`trx.objects`](OBJECTS.md#objects) and [`trx.items`](ITEMS.md#items) call this to make the query a script reaches through [`trx.objects.query`](OBJECTS.md#objects.query) and [`trx.items.query`](ITEMS.md#items.query).
 
   Parameters:
   - **`domain`** (table). What the query runs against: `enumerate`, `id_of`, `searchable`, and an optional `names_of`/`default_names_of` name layer. See the module source.
   - **`class`** (table). The query type the domain's narrowings were declared on.
 
-  Returns: Query. The identity query, matching everything until narrowed.
+  Returns: [trx.query.Query](#query.Query). The identity query, matching everything until narrowed.

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -178,7 +178,7 @@ end
 ### Functions
 
 - [lua]`trx.rooms.get(num)`  
-  Retrieves a room by number. Rooms count from zero, matching the room numbers level editors show.
+  Retrieves a room by number.
 
   Parameters:
   - **`num`** (integer). 0-based room number, matching the numbers level editors show.

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -71,7 +71,7 @@ end
     - <a id="rooms.Room.wind" name="rooms.Room.wind"></a>**`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
 
     Computed properties (derived, not stored on the object):
-    - <a id="rooms.Room.bounds" name="rooms.Room.bounds"></a>**`bounds`**: [trx.math.Box](MATH.md#math.Box). Where the room sits, in world coordinates.
+    - <a id="rooms.Room.bounds" name="rooms.Room.bounds"></a>**`bounds`**: [trx.math.Box](MATH.md#math.Box). Where the room sits in the world.
     - <a id="rooms.Room.flipped_room" name="rooms.Room.flipped_room"></a>**`flipped_room`**: [trx.rooms.Room](#rooms.Room). This room's flip pair, or `nil` if it has none.
     - <a id="rooms.Room.internal_bounds" name="rooms.Room.internal_bounds"></a>**`internal_bounds`**: [trx.math.Box](MATH.md#math.Box). As [`bounds`](#rooms.Room.bounds), but excluding the outer ring of sectors, which is solid wall.
 
@@ -87,7 +87,7 @@ end
         Keys:
         - <a id="rooms.Room.floor_height.opts.fix_tilts" name="rooms.Room.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
 
-      Returns: integer or `nil`. The height, in world units, with `nil` where there is no floor.
+      Returns: [trx.math.Distance](MATH.md#math.Distance) or `nil`. The height, with `nil` where there is no floor.
 
     - <a id="rooms.Room.is_valid" name="rooms.Room.is_valid"></a>[lua]`room:is_valid()`  
       Whether the handle still refers to a room of the level that is loaded. A level change replaces the rooms, so a handle held across one goes stale rather than naming a different room: reading or writing a field on it raises an error. Check this for a handle held across time.
@@ -235,7 +235,7 @@ end
     Keys:
     - <a id="rooms.floor_height.opts.fix_tilts" name="rooms.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
 
-  Returns: integer or `nil`. The height, in world units, with `nil` where there is no floor.
+  Returns: [trx.math.Distance](MATH.md#math.Distance) or `nil`. The height, with `nil` where there is no floor.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -10,7 +10,7 @@ order: 6
   src/lua/api/rooms.lua. Edit it there.
 -->
 
-## Rooms module
+## <a id="rooms" name="rooms"></a>Rooms module
 
 Module for inspecting and altering the rooms of the current level.
 
@@ -18,7 +18,7 @@ Module for inspecting and altering the rooms of the current level.
 
 Indexing the module reaches a room, and `#trx.rooms` is how many the level has. `pairs()` walks them in order, keyed by the room number.
 
-- <a name="rooms[]"></a>**`trx.rooms[key]`** ([trx.rooms.Room](#rooms.Room) or `nil`).
+- <a id="rooms[]" name="rooms[]"></a>**`trx.rooms[key]`** ([trx.rooms.Room](#rooms.Room) or `nil`).
 - **`#trx.rooms`** (integer). How many there are.
 
 Example:
@@ -31,14 +31,14 @@ end
 
 ### Properties
 
-- <a name="rooms.flipped"></a>**`trx.rooms.flipped`** (boolean). Whether the room map is currently flipped. *(read-only)*
-- <a name="rooms.query"></a>**`trx.rooms.query`** ([trx.rooms.RoomQuery](#rooms.RoomQuery)). The identity query over every room in the level. Narrow it and read it. *(read-only)*
+- <a id="rooms.flipped" name="rooms.flipped"></a>**`trx.rooms.flipped`** (boolean). Whether the room map is currently flipped. *(read-only)*
+- <a id="rooms.query" name="rooms.query"></a>**`trx.rooms.query`** ([trx.rooms.RoomQuery](#rooms.RoomQuery)). The identity query over every room in the level. Narrow it and read it. *(read-only)*
 
 ### Enums
 
-- <a name="rooms.FlipStatus"></a>[lua]`trx.rooms.FlipStatus`
+- <a id="rooms.FlipStatus" name="rooms.FlipStatus"></a>[lua]`trx.rooms.FlipStatus`
 
-    The values `room.flip_status` can take.
+    The values [`trx.rooms.Room.flip_status`](#rooms.Room.flip_status) can take.
 
     - `trx.rooms.FlipStatus.NONE` = `0`  
         This is a normal room.
@@ -49,11 +49,11 @@ end
 
 ### Structures
 
-- <a name="rooms.Num"></a>[lua]`trx.rooms.Num`
+- <a id="rooms.Num" name="rooms.Num"></a>[lua]`trx.rooms.Num`
 
     Room number, matching the numbers level editors show. Counted from 0.
 
-- <a name="rooms.Room"></a>[lua]`trx.rooms.Room`
+- <a id="rooms.Room" name="rooms.Room"></a>[lua]`trx.rooms.Room`
 
     A room in the current level.
 
@@ -62,22 +62,22 @@ end
     unrelated one.
 
     Properties:
-    - <a name="rooms.Room.cold"></a>**`cold`**: boolean. Whether Lara's breath is visible in the room.
-    - <a name="rooms.Room.damaging"></a>**`damaging`**: boolean. Whether the room drains Lara's exposure meter.
-    - <a name="rooms.Room.flip_status"></a>**`flip_status`**: [trx.rooms.FlipStatus](#rooms.FlipStatus). Current flip status. *(read-only)*
-    - <a name="rooms.Room.num"></a>**`num`**: [trx.rooms.Num](#rooms.Num). *(read-only)*
-    - <a name="rooms.Room.swamp"></a>**`swamp`**: boolean. Whether the room is filled with swamp water, which Lara wades through and sinks into rather than swimming.
-    - <a name="rooms.Room.underwater"></a>**`underwater`**: boolean. Whether the room is filled with water.
-    - <a name="rooms.Room.wind"></a>**`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
+    - <a id="rooms.Room.cold" name="rooms.Room.cold"></a>**`cold`**: boolean. Whether Lara's breath is visible in the room.
+    - <a id="rooms.Room.damaging" name="rooms.Room.damaging"></a>**`damaging`**: boolean. Whether the room drains Lara's exposure meter.
+    - <a id="rooms.Room.flip_status" name="rooms.Room.flip_status"></a>**`flip_status`**: [trx.rooms.FlipStatus](#rooms.FlipStatus). Current flip status. *(read-only)*
+    - <a id="rooms.Room.num" name="rooms.Room.num"></a>**`num`**: [trx.rooms.Num](#rooms.Num). *(read-only)*
+    - <a id="rooms.Room.swamp" name="rooms.Room.swamp"></a>**`swamp`**: boolean. Whether the room is filled with swamp water, which Lara wades through and sinks into rather than swimming.
+    - <a id="rooms.Room.underwater" name="rooms.Room.underwater"></a>**`underwater`**: boolean. Whether the room is filled with water.
+    - <a id="rooms.Room.wind" name="rooms.Room.wind"></a>**`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
 
     Computed properties (derived, not stored on the object):
-    - <a name="rooms.Room.bounds"></a>**`bounds`**: table. World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`.
-    - <a name="rooms.Room.flipped_room"></a>**`flipped_room`**: [trx.rooms.Room](#rooms.Room). This room's flip pair, or `nil` if it has none.
-    - <a name="rooms.Room.internal_bounds"></a>**`internal_bounds`**: table. As `bounds`, but excluding the outer ring of sectors, which is solid wall.
+    - <a id="rooms.Room.bounds" name="rooms.Room.bounds"></a>**`bounds`**: table. World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`.
+    - <a id="rooms.Room.flipped_room" name="rooms.Room.flipped_room"></a>**`flipped_room`**: [trx.rooms.Room](#rooms.Room). This room's flip pair, or `nil` if it has none.
+    - <a id="rooms.Room.internal_bounds" name="rooms.Room.internal_bounds"></a>**`internal_bounds`**: table. As [`bounds`](#rooms.Room.bounds), but excluding the outer ring of sectors, which is solid wall.
 
     Methods:
 
-    - <a name="rooms.Room.floor_height"></a>[lua]`room:floor_height(pos, [opts])`  
+    - <a id="rooms.Room.floor_height" name="rooms.Room.floor_height"></a>[lua]`room:floor_height(pos, [opts])`  
       As [`trx.rooms.floor_height`](#rooms.floor_height), looking from this room.
 
       Parameters:
@@ -86,7 +86,7 @@ end
 
       Returns: integer or `nil`.
 
-    - <a name="rooms.Room.is_valid"></a>[lua]`room:is_valid()`  
+    - <a id="rooms.Room.is_valid" name="rooms.Room.is_valid"></a>[lua]`room:is_valid()`  
       Whether the handle still refers to a room of the level that is loaded. A level change replaces the rooms, so a handle held across one goes stale rather than naming a different room: reading or writing a field on it raises an error. Check this for a handle held across time.
 
       Returns: boolean.
@@ -101,7 +101,7 @@ end
       end)
       ```
 
-    - <a name="rooms.Room.on_enter"></a>[lua]`room:on_enter(callback, [opts])`  
+    - <a id="rooms.Room.on_enter" name="rooms.Room.on_enter"></a>[lua]`room:on_enter(callback, [opts])`  
       Happens when something changes rooms into this one.
 
       Parameters:
@@ -119,7 +119,7 @@ end
       end)
       ```
 
-    - <a name="rooms.Room.on_exit"></a>[lua]`room:on_exit(callback, [opts])`  
+    - <a id="rooms.Room.on_exit" name="rooms.Room.on_exit"></a>[lua]`room:on_exit(callback, [opts])`  
       Happens when something changes rooms out of this one.
 
       Parameters:
@@ -130,13 +130,13 @@ end
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
-- <a name="rooms.RoomQuery"></a>[lua]`trx.rooms.RoomQuery`
+- <a id="rooms.RoomQuery" name="rooms.RoomQuery"></a>[lua]`trx.rooms.RoomQuery`
 
     A [`trx.query.Query`](QUERY.md#query.Query) over the rooms of the current level, with the narrowings below on top of the ones every query has. Rooms answer to no names, so the name layer is absent.
 
     Methods:
 
-    - <a name="rooms.RoomQuery.at"></a>[lua]`roomquery:at(pos)`  
+    - <a id="rooms.RoomQuery.at" name="rooms.RoomQuery.at"></a>[lua]`roomquery:at(pos)`  
       The room contains a world position. Rooms overlap, so a position can be in several at once and every one of them matches, in room order. A room claims a point when the point is within its bounds, the outer ring of solid wall aside, and the column it stands in has a floor - the test the engine itself puts a position through. The hidden half of a flip pair is passed over.
 
       Parameters:
@@ -149,18 +149,18 @@ end
       trx.rooms.query:at(trx.lara.item.pos):first()
       ```
 
-    - <a name="rooms.RoomQuery.dry"></a>[lua]`roomquery:dry()`  
+    - <a id="rooms.RoomQuery.dry" name="rooms.RoomQuery.dry"></a>[lua]`roomquery:dry()`  
       The room holds neither water nor swamp water.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="rooms.RoomQuery.flipped"></a>[lua]`roomquery:flipped()`  
+    - <a id="rooms.RoomQuery.flipped" name="rooms.RoomQuery.flipped"></a>[lua]`roomquery:flipped()`  
       The room is the half of a flip pair the level is not showing. Its geometry is still there to inspect, but nothing can be in it.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="rooms.RoomQuery.reachable"></a>[lua]`roomquery:reachable()`  
-      The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what `at` already applies.
+    - <a id="rooms.RoomQuery.reachable" name="rooms.RoomQuery.reachable"></a>[lua]`roomquery:reachable()`  
+      The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what [`at`](#rooms.RoomQuery.at) already applies.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -169,19 +169,19 @@ end
       trx.rooms.query:reachable():underwater():count()
       ```
 
-    - <a name="rooms.RoomQuery.swamp"></a>[lua]`roomquery:swamp()`  
+    - <a id="rooms.RoomQuery.swamp" name="rooms.RoomQuery.swamp"></a>[lua]`roomquery:swamp()`  
       The room is filled with swamp water.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - <a name="rooms.RoomQuery.underwater"></a>[lua]`roomquery:underwater()`  
+    - <a id="rooms.RoomQuery.underwater" name="rooms.RoomQuery.underwater"></a>[lua]`roomquery:underwater()`  
       The room is filled with water.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
 ### Functions
 
-- <a name="rooms.get"></a>[lua]`trx.rooms.get(num)`  
+- <a id="rooms.get" name="rooms.get"></a>[lua]`trx.rooms.get(num)`  
   Retrieves a room by number.
 
   Parameters:
@@ -195,15 +195,15 @@ end
   room.underwater = true
   ```
 
-- <a name="rooms.count"></a>[lua]`trx.rooms.count()`  
+- <a id="rooms.count" name="rooms.count"></a>[lua]`trx.rooms.count()`  
   Returns the number of rooms in the level. Same as `#trx.rooms`.
 
   Returns: integer.
 
-- <a name="rooms.flip"></a>[lua]`trx.rooms.flip()`  
+- <a id="rooms.flip" name="rooms.flip"></a>[lua]`trx.rooms.flip()`  
   Flips the current room map, swapping every room with its flip pair.
 
-- <a name="rooms.flip_effect"></a>[lua]`trx.rooms.flip_effect(effect_id, [timer])`  
+- <a id="rooms.flip_effect" name="rooms.flip_effect"></a>[lua]`trx.rooms.flip_effect(effect_id, [timer])`  
   Sets the active flip effect, and optionally its timer.
 
   Parameters:
@@ -215,12 +215,12 @@ end
   trx.rooms.flip_effect(trx.catalog.flip_effects.floor_shake, 10)
   ```
 
-- <a name="rooms.floor_height"></a>[lua]`trx.rooms.floor_height(pos, [room_num], [opts])`  
+- <a id="rooms.floor_height" name="rooms.floor_height"></a>[lua]`trx.rooms.floor_height(pos, [room_num], [opts])`  
   The height of the floor under a world position. `nil` where there is no floor at all: inside solid geometry, or off the edge of the level.
 
   Parameters:
   - **`pos`** (vec3). World position.
-  - **`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `room:floor_height`.
+  - **`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with [`trx.rooms.Room:floor_height`](#rooms.Room.floor_height).
   - **`opts`** (table, optional). `fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
 
   Returns: integer or `nil`.
@@ -230,7 +230,7 @@ end
   local floor = trx.lara.item.room:floor_height(trx.lara.item.pos)
   ```
 
-- <a name="rooms.find_valid_pos"></a>[lua]`trx.rooms.find_valid_pos(pos, room_num)`  
+- <a id="rooms.find_valid_pos" name="rooms.find_valid_pos"></a>[lua]`trx.rooms.find_valid_pos(pos, room_num)`  
   Nudges a position into valid room geometry, e.g. to find somewhere an item can legally be placed.
 
   Parameters:

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -16,9 +16,9 @@ Module for inspecting and altering the rooms of the current level.
 
 ### Indexing
 
-Indexing the module reaches a room, and `#trx.rooms` is how many the level has. Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them in order, keyed by that number.
+Indexing the module reaches a room, and `#trx.rooms` is how many the level has. `pairs()` walks them in order, keyed by the room number.
 
-- **`trx.rooms[key]`** (Room or `nil`). 0-based room number, matching the numbers level editors show.
+- <a name="rooms[]"></a>**`trx.rooms[key]`** ([trx.rooms.Room](#rooms.Room) or `nil`).
 - **`#trx.rooms`** (integer). How many there are.
 
 Example:
@@ -31,12 +31,12 @@ end
 
 ### Properties
 
-- **`trx.rooms.flipped`** (boolean). Whether the room map is currently flipped. *(read-only)*
-- **`trx.rooms.query`** (RoomQuery). The identity query over every room in the level. Narrow it and read it - see `trx.rooms.RoomQuery`. *(read-only)*
+- <a name="rooms.flipped"></a>**`trx.rooms.flipped`** (boolean). Whether the room map is currently flipped. *(read-only)*
+- <a name="rooms.query"></a>**`trx.rooms.query`** ([trx.rooms.RoomQuery](#rooms.RoomQuery)). The identity query over every room in the level. Narrow it and read it. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.rooms.FlipStatus`
+- <a name="rooms.FlipStatus"></a>[lua]`trx.rooms.FlipStatus`
 
     The values `room.flip_status` can take.
 
@@ -49,7 +49,11 @@ end
 
 ### Structures
 
-- [lua]`trx.rooms.Room`
+- <a name="rooms.Num"></a>[lua]`trx.rooms.Num`
+
+    Room number, matching the numbers level editors show. Counted from 0.
+
+- <a name="rooms.Room"></a>[lua]`trx.rooms.Room`
 
     A room in the current level.
 
@@ -58,23 +62,23 @@ end
     unrelated one.
 
     Properties:
-    - **`cold`**: boolean. Whether Lara's breath is visible in the room.
-    - **`damaging`**: boolean. Whether the room drains Lara's exposure meter.
-    - **`flip_status`**: integer. Current flip status. Compare against `trx.rooms.FlipStatus`. *(read-only)*
-    - **`num`**: integer. 0-based room number, matching the numbers level editors show. *(read-only)*
-    - **`swamp`**: boolean. Whether the room is filled with swamp water, which Lara wades through and sinks into rather than swimming.
-    - **`underwater`**: boolean. Whether the room is filled with water.
-    - **`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
+    - <a name="rooms.Room.cold"></a>**`cold`**: boolean. Whether Lara's breath is visible in the room.
+    - <a name="rooms.Room.damaging"></a>**`damaging`**: boolean. Whether the room drains Lara's exposure meter.
+    - <a name="rooms.Room.flip_status"></a>**`flip_status`**: [trx.rooms.FlipStatus](#rooms.FlipStatus). Current flip status. *(read-only)*
+    - <a name="rooms.Room.num"></a>**`num`**: [trx.rooms.Num](#rooms.Num). *(read-only)*
+    - <a name="rooms.Room.swamp"></a>**`swamp`**: boolean. Whether the room is filled with swamp water, which Lara wades through and sinks into rather than swimming.
+    - <a name="rooms.Room.underwater"></a>**`underwater`**: boolean. Whether the room is filled with water.
+    - <a name="rooms.Room.wind"></a>**`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
 
     Computed properties (derived, not stored on the object):
-    - **`bounds`**: table. World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`.
-    - **`flipped_room`**: Room. This room's flip pair, or `nil` if it has none.
-    - **`internal_bounds`**: table. As `bounds`, but excluding the outer ring of sectors, which is solid wall.
+    - <a name="rooms.Room.bounds"></a>**`bounds`**: table. World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`.
+    - <a name="rooms.Room.flipped_room"></a>**`flipped_room`**: [trx.rooms.Room](#rooms.Room). This room's flip pair, or `nil` if it has none.
+    - <a name="rooms.Room.internal_bounds"></a>**`internal_bounds`**: table. As `bounds`, but excluding the outer ring of sectors, which is solid wall.
 
     Methods:
 
-    - [lua]`room:floor_height(pos, [opts])`  
-      As `trx.rooms.floor_height`, looking from this room.
+    - <a name="rooms.Room.floor_height"></a>[lua]`room:floor_height(pos, [opts])`  
+      As [`trx.rooms.floor_height`](#rooms.floor_height), looking from this room.
 
       Parameters:
       - **`pos`** (vec3). World position.
@@ -82,7 +86,7 @@ end
 
       Returns: integer or `nil`.
 
-    - [lua]`room:is_valid()`  
+    - <a name="rooms.Room.is_valid"></a>[lua]`room:is_valid()`  
       Whether the handle still refers to a room of the level that is loaded. A level change replaces the rooms, so a handle held across one goes stale rather than naming a different room: reading or writing a field on it raises an error. Check this for a handle held across time.
 
       Returns: boolean.
@@ -97,16 +101,16 @@ end
       end)
       ```
 
-    - [lua]`room:on_enter(callback, [opts])`  
+    - <a name="rooms.Room.on_enter"></a>[lua]`room:on_enter(callback, [opts])`  
       Happens when something changes rooms into this one.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). The `trx.items.Item` that changed rooms.
+        - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
       - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
       Example:
       ```lua
@@ -115,75 +119,75 @@ end
       end)
       ```
 
-    - [lua]`room:on_exit(callback, [opts])`  
+    - <a name="rooms.Room.on_exit"></a>[lua]`room:on_exit(callback, [opts])`  
       Happens when something changes rooms out of this one.
 
       Parameters:
       - **`callback`** (function).
         Called with:
-        - **`item`** (Item). The `trx.items.Item` that changed rooms.
+        - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
       - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
 
-      Returns: events.Listener. The attached handler.
+      Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
-- [lua]`trx.rooms.RoomQuery`
+- <a name="rooms.RoomQuery"></a>[lua]`trx.rooms.RoomQuery`
 
-    A `trx.query.Query` over the rooms of the current level, with the narrowings below on top of the ones every query has. Rooms answer to no names, so the name layer is absent.
+    A [`trx.query.Query`](QUERY.md#query.Query) over the rooms of the current level, with the narrowings below on top of the ones every query has. Rooms answer to no names, so the name layer is absent.
 
     Methods:
 
-    - [lua]`roomquery:at(pos)`  
+    - <a name="rooms.RoomQuery.at"></a>[lua]`roomquery:at(pos)`  
       The room contains a world position. Rooms overlap, so a position can be in several at once and every one of them matches, in room order. A room claims a point when the point is within its bounds, the outer ring of solid wall aside, and the column it stands in has a floor - the test the engine itself puts a position through. The hidden half of a flip pair is passed over.
 
       Parameters:
       - **`pos`** (vec3). World position.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
       Example:
       ```lua
       trx.rooms.query:at(trx.lara.item.pos):first()
       ```
 
-    - [lua]`roomquery:dry()`  
+    - <a name="rooms.RoomQuery.dry"></a>[lua]`roomquery:dry()`  
       The room holds neither water nor swamp water.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`roomquery:flipped()`  
+    - <a name="rooms.RoomQuery.flipped"></a>[lua]`roomquery:flipped()`  
       The room is the half of a flip pair the level is not showing. Its geometry is still there to inspect, but nothing can be in it.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`roomquery:reachable()`  
+    - <a name="rooms.RoomQuery.reachable"></a>[lua]`roomquery:reachable()`  
       The room is part of the level as it stands: an ordinary room, or the half of a flip pair the level is showing. This is what a script asking about the world wants, and what `at` already applies.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
       Example:
       ```lua
       trx.rooms.query:reachable():underwater():count()
       ```
 
-    - [lua]`roomquery:swamp()`  
+    - <a name="rooms.RoomQuery.swamp"></a>[lua]`roomquery:swamp()`  
       The room is filled with swamp water.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
-    - [lua]`roomquery:underwater()`  
+    - <a name="rooms.RoomQuery.underwater"></a>[lua]`roomquery:underwater()`  
       The room is filled with water.
 
-      Returns: Query. The narrowed query.
+      Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
 ### Functions
 
-- [lua]`trx.rooms.get(num)`  
+- <a name="rooms.get"></a>[lua]`trx.rooms.get(num)`  
   Retrieves a room by number.
 
   Parameters:
-  - **`num`** (integer). 0-based room number, matching the numbers level editors show.
+  - **`num`** ([trx.rooms.Num](#rooms.Num)).
 
-  Returns: Room or `nil`.
+  Returns: [trx.rooms.Room](#rooms.Room) or `nil`.
 
   Example:
   ```lua
@@ -191,19 +195,19 @@ end
   room.underwater = true
   ```
 
-- [lua]`trx.rooms.count()`  
+- <a name="rooms.count"></a>[lua]`trx.rooms.count()`  
   Returns the number of rooms in the level. Same as `#trx.rooms`.
 
   Returns: integer.
 
-- [lua]`trx.rooms.flip()`  
+- <a name="rooms.flip"></a>[lua]`trx.rooms.flip()`  
   Flips the current room map, swapping every room with its flip pair.
 
-- [lua]`trx.rooms.flip_effect(effect_id, [timer])`  
+- <a name="rooms.flip_effect"></a>[lua]`trx.rooms.flip_effect(effect_id, [timer])`  
   Sets the active flip effect, and optionally its timer.
 
   Parameters:
-  - **`effect_id`** (integer). Use `-1` to clear the current effect. Compare against `trx.catalog.flip_effects`.
+  - **`effect_id`** ([trx.catalog.flip_effects](CATALOG.md#catalog.flip_effects)). Use `-1` to clear the current effect.
   - **`timer`** (integer, optional). Flip timer value.
 
   Example:
@@ -211,12 +215,12 @@ end
   trx.rooms.flip_effect(trx.catalog.flip_effects.floor_shake, 10)
   ```
 
-- [lua]`trx.rooms.floor_height(pos, [room_num], [opts])`  
+- <a name="rooms.floor_height"></a>[lua]`trx.rooms.floor_height(pos, [room_num], [opts])`  
   The height of the floor under a world position. `nil` where there is no floor at all: inside solid geometry, or off the edge of the level.
 
   Parameters:
   - **`pos`** (vec3). World position.
-  - **`room_num`** (integer, optional). 0-based room to look from. The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `room:floor_height`.
+  - **`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `room:floor_height`.
   - **`opts`** (table, optional). `fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
 
   Returns: integer or `nil`.
@@ -226,13 +230,13 @@ end
   local floor = trx.lara.item.room:floor_height(trx.lara.item.pos)
   ```
 
-- [lua]`trx.rooms.find_valid_pos(pos, room_num)`  
+- <a name="rooms.find_valid_pos"></a>[lua]`trx.rooms.find_valid_pos(pos, room_num)`  
   Nudges a position into valid room geometry, e.g. to find somewhere an item can legally be placed.
 
   Parameters:
   - **`pos`** (vec3). Position to search near.
-  - **`room_num`** (integer). 0-based room to search from.
+  - **`room_num`** ([trx.rooms.Num](#rooms.Num)).
 
   Returns:
   - vec3 or `nil`. The valid position, or `nil` if none was found nearby.
-  - integer. The 0-based room the position is in.
+  - [trx.rooms.Num](#rooms.Num). The room the position is in.

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -71,9 +71,9 @@ end
     - <a id="rooms.Room.wind" name="rooms.Room.wind"></a>**`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
 
     Computed properties (derived, not stored on the object):
-    - <a id="rooms.Room.bounds" name="rooms.Room.bounds"></a>**`bounds`**: table. World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, `max_y`, `max_z`.
+    - <a id="rooms.Room.bounds" name="rooms.Room.bounds"></a>**`bounds`**: [trx.math.Box](MATH.md#math.Box). Where the room sits, in world coordinates.
     - <a id="rooms.Room.flipped_room" name="rooms.Room.flipped_room"></a>**`flipped_room`**: [trx.rooms.Room](#rooms.Room). This room's flip pair, or `nil` if it has none.
-    - <a id="rooms.Room.internal_bounds" name="rooms.Room.internal_bounds"></a>**`internal_bounds`**: table. As [`bounds`](#rooms.Room.bounds), but excluding the outer ring of sectors, which is solid wall.
+    - <a id="rooms.Room.internal_bounds" name="rooms.Room.internal_bounds"></a>**`internal_bounds`**: [trx.math.Box](MATH.md#math.Box). As [`bounds`](#rooms.Room.bounds), but excluding the outer ring of sectors, which is solid wall.
 
     Methods:
 
@@ -81,15 +81,18 @@ end
       As [`trx.rooms.floor_height`](#rooms.floor_height), looking from this room.
 
       Parameters:
-      - **`pos`** (vec3). World position.
-      - **`opts`** (table, optional). `fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
+      - <a id="rooms.Room.floor_height.pos" name="rooms.Room.floor_height.pos"></a>**`pos`** (vec3). World position.
+      - <a id="rooms.Room.floor_height.opts" name="rooms.Room.floor_height.opts"></a>**`opts`** (table, optional). How to read the floor.
 
-      Returns: integer or `nil`.
+        Keys:
+        - <a id="rooms.Room.floor_height.opts.fix_tilts" name="rooms.Room.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
+
+      Returns: integer or `nil`. The height, in world units, with `nil` where there is no floor.
 
     - <a id="rooms.Room.is_valid" name="rooms.Room.is_valid"></a>[lua]`room:is_valid()`  
       Whether the handle still refers to a room of the level that is loaded. A level change replaces the rooms, so a handle held across one goes stale rather than naming a different room: reading or writing a field on it raises an error. Check this for a handle held across time.
 
-      Returns: boolean.
+      Returns: boolean. False once the level that held the room has been left.
 
       Example:
       ```lua
@@ -105,10 +108,13 @@ end
       Happens when something changes rooms into this one.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="rooms.Room.on_enter.callback" name="rooms.Room.on_enter.callback"></a>**`callback`** (function). What to run when it happens.
         Called with:
-        - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
-      - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
+        - <a id="rooms.Room.on_enter.item" name="rooms.Room.on_enter.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
+      - <a id="rooms.Room.on_enter.opts" name="rooms.Room.on_enter.opts"></a>**`opts`** (table, optional). What to watch for.
+
+        Keys:
+        - <a id="rooms.Room.on_enter.opts.watch" name="rooms.Room.on_enter.opts.watch"></a>**`watch`** (string, optional, default `"lara"`). Either `"lara"`, which reacts to Lara alone, or `"all"`, which reacts to every item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -123,10 +129,13 @@ end
       Happens when something changes rooms out of this one.
 
       Parameters:
-      - **`callback`** (function).
+      - <a id="rooms.Room.on_exit.callback" name="rooms.Room.on_exit.callback"></a>**`callback`** (function). What to run when it happens.
         Called with:
-        - **`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
-      - **`opts`** (table, optional). Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` to every item.
+        - <a id="rooms.Room.on_exit.item" name="rooms.Room.on_exit.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item that changed rooms.
+      - <a id="rooms.Room.on_exit.opts" name="rooms.Room.on_exit.opts"></a>**`opts`** (table, optional). What to watch for.
+
+        Keys:
+        - <a id="rooms.Room.on_exit.opts.watch" name="rooms.Room.on_exit.opts.watch"></a>**`watch`** (string, optional, default `"lara"`). Either `"lara"`, which reacts to Lara alone, or `"all"`, which reacts to every item.
 
       Returns: [trx.events.Listener](EVENTS.md#events.Listener). The attached handler.
 
@@ -140,7 +149,7 @@ end
       The room contains a world position. Rooms overlap, so a position can be in several at once and every one of them matches, in room order. A room claims a point when the point is within its bounds, the outer ring of solid wall aside, and the column it stands in has a floor - the test the engine itself puts a position through. The hidden half of a flip pair is passed over.
 
       Parameters:
-      - **`pos`** (vec3). World position.
+      - <a id="rooms.RoomQuery.at.pos" name="rooms.RoomQuery.at.pos"></a>**`pos`** (vec3). World position.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -185,9 +194,9 @@ end
   Retrieves a room by number.
 
   Parameters:
-  - **`num`** ([trx.rooms.Num](#rooms.Num)).
+  - <a id="rooms.get.num" name="rooms.get.num"></a>**`num`** ([trx.rooms.Num](#rooms.Num)).
 
-  Returns: [trx.rooms.Room](#rooms.Room) or `nil`.
+  Returns: [trx.rooms.Room](#rooms.Room) or `nil`. The room, or `nil` where the level has no such number.
 
   Example:
   ```lua
@@ -198,7 +207,7 @@ end
 - <a id="rooms.count" name="rooms.count"></a>[lua]`trx.rooms.count()`  
   Returns the number of rooms in the level. Same as `#trx.rooms`.
 
-  Returns: integer.
+  Returns: integer. How many rooms the loaded level holds.
 
 - <a id="rooms.flip" name="rooms.flip"></a>[lua]`trx.rooms.flip()`  
   Flips the current room map, swapping every room with its flip pair.
@@ -207,8 +216,8 @@ end
   Sets the active flip effect, and optionally its timer.
 
   Parameters:
-  - **`effect_id`** ([trx.catalog.flip_effects](CATALOG.md#catalog.flip_effects)). Use `-1` to clear the current effect.
-  - **`timer`** (integer, optional). Flip timer value.
+  - <a id="rooms.flip_effect.effect_id" name="rooms.flip_effect.effect_id"></a>**`effect_id`** ([trx.catalog.flip_effects](CATALOG.md#catalog.flip_effects)). Use `-1` to clear the current effect.
+  - <a id="rooms.flip_effect.timer" name="rooms.flip_effect.timer"></a>**`timer`** (integer, optional). Flip timer value.
 
   Example:
   ```lua
@@ -219,11 +228,14 @@ end
   The height of the floor under a world position. `nil` where there is no floor at all: inside solid geometry, or off the edge of the level.
 
   Parameters:
-  - **`pos`** (vec3). World position.
-  - **`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with [`trx.rooms.Room:floor_height`](#rooms.Room.floor_height).
-  - **`opts`** (table, optional). `fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, `true` by default. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
+  - <a id="rooms.floor_height.pos" name="rooms.floor_height.pos"></a>**`pos`** (vec3). World position.
+  - <a id="rooms.floor_height.room_num" name="rooms.floor_height.room_num"></a>**`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with [`trx.rooms.Room:floor_height`](#rooms.Room.floor_height).
+  - <a id="rooms.floor_height.opts" name="rooms.floor_height.opts"></a>**`opts`** (table, optional). How to read the floor.
 
-  Returns: integer or `nil`.
+    Keys:
+    - <a id="rooms.floor_height.opts.fix_tilts" name="rooms.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
+
+  Returns: integer or `nil`. The height, in world units, with `nil` where there is no floor.
 
   Example:
   ```lua
@@ -234,8 +246,8 @@ end
   Nudges a position into valid room geometry, e.g. to find somewhere an item can legally be placed.
 
   Parameters:
-  - **`pos`** (vec3). Position to search near.
-  - **`room_num`** ([trx.rooms.Num](#rooms.Num)).
+  - <a id="rooms.find_valid_pos.pos" name="rooms.find_valid_pos.pos"></a>**`pos`** (vec3). Position to search near.
+  - <a id="rooms.find_valid_pos.room_num" name="rooms.find_valid_pos.room_num"></a>**`room_num`** ([trx.rooms.Num](#rooms.Num)).
 
   Returns:
   - vec3 or `nil`. The valid position, or `nil` if none was found nearby.

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -15,7 +15,7 @@ order: 14
 Module for the numbers the engine plays by.
 
 These are the game's rules: a mechanic that no single item owns. An object's own numbers live on
-the object, as `trx.objects.<name>.properties`, and the player's own choices live in `trx.config`.
+the object, as `trx.objects.<name>.properties`, and the player's own choices live in [`trx.config`](CONFIG.md#config).
 
 A rule lasts as long as the playthrough: it is saved with the game and restored with it, and a
 new game starts from the defaults. A level script states what its level wants, and states it
@@ -23,21 +23,21 @@ again on every entry, so a level that wants the defaults back asks for them.
 
 ### Properties
 
-- **`trx.rules.exposure.max`** (integer). How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills to. Warmth only moves in a room carrying the `damaging` flag, such as the cold water of Antarctica.
-- **`trx.rules.exposure.drain_land`** (integer). Warmth lost each frame in the cold, on land or wading.
-- **`trx.rules.exposure.drain_water`** (integer). Warmth lost each frame in the cold, underwater or at the surface.
-- **`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
-- **`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
-- **`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
+- <a name="rules.exposure.max"></a>**`trx.rules.exposure.max`** (integer). How much warmth Lara holds, in frames, and what [`trx.lara.exposure_bar`](LARA.md#lara.exposure_bar) fills to. Warmth only moves in a room carrying the `damaging` flag, such as the cold water of Antarctica.
+- <a name="rules.exposure.drain_land"></a>**`trx.rules.exposure.drain_land`** (integer). Warmth lost each frame in the cold, on land or wading.
+- <a name="rules.exposure.drain_water"></a>**`trx.rules.exposure.drain_water`** (integer). Warmth lost each frame in the cold, underwater or at the surface.
+- <a name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
+- <a name="rules.exposure.damage"></a>**`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
+- <a name="rules.corpse.fade_speed"></a>**`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
 
 ### Functions
 
-- [lua]`trx.rules.list()`  
+- <a name="rules.list"></a>[lua]`trx.rules.list()`  
   Every rule there is, as dotted `group.field` keys.
 
   Returns: table.
 
-- [lua]`trx.rules.get(key)`  
+- <a name="rules.get"></a>[lua]`trx.rules.get(key)`  
   Reads a rule by its key, for code that does not know which one it wants.
 
   Parameters:
@@ -45,20 +45,20 @@ again on every entry, so a level that wants the defaults back asks for them.
 
   Returns: any. Raises if no rule has that key.
 
-- [lua]`trx.rules.set(key, value)`  
+- <a name="rules.set"></a>[lua]`trx.rules.set(key, value)`  
   Changes a rule by its key. A string is read as text, the way the console gives it; any other value is taken as the rule's own type.
 
   Parameters:
   - **`key`** (string). Dotted path, e.g. `exposure.damage`.
   - **`value`** (any).
 
-- [lua]`trx.rules.reset([key])`  
+- <a name="rules.reset"></a>[lua]`trx.rules.reset([key])`  
   Puts a rule back to the value the engine ships with, or every rule when given no key. Happens on its own when a new game starts.
 
   Parameters:
   - **`key`** (string, optional). Dotted path.
 
-- [lua]`trx.rules.format_value(key)`  
+- <a name="rules.format_value"></a>[lua]`trx.rules.format_value(key)`  
   How a rule's value reads as text, for showing it to the player.
 
   Parameters:

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -35,13 +35,13 @@ again on every entry, so a level that wants the defaults back asks for them.
 - <a id="rules.list" name="rules.list"></a>[lua]`trx.rules.list()`  
   Every rule there is, as dotted `group.field` keys.
 
-  Returns: table.
+  Returns: table. The keys, in no particular order.
 
 - <a id="rules.get" name="rules.get"></a>[lua]`trx.rules.get(key)`  
   Reads a rule by its key, for code that does not know which one it wants.
 
   Parameters:
-  - **`key`** (string). Dotted path, e.g. `exposure.damage`.
+  - <a id="rules.get.key" name="rules.get.key"></a>**`key`** (string). Dotted path, e.g. `exposure.damage`.
 
   Returns: any. Raises if no rule has that key.
 
@@ -49,19 +49,19 @@ again on every entry, so a level that wants the defaults back asks for them.
   Changes a rule by its key. A string is read as text, the way the console gives it; any other value is taken as the rule's own type.
 
   Parameters:
-  - **`key`** (string). Dotted path, e.g. `exposure.damage`.
-  - **`value`** (any).
+  - <a id="rules.set.key" name="rules.set.key"></a>**`key`** (string). Dotted path, e.g. `exposure.damage`.
+  - <a id="rules.set.value" name="rules.set.value"></a>**`value`** (any). The value to write, of the type the rule declares.
 
 - <a id="rules.reset" name="rules.reset"></a>[lua]`trx.rules.reset([key])`  
   Puts a rule back to the value the engine ships with, or every rule when given no key. Happens on its own when a new game starts.
 
   Parameters:
-  - **`key`** (string, optional). Dotted path.
+  - <a id="rules.reset.key" name="rules.reset.key"></a>**`key`** (string, optional). Dotted path.
 
 - <a id="rules.format_value" name="rules.format_value"></a>[lua]`trx.rules.format_value(key)`  
   How a rule's value reads as text, for showing it to the player.
 
   Parameters:
-  - **`key`** (string). Dotted path.
+  - <a id="rules.format_value.key" name="rules.format_value.key"></a>**`key`** (string). Dotted path.
 
-  Returns: string.
+  Returns: string. The text, ready to print.

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -23,7 +23,7 @@ again on every entry, so a level that wants the defaults back asks for them.
 
 ### Properties
 
-- <a id="rules.exposure.max" name="rules.exposure.max"></a>**`trx.rules.exposure.max`** (integer). How much warmth Lara holds, in frames, and what [`trx.lara.exposure_bar`](LARA.md#lara.Lara.exposure_bar) fills to. Warmth only moves in a room carrying the [`trx.rooms.Room.damaging`](ROOMS.md#rooms.Room.damaging) flag, such as the cold water of Antarctica.
+- <a id="rules.exposure.max" name="rules.exposure.max"></a>**`trx.rules.exposure.max`** ([trx.game.Frames](GAME.md#game.Frames)). How much warmth Lara holds, and what [`trx.lara.exposure_bar`](LARA.md#lara.Lara.exposure_bar) fills to. Warmth only moves in a room carrying the [`trx.rooms.Room.damaging`](ROOMS.md#rooms.Room.damaging) flag, such as the cold water of Antarctica.
 - <a id="rules.exposure.drain_land" name="rules.exposure.drain_land"></a>**`trx.rules.exposure.drain_land`** (integer). Warmth lost each frame in the cold, on land or wading.
 - <a id="rules.exposure.drain_water" name="rules.exposure.drain_water"></a>**`trx.rules.exposure.drain_water`** (integer). Warmth lost each frame in the cold, underwater or at the surface.
 - <a id="rules.exposure.recovery" name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -10,7 +10,7 @@ order: 14
   src/lua/api/rules.lua. Edit it there.
 -->
 
-## Rules module
+## <a id="rules" name="rules"></a>Rules module
 
 Module for the numbers the engine plays by.
 
@@ -23,21 +23,21 @@ again on every entry, so a level that wants the defaults back asks for them.
 
 ### Properties
 
-- <a name="rules.exposure.max"></a>**`trx.rules.exposure.max`** (integer). How much warmth Lara holds, in frames, and what [`trx.lara.exposure_bar`](LARA.md#lara.exposure_bar) fills to. Warmth only moves in a room carrying the `damaging` flag, such as the cold water of Antarctica.
-- <a name="rules.exposure.drain_land"></a>**`trx.rules.exposure.drain_land`** (integer). Warmth lost each frame in the cold, on land or wading.
-- <a name="rules.exposure.drain_water"></a>**`trx.rules.exposure.drain_water`** (integer). Warmth lost each frame in the cold, underwater or at the surface.
-- <a name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
-- <a name="rules.exposure.damage"></a>**`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
-- <a name="rules.corpse.fade_speed"></a>**`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
+- <a id="rules.exposure.max" name="rules.exposure.max"></a>**`trx.rules.exposure.max`** (integer). How much warmth Lara holds, in frames, and what [`trx.lara.exposure_bar`](LARA.md#lara.Lara.exposure_bar) fills to. Warmth only moves in a room carrying the [`trx.rooms.Room.damaging`](ROOMS.md#rooms.Room.damaging) flag, such as the cold water of Antarctica.
+- <a id="rules.exposure.drain_land" name="rules.exposure.drain_land"></a>**`trx.rules.exposure.drain_land`** (integer). Warmth lost each frame in the cold, on land or wading.
+- <a id="rules.exposure.drain_water" name="rules.exposure.drain_water"></a>**`trx.rules.exposure.drain_water`** (integer). Warmth lost each frame in the cold, underwater or at the surface.
+- <a id="rules.exposure.recovery" name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
+- <a id="rules.exposure.damage" name="rules.exposure.damage"></a>**`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
+- <a id="rules.corpse.fade_speed" name="rules.corpse.fade_speed"></a>**`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
 
 ### Functions
 
-- <a name="rules.list"></a>[lua]`trx.rules.list()`  
+- <a id="rules.list" name="rules.list"></a>[lua]`trx.rules.list()`  
   Every rule there is, as dotted `group.field` keys.
 
   Returns: table.
 
-- <a name="rules.get"></a>[lua]`trx.rules.get(key)`  
+- <a id="rules.get" name="rules.get"></a>[lua]`trx.rules.get(key)`  
   Reads a rule by its key, for code that does not know which one it wants.
 
   Parameters:
@@ -45,20 +45,20 @@ again on every entry, so a level that wants the defaults back asks for them.
 
   Returns: any. Raises if no rule has that key.
 
-- <a name="rules.set"></a>[lua]`trx.rules.set(key, value)`  
+- <a id="rules.set" name="rules.set"></a>[lua]`trx.rules.set(key, value)`  
   Changes a rule by its key. A string is read as text, the way the console gives it; any other value is taken as the rule's own type.
 
   Parameters:
   - **`key`** (string). Dotted path, e.g. `exposure.damage`.
   - **`value`** (any).
 
-- <a name="rules.reset"></a>[lua]`trx.rules.reset([key])`  
+- <a id="rules.reset" name="rules.reset"></a>[lua]`trx.rules.reset([key])`  
   Puts a rule back to the value the engine ships with, or every rule when given no key. Happens on its own when a new game starts.
 
   Parameters:
   - **`key`** (string, optional). Dotted path.
 
-- <a name="rules.format_value"></a>[lua]`trx.rules.format_value(key)`  
+- <a id="rules.format_value" name="rules.format_value"></a>[lua]`trx.rules.format_value(key)`  
   How a rule's value reads as text, for showing it to the player.
 
   Parameters:

--- a/docs/trx/lua/reference/SAVEGAME.md
+++ b/docs/trx/lua/reference/SAVEGAME.md
@@ -10,13 +10,13 @@ order: 23
   src/lua/api/savegame.lua. Edit it there.
 -->
 
-## Savegame module
+## <a id="savegame" name="savegame"></a>Savegame module
 
 The save slots, and starting or reading a saved game.
 
 ### Enums
 
-- <a name="savegame.Pool"></a>[lua]`trx.savegame.Pool`
+- <a id="savegame.Pool" name="savegame.Pool"></a>[lua]`trx.savegame.Pool`
 
     Which set of save slots a slot belongs to.
 
@@ -27,13 +27,13 @@ The save slots, and starting or reading a saved game.
 
 ### Structures
 
-- <a name="savegame.SlotNum"></a>[lua]`trx.savegame.SlotNum`
+- <a id="savegame.SlotNum" name="savegame.SlotNum"></a>[lua]`trx.savegame.SlotNum`
 
     Slot number within the pool. For the quick pool this is the on-screen order. Counted from 1.
 
 ### Functions
 
-- <a name="savegame.slot_count"></a>[lua]`trx.savegame.slot_count([pool])`  
+- <a id="savegame.slot_count" name="savegame.slot_count"></a>[lua]`trx.savegame.slot_count([pool])`  
   How many slots a pool has. The quick pool counts only the slots that hold a save, which is how it is shown and addressed.
 
   Parameters:
@@ -42,7 +42,7 @@ The save slots, and starting or reading a saved game.
   Returns:
   - integer. The number of slots.
 
-- <a name="savegame.is_free"></a>[lua]`trx.savegame.is_free(slot_num, [pool])`  
+- <a id="savegame.is_free" name="savegame.is_free"></a>[lua]`trx.savegame.is_free(slot_num, [pool])`  
   Whether a slot holds no save.
 
   Parameters:
@@ -52,7 +52,7 @@ The save slots, and starting or reading a saved game.
   Returns:
   - boolean. Whether the slot is empty.
 
-- <a name="savegame.load"></a>[lua]`trx.savegame.load(slot_num, [pool])`  
+- <a id="savegame.load" name="savegame.load"></a>[lua]`trx.savegame.load(slot_num, [pool])`  
   Starts the saved game in a slot. The load happens once the game flow picks it up, not on the call.
 
   Parameters:
@@ -64,7 +64,7 @@ The save slots, and starting or reading a saved game.
   trx.savegame.load(1)
   ```
 
-- <a name="savegame.save"></a>[lua]`trx.savegame.save([slot_num], [pool])`  
+- <a id="savegame.save" name="savegame.save"></a>[lua]`trx.savegame.save([slot_num], [pool])`  
   Writes a saved game to a slot. A quick save with no slot number goes to the next slot in the rotation; with one, it saves to the slot named.
 
   Parameters:

--- a/docs/trx/lua/reference/SAVEGAME.md
+++ b/docs/trx/lua/reference/SAVEGAME.md
@@ -36,21 +36,21 @@ The save slots, and starting or reading a saved game.
   Returns:
   - integer. The number of slots.
 
-- [lua]`trx.savegame.is_free(index, [pool])`  
+- [lua]`trx.savegame.is_free(slot_num, [pool])`  
   Whether a slot holds no save.
 
   Parameters:
-  - **`index`** (integer). 1-based slot number. For the quick pool this is the on-screen order.
+  - **`slot_num`** (integer). 1-based slot number. For the quick pool this is the on-screen order.
   - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
 
   Returns:
   - boolean. Whether the slot is empty.
 
-- [lua]`trx.savegame.load(index, [pool])`  
+- [lua]`trx.savegame.load(slot_num, [pool])`  
   Starts the saved game in a slot. The load happens once the game flow picks it up, not on the call.
 
   Parameters:
-  - **`index`** (integer). 1-based slot number. For the quick pool this is the on-screen order.
+  - **`slot_num`** (integer). 1-based slot number. For the quick pool this is the on-screen order.
   - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
 
   Example:
@@ -58,11 +58,11 @@ The save slots, and starting or reading a saved game.
   trx.savegame.load(1)
   ```
 
-- [lua]`trx.savegame.save([index], [pool])`  
-  Writes a saved game to a slot. A quick save with no index goes to the next slot in the rotation; with one, it saves to the slot named.
+- [lua]`trx.savegame.save([slot_num], [pool])`  
+  Writes a saved game to a slot. A quick save with no slot number goes to the next slot in the rotation; with one, it saves to the slot named.
 
   Parameters:
-  - **`index`** (integer, optional). 1-based slot number. The quick pool uses the next slot in its rotation when it is omitted.
+  - **`slot_num`** (integer, optional). 1-based slot number. The quick pool uses the next slot in its rotation when it is omitted.
   - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
 
   Returns:

--- a/docs/trx/lua/reference/SAVEGAME.md
+++ b/docs/trx/lua/reference/SAVEGAME.md
@@ -37,7 +37,7 @@ The save slots, and starting or reading a saved game.
   How many slots a pool has. The quick pool counts only the slots that hold a save, which is how it is shown and addressed.
 
   Parameters:
-  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
+  - <a id="savegame.slot_count.pool" name="savegame.slot_count.pool"></a>**`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Returns:
   - integer. The number of slots.
@@ -46,8 +46,8 @@ The save slots, and starting or reading a saved game.
   Whether a slot holds no save.
 
   Parameters:
-  - **`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum)).
-  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
+  - <a id="savegame.is_free.slot_num" name="savegame.is_free.slot_num"></a>**`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum)).
+  - <a id="savegame.is_free.pool" name="savegame.is_free.pool"></a>**`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Returns:
   - boolean. Whether the slot is empty.
@@ -56,8 +56,8 @@ The save slots, and starting or reading a saved game.
   Starts the saved game in a slot. The load happens once the game flow picks it up, not on the call.
 
   Parameters:
-  - **`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum)).
-  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
+  - <a id="savegame.load.slot_num" name="savegame.load.slot_num"></a>**`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum)).
+  - <a id="savegame.load.pool" name="savegame.load.pool"></a>**`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Example:
   ```lua
@@ -68,8 +68,8 @@ The save slots, and starting or reading a saved game.
   Writes a saved game to a slot. A quick save with no slot number goes to the next slot in the rotation; with one, it saves to the slot named.
 
   Parameters:
-  - **`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum), optional). The quick pool uses the next slot in its rotation when it is omitted.
-  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
+  - <a id="savegame.save.slot_num" name="savegame.save.slot_num"></a>**`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum), optional). The quick pool uses the next slot in its rotation when it is omitted.
+  - <a id="savegame.save.pool" name="savegame.save.pool"></a>**`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Returns:
   - boolean. Whether the save was written. `false` means the quick pool had no slot.

--- a/docs/trx/lua/reference/SAVEGAME.md
+++ b/docs/trx/lua/reference/SAVEGAME.md
@@ -16,7 +16,7 @@ The save slots, and starting or reading a saved game.
 
 ### Enums
 
-- [lua]`trx.savegame.Pool`
+- <a name="savegame.Pool"></a>[lua]`trx.savegame.Pool`
 
     Which set of save slots a slot belongs to.
 
@@ -25,45 +25,51 @@ The save slots, and starting or reading a saved game.
     - `trx.savegame.Pool.QUICK` = `1`  
         The quick-save slots, counted and addressed by their on-screen order.
 
+### Structures
+
+- <a name="savegame.SlotNum"></a>[lua]`trx.savegame.SlotNum`
+
+    Slot number within the pool. For the quick pool this is the on-screen order. Counted from 1.
+
 ### Functions
 
-- [lua]`trx.savegame.slot_count([pool])`  
+- <a name="savegame.slot_count"></a>[lua]`trx.savegame.slot_count([pool])`  
   How many slots a pool has. The quick pool counts only the slots that hold a save, which is how it is shown and addressed.
 
   Parameters:
-  - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
+  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Returns:
   - integer. The number of slots.
 
-- [lua]`trx.savegame.is_free(slot_num, [pool])`  
+- <a name="savegame.is_free"></a>[lua]`trx.savegame.is_free(slot_num, [pool])`  
   Whether a slot holds no save.
 
   Parameters:
-  - **`slot_num`** (integer). 1-based slot number. For the quick pool this is the on-screen order.
-  - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
+  - **`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum)).
+  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Returns:
   - boolean. Whether the slot is empty.
 
-- [lua]`trx.savegame.load(slot_num, [pool])`  
+- <a name="savegame.load"></a>[lua]`trx.savegame.load(slot_num, [pool])`  
   Starts the saved game in a slot. The load happens once the game flow picks it up, not on the call.
 
   Parameters:
-  - **`slot_num`** (integer). 1-based slot number. For the quick pool this is the on-screen order.
-  - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
+  - **`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum)).
+  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Example:
   ```lua
   trx.savegame.load(1)
   ```
 
-- [lua]`trx.savegame.save([slot_num], [pool])`  
+- <a name="savegame.save"></a>[lua]`trx.savegame.save([slot_num], [pool])`  
   Writes a saved game to a slot. A quick save with no slot number goes to the next slot in the rotation; with one, it saves to the slot named.
 
   Parameters:
-  - **`slot_num`** (integer, optional). 1-based slot number. The quick pool uses the next slot in its rotation when it is omitted.
-  - **`pool`** (integer, optional). Which set of slots to look in. Defaults to `NORMAL`. Compare against `trx.savegame.Pool`.
+  - **`slot_num`** ([trx.savegame.SlotNum](#savegame.SlotNum), optional). The quick pool uses the next slot in its rotation when it is omitted.
+  - **`pool`** ([trx.savegame.Pool](#savegame.Pool), optional). Which set of slots to look in. Defaults to `NORMAL`.
 
   Returns:
   - boolean. Whether the save was written. `false` means the quick pool had no slot.

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -30,7 +30,7 @@ Module for playing sound effects.
     unrelated one.
 
     Properties:
-    - **`id`**: integer. The sample's id, in the level's own numbering. *(read-only)*
+    - **`num`**: integer. The number the level gives this sample. *(read-only)*
     - **`pitch`**: integer. The sample's base pitch. *(read-only)*
     - **`randomness`**: integer. How much the sample's playback is randomized. *(read-only)*
     - **`range`**: integer. How far the sample carries. *(read-only)*
@@ -63,7 +63,7 @@ Module for playing sound effects.
     unrelated one.
 
     Properties:
-    - **`sample_id`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
+    - **`sample_num`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
 
     Methods:
 

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -10,40 +10,40 @@ order: 17
   src/lua/api/sound.lua. Edit it there.
 -->
 
-## Sound module
+## <a id="sound" name="sound"></a>Sound module
 
 Module for playing sound effects.
 
 ### Properties
 
-- <a name="sound.samples"></a>**`trx.sound.samples`** (table). The samples the current level carries, as [`trx.sound.Sample`](#sound.Sample) handles keyed by id: `trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
-- <a name="sound.streams"></a>**`trx.sound.streams`** (table). The sound effects playing now, as [`trx.sound.Stream`](#sound.Stream) handles. A slot that is silent still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
+- <a id="sound.samples" name="sound.samples"></a>**`trx.sound.samples`** (table). The samples the current level carries, as [`trx.sound.Sample`](#sound.Sample) handles keyed by id: `trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
+- <a id="sound.streams" name="sound.streams"></a>**`trx.sound.streams`** (table). The sound effects playing now, as [`trx.sound.Stream`](#sound.Stream) handles. A slot that is silent still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
 
 ### Structures
 
-- <a name="sound.Sample"></a>[lua]`trx.sound.Sample`
+- <a id="sound.Sample" name="sound.Sample"></a>[lua]`trx.sound.Sample`
 
-    A sound sample the current level carries. Reach them through [`trx.sound.samples`](#sound.samples). A handle to a sample the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.
+    A sound sample the current level carries. Reach them through [`trx.sound.samples`](#sound.samples). A handle to a sample the loaded level does not carry goes stale, so [`is_valid`](#sound.Sample.is_valid) answers whether it is still there.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - <a name="sound.Sample.num"></a>**`num`**: integer. The number the level gives this sample. *(read-only)*
-    - <a name="sound.Sample.pitch"></a>**`pitch`**: integer. The sample's base pitch. *(read-only)*
-    - <a name="sound.Sample.randomness"></a>**`randomness`**: integer. How much the sample's playback is randomized. *(read-only)*
-    - <a name="sound.Sample.range"></a>**`range`**: integer. How far the sample carries. *(read-only)*
-    - <a name="sound.Sample.volume"></a>**`volume`**: integer. The sample's base volume. *(read-only)*
+    - <a id="sound.Sample.num" name="sound.Sample.num"></a>**`num`**: integer. The number the level gives this sample. *(read-only)*
+    - <a id="sound.Sample.pitch" name="sound.Sample.pitch"></a>**`pitch`**: integer. The sample's base pitch. *(read-only)*
+    - <a id="sound.Sample.randomness" name="sound.Sample.randomness"></a>**`randomness`**: integer. How much the sample's playback is randomized. *(read-only)*
+    - <a id="sound.Sample.range" name="sound.Sample.range"></a>**`range`**: integer. How far the sample carries. *(read-only)*
+    - <a id="sound.Sample.volume" name="sound.Sample.volume"></a>**`volume`**: integer. The sample's base volume. *(read-only)*
 
     Methods:
 
-    - <a name="sound.Sample.is_valid"></a>[lua]`sample:is_valid()`  
+    - <a id="sound.Sample.is_valid" name="sound.Sample.is_valid"></a>[lua]`sample:is_valid()`  
       Whether the loaded level still carries this sample.
 
       Returns: boolean.
 
-    - <a name="sound.Sample.play"></a>[lua]`sample:play([opts])`  
+    - <a id="sound.Sample.play" name="sound.Sample.play"></a>[lua]`sample:play([opts])`  
       Plays this sample.
 
       Parameters:
@@ -51,39 +51,39 @@ Module for playing sound effects.
 
       Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 
-    - <a name="sound.Sample.stop"></a>[lua]`sample:stop()`  
+    - <a id="sound.Sample.stop" name="sound.Sample.stop"></a>[lua]`sample:stop()`  
       Stops every voice playing this sample.
 
-- <a name="sound.Stream"></a>[lua]`trx.sound.Stream`
+- <a id="sound.Stream" name="sound.Stream"></a>[lua]`trx.sound.Stream`
 
-    One of the sound effects playing now. Reach them through [`trx.sound.streams`](#sound.streams). A handle to a voice that has fallen silent goes stale, so check `is_valid()` first.
+    One of the sound effects playing now. Reach them through [`trx.sound.streams`](#sound.streams). A handle to a voice that has fallen silent goes stale, so check [`is_valid`](#sound.Stream.is_valid) first.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - <a name="sound.Stream.sample_num"></a>**`sample_num`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
+    - <a id="sound.Stream.sample_num" name="sound.Stream.sample_num"></a>**`sample_num`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
 
     Methods:
 
-    - <a name="sound.Stream.is_valid"></a>[lua]`stream:is_valid()`  
+    - <a id="sound.Stream.is_valid" name="sound.Stream.is_valid"></a>[lua]`stream:is_valid()`  
       Whether this voice is still playing.
 
       Returns: boolean.
 
-    - <a name="sound.Stream.pause"></a>[lua]`stream:pause()`  
+    - <a id="sound.Stream.pause" name="sound.Stream.pause"></a>[lua]`stream:pause()`  
       Pauses this voice.
 
-    - <a name="sound.Stream.stop"></a>[lua]`stream:stop()`  
+    - <a id="sound.Stream.stop" name="sound.Stream.stop"></a>[lua]`stream:stop()`  
       Stops this voice.
 
-    - <a name="sound.Stream.unpause"></a>[lua]`stream:unpause()`  
+    - <a id="sound.Stream.unpause" name="sound.Stream.unpause"></a>[lua]`stream:unpause()`  
       Resumes this voice.
 
 ### Functions
 
-- <a name="sound.play"></a>[lua]`trx.sound.play(id, [opts])`  
+- <a id="sound.play" name="sound.play"></a>[lua]`trx.sound.play(id, [opts])`  
   Plays a sound effect by catalog id, mapping it to the level's own sample. A game that does not carry the sample plays nothing.
 
   Parameters:
@@ -98,11 +98,11 @@ Module for playing sound effects.
   trx.sound.play(trx.catalog.samples.LARA_NO, { pos = { x = 100, y = 200, z = 50 } })
   ```
 
-- <a name="sound.stop"></a>[lua]`trx.sound.stop(id)`  
+- <a id="sound.stop" name="sound.stop"></a>[lua]`trx.sound.stop(id)`  
   Stops a sound effect by catalog id.
 
   Parameters:
   - **`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to stop. To reach a sample by the level's own slot, stop it through a handle: `trx.sound.samples[slot]:stop()`.
 
-- <a name="sound.stop_all"></a>[lua]`trx.sound.stop_all()`  
+- <a id="sound.stop_all" name="sound.stop_all"></a>[lua]`trx.sound.stop_all()`  
   Stops every sound effect currently playing.

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -21,6 +21,10 @@ Module for playing sound effects.
 
 ### Structures
 
+- <a id="sound.SampleNum" name="sound.SampleNum"></a>[lua]`trx.sound.SampleNum`
+
+    Sample number, in the numbering the loaded level carries. Not a [`trx.catalog.samples`](CATALOG.md#catalog.samples) name, which is the sound bank's own.
+
 - <a id="sound.Sample" name="sound.Sample"></a>[lua]`trx.sound.Sample`
 
     A sound sample the current level carries. Reach them through [`trx.sound.samples`](#sound.samples). A handle to a sample the loaded level does not carry goes stale, so [`is_valid`](#sound.Sample.is_valid) answers whether it is still there.
@@ -30,7 +34,7 @@ Module for playing sound effects.
     unrelated one.
 
     Properties:
-    - <a id="sound.Sample.num" name="sound.Sample.num"></a>**`num`**: integer. The number the level gives this sample. *(read-only)*
+    - <a id="sound.Sample.num" name="sound.Sample.num"></a>**`num`**: [trx.sound.SampleNum](#sound.SampleNum). *(read-only)*
     - <a id="sound.Sample.pitch" name="sound.Sample.pitch"></a>**`pitch`**: integer. The sample's base pitch. *(read-only)*
     - <a id="sound.Sample.randomness" name="sound.Sample.randomness"></a>**`randomness`**: integer. How much the sample's playback is randomized. *(read-only)*
     - <a id="sound.Sample.range" name="sound.Sample.range"></a>**`range`**: integer. How far the sample carries. *(read-only)*
@@ -41,13 +45,16 @@ Module for playing sound effects.
     - <a id="sound.Sample.is_valid" name="sound.Sample.is_valid"></a>[lua]`sample:is_valid()`  
       Whether the loaded level still carries this sample.
 
-      Returns: boolean.
+      Returns: boolean. False once a level change has replaced the samples.
 
     - <a id="sound.Sample.play" name="sound.Sample.play"></a>[lua]`sample:play([opts])`  
       Plays this sample.
 
       Parameters:
-      - **`opts`** (table, optional). `pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.
+      - <a id="sound.Sample.play.opts" name="sound.Sample.play.opts"></a>**`opts`** (table, optional). How to play it.
+
+        Keys:
+        - <a id="sound.Sample.play.opts.pos" name="sound.Sample.play.opts.pos"></a>**`pos`** (vec3, optional). A world position to play from, which applies pan and volume. Omit to play at full volume.
 
       Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 
@@ -63,14 +70,14 @@ Module for playing sound effects.
     unrelated one.
 
     Properties:
-    - <a id="sound.Stream.sample_num" name="sound.Stream.sample_num"></a>**`sample_num`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
+    - <a id="sound.Stream.sample_num" name="sound.Stream.sample_num"></a>**`sample_num`**: [trx.sound.SampleNum](#sound.SampleNum). The sample this voice is playing. *(read-only)*
 
     Methods:
 
     - <a id="sound.Stream.is_valid" name="sound.Stream.is_valid"></a>[lua]`stream:is_valid()`  
       Whether this voice is still playing.
 
-      Returns: boolean.
+      Returns: boolean. False once the voice has fallen silent.
 
     - <a id="sound.Stream.pause" name="sound.Stream.pause"></a>[lua]`stream:pause()`  
       Pauses this voice.
@@ -87,8 +94,11 @@ Module for playing sound effects.
   Plays a sound effect by catalog id, mapping it to the level's own sample. A game that does not carry the sample plays nothing.
 
   Parameters:
-  - **`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to play. To reach a sample by the level's own slot, play it through a handle: `trx.sound.samples[slot]:play()`.
-  - **`opts`** (table, optional). `pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.
+  - <a id="sound.play.id" name="sound.play.id"></a>**`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to play. To reach a sample by the level's own slot, play it through a handle: `trx.sound.samples[slot]:play()`.
+  - <a id="sound.play.opts" name="sound.play.opts"></a>**`opts`** (table, optional). How to play it.
+
+    Keys:
+    - <a id="sound.play.opts.pos" name="sound.play.opts.pos"></a>**`pos`** (vec3, optional). A world position to play from, which applies pan and volume. Omit to play at full volume.
 
   Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 
@@ -102,7 +112,7 @@ Module for playing sound effects.
   Stops a sound effect by catalog id.
 
   Parameters:
-  - **`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to stop. To reach a sample by the level's own slot, stop it through a handle: `trx.sound.samples[slot]:stop()`.
+  - <a id="sound.stop.id" name="sound.stop.id"></a>**`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to stop. To reach a sample by the level's own slot, stop it through a handle: `trx.sound.samples[slot]:stop()`.
 
 - <a id="sound.stop_all" name="sound.stop_all"></a>[lua]`trx.sound.stop_all()`  
   Stops every sound effect currently playing.

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -16,81 +16,81 @@ Module for playing sound effects.
 
 ### Properties
 
-- **`trx.sound.samples`** (table). The samples the current level carries, as `trx.sound.Sample` handles keyed by id: `trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
-- **`trx.sound.streams`** (table). The sound effects playing now, as `trx.sound.Stream` handles. A slot that is silent still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
+- <a name="sound.samples"></a>**`trx.sound.samples`** (table). The samples the current level carries, as [`trx.sound.Sample`](#sound.Sample) handles keyed by id: `trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
+- <a name="sound.streams"></a>**`trx.sound.streams`** (table). The sound effects playing now, as [`trx.sound.Stream`](#sound.Stream) handles. A slot that is silent still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
 
 ### Structures
 
-- [lua]`trx.sound.Sample`
+- <a name="sound.Sample"></a>[lua]`trx.sound.Sample`
 
-    A sound sample the current level carries. Reach them through `trx.sound.samples`. A handle to a sample the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.
+    A sound sample the current level carries. Reach them through [`trx.sound.samples`](#sound.samples). A handle to a sample the loaded level does not carry goes stale, so `is_valid()` answers whether it is still there.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - **`num`**: integer. The number the level gives this sample. *(read-only)*
-    - **`pitch`**: integer. The sample's base pitch. *(read-only)*
-    - **`randomness`**: integer. How much the sample's playback is randomized. *(read-only)*
-    - **`range`**: integer. How far the sample carries. *(read-only)*
-    - **`volume`**: integer. The sample's base volume. *(read-only)*
+    - <a name="sound.Sample.num"></a>**`num`**: integer. The number the level gives this sample. *(read-only)*
+    - <a name="sound.Sample.pitch"></a>**`pitch`**: integer. The sample's base pitch. *(read-only)*
+    - <a name="sound.Sample.randomness"></a>**`randomness`**: integer. How much the sample's playback is randomized. *(read-only)*
+    - <a name="sound.Sample.range"></a>**`range`**: integer. How far the sample carries. *(read-only)*
+    - <a name="sound.Sample.volume"></a>**`volume`**: integer. The sample's base volume. *(read-only)*
 
     Methods:
 
-    - [lua]`sample:is_valid()`  
+    - <a name="sound.Sample.is_valid"></a>[lua]`sample:is_valid()`  
       Whether the loaded level still carries this sample.
 
       Returns: boolean.
 
-    - [lua]`sample:play([opts])`  
+    - <a name="sound.Sample.play"></a>[lua]`sample:play([opts])`  
       Plays this sample.
 
       Parameters:
       - **`opts`** (table, optional). `pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.
 
-      Returns: sound.Stream or `nil`. The voice it started, or `nil` if none did.
+      Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 
-    - [lua]`sample:stop()`  
+    - <a name="sound.Sample.stop"></a>[lua]`sample:stop()`  
       Stops every voice playing this sample.
 
-- [lua]`trx.sound.Stream`
+- <a name="sound.Stream"></a>[lua]`trx.sound.Stream`
 
-    One of the sound effects playing now. Reach them through `trx.sound.streams`. A handle to a voice that has fallen silent goes stale, so check `is_valid()` first.
+    One of the sound effects playing now. Reach them through [`trx.sound.streams`](#sound.streams). A handle to a voice that has fallen silent goes stale, so check `is_valid()` first.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - **`sample_num`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
+    - <a name="sound.Stream.sample_num"></a>**`sample_num`**: integer. The sample this voice is playing, in the level's own numbering. *(read-only)*
 
     Methods:
 
-    - [lua]`stream:is_valid()`  
+    - <a name="sound.Stream.is_valid"></a>[lua]`stream:is_valid()`  
       Whether this voice is still playing.
 
       Returns: boolean.
 
-    - [lua]`stream:pause()`  
+    - <a name="sound.Stream.pause"></a>[lua]`stream:pause()`  
       Pauses this voice.
 
-    - [lua]`stream:stop()`  
+    - <a name="sound.Stream.stop"></a>[lua]`stream:stop()`  
       Stops this voice.
 
-    - [lua]`stream:unpause()`  
+    - <a name="sound.Stream.unpause"></a>[lua]`stream:unpause()`  
       Resumes this voice.
 
 ### Functions
 
-- [lua]`trx.sound.play(id, [opts])`  
+- <a name="sound.play"></a>[lua]`trx.sound.play(id, [opts])`  
   Plays a sound effect by catalog id, mapping it to the level's own sample. A game that does not carry the sample plays nothing.
 
   Parameters:
-  - **`id`** (integer). Sample to play. To reach a sample by the level's own slot, play it through a handle: `trx.sound.samples[slot]:play()`. Compare against `trx.catalog.samples`.
+  - **`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to play. To reach a sample by the level's own slot, play it through a handle: `trx.sound.samples[slot]:play()`.
   - **`opts`** (table, optional). `pos`: a `{ x =, y =, z = }` world position to play from, which applies pan and volume. Omit to play at full volume.
 
-  Returns: sound.Stream or `nil`. The voice it started, or `nil` if none did.
+  Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 
   Example:
   ```lua
@@ -98,11 +98,11 @@ Module for playing sound effects.
   trx.sound.play(trx.catalog.samples.LARA_NO, { pos = { x = 100, y = 200, z = 50 } })
   ```
 
-- [lua]`trx.sound.stop(id)`  
+- <a name="sound.stop"></a>[lua]`trx.sound.stop(id)`  
   Stops a sound effect by catalog id.
 
   Parameters:
-  - **`id`** (integer). Sample to stop. To reach a sample by the level's own slot, stop it through a handle: `trx.sound.samples[slot]:stop()`. Compare against `trx.catalog.samples`.
+  - **`id`** ([trx.catalog.samples](CATALOG.md#catalog.samples)). Sample to stop. To reach a sample by the level's own slot, stop it through a handle: `trx.sound.samples[slot]:stop()`.
 
-- [lua]`trx.sound.stop_all()`  
+- <a name="sound.stop_all"></a>[lua]`trx.sound.stop_all()`  
   Stops every sound effect currently playing.

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -52,7 +52,7 @@ here reads `nil`.
     - <a id="stats.Stats.ammo_hits" name="stats.Stats.ammo_hits"></a>**`ammo_hits`**: integer. How many of them hit something.
     - <a id="stats.Stats.ammo_used" name="stats.Stats.ammo_used"></a>**`ammo_used`**: integer. How many rounds Lara has fired.
     - <a id="stats.Stats.deaths" name="stats.Stats.deaths"></a>**`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
-    - <a id="stats.Stats.distance_travelled" name="stats.Stats.distance_travelled"></a>**`distance_travelled`**: integer. How far Lara has travelled, in world units.
+    - <a id="stats.Stats.distance_travelled" name="stats.Stats.distance_travelled"></a>**`distance_travelled`**: [trx.math.Distance](MATH.md#math.Distance). How far Lara has travelled.
     - <a id="stats.Stats.medipacks_used" name="stats.Stats.medipacks_used"></a>**`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
     - <a id="stats.Stats.timer" name="stats.Stats.timer"></a>**`timer`**: integer. How long the level has been played, in game frames.
 

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -15,14 +15,18 @@ order: 24
 Module for what a level keeps count of: what Lara has found in it, and how much
 there was to find.
 
-The module is the level being played, so `trx.stats.pickups.count` is what she
+The module is the level being played, so [`trx.stats.pickups.count`](#stats.Category.count) is what she
 has picked up in it. Any other level's counters are reached the same way through
-`trx.game.Level.stats`. At the title screen there is no level, and everything
+[`trx.game.Level.stats`](GAME.md#game.Level.stats). At the title screen there is no level, and everything
 here reads `nil`.
 
 ### Structures
 
-- [lua]`trx.stats.Category`
+- <a name="stats.SecretNum"></a>[lua]`trx.stats.SecretNum`
+
+    The secret's number, as the player counts them. Counted from 1.
+
+- <a name="stats.Category"></a>[lua]`trx.stats.Category`
 
     One thing a level is counted on, which is one row of the statistics screen. `raw` is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.
 
@@ -31,12 +35,12 @@ here reads `nil`.
     unrelated one.
 
     Properties:
-    - **`count`**: integer. How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `give_secret` and `take_secret` are how they change.
-    - **`max`**: integer. How many of them count towards completing the level. *(read-only)*
-    - **`raw`**: integer. How many of them the level holds, obtainable or not. *(read-only)*
-    - **`unobtainable`**: integer. How many of them the game flow declares out of reach, and so must not be held against the player. *(read-only)*
+    - <a name="stats.Category.count"></a>**`count`**: integer. How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `give_secret` and `take_secret` are how they change.
+    - <a name="stats.Category.max"></a>**`max`**: integer. How many of them count towards completing the level. *(read-only)*
+    - <a name="stats.Category.raw"></a>**`raw`**: integer. How many of them the level holds, obtainable or not. *(read-only)*
+    - <a name="stats.Category.unobtainable"></a>**`unobtainable`**: integer. How many of them the game flow declares out of reach, and so must not be held against the player. *(read-only)*
 
-- [lua]`trx.stats.Stats`
+- <a name="stats.Stats"></a>[lua]`trx.stats.Stats`
 
     What one level keeps count of. The counters are the level's own and can be written, which is what a script correcting or seeding them wants.
 
@@ -45,29 +49,29 @@ here reads `nil`.
     unrelated one.
 
     Properties:
-    - **`ammo_hits`**: integer. How many of them hit something.
-    - **`ammo_used`**: integer. How many rounds Lara has fired.
-    - **`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
-    - **`distance_travelled`**: integer. How far Lara has travelled, in world units.
-    - **`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
-    - **`timer`**: integer. How long the level has been played, in game frames.
+    - <a name="stats.Stats.ammo_hits"></a>**`ammo_hits`**: integer. How many of them hit something.
+    - <a name="stats.Stats.ammo_used"></a>**`ammo_used`**: integer. How many rounds Lara has fired.
+    - <a name="stats.Stats.deaths"></a>**`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
+    - <a name="stats.Stats.distance_travelled"></a>**`distance_travelled`**: integer. How far Lara has travelled, in world units.
+    - <a name="stats.Stats.medipacks_used"></a>**`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
+    - <a name="stats.Stats.timer"></a>**`timer`**: integer. How long the level has been played, in game frames.
 
     Computed properties (derived, not stored on the object):
-    - **`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.
-    - **`crystals`**: Category. The save crystals, where the game has them.
-    - **`kills`**: Category. The enemies the level counts, allies among them.
-    - **`max_ally_kills`**: integer. How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.
-    - **`max_enemy_kills`**: integer. How many of `kills.max` are enemies rather than allies.
-    - **`pickups`**: Category. The items lying in the level for Lara to take.
-    - **`secrets`**: Category. The level's secrets. Which ones Lara holds is `secret_list`.
+    - <a name="stats.Stats.allies_hurt"></a>**`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.
+    - <a name="stats.Stats.crystals"></a>**`crystals`**: [trx.stats.Category](#stats.Category). The save crystals, where the game has them.
+    - <a name="stats.Stats.kills"></a>**`kills`**: [trx.stats.Category](#stats.Category). The enemies the level counts, allies among them.
+    - <a name="stats.Stats.max_ally_kills"></a>**`max_ally_kills`**: integer. How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.
+    - <a name="stats.Stats.max_enemy_kills"></a>**`max_enemy_kills`**: integer. How many of `kills.max` are enemies rather than allies.
+    - <a name="stats.Stats.pickups"></a>**`pickups`**: [trx.stats.Category](#stats.Category). The items lying in the level for Lara to take.
+    - <a name="stats.Stats.secrets"></a>**`secrets`**: [trx.stats.Category](#stats.Category). The level's secrets. Which ones Lara holds is `secret_list`.
 
     Methods:
 
-    - [lua]`stats:give_secret(num)`  
+    - <a name="stats.Stats.give_secret"></a>[lua]`stats:give_secret(secret_num)`  
       Marks a secret as found, as walking into its trigger would.
 
       Parameters:
-      - **`num`** (integer). The secret's number, counted from one.
+      - **`secret_num`** ([trx.stats.SecretNum](#stats.SecretNum)).
 
       Returns: boolean. `false` if the level has no such secret, or Lara already has it.
 
@@ -76,8 +80,8 @@ here reads `nil`.
       trx.stats.give_secret(1)
       ```
 
-    - [lua]`stats:secret_list()`  
-      The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, counted from one, and `found` is whether Lara has it.
+    - <a name="stats.Stats.secret_list"></a>[lua]`stats:secret_list()`  
+      The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, and `found` is whether Lara has it.
 
       Returns: table. The secrets, one by one.
 
@@ -88,10 +92,10 @@ here reads `nil`.
       end
       ```
 
-    - [lua]`stats:take_secret(num)`  
+    - <a name="stats.Stats.take_secret"></a>[lua]`stats:take_secret(secret_num)`  
       Takes a secret back, leaving it to be found again.
 
       Parameters:
-      - **`num`** (integer). The secret's number, counted from one.
+      - **`secret_num`** ([trx.stats.SecretNum](#stats.SecretNum)).
 
       Returns: boolean. `false` if the level has no such secret, or Lara does not have it.

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -54,7 +54,7 @@ here reads `nil`.
     - <a id="stats.Stats.deaths" name="stats.Stats.deaths"></a>**`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
     - <a id="stats.Stats.distance_travelled" name="stats.Stats.distance_travelled"></a>**`distance_travelled`**: [trx.math.Distance](MATH.md#math.Distance). How far Lara has travelled.
     - <a id="stats.Stats.medipacks_used" name="stats.Stats.medipacks_used"></a>**`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
-    - <a id="stats.Stats.timer" name="stats.Stats.timer"></a>**`timer`**: integer. How long the level has been played, in game frames.
+    - <a id="stats.Stats.timer" name="stats.Stats.timer"></a>**`timer`**: [trx.game.Frames](GAME.md#game.Frames). How long the level has been played.
 
     Computed properties (derived, not stored on the object):
     - <a id="stats.Stats.allies_hurt" name="stats.Stats.allies_hurt"></a>**`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -71,7 +71,7 @@ here reads `nil`.
       Marks a secret as found, as walking into its trigger would.
 
       Parameters:
-      - **`secret_num`** ([trx.stats.SecretNum](#stats.SecretNum)).
+      - <a id="stats.Stats.give_secret.secret_num" name="stats.Stats.give_secret.secret_num"></a>**`secret_num`** ([trx.stats.SecretNum](#stats.SecretNum)).
 
       Returns: boolean. `false` if the level has no such secret, or Lara already has it.
 
@@ -81,9 +81,13 @@ here reads `nil`.
       ```
 
     - <a id="stats.Stats.secret_list" name="stats.Stats.secret_list"></a>[lua]`stats:secret_list()`  
-      The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, and `found` is whether Lara has it.
+      The level's secrets, in order.
 
       Returns: table. The secrets, one by one.
+
+        Each entry:
+        - <a id="stats.Stats.secret_list.num" name="stats.Stats.secret_list.num"></a>**`num`** ([trx.stats.SecretNum](#stats.SecretNum)). Which secret it is.
+        - <a id="stats.Stats.secret_list.found" name="stats.Stats.secret_list.found"></a>**`found`** (boolean). Whether Lara has it.
 
       Example:
       ```lua
@@ -96,6 +100,6 @@ here reads `nil`.
       Takes a secret back, leaving it to be found again.
 
       Parameters:
-      - **`secret_num`** ([trx.stats.SecretNum](#stats.SecretNum)).
+      - <a id="stats.Stats.take_secret.secret_num" name="stats.Stats.take_secret.secret_num"></a>**`secret_num`** ([trx.stats.SecretNum](#stats.SecretNum)).
 
       Returns: boolean. `false` if the level has no such secret, or Lara does not have it.

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -10,7 +10,7 @@ order: 24
   src/lua/api/stats.lua. Edit it there.
 -->
 
-## Stats module
+## <a id="stats" name="stats"></a>Stats module
 
 Module for what a level keeps count of: what Lara has found in it, and how much
 there was to find.
@@ -22,25 +22,25 @@ here reads `nil`.
 
 ### Structures
 
-- <a name="stats.SecretNum"></a>[lua]`trx.stats.SecretNum`
+- <a id="stats.SecretNum" name="stats.SecretNum"></a>[lua]`trx.stats.SecretNum`
 
     The secret's number, as the player counts them. Counted from 1.
 
-- <a name="stats.Category"></a>[lua]`trx.stats.Category`
+- <a id="stats.Category" name="stats.Category"></a>[lua]`trx.stats.Category`
 
-    One thing a level is counted on, which is one row of the statistics screen. `raw` is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.
+    One thing a level is counted on, which is one row of the statistics screen. [`raw`](#stats.Category.raw) is [`max`](#stats.Category.max) plus [`unobtainable`](#stats.Category.unobtainable): the game flow can declare part of a level out of reach, and what it writes off is left out of what counts towards completion while still being in the level.
 
     Handles are live references: if the underlying object is destroyed,
     using the handle raises an error rather than silently reading an
     unrelated one.
 
     Properties:
-    - <a name="stats.Category.count"></a>**`count`**: integer. How many of them Lara has. The secrets cannot be set this way: they are held one by one, so `give_secret` and `take_secret` are how they change.
-    - <a name="stats.Category.max"></a>**`max`**: integer. How many of them count towards completing the level. *(read-only)*
-    - <a name="stats.Category.raw"></a>**`raw`**: integer. How many of them the level holds, obtainable or not. *(read-only)*
-    - <a name="stats.Category.unobtainable"></a>**`unobtainable`**: integer. How many of them the game flow declares out of reach, and so must not be held against the player. *(read-only)*
+    - <a id="stats.Category.count" name="stats.Category.count"></a>**`count`**: integer. How many of them Lara has. The secrets cannot be set this way: they are held one by one, so [`trx.stats.give_secret`](#stats.Stats.give_secret) and [`trx.stats.take_secret`](#stats.Stats.take_secret) are how they change.
+    - <a id="stats.Category.max" name="stats.Category.max"></a>**`max`**: integer. How many of them count towards completing the level. *(read-only)*
+    - <a id="stats.Category.raw" name="stats.Category.raw"></a>**`raw`**: integer. How many of them the level holds, obtainable or not. *(read-only)*
+    - <a id="stats.Category.unobtainable" name="stats.Category.unobtainable"></a>**`unobtainable`**: integer. How many of them the game flow declares out of reach, and so must not be held against the player. *(read-only)*
 
-- <a name="stats.Stats"></a>[lua]`trx.stats.Stats`
+- <a id="stats.Stats" name="stats.Stats"></a>[lua]`trx.stats.Stats`
 
     What one level keeps count of. The counters are the level's own and can be written, which is what a script correcting or seeding them wants.
 
@@ -49,25 +49,25 @@ here reads `nil`.
     unrelated one.
 
     Properties:
-    - <a name="stats.Stats.ammo_hits"></a>**`ammo_hits`**: integer. How many of them hit something.
-    - <a name="stats.Stats.ammo_used"></a>**`ammo_used`**: integer. How many rounds Lara has fired.
-    - <a name="stats.Stats.deaths"></a>**`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
-    - <a name="stats.Stats.distance_travelled"></a>**`distance_travelled`**: integer. How far Lara has travelled, in world units.
-    - <a name="stats.Stats.medipacks_used"></a>**`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
-    - <a name="stats.Stats.timer"></a>**`timer`**: integer. How long the level has been played, in game frames.
+    - <a id="stats.Stats.ammo_hits" name="stats.Stats.ammo_hits"></a>**`ammo_hits`**: integer. How many of them hit something.
+    - <a id="stats.Stats.ammo_used" name="stats.Stats.ammo_used"></a>**`ammo_used`**: integer. How many rounds Lara has fired.
+    - <a id="stats.Stats.deaths" name="stats.Stats.deaths"></a>**`deaths`**: integer. How many times Lara has died. Unlike the rest, this is not cleared when the level is entered again: a death stays with the level it happened on.
+    - <a id="stats.Stats.distance_travelled" name="stats.Stats.distance_travelled"></a>**`distance_travelled`**: integer. How far Lara has travelled, in world units.
+    - <a id="stats.Stats.medipacks_used" name="stats.Stats.medipacks_used"></a>**`medipacks_used`**: number. How many medipacks Lara has used, a small one counting as half of one.
+    - <a id="stats.Stats.timer" name="stats.Stats.timer"></a>**`timer`**: integer. How long the level has been played, in game frames.
 
     Computed properties (derived, not stored on the object):
-    - <a name="stats.Stats.allies_hurt"></a>**`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.
-    - <a name="stats.Stats.crystals"></a>**`crystals`**: [trx.stats.Category](#stats.Category). The save crystals, where the game has them.
-    - <a name="stats.Stats.kills"></a>**`kills`**: [trx.stats.Category](#stats.Category). The enemies the level counts, allies among them.
-    - <a name="stats.Stats.max_ally_kills"></a>**`max_ally_kills`**: integer. How many of `kills.max` are allies. The statistics screen holds them against the player only once `allies_hurt`, so a screen written in Lua wants to do the same: `max_enemy_kills`, and these as well once she has turned on one.
-    - <a name="stats.Stats.max_enemy_kills"></a>**`max_enemy_kills`**: integer. How many of `kills.max` are enemies rather than allies.
-    - <a name="stats.Stats.pickups"></a>**`pickups`**: [trx.stats.Category](#stats.Category). The items lying in the level for Lara to take.
-    - <a name="stats.Stats.secrets"></a>**`secrets`**: [trx.stats.Category](#stats.Category). The level's secrets. Which ones Lara holds is `secret_list`.
+    - <a id="stats.Stats.allies_hurt" name="stats.Stats.allies_hurt"></a>**`allies_hurt`**: boolean. Whether Lara has turned on an ally in this level.
+    - <a id="stats.Stats.crystals" name="stats.Stats.crystals"></a>**`crystals`**: [trx.stats.Category](#stats.Category). The save crystals, where the game has them.
+    - <a id="stats.Stats.kills" name="stats.Stats.kills"></a>**`kills`**: [trx.stats.Category](#stats.Category). The enemies the level counts, allies among them.
+    - <a id="stats.Stats.max_ally_kills" name="stats.Stats.max_ally_kills"></a>**`max_ally_kills`**: integer. How many of [`kills.max`](#stats.Category.max) are allies. The statistics screen holds them against the player only once [`allies_hurt`](#stats.Stats.allies_hurt), so a screen written in Lua wants to do the same: [`max_enemy_kills`](#stats.Stats.max_enemy_kills), and these as well once she has turned on one.
+    - <a id="stats.Stats.max_enemy_kills" name="stats.Stats.max_enemy_kills"></a>**`max_enemy_kills`**: integer. How many of [`kills.max`](#stats.Category.max) are enemies rather than allies.
+    - <a id="stats.Stats.pickups" name="stats.Stats.pickups"></a>**`pickups`**: [trx.stats.Category](#stats.Category). The items lying in the level for Lara to take.
+    - <a id="stats.Stats.secrets" name="stats.Stats.secrets"></a>**`secrets`**: [trx.stats.Category](#stats.Category). The level's secrets. Which ones Lara holds is [`secret_list`](#stats.Stats.secret_list).
 
     Methods:
 
-    - <a name="stats.Stats.give_secret"></a>[lua]`stats:give_secret(secret_num)`  
+    - <a id="stats.Stats.give_secret" name="stats.Stats.give_secret"></a>[lua]`stats:give_secret(secret_num)`  
       Marks a secret as found, as walking into its trigger would.
 
       Parameters:
@@ -80,7 +80,7 @@ here reads `nil`.
       trx.stats.give_secret(1)
       ```
 
-    - <a name="stats.Stats.secret_list"></a>[lua]`stats:secret_list()`  
+    - <a id="stats.Stats.secret_list" name="stats.Stats.secret_list"></a>[lua]`stats:secret_list()`  
       The level's secrets, in order, as a list of `{ num, found }`. `num` is the number the player says, and `found` is whether Lara has it.
 
       Returns: table. The secrets, one by one.
@@ -92,7 +92,7 @@ here reads `nil`.
       end
       ```
 
-    - <a name="stats.Stats.take_secret"></a>[lua]`stats:take_secret(secret_num)`  
+    - <a id="stats.Stats.take_secret" name="stats.Stats.take_secret"></a>[lua]`stats:take_secret(secret_num)`  
       Takes a secret back, leaving it to be found again.
 
       Parameters:

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -21,13 +21,25 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
 - <a id="strings.fuzzy_match" name="strings.fuzzy_match"></a>[lua]`trx.strings.fuzzy_match(input, sources)`  
   Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.
 
-  Candidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.
+  Candidates are ranked, best first. Each carries a [`sources.value`](#strings.fuzzy_match.sources.value) of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.
 
   Parameters:
-  - **`input`** (string). What the player typed.
-  - **`sources`** (table). List of `{ key = <the name>, value = <anything>, weight = <integer> }`. The key is a non-empty string. A heavier candidate wins a tie; weight defaults to 1, and a weight of zero or less drops the candidate.
+  - <a id="strings.fuzzy_match.input" name="strings.fuzzy_match.input"></a>**`input`** (string). What the player typed.
+  - <a id="strings.fuzzy_match.sources" name="strings.fuzzy_match.sources"></a>**`sources`** (table). The candidates.
 
-  Returns: table. The matches, best first: `{ key, value, score, is_full, is_word }`. `is_full` means the whole candidate matched, `is_word` that a whole word did.
+    Each entry:
+    - <a id="strings.fuzzy_match.sources.key" name="strings.fuzzy_match.sources.key"></a>**`key`** (string). The name to match against. Non-empty.
+    - <a id="strings.fuzzy_match.sources.value" name="strings.fuzzy_match.sources.value"></a>**`value`** (any). Anything of the caller's, handed back on the match.
+    - <a id="strings.fuzzy_match.sources.weight" name="strings.fuzzy_match.sources.weight"></a>**`weight`** (integer, optional, default `1`). A heavier candidate wins a tie. Zero or less drops it.
+
+  Returns: table. The matches, best first.
+
+    Each entry:
+    - <a id="strings.fuzzy_match.key" name="strings.fuzzy_match.key"></a>**`key`** (string). The candidate that matched.
+    - <a id="strings.fuzzy_match.value" name="strings.fuzzy_match.value"></a>**`value`** (any). What the candidate carried.
+    - <a id="strings.fuzzy_match.score" name="strings.fuzzy_match.score"></a>**`score`** (number). How well it matched.
+    - <a id="strings.fuzzy_match.is_full" name="strings.fuzzy_match.is_full"></a>**`is_full`** (boolean). Whether the whole candidate matched.
+    - <a id="strings.fuzzy_match.is_word" name="strings.fuzzy_match.is_word"></a>**`is_word`** (boolean). Whether a whole word matched.
 
   Example:
   ```lua
@@ -42,7 +54,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, `false` or `off` for false, in any case. Anything else is not a boolean.
 
   Parameters:
-  - **`text`** (string). The text to read.
+  - <a id="strings.parse_bool.text" name="strings.parse_bool.text"></a>**`text`** (string). The text to read.
 
   Returns: boolean or `nil`. `nil` when the text does not name a boolean.
 
@@ -57,8 +69,8 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   The list is sorted first, and duplicates survive as they are, so the caller need not tidy up before handing it over.
 
   Parameters:
-  - **`numbers`** (table). List of integers.
-  - **`separator`** (string, optional). What to put between the parts. Defaults to `", "`.
+  - <a id="strings.collapse_ranges.numbers" name="strings.collapse_ranges.numbers"></a>**`numbers`** (table). List of integers.
+  - <a id="strings.collapse_ranges.separator" name="strings.collapse_ranges.separator"></a>**`separator`** (string, optional). What to put between the parts. Defaults to `", "`.
 
   Returns: string. Empty when the list is.
 
@@ -71,10 +83,10 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   Whether a subject matches a regular expression. Case-insensitive.
 
   Parameters:
-  - **`subject`** (string).
-  - **`pattern`** (string). A PCRE regular expression.
+  - <a id="strings.regex_match.subject" name="strings.regex_match.subject"></a>**`subject`** (string). The text to search.
+  - <a id="strings.regex_match.pattern" name="strings.regex_match.pattern"></a>**`pattern`** (string). A PCRE regular expression.
 
-  Returns: boolean.
+  Returns: boolean. True where the pattern matches anywhere in the subject.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -10,7 +10,7 @@ order: 28
   src/lua/api/strings.lua. Edit it there.
 -->
 
-## Strings module
+## <a id="strings" name="strings"></a>Strings module
 
 Utilities for working with strings.
 
@@ -18,7 +18,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
 
 ### Functions
 
-- <a name="strings.fuzzy_match"></a>[lua]`trx.strings.fuzzy_match(input, sources)`  
+- <a id="strings.fuzzy_match" name="strings.fuzzy_match"></a>[lua]`trx.strings.fuzzy_match(input, sources)`  
   Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.
 
   Candidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.
@@ -38,7 +38,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   local best = matches[1]
   ```
 
-- <a name="strings.parse_bool"></a>[lua]`trx.strings.parse_bool(text)`  
+- <a id="strings.parse_bool" name="strings.parse_bool"></a>[lua]`trx.strings.parse_bool(text)`  
   Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, `false` or `off` for false, in any case. Anything else is not a boolean.
 
   Parameters:
@@ -51,7 +51,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   local on = trx.strings.parse_bool("on")
   ```
 
-- <a name="strings.collapse_ranges"></a>[lua]`trx.strings.collapse_ranges(numbers, [separator])`  
+- <a id="strings.collapse_ranges" name="strings.collapse_ranges"></a>[lua]`trx.strings.collapse_ranges(numbers, [separator])`  
   Writes a list of whole numbers as ranges, so that a long run reads as one: `{ 0, 2, 3, 4, 9 }` becomes `0, 2-4, 9`.
 
   The list is sorted first, and duplicates survive as they are, so the caller need not tidy up before handing it over.
@@ -67,7 +67,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   trx.strings.collapse_ranges({ 4, 1, 2, 3 }) -- "1-4"
   ```
 
-- <a name="strings.regex_match"></a>[lua]`trx.strings.regex_match(subject, pattern)`  
+- <a id="strings.regex_match" name="strings.regex_match"></a>[lua]`trx.strings.regex_match(subject, pattern)`  
   Whether a subject matches a regular expression. Case-insensitive.
 
   Parameters:

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -14,11 +14,11 @@ order: 28
 
 Utilities for working with strings.
 
-Not to be confused with `trx.locale`, which is the text a player reads: this module is about manipulating strings, that one is about which string the player gets.
+Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a player reads: this module is about manipulating strings, that one is about which string the player gets.
 
 ### Functions
 
-- [lua]`trx.strings.fuzzy_match(input, sources)`  
+- <a name="strings.fuzzy_match"></a>[lua]`trx.strings.fuzzy_match(input, sources)`  
   Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.
 
   Candidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.
@@ -38,7 +38,7 @@ Not to be confused with `trx.locale`, which is the text a player reads: this mod
   local best = matches[1]
   ```
 
-- [lua]`trx.strings.parse_bool(text)`  
+- <a name="strings.parse_bool"></a>[lua]`trx.strings.parse_bool(text)`  
   Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, `false` or `off` for false, in any case. Anything else is not a boolean.
 
   Parameters:
@@ -51,7 +51,7 @@ Not to be confused with `trx.locale`, which is the text a player reads: this mod
   local on = trx.strings.parse_bool("on")
   ```
 
-- [lua]`trx.strings.collapse_ranges(numbers, [separator])`  
+- <a name="strings.collapse_ranges"></a>[lua]`trx.strings.collapse_ranges(numbers, [separator])`  
   Writes a list of whole numbers as ranges, so that a long run reads as one: `{ 0, 2, 3, 4, 9 }` becomes `0, 2-4, 9`.
 
   The list is sorted first, and duplicates survive as they are, so the caller need not tidy up before handing it over.
@@ -67,7 +67,7 @@ Not to be confused with `trx.locale`, which is the text a player reads: this mod
   trx.strings.collapse_ranges({ 4, 1, 2, 3 }) -- "1-4"
   ```
 
-- [lua]`trx.strings.regex_match(subject, pattern)`  
+- <a name="strings.regex_match"></a>[lua]`trx.strings.regex_match(subject, pattern)`  
   Whether a subject matches a regular expression. Case-insensitive.
 
   Parameters:

--- a/docs/trx/lua/reference/WEAPONS.md
+++ b/docs/trx/lua/reference/WEAPONS.md
@@ -26,15 +26,15 @@ has are [`trx.inventory`](INVENTORY.md#inventory).
   without.
 
   Parameters:
-  - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
+  - <a id="weapons.is_available.weapon" name="weapons.is_available.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
-  Returns: boolean.
+  Returns: boolean. True where this game has the weapon at all.
 
 - <a id="weapons.object" name="weapons.object"></a>[lua]`trx.weapons.object(weapon)`  
   The pickup the weapon is, for handing it to [`trx.inventory:give`](INVENTORY.md#inventory.Inventory.give).
 
   Parameters:
-  - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
+  - <a id="weapons.object.weapon" name="weapons.object.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
   Returns: [trx.catalog.objects](CATALOG.md#catalog.objects). The object id, or `nil` if this game has no such weapon.
 
@@ -47,6 +47,6 @@ has are [`trx.inventory`](INVENTORY.md#inventory).
   How many shots one box of ammunition for it is worth.
 
   Parameters:
-  - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
+  - <a id="weapons.shots_per_box.weapon" name="weapons.shots_per_box.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
-  Returns: integer.
+  Returns: integer. Shots, not rounds.

--- a/docs/trx/lua/reference/WEAPONS.md
+++ b/docs/trx/lua/reference/WEAPONS.md
@@ -16,37 +16,37 @@ What a weapon is, rather than what Lara has of it.
 
 None of this differs between the inventory she carries and the one a level
 keeps for her, so it belongs to neither: what she holds and how many shots she
-has are `trx.inventory`.
+has are [`trx.inventory`](INVENTORY.md#inventory).
 
 ### Functions
 
-- [lua]`trx.weapons.is_available(weapon)`  
+- <a name="weapons.is_available"></a>[lua]`trx.weapons.is_available(weapon)`  
   Whether the game allows this weapon at all. The game flow can keep one out, and
   a cheat that hands it over anyway leaves Lara with a gun the level was built
   without.
 
   Parameters:
-  - **`weapon`** (integer). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is. Compare against `trx.catalog.weapons`.
+  - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
   Returns: boolean.
 
-- [lua]`trx.weapons.object(weapon)`  
+- <a name="weapons.object"></a>[lua]`trx.weapons.object(weapon)`  
   The pickup the weapon is, for handing it to `trx.inventory:give`.
 
   Parameters:
-  - **`weapon`** (integer). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is. Compare against `trx.catalog.weapons`.
+  - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
-  Returns: integer. The object id, or `nil` if this game has no such weapon. Compare against `trx.catalog.objects`.
+  Returns: [trx.catalog.objects](CATALOG.md#catalog.objects). The object id, or `nil` if this game has no such weapon.
 
   Example:
   ```lua
   trx.inventory:give(trx.weapons.object(trx.catalog.weapons.SHOTGUN))
   ```
 
-- [lua]`trx.weapons.shots_per_box(weapon)`  
+- <a name="weapons.shots_per_box"></a>[lua]`trx.weapons.shots_per_box(weapon)`  
   How many shots one box of ammunition for it is worth.
 
   Parameters:
-  - **`weapon`** (integer). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is. Compare against `trx.catalog.weapons`.
+  - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
 
   Returns: integer.

--- a/docs/trx/lua/reference/WEAPONS.md
+++ b/docs/trx/lua/reference/WEAPONS.md
@@ -10,7 +10,7 @@ order: 5
   src/lua/api/weapons.lua. Edit it there.
 -->
 
-## Weapons module
+## <a id="weapons" name="weapons"></a>Weapons module
 
 What a weapon is, rather than what Lara has of it.
 
@@ -20,7 +20,7 @@ has are [`trx.inventory`](INVENTORY.md#inventory).
 
 ### Functions
 
-- <a name="weapons.is_available"></a>[lua]`trx.weapons.is_available(weapon)`  
+- <a id="weapons.is_available" name="weapons.is_available"></a>[lua]`trx.weapons.is_available(weapon)`  
   Whether the game allows this weapon at all. The game flow can keep one out, and
   a cheat that hands it over anyway leaves Lara with a gun the level was built
   without.
@@ -30,8 +30,8 @@ has are [`trx.inventory`](INVENTORY.md#inventory).
 
   Returns: boolean.
 
-- <a name="weapons.object"></a>[lua]`trx.weapons.object(weapon)`  
-  The pickup the weapon is, for handing it to `trx.inventory:give`.
+- <a id="weapons.object" name="weapons.object"></a>[lua]`trx.weapons.object(weapon)`  
+  The pickup the weapon is, for handing it to [`trx.inventory:give`](INVENTORY.md#inventory.Inventory.give).
 
   Parameters:
   - **`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.
@@ -43,7 +43,7 @@ has are [`trx.inventory`](INVENTORY.md#inventory).
   trx.inventory:give(trx.weapons.object(trx.catalog.weapons.SHOTGUN))
   ```
 
-- <a name="weapons.shots_per_box"></a>[lua]`trx.weapons.shots_per_box(weapon)`  
+- <a id="weapons.shots_per_box" name="weapons.shots_per_box"></a>[lua]`trx.weapons.shots_per_box(weapon)`  
   How many shots one box of ammunition for it is worth.
 
   Parameters:

--- a/docs/trx/lua/reference/WEATHER.md
+++ b/docs/trx/lua/reference/WEATHER.md
@@ -37,7 +37,7 @@ The runtime weather effect the current level shows.
   Sets the active weather.
 
   Parameters:
-  - **`type`** ([trx.weather.Type](#weather.Type)). The weather to show.
+  - <a id="weather.set.type" name="weather.set.type"></a>**`type`** ([trx.weather.Type](#weather.Type)). The weather to show.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/WEATHER.md
+++ b/docs/trx/lua/reference/WEATHER.md
@@ -16,11 +16,11 @@ The runtime weather effect the current level shows.
 
 ### Properties
 
-- **`trx.weather.current`** (integer). The active weather. Compare against `trx.weather.Type`. *(read-only)*
+- <a name="weather.current"></a>**`trx.weather.current`** ([trx.weather.Type](#weather.Type)). The active weather. *(read-only)*
 
 ### Enums
 
-- [lua]`trx.weather.Type`
+- <a name="weather.Type"></a>[lua]`trx.weather.Type`
 
     The kinds of weather a level can show.
 
@@ -33,11 +33,11 @@ The runtime weather effect the current level shows.
 
 ### Functions
 
-- [lua]`trx.weather.set(type)`  
+- <a name="weather.set"></a>[lua]`trx.weather.set(type)`  
   Sets the active weather.
 
   Parameters:
-  - **`type`** (integer). The weather to show. Compare against `trx.weather.Type`.
+  - **`type`** ([trx.weather.Type](#weather.Type)). The weather to show.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/WEATHER.md
+++ b/docs/trx/lua/reference/WEATHER.md
@@ -10,17 +10,17 @@ order: 15
   src/lua/api/weather.lua. Edit it there.
 -->
 
-## Weather module
+## <a id="weather" name="weather"></a>Weather module
 
 The runtime weather effect the current level shows.
 
 ### Properties
 
-- <a name="weather.current"></a>**`trx.weather.current`** ([trx.weather.Type](#weather.Type)). The active weather. *(read-only)*
+- <a id="weather.current" name="weather.current"></a>**`trx.weather.current`** ([trx.weather.Type](#weather.Type)). The active weather. *(read-only)*
 
 ### Enums
 
-- <a name="weather.Type"></a>[lua]`trx.weather.Type`
+- <a id="weather.Type" name="weather.Type"></a>[lua]`trx.weather.Type`
 
     The kinds of weather a level can show.
 
@@ -33,7 +33,7 @@ The runtime weather effect the current level shows.
 
 ### Functions
 
-- <a name="weather.set"></a>[lua]`trx.weather.set(type)`  
+- <a id="weather.set" name="weather.set"></a>[lua]`trx.weather.set(type)`  
   Sets the active weather.
 
   Parameters:

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -66,6 +66,9 @@ local checkers
 -- What a number is, written once where it belongs: what an item number is is
 -- the items module's to say, and everything that holds one is typed by it.
 local numbers = ordered()
+-- What a value is measured in, written once where it belongs: a distance is a
+-- distance however many declarations hold one.
+local units = ordered()
 local containers = ordered()
 -- module -> { get, count, accepts }. What indexing the module table reaches.
 local module_containers = {}
@@ -1221,6 +1224,41 @@ function api.number(path, spec)
   register_checker(path, checkers.integer)
 end
 
+-- Declares a unit: what a value is measured in. An angle is measured the same
+-- way wherever one turns up, so it is written here and the declarations that
+-- hold one name it. Doc-only as a number is, and a type like any other.
+--
+-- `type` is what a value of it is: whole where the engine counts in steps of
+-- one, as it does for an angle and a distance, and a real number where it does
+-- not, as for a time in seconds.
+function api.unit(path, spec)
+  opening("api.unit", spec)
+  assert(type(path) == "string", "api.unit: path must be a string")
+  -- A unit belongs to the module that says what it measures, and the docs
+  -- reach it there.
+  split_path(path)
+  assert(
+    type(spec.description) == "string",
+    "api.unit: description must be a string"
+  )
+  local measured = spec.type or "integer"
+  assert(
+    measured == "integer" or measured == "number",
+    "api.unit: a unit measures an integer or a number"
+  )
+  assert(
+    spec.spellings == nil or type(spec.spellings) == "table",
+    "api.unit: spellings must list the words that mean this unit"
+  )
+  assert(
+    units.by_path[path] == nil,
+    "api.unit: '" .. path .. "' is already written"
+  )
+  record(units, path, spec)
+
+  register_checker(path, checkers[measured])
+end
+
 -- A spec as the docs read it. What it is typed by is written out as the path
 -- that names it, so the docs can link to the declaration and a description
 -- several places share is still written once.
@@ -1312,6 +1350,16 @@ function api.describe()
       path = path,
       description = spec.description,
       base = spec.base,
+    }
+  end)
+  out.units = collect(units, function(path, spec)
+    return {
+      path = path,
+      description = spec.description,
+      -- What a value of it is. Written out even where it is the default, so
+      -- the docs need not know what that default is.
+      type = spec.type or "integer",
+      spellings = spec.spellings,
     }
   end)
   out.modules = collect(modules, function(name, spec)
@@ -1431,6 +1479,7 @@ function api.describe()
     return {
       path = path,
       value = spec.value,
+      type = spec.type,
       description = spec.description,
     }
   end)
@@ -1483,6 +1532,8 @@ function api.describe()
   by_module(out.constants)
   by_module(out.namespaces)
   by_module(out.properties)
+  by_module(out.numbers)
+  by_module(out.units)
   -- Keyed by module, not by path, so by_module has nothing to sort on.
   table.sort(out.containers, function(a, b)
     return a.module < b.module
@@ -1520,6 +1571,7 @@ function api.describe()
   end
   for _, group in ipairs({
     out.numbers,
+    out.units,
     out.enums,
     out.functions,
     out.properties,

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -921,18 +921,25 @@ function api.type(path, spec)
     local getters, setters = {}, {}
     local has_fields = false
     for name, field in pairs(spec.fields or {}) do
-      assert(
-        type(field.get) == "function",
-        "api.type: field '" .. name .. "' needs a get"
-      )
-      assert(
-        field.set == nil or type(field.set) == "function",
-        "api.type: field '" .. name .. "' has a set that is not a function"
-      )
-      getters[name] = field.get
-      setters[name] = field.set
-      field.writable = field.set ~= nil
-      has_fields = true
+      -- A field with no accessors is an entry the value carries itself, which
+      -- is what a plain table of numbers is: the class says what the keys are
+      -- called and what they hold, and reading one reaches the entry.
+      if field.get == nil then
+        assert(
+          field.set == nil,
+          "api.type: field '" .. name .. "' has a set but no get"
+        )
+        field.writable = field.writable ~= false
+      else
+        assert(
+          field.set == nil or type(field.set) == "function",
+          "api.type: field '" .. name .. "' has a set that is not a function"
+        )
+        getters[name] = field.get
+        setters[name] = field.set
+        field.writable = field.set ~= nil
+        has_fields = true
+      end
     end
 
     if has_fields then
@@ -1229,12 +1236,16 @@ local function noted(spec)
     local accepted = types_of(out.type)
     out.type = #accepted == 1 and accepted[1] or accepted
   end
-  if type(out.params) == "table" then
-    local params = {}
-    for i, param in ipairs(out.params) do
-      params[i] = noted(param)
+  -- A table argument or result declares the keys it is made of, and each of
+  -- them reads like any other spec.
+  for _, key in ipairs({ "params", "fields" }) do
+    if type(out[key]) == "table" then
+      local list = {}
+      for i, nested in ipairs(out[key]) do
+        list[i] = noted(nested)
+      end
+      out[key] = list
     end
-    out.params = params
   end
   return out
 end
@@ -1523,6 +1534,41 @@ function api.describe()
   for _, module in ipairs(out.modules) do
     claim(module.name)
   end
+  -- What a call declares of its own: the arguments it takes, the keys of a
+  -- table among them, and the keys of what it hands back. A result has no name
+  -- of its own, so its keys hang off the call.
+  local function claim_call(entry, path)
+    for _, param in ipairs(entry.params or {}) do
+      claim(path .. "." .. param.name)
+      for _, field in ipairs(param.fields or {}) do
+        claim(path .. "." .. param.name .. "." .. field.name)
+      end
+      -- A hook has one callback, so what it is called with reads as the hook's.
+      for _, arg in ipairs(param.params or {}) do
+        claim(path .. "." .. arg.name)
+        for _, field in ipairs(arg.fields or {}) do
+          claim(path .. "." .. arg.name .. "." .. field.name)
+        end
+      end
+    end
+    local returns = entry.returns
+    for _, one in
+      ipairs(
+        returns ~= nil and returns.type ~= nil and { returns } or returns or {}
+      )
+    do
+      for _, field in ipairs(one.fields or {}) do
+        claim(path .. "." .. field.name)
+      end
+    end
+  end
+
+  for _, group in ipairs({ out.functions, out.namespaces }) do
+    for _, entry in ipairs(group) do
+      claim_call(entry, entry.path)
+    end
+  end
+
   local members = {}
   for _, entry in ipairs(out.types) do
     claim(entry.path)
@@ -1532,6 +1578,9 @@ function api.describe()
         claim(entry.path .. "." .. member.name)
         table.insert(members[entry.path], member.name)
       end
+    end
+    for _, method in ipairs(entry.methods) do
+      claim_call(method, entry.path .. "." .. method.name)
     end
   end
   for module, type_path in pairs(module_instance_types) do

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -59,26 +59,24 @@ local namespaces = ordered()
 -- metatable so api.strict can swap the wrapper in.
 local namespace_dispatch = {}
 -- Type name -> predicate. Private: reachable, a script could hand strict mode a
--- checker that accepts anything. A type answers to its bare name and to its
--- full path alike, so a declaration in another module can say which Listener it
--- means.
+-- checker that accepts anything. A declared type answers to the path it was
+-- declared under and to nothing else, so nothing names it by a spelling the
+-- declaration never chose.
 local checkers
--- Bare type name -> the path that claimed it, so two modules cannot quietly
--- declare the same name and have the later one answer for both.
-local checker_paths = {}
--- Descriptions written once and pointed at from wherever they belong, keyed by
--- a name of the module's choosing. `see` on a param, a return or a field pulls
--- one in - what "0-based item number" means is the items module's to say, and
--- every hook that carries one says it by pointing here.
-local notes = {}
+-- What a number is, written once where it belongs: what an item number is is
+-- the items module's to say, and everything that holds one is typed by it.
+local numbers = ordered()
 local containers = ordered()
 -- module -> { get, count, accepts }. What indexing the module table reaches.
 local module_containers = {}
 -- container path -> { name -> spec }. What the container's __index dispatches
 -- on. A module's path is its name; a namespace's is 'module.namespace'.
 local container_properties = {}
--- module -> function returning the handle it stands for.
+-- module -> function returning the handle it stands for, and the path of the
+-- type that handle has: trx.lara.air is a member of lara.Lara, so the docs can
+-- say where a script writing trx.lara.<member> lands.
 local module_instances = {}
+local module_instance_types = {}
 -- type path -> the class table of a type written in Lua, which is both what a
 -- value of that type carries as its metatable and where its methods live.
 local lua_classes = {}
@@ -87,6 +85,46 @@ local lua_classes = {}
 local class_parents = {}
 local strict_enabled = false
 local sealed = false
+
+-- Every type a spec accepts, in the order it declared them: one, or the
+-- several a container key answers to - a number, and the name that reaches the
+-- same thing.
+local function types_of(value)
+  return type(value) == "table" and value or { value }
+end
+
+-- What a declaration accepts, as the reader writes it: one type, or the
+-- several it answers to. What the errors below name.
+local function type_label(declared)
+  local names = {}
+  for i, one in ipairs(types_of(declared)) do
+    names[i] = tostring(one)
+  end
+  return #names == 0 and tostring(declared) or table.concat(names, " or ")
+end
+
+-- The predicate a declaration is checked by, or nil where this surface has no
+-- type of that name. One that names several passes on any of them.
+local function checker_for(declared)
+  if type(declared) ~= "table" then
+    return checkers[declared]
+  end
+  local each = {}
+  for i, one in ipairs(declared) do
+    each[i] = checkers[one]
+    if each[i] == nil then
+      return nil
+    end
+  end
+  return function(value)
+    for _, check in ipairs(each) do
+      if check(value) then
+        return true
+      end
+    end
+    return false
+  end
+end
 
 local function split_path(path)
   local module, name = path:match("^([%w_]+)%.([%w_]+)$")
@@ -218,16 +256,19 @@ local function install_meta(owner, tbl)
         end
         -- A property is written, not called, so make_checked never sees it.
         -- Strict mode still has to.
-        if strict_enabled and not checkers[prop.type](value) then
-          error(
-            "trx."
-              .. owner
-              .. "."
-              .. tostring(key)
-              .. ": expected a "
-              .. tostring(prop.type),
-            2
-          )
+        if strict_enabled then
+          local check = checker_for(prop.type)
+          if check ~= nil and not check(value) then
+            error(
+              "trx."
+                .. owner
+                .. "."
+                .. tostring(key)
+                .. ": expected a "
+                .. type_label(prop.type),
+              2
+            )
+          end
         end
         prop.set(value)
         return
@@ -278,7 +319,7 @@ local function install_meta(owner, tbl)
 end
 
 function api.module(name, spec)
-  opening("api.module")
+  opening("api.module", spec)
   assert(type(name) == "string", "api.module: name must be a string")
   spec = record(modules, name, spec or {})
 
@@ -289,7 +330,12 @@ function api.module(name, spec)
       type(spec.instance) == "function",
       "api.module: instance must be a function"
     )
+    assert(
+      type(spec.instance_type) == "string",
+      "api.module: instance_type must name the type the module stands for"
+    )
     module_instances[name] = spec.instance
+    module_instance_types[name] = spec.instance_type
     install_meta(name, module_table(name))
   end
 end
@@ -365,11 +411,12 @@ local function make_checked(fn, path, params)
   local param_checkers, defaults = {}, {}
   for i = 1, fixed do
     local p = params[i]
-    local check = checkers[p.type]
-    assert(
-      check ~= nil,
-      path .. ": no checker for type '" .. tostring(p.type) .. "'"
-    )
+    -- Strict mode checks what it can. A type this surface does not declare -
+    -- a test standing up a few modules names one - has nothing to check
+    -- against, and is caught where every other name is: the seal, and the dump.
+    local check = checker_for(p.type) or function()
+      return true
+    end
     param_checkers[i] = check
     defaults[i] = p.default
   end
@@ -432,20 +479,19 @@ end
 -- A value of a type written in Lua carries its class as its metatable, and a
 -- derived class carries the one it extends. Walking that chain is what lets an
 -- ItemQuery satisfy a parameter declared as a Query.
--- A type answers to its path always, and to its bare name while that name means
--- one type. Two modules with a type of the same name - music.Stream and
--- sound.Stream - leave the bare name meaning neither, so a declaration that
--- used it stops checking rather than checking against whichever module declared
--- last, and says as much at boot.
-local function register_checker(path, type_name, check)
-  local claimed = checker_paths[type_name]
-  if claimed ~= nil and claimed ~= path then
-    checkers[type_name] = nil
-    checker_paths[type_name] = false
-  elseif claimed == nil then
-    checker_paths[type_name] = path
-    checkers[type_name] = check
-  end
+-- A type answers to the path it was declared under. There is no second name to
+-- keep in step with it: a declaration that means items.Item says items.Item,
+-- and one that means something nobody declared fails the audit rather than
+-- waving values through under a name that once meant something else.
+--
+-- One path, one declaration: a number written over a type's path would leave
+-- the type checked for the number instead, and strict mode would report a
+-- clean run while a handle's own values went unrecognized.
+local function register_checker(path, check)
+  assert(
+    checkers[path] == nil,
+    "api: '" .. path .. "' is declared twice, and a name answers to one thing"
+  )
   checkers[path] = check
 end
 
@@ -468,7 +514,8 @@ end
 --
 -- Also audits the finished surface: an assignment straight onto a module table
 -- works for scripts, but the docs never see it. Refuse to boot instead.
-function api.seal()
+function api.seal(spec)
+  local partial = spec ~= nil and spec.partial == true
   -- The declaring half has done its job, and every one of those functions
   -- raises from here on. It goes the way trxc goes at this same moment: what a
   -- script cannot successfully call, it should not be able to reach. Done
@@ -537,14 +584,14 @@ function api.seal()
   -- value through while strict mode reports a clean run over it.
   local bad = {}
   local function audit_type(where, what, type_name)
-    if checkers[type_name] == nil then
+    if checker_for(type_name) == nil and not partial then
       table.insert(
         bad,
         where
           .. ": "
           .. what
           .. " has an unknown type '"
-          .. tostring(type_name)
+          .. type_label(type_name)
           .. "'"
       )
       return false
@@ -560,14 +607,14 @@ function api.seal()
           audit_type(where, "'" .. tostring(p.name) .. "'", p.type)
           and p.default ~= nil
         then
-          if not checkers[p.type](p.default) then
+          if not checker_for(p.type)(p.default) then
             table.insert(
               bad,
               where
                 .. ": the default for '"
                 .. p.name
                 .. "' is not a "
-                .. p.type
+                .. type_label(p.type)
             )
           end
         end
@@ -664,6 +711,21 @@ end
 -- The registry owns the module's metatable, so a module that set its own would
 -- lose it to the first property declared on it. And pairs() never sees a
 -- metatable, so only a declaration puts the indexing in the reference.
+-- What indexing counts from: the key's own base, or the base of whatever it
+-- points at, since a container keyed by an item number counts as items do.
+local function key_base(key)
+  if key.base ~= nil then
+    return key.base
+  end
+  for _, one in ipairs(types_of(key.type)) do
+    local number = numbers.by_path[one]
+    if number ~= nil and number.base ~= nil then
+      return number.base
+    end
+  end
+  return nil
+end
+
 function api.container(name, spec)
   opening("api.container", spec)
   assert(type(spec.get) == "function", "api.container: get must be a function")
@@ -675,16 +737,31 @@ function api.container(name, spec)
     type(spec.key) == "table",
     "api.container: key must describe what the module is indexed by"
   )
+  -- Where a collection counts from is the key's, so that a container keyed by
+  -- an item number counts as items do without saying so twice.
+  assert(
+    spec.base == nil,
+    "api.container: where it counts from belongs to the key"
+  )
 
-  -- A module keyed only by number leaves a string key to the rest of the
-  -- metatable, so trx.rooms.nonsense is nil rather than an error out of C.
-  local by_number_only = spec.key.type == "integer"
+  -- What the key accepts: one type, or several where a thing answers to a name
+  -- as well as to its number. A module keyed only by number leaves a string key
+  -- to the rest of the metatable, so trx.rooms.nonsense is nil rather than an
+  -- error out of C.
+  local accepted = types_of(spec.key.type)
+  local by_number_only = true
+  for _, one in ipairs(accepted) do
+    if one == "string" or one == "any" then
+      by_number_only = false
+    end
+  end
   module_containers[name] = {
     get = spec.get,
     count = spec.count,
-    -- Where the collection's first entry sits. A list of its own is counted
-    -- from one; what carries an engine number keeps it and counts from zero.
-    base = spec.base or 0,
+    -- Where the collection's first entry sits, which is the key's own base: a
+    -- list of its own is counted from one, and what carries an engine number
+    -- keeps it and counts from zero.
+    base = key_base(spec.key) or 0,
     accepts = function(key)
       local kind = type(key)
       return kind == "number" or (kind == "string" and not by_number_only)
@@ -729,7 +806,6 @@ end
 local function bind_type_methods(path)
   local spec = types.by_path[path]
   local backing = spec.backing
-  local _, type_name = split_path(path)
   local class = lua_classes[path]
 
   -- A type written in Lua keeps its methods in the class table, so binding one
@@ -747,7 +823,7 @@ local function bind_type_methods(path)
         bound(
           method.impl,
           path .. "." .. name,
-          method_params(method.params, type_name)
+          method_params(method.params, path)
         )
       )
     end
@@ -762,7 +838,7 @@ local function bind_type_methods(path)
       exposed = make_checked(
         method.impl or struct.method(backing, method.from or name),
         path .. "." .. name,
-        method_params(method.params, type_name)
+        method_params(method.params, path)
       )
     end
     struct.expose_method(backing, name, exposed)
@@ -798,7 +874,6 @@ end
 -- called. A member C can reach but nobody declares simply does not exist.
 function api.type(path, spec)
   opening("api.type", spec)
-  local _, type_name = split_path(path)
 
   -- A type written in Lua names no C struct. The declaration owns its class
   -- table and hands it back: the module gives a value that class as its
@@ -886,7 +961,7 @@ function api.type(path, spec)
     end
 
     lua_classes[path] = class
-    register_checker(path, type_name, class_checker(class))
+    register_checker(path, class_checker(class))
     record(types, path, spec)
     bind_type_methods(path)
     return class
@@ -899,7 +974,7 @@ function api.type(path, spec)
   local backing = spec.backing
 
   -- Declaring the type is what makes its name checkable in a params list.
-  register_checker(path, type_name, handle_checker(backing))
+  register_checker(path, handle_checker(backing))
 
   for name, field in pairs(spec.fields or {}) do
     local from = field.from or name
@@ -917,6 +992,15 @@ function api.type(path, spec)
   record(types, path, spec)
 
   bind_type_methods(path)
+end
+
+-- The class of a type written in Lua, for a module that hands one of its values
+-- out but is not where it is declared: trx.items hands back a math.Box, and a
+-- box carries that class. Everything else names a type by its path.
+function api.class(path)
+  local class = lua_classes[path]
+  assert(class ~= nil, "api.class: '" .. path .. "' is not a declared type")
+  return class
 end
 
 -- Declares an enum: what the constants of a C enum are called in Lua, and what
@@ -1039,6 +1123,11 @@ function api.enum(path, spec)
 
   rawset(module_table(module), name, face)
 
+  -- What the engine passes is a number. Which numbers have names is the
+  -- catalog's business - a bulk enum runs to hundreds, and carries ids no
+  -- constant names - so a declaration typed by an enum checks for the number.
+  register_checker(path, checkers.integer)
+
   record(enums, path, spec)
   return face
 end
@@ -1097,18 +1186,37 @@ function api.property(path, spec)
   return spec
 end
 
--- Declares a description other declarations point at with `see`. Doc-only: it
--- reaches no module table and a script never sees it.
-function api.note(name, text)
-  opening("api.note")
-  assert(type(name) == "string", "api.note: name must be a string")
-  assert(type(text) == "string", "api.note: text must be a string")
-  assert(notes[name] == nil, "api.note: '" .. name .. "' is already written")
-  notes[name] = text
+-- Declares a number: what it counts, and where it counts from. A room number
+-- is one thing however many declarations hold one, so it is written here and
+-- they name it. Doc-only in the sense that no member of it reaches a script -
+-- what a script gets is the number itself - but it is a type like any other,
+-- and a declaration that holds one says so.
+function api.number(path, spec)
+  opening("api.number", spec)
+  assert(type(path) == "string", "api.number: path must be a string")
+  -- A number belongs to the module that says what it counts, and the docs
+  -- reach it there.
+  split_path(path)
+  assert(
+    type(spec.description) == "string",
+    "api.number: description must be a string"
+  )
+  assert(
+    spec.base == nil or spec.base == 0 or spec.base == 1,
+    "api.number: base counts from 0 or from 1"
+  )
+  assert(
+    numbers.by_path[path] == nil,
+    "api.number: '" .. path .. "' is already written"
+  )
+  record(numbers, path, spec)
+
+  register_checker(path, checkers.integer)
 end
 
--- A spec as the docs read it: what `see` points at, ahead of anything the spec
--- adds of its own, and the same done to the arguments a callback takes.
+-- A spec as the docs read it. What it is typed by is written out as the path
+-- that names it, so the docs can link to the declaration and a description
+-- several places share is still written once.
 local function noted(spec)
   if type(spec) ~= "table" then
     return spec
@@ -1117,13 +1225,9 @@ local function noted(spec)
   for key, value in pairs(spec) do
     out[key] = value
   end
-  if out.see ~= nil then
-    local note = notes[out.see]
-    assert(note ~= nil, "api: no note called '" .. tostring(out.see) .. "'")
-    out.description = out.description ~= nil
-        and (note .. " " .. out.description)
-      or note
-    out.see = nil
+  if out.type ~= nil then
+    local accepted = types_of(out.type)
+    out.type = #accepted == 1 and accepted[1] or accepted
   end
   if type(out.params) == "table" then
     local params = {}
@@ -1192,12 +1296,23 @@ function api.describe()
       examples = spec.examples,
     }
   end)
+  out.numbers = collect(numbers, function(path, spec)
+    return {
+      path = path,
+      description = spec.description,
+      base = spec.base,
+    }
+  end)
   out.modules = collect(modules, function(name, spec)
     return {
       name = name,
       title = spec.title,
       description = spec.description,
       order = spec.order,
+      -- What indexing the module reaches, where it stands for one thing:
+      -- trx.lara.air is a member of lara.Lara, and a reference written the way
+      -- a script writes it lands there.
+      instance_type = module_instance_types[name],
     }
   end)
   out.functions = collect(registry, function(path, spec)
@@ -1236,7 +1351,7 @@ function api.describe()
         type = noted_field.type,
         writable = noted_field.writable ~= false,
         description = noted_field.description,
-        enum = noted_field.enum,
+        base = noted_field.base,
       })
     end
     for name, method in pairs(spec.methods or {}) do
@@ -1253,6 +1368,7 @@ function api.describe()
         name = name,
         type = computed.type,
         description = computed.description,
+        base = computed.base,
       })
     end
     local by_name = function(a, b)
@@ -1324,7 +1440,7 @@ function api.describe()
       path = path,
       type = spec.type,
       description = spec.description,
-      enum = spec.enum,
+      base = spec.base,
       writable = spec.set ~= nil,
     }
   end)
@@ -1381,6 +1497,203 @@ function api.describe()
     end
   end
   dedent_prose(out)
+
+  -- Everything a declaration can be pointed at by, which is the path it was
+  -- declared under and nothing else. A member is reachable as its type's path
+  -- and its own name; a module standing for an instance also answers for that
+  -- type's members, since a script writes trx.lara.air rather than the type.
+  local anchors = {}
+  local function claim(path)
+    if type(path) == "string" then
+      anchors[path] = true
+    end
+  end
+  for _, group in ipairs({
+    out.numbers,
+    out.enums,
+    out.functions,
+    out.properties,
+    out.namespaces,
+    out.constants,
+  }) do
+    for _, entry in ipairs(group) do
+      claim(entry.path)
+    end
+  end
+  for _, module in ipairs(out.modules) do
+    claim(module.name)
+  end
+  local members = {}
+  for _, entry in ipairs(out.types) do
+    claim(entry.path)
+    members[entry.path] = {}
+    for _, kind in ipairs({ entry.fields, entry.methods, entry.extensions }) do
+      for _, member in ipairs(kind) do
+        claim(entry.path .. "." .. member.name)
+        table.insert(members[entry.path], member.name)
+      end
+    end
+  end
+  for module, type_path in pairs(module_instance_types) do
+    assert(
+      members[type_path] ~= nil,
+      "api: module '"
+        .. module
+        .. "' stands for '"
+        .. type_path
+        .. "', which nothing declares"
+    )
+    for _, name in ipairs(members[type_path]) do
+      claim(module .. "." .. name)
+    end
+  end
+
+  -- What a declared member hands back, where that is a declared type too, so
+  -- a path can be walked through it: stats.pickups is a stats.Category, and
+  -- its count is that type's own member.
+  -- A container keyed by an enum is indexed by its constants, which is how
+  -- trx.objects.wolf is written; the key says which enum, so the constant is
+  -- checked against it rather than waved through.
+  local constants = {}
+  for _, entry in ipairs(out.enums) do
+    constants[entry.path] = {}
+    for _, value in ipairs(entry.values or {}) do
+      constants[entry.path][value.name:upper()] = true
+    end
+    for _, name in ipairs(entry.names or {}) do
+      constants[entry.path][name:upper()] = true
+    end
+  end
+
+  local keyed_by = {}
+  for _, entry in ipairs(out.containers) do
+    -- What a key accepts may be several things; the enum among them is what a
+    -- name indexes through.
+    local accepted = entry.key ~= nil and entry.key.type or nil
+    if type(accepted) == "table" then
+      for _, one in ipairs(accepted) do
+        if constants[one] ~= nil then
+          accepted = one
+          break
+        end
+      end
+    end
+    keyed_by[entry.module] = type(accepted) == "string" and accepted or nil
+  end
+
+  local stands_for = {}
+  for _, entry in ipairs(out.types) do
+    for _, member in ipairs(entry.fields) do
+      stands_for[entry.path .. "." .. member.name] = member.type
+    end
+    for _, member in ipairs(entry.extensions) do
+      stands_for[entry.path .. "." .. member.name] = member.type
+    end
+  end
+  for _, entry in ipairs(out.properties) do
+    stands_for[entry.path] = entry.type
+  end
+  for module, type_path in pairs(module_instance_types) do
+    for _, name in ipairs(members[type_path] or {}) do
+      stands_for[module .. "." .. name] = stands_for[type_path .. "." .. name]
+    end
+  end
+
+  -- The path a reference names, walked a segment at a time: through the thing
+  -- itself where it is anchored, and through what it hands back where that is
+  -- a type of its own. Nothing is guessed - a name one segment off used to
+  -- resolve to the module it sat under, which is how a reference to something
+  -- renamed went on looking fine.
+  local function resolve(path)
+    if anchors[path] then
+      return path
+    end
+    local parts = {}
+    for part in path:gmatch("[^.]+") do
+      parts[#parts + 1] = part
+    end
+    local at = parts[1]
+    if not anchors[at] then
+      return nil
+    end
+    for i = 2, #parts do
+      local step = parts[i]
+      if anchors[at .. "." .. step] then
+        at = at .. "." .. step
+      elseif
+        stands_for[at] ~= nil and anchors[stands_for[at] .. "." .. step]
+      then
+        at = stands_for[at] .. "." .. step
+      elseif
+        keyed_by[at] ~= nil
+        and constants[keyed_by[at]] ~= nil
+        and constants[keyed_by[at]][step:upper()]
+      then
+        -- Indexing a container by one of the names its key accepts.
+        return at
+      elseif constants[at] ~= nil and constants[at][step:upper()] then
+        -- An enum's constants are not anchored one by one - a catalog runs to
+        -- hundreds - so the enum that holds it is where the link lands.
+        return at
+      else
+        return nil
+      end
+    end
+    return at
+  end
+
+  -- A path that resolves to nothing is a reference to something that has been
+  -- renamed or was never there: a silent broken link in the reference, and a
+  -- description that quietly goes missing. It stops the dump instead.
+  local function must_resolve(where, what, path, exact)
+    local hit = resolve(path)
+    assert(
+      hit ~= nil and (not exact or hit == path),
+      "api: "
+        .. tostring(where)
+        .. "'s "
+        .. what
+        .. " names '"
+        .. path
+        .. "', which nothing declares"
+    )
+  end
+
+  local function check_refs(node, where)
+    if type(node) ~= "table" then
+      return
+    end
+    -- A container is named by the module it is indexed on, which is what a
+    -- reader has to be told to find the declaration.
+    local here = node.path or node.name or node.module or where
+    for _, one in ipairs(types_of(node.type)) do
+      if type(one) == "string" then
+        if numbers.by_path[one] ~= nil then
+          assert(
+            node.base == nil,
+            "api: "
+              .. tostring(here)
+              .. " is a '"
+              .. one
+              .. "' and declares a base of its own"
+          )
+        end
+        if one:find("%.") ~= nil then
+          must_resolve(here, "type", one, true)
+        end
+      end
+    end
+    -- Prose names things the same way a script does, and the reference links
+    -- every one of them, so a name that has moved has to be caught here too.
+    for path in (node.description or ""):gmatch("`trx%.([%w_.]+)`") do
+      must_resolve(here, "description", path, false)
+    end
+    for _, value in pairs(node) do
+      check_refs(value, here)
+    end
+  end
+  check_refs(out, "api")
+
   return out
 end
 
@@ -1465,14 +1778,23 @@ api.define("api.strict", {
   description = "Turns argument checking on or off for every function in `trx`, and for the methods "
     .. "on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler "
     .. "notices. Turn it on while writing a level, and leave it off in play.",
-  params = { { name = "enabled", type = "boolean" } },
+  params = {
+    {
+      name = "enabled",
+      type = "boolean",
+      description = "Whether to check.",
+    },
+  },
   examples = { [[trx.api.strict(true)]] },
   impl = api.strict,
 })
 
 api.define("api.is_strict", {
   description = "Whether argument checking is on.",
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "False as the game starts, and true once something turns it on.",
+  },
   impl = api.is_strict,
 })
 

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -1399,7 +1399,6 @@ function api.describe()
       examples = spec.examples,
       bulk = spec.bulk == true,
       count = spec.count,
-      source = spec.source,
       values = {},
     }
     -- Names only, and no values: the ids are TRX's own, and a script refers to

--- a/src/lua/api/argparse.lua
+++ b/src/lua/api/argparse.lua
@@ -10,24 +10,17 @@ Python's argparse.
 
 A parser both reads a command's arguments and offers completions for them,
 from one declaration. Every command written with `trx.console.register` has
-one; a command shapes it through the `args` function it hands over, and `run`
-then receives a table of parsed values. A command that shapes nothing takes no
-arguments, and is told so when given one.
+one; a command shapes it through the `trx.console.register.spec.args` function
+it hands over, and `trx.console.register.spec.run` then receives a table of
+parsed values. A command that shapes nothing takes no arguments, and is told so
+when given one.
 
 Every parser answers `-h` and `--help` on its own, printing what it accepts.
 
-How a positional reads a token is its `matcher`, one of:
-
-- `type` - coerce to `"integer"`, `"number"`, `"string"` or `"boolean"`.
-- `choices` - the allowed set: a list of values or a `function(parsed)`
-  returning one. The token must match one; the set is shown in errors and
-  completes.
-- `match` - a `function(token, parsed)` returning `value, ok`, for a shape of its own.
-
-These do not combine on one positional; a value that is a number *or* a name is
-two matchers, declared with `any_of`. Separately, `suggest` offers completions
-without restricting or being shown in errors - for a free value with a long
-list behind it, like a setting name.
+How a positional reads a token is its matcher: a type to coerce to, a set of
+choices, or a function of its own. These do not combine on one positional; a
+value that is a number *or* a name is two matchers, declared with
+`trx.argparse.Parser:any_of`.
 
 Positionals are read in order, and an optional one a token does not fit is
 passed over: the token goes to the next positional, and the one skipped stays
@@ -36,34 +29,10 @@ without - a verb before a value, a count before a name. Completion follows the
 same path, so a slot offers what every argument reachable from it takes. A
 token nothing takes is reported against the first argument that refused it.
 
-A parser has these methods, each returning the parser so calls chain:
-
-- `positional(name, opts)` - a positional with one matcher (`opts.type`,
-  `opts.choices` or `opts.match`). `opts.optional` lets it be left out;
-  `opts.greedy` reads the rest of the line as one token, so a value with spaces
-  in it still arrives whole; `opts.suggest` completes it; `opts.help` describes
-  it.
-- `any_of(name, alternatives, opts)` - a positional whose value is the first of
-  several matchers to take the token. Each alternative is a matcher table,
-  `{ type = ... }` or `{ choices = ... }`. Same `opts` as `positional`.
-- `rest(name, opts)` - the rest of the line from here on, verbatim as one
-  string, or nil when an optional one is absent. Always the last argument;
-  `opts.suggest` completes it.
-- `flag(name, opts)` - a boolean that may sit anywhere. `opts.short` and
-  `opts.long` are the spellings, e.g. `"-f"` and `"--force"`; `opts.help`
-  describes it.
-- `parse(args)` - reads the argument string, returning a table of values, or
-  `nil` and a structured error the console layer turns into localized text. A
-  value carried by a `{ key, value }` choice comes back as its `value`;
-  `-h`/`--help` comes back as `{ help = true }`.
-- `complete(text, caret)` - the candidate completions for the token the caret
-  sits in, and the byte offsets `start, end` of the run they replace (reaching
-  to the end of the line for a greedy argument).
-- `usage()` - a short description of what the command accepts.
-
 A choice is either a bare string, where the key and value are the same, or a
-`{ key, value }` pair, where `key` is matched and shown and `value` is what
-`parse` gives back. Matching is forgiving, through `trx.strings.fuzzy_match`.]],
+`{ key, value }` pair, where the key is matched and shown and the value is what
+`trx.argparse.Parser:parse` gives back. Matching is forgiving, through
+`trx.strings.fuzzy_match`.]],
 })
 
 trx.locale.declare({
@@ -239,10 +208,13 @@ local function format_hint(hint)
   return out
 end
 
-local Parser = {}
-Parser.__index = Parser
+-- The class is the declaration's, further down: what a script may call on a
+-- parser is what api.type names, and these are the bodies behind it. The name
+-- is taken here, because the declaration's own methods hand a parser back.
+local Parser
+local P = {}
 
-function Parser.new(spec)
+function P.new(spec)
   spec = spec or {}
   local self = setmetatable({
     prog = spec.prog,
@@ -287,7 +259,7 @@ local function make_matcher(opts)
   }
 end
 
-function Parser:positional(name, opts)
+function P:positional(name, opts)
   opts = opts or {}
   self.positionals[#self.positionals + 1] = {
     name = name,
@@ -303,7 +275,7 @@ function Parser:positional(name, opts)
   return self
 end
 
-function Parser:any_of(name, alternatives, opts)
+function P:any_of(name, alternatives, opts)
   opts = opts or {}
   local matchers = {}
   for _, alt in ipairs(alternatives) do
@@ -324,7 +296,7 @@ end
 -- The rest of the line, from here on, verbatim as one string. Required unless
 -- `opts.optional`; when it is optional and nothing is left, it comes back as
 -- nil. Always the last argument. A plain-string matcher takes the line whole.
-function Parser:rest(name, opts)
+function P:rest(name, opts)
   opts = opts or {}
   self.positionals[#self.positionals + 1] = {
     name = name,
@@ -338,7 +310,7 @@ function Parser:rest(name, opts)
   return self
 end
 
-function Parser:flag(name, opts)
+function P:flag(name, opts)
   opts = opts or {}
   assert(name ~= "help", "argparse: 'help' is a reserved flag name")
   self.flags[#self.flags + 1] = {
@@ -367,7 +339,7 @@ local function tokenize_offsets(s)
   return out
 end
 
-function Parser:flag_for(token)
+function P:flag_for(token)
   for _, flag in ipairs(self.flags) do
     if token == flag.short or token == flag.long then
       return flag
@@ -420,7 +392,7 @@ local function take(parser, pos_idx, tok, args, values)
   return nil, nil, nil, first_err
 end
 
-function Parser:parse(args)
+function P:parse(args)
   args = args or ""
   local values = {}
   for _, flag in ipairs(self.flags) do
@@ -433,7 +405,7 @@ function Parser:parse(args)
 
   while i <= #toks do
     local tok = toks[i]
-    local flag = self:flag_for(tok.text)
+    local flag = P.flag_for(self, tok.text)
     if flag ~= nil then
       -- Help answers the moment it is seen, ahead of any later token that would
       -- otherwise fail first. A greedy positional swallows a -h that follows it,
@@ -471,7 +443,7 @@ end
 
 -- Turns a parse error into a localized, capitalized line naming what was wrong
 -- and what was expected.
-function Parser:format_error(err)
+function P:format_error(err)
   local msg
   if err.kind == "missing" then
     msg = trx.locale.format("console/argparse/missing", err.metavar)
@@ -534,7 +506,7 @@ end
 -- or the whole tail a greedy argument swallows, reaching to the end of the line;
 -- in whitespace it is empty, at the caret. Matching is against the text before
 -- the caret.
-function Parser:complete(text, caret)
+function P:complete(text, caret)
   text = text or ""
   caret = caret or #text
   if caret < 0 then
@@ -587,7 +559,7 @@ function Parser:complete(text, caret)
   -- them.
   local consumed = {}
   for i, tok in ipairs(toks) do
-    if i ~= active and self:flag_for(tok.text) == nil then
+    if i ~= active and P.flag_for(self, tok.text) == nil then
       if (tok.start - 1) + #tok.text <= caret then
         consumed[#consumed + 1] = tok
       end
@@ -688,7 +660,7 @@ local function is_detailed(arg)
   return false
 end
 
-function Parser:usage()
+function P:usage()
   local parts = { self.prog or "?" }
   for _, flag in ipairs(self.flags) do
     if flag.name ~= "help" then
@@ -749,25 +721,340 @@ function Parser:usage()
   return table.concat(lines, "\n")
 end
 
+-- The options every positional takes, whichever way it reads its token.
+local ARG_OPTS = {
+  {
+    name = "optional",
+    type = "boolean",
+    optional = true,
+    description = "Lets the argument be left out.",
+  },
+  {
+    name = "greedy",
+    type = "boolean",
+    optional = true,
+    description = "Reads the rest of the line as one token, so a value with spaces in it "
+      .. "still arrives whole.",
+  },
+  {
+    name = "metavar",
+    type = "string",
+    optional = true,
+    description = "What the argument is called in messages and in the synopsis. Its own name "
+      .. "by default.",
+  },
+  {
+    name = "suggest",
+    type = "function",
+    optional = true,
+    description = "Completions to offer, without restricting what is accepted or being shown "
+      .. "in errors. For a free value with a long list behind it, like a setting name.",
+  },
+  {
+    name = "help",
+    type = "string",
+    optional = true,
+    description = "What the argument is for, shown in the help.",
+  },
+}
+
+-- A matcher and the options around it, which is what a single-matcher argument
+-- declares in one table.
+local function positional_opts()
+  local out = {
+    {
+      name = "type",
+      type = "string",
+      optional = true,
+      description = 'Coerce the token: `"integer"`, `"number"`, `"string"` or `"boolean"`.',
+    },
+    {
+      name = "choices",
+      type = "any",
+      optional = true,
+      description = "The allowed set: a list of values, or a function of the values parsed so "
+        .. "far returning one. The token must match one; the set is shown in errors and "
+        .. "completes.",
+    },
+    {
+      name = "match",
+      type = "function",
+      optional = true,
+      description = "A function of the token and the values parsed so far, returning the "
+        .. "value and whether it took, for a shape of its own.",
+    },
+  }
+  for _, opt in ipairs(ARG_OPTS) do
+    out[#out + 1] = opt
+  end
+  return out
+end
+
+Parser = api.type("argparse.Parser", {
+  description = "An argument parser, built up a call at a time. Every method hands the parser "
+    .. "back, so the calls chain.",
+
+  methods = {
+    positional = {
+      description = "Adds a positional argument, read one way.",
+      params = {
+        {
+          name = "name",
+          type = "string",
+          description = "What the parsed value is keyed by.",
+        },
+        {
+          name = "opts",
+          type = "table",
+          optional = true,
+          description = "How it reads its token, and how it behaves. It reads a token one "
+            .. "way: name at most one of `trx.argparse.Parser.positional.opts.type`, "
+            .. "`trx.argparse.Parser.positional.opts.choices` and "
+            .. "`trx.argparse.Parser.positional.opts.match`, and use "
+            .. "`trx.argparse.Parser:any_of` for several.",
+          fields = positional_opts(),
+        },
+      },
+      returns = { type = "argparse.Parser", description = "The parser." },
+      impl = P.positional,
+    },
+
+    any_of = {
+      description = "Adds a positional whose value is the first of several matchers to take "
+        .. "the token, for an argument that is a number or a name.",
+      params = {
+        {
+          name = "name",
+          type = "string",
+          description = "What the parsed value is keyed by.",
+        },
+        {
+          name = "alternatives",
+          type = "table",
+          list = true,
+          description = "The ways the token may read, tried in order.",
+          fields = {
+            {
+              name = "type",
+              type = "string",
+              optional = true,
+              description = "As for `trx.argparse.Parser:positional`.",
+            },
+            {
+              name = "choices",
+              type = "any",
+              optional = true,
+              description = "As for `trx.argparse.Parser:positional`.",
+            },
+            {
+              name = "match",
+              type = "function",
+              optional = true,
+              description = "As for `trx.argparse.Parser:positional`.",
+            },
+            {
+              name = "metavar",
+              type = "string",
+              optional = true,
+              description = "Names this alternative, which earns it a line of its own in the "
+                .. "help.",
+            },
+            {
+              name = "help",
+              type = "string",
+              optional = true,
+              description = "What this alternative is for.",
+            },
+          },
+        },
+        {
+          name = "opts",
+          type = "table",
+          optional = true,
+          description = "How the argument behaves.",
+          fields = ARG_OPTS,
+        },
+      },
+      returns = { type = "argparse.Parser", description = "The parser." },
+      impl = P.any_of,
+    },
+
+    rest = {
+      description = "Adds an argument taking the rest of the line from here on, verbatim as "
+        .. "one string, or `nil` where an optional one is absent. Always the last argument.",
+      params = {
+        {
+          name = "name",
+          type = "string",
+          description = "What the parsed value is keyed by.",
+        },
+        {
+          name = "opts",
+          type = "table",
+          optional = true,
+          description = "How the argument behaves.",
+          fields = ARG_OPTS,
+        },
+      },
+      returns = { type = "argparse.Parser", description = "The parser." },
+      impl = P.rest,
+    },
+
+    flag = {
+      description = "Adds a boolean flag, which may sit anywhere in the line.",
+      params = {
+        {
+          name = "name",
+          type = "string",
+          description = "What the parsed value is keyed by. `help` is reserved.",
+        },
+        {
+          name = "opts",
+          type = "table",
+          optional = true,
+          description = "How it is spelled and what it is for.",
+          fields = {
+            {
+              name = "short",
+              type = "string",
+              optional = true,
+              description = 'The short spelling, such as `"-f"`.',
+            },
+            {
+              name = "long",
+              type = "string",
+              optional = true,
+              description = 'The long spelling, such as `"--force"`.',
+            },
+            {
+              name = "help",
+              type = "string",
+              optional = true,
+              description = "What the flag is for, shown in the help.",
+            },
+          },
+        },
+      },
+      returns = { type = "argparse.Parser", description = "The parser." },
+      impl = P.flag,
+    },
+
+    parse = {
+      description = "Reads an argument line. A value carried by a `{ key, value }` choice "
+        .. "comes back as its value, and `-h`/`--help` comes back as `{ help = true }`.",
+      params = {
+        {
+          name = "args",
+          type = "string",
+          optional = true,
+          description = "The line as the player typed it.",
+        },
+      },
+      returns = {
+        {
+          type = "table",
+          nullable = true,
+          description = "The values, keyed by argument name, or `nil` where the line was "
+            .. "refused.",
+        },
+        {
+          type = "table",
+          nullable = true,
+          description = "What was wrong, for `trx.argparse.Parser:format_error` to put into "
+            .. "words.",
+        },
+      },
+      impl = P.parse,
+    },
+
+    format_error = {
+      description = "Turns what a refused line reported into a localized line naming what was "
+        .. "wrong and what was expected.",
+      params = {
+        {
+          name = "err",
+          type = "table",
+          description = "What `trx.argparse.Parser:parse` handed back.",
+        },
+      },
+      returns = { type = "string", description = "The line, ready to print." },
+      impl = P.format_error,
+    },
+
+    complete = {
+      description = "The candidate completions for the token the caret sits in. Matching is "
+        .. "against the text before the caret.",
+      params = {
+        {
+          name = "text",
+          type = "string",
+          optional = true,
+          description = "The line so far.",
+        },
+        {
+          name = "caret",
+          type = "integer",
+          optional = true,
+          description = "Where the caret sits, as a byte offset. The end of the line by "
+            .. "default.",
+        },
+      },
+      returns = {
+        { type = "table", description = "The candidates, best first." },
+        {
+          type = "integer",
+          description = "Where the run they replace starts. The run is the token, or the "
+            .. "whole tail a greedy argument swallows; in whitespace it is empty, at the "
+            .. "caret.",
+        },
+        { type = "integer", description = "Where that run ends." },
+      },
+      impl = P.complete,
+    },
+
+    usage = {
+      description = "A short description of what the command accepts.",
+      returns = {
+        type = "string",
+        description = "The synopsis, and a line per argument.",
+      },
+      impl = P.usage,
+    },
+  },
+})
+
 api.define("argparse.new", {
-  description = "Creates an argument parser. See the module description for the parser's methods.",
+  description = "Creates an argument parser.",
   params = {
     {
       name = "spec",
       type = "table",
       optional = true,
-      description = "`prog`: the command word, for messages. `description`: what the command does.",
+      description = "What the parser calls itself in messages.",
+      fields = {
+        {
+          name = "prog",
+          type = "string",
+          optional = true,
+          description = "The command word.",
+        },
+        {
+          name = "description",
+          type = "string",
+          optional = true,
+          description = "What the command does.",
+        },
+      },
     },
   },
   returns = {
-    type = "table",
-    description = "A parser. Describe its arguments with `positional`, `any_of`, `rest` and "
-      .. "`flag`, then read them with `parse` or offer completions with `complete`.",
+    type = "argparse.Parser",
+    description = "A parser, with no arguments declared on it yet.",
   },
   examples = {
     [[local p = trx.argparse.new({ prog = "weather" })
 p:positional("state", { choices = { "snow", "rain", "none" } })
 local parsed = p:parse("snow")  -- { state = "snow" }]],
   },
-  impl = Parser.new,
+  impl = P.new,
 })

--- a/src/lua/api/argparse.lua
+++ b/src/lua/api/argparse.lua
@@ -906,7 +906,7 @@ Parser = api.type("argparse.Parser", {
         {
           name = "name",
           type = "string",
-          description = "What the parsed value is keyed by. `help` is reserved.",
+          description = "What the parsed value is keyed by. `help` is reserved. <!--noref: help-->",
         },
         {
           name = "opts",

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -7,6 +7,11 @@ api.module("assault", {
   description = "Module for controlling the Assault Course and Quad Bike timers in gym levels.",
 })
 
+api.number("assault.RecordNum", {
+  base = 1,
+  description = "Where a time sits in the table of best times, fastest first.",
+})
+
 local Track = api.enum("assault.Track", {
   backing = "GYM_TRACK_TYPE",
   description = "A timed gym track.",
@@ -55,14 +60,20 @@ api.define("assault.reset", {
 api.define("assault.is_running", {
   description = "Whether the timer is counting. False outside a gym level.",
   params = { track_param() },
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "True from the start of a run until it is finished or stopped.",
+  },
   impl = raw.is_running,
 })
 
 api.define("assault.is_visible", {
   description = "Whether the timer is shown on screen. It stays visible after `trx.assault.stop`.",
   params = { track_param() },
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "True while the timer is drawn, counting or not.",
+  },
   impl = raw.is_visible,
 })
 
@@ -101,9 +112,7 @@ api.define("assault.stats.remove_record", {
   params = {
     {
       name = "record_num",
-      type = "integer",
-      base = 1,
-      description = "Position in the table.",
+      type = "assault.RecordNum",
     },
     track_param(),
   },
@@ -119,8 +128,21 @@ api.define("assault.stats.list_records", {
   params = { track_param() },
   returns = {
     type = "table",
-    description = "List of `{ time = seconds, attempt_num = which attempt it "
-      .. "was }`.",
+    description = "The records.",
+    list = true,
+    fields = {
+      {
+        name = "time",
+        type = "number",
+        description = "The time, in seconds.",
+      },
+      {
+        name = "attempt_num",
+        type = "integer",
+        base = 1,
+        description = "Which attempt it was.",
+      },
+    },
   },
   examples = {
     [[for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -60,7 +60,7 @@ api.define("assault.is_running", {
 })
 
 api.define("assault.is_visible", {
-  description = "Whether the timer is shown on screen. It stays visible after `stop`.",
+  description = "Whether the timer is shown on screen. It stays visible after `trx.assault.stop`.",
   params = { track_param() },
   returns = { type = "boolean" },
   impl = raw.is_visible,

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -21,10 +21,9 @@ local Track = api.enum("assault.Track", {
 local function track_param()
   return {
     name = "track",
-    type = "integer",
+    type = "assault.Track",
     optional = true,
     default = Track.COURSE,
-    enum = "assault.Track",
   }
 end
 
@@ -68,8 +67,7 @@ api.define("assault.is_visible", {
 })
 
 api.property("assault.active_track", {
-  type = "integer",
-  enum = "assault.Track",
+  type = "assault.Track",
   description = "The track Lara is currently running, or `nil` if none.",
   get = raw.get_active_track,
 })
@@ -102,9 +100,10 @@ api.define("assault.stats.remove_record", {
   description = "Removes a record, closing the gap behind it.",
   params = {
     {
-      name = "record_id",
+      name = "record_num",
       type = "integer",
-      description = "1-based position in the table.",
+      base = 1,
+      description = "Position in the table.",
     },
     track_param(),
   },
@@ -120,7 +119,7 @@ api.define("assault.stats.list_records", {
   params = { track_param() },
   returns = {
     type = "table",
-    description = "List, counted from one, of `{ time = seconds, attempt_num = which attempt it "
+    description = "List of `{ time = seconds, attempt_num = which attempt it "
       .. "was }`.",
   },
   examples = {

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -94,8 +94,8 @@ api.define("assault.stats.add_record", {
   params = {
     {
       name = "time",
-      type = "number",
-      description = "Time in seconds. Must be greater than zero.",
+      type = "game.Seconds",
+      description = "Must be greater than zero.",
     },
     track_param(),
   },
@@ -133,8 +133,8 @@ api.define("assault.stats.list_records", {
     fields = {
       {
         name = "time",
-        type = "number",
-        description = "The time, in seconds.",
+        type = "game.Seconds",
+        description = "The time it took.",
       },
       {
         name = "attempt_num",

--- a/src/lua/api/camera.lua
+++ b/src/lua/api/camera.lua
@@ -13,14 +13,14 @@ api.property("camera.pos", {
 })
 
 api.property("camera.room_num", {
-  type = "integer",
-  description = "0-based number of the room the camera is in, or `nil` if unknown.",
+  type = "rooms.Num",
+  description = "The room the camera is in, or `nil` if unknown.",
   get = raw.get_room,
 })
 
 api.property("camera.room", {
-  type = "Room",
-  description = "The `trx.rooms.Room` the camera is in, or `nil` if unknown.",
+  type = "rooms.Room",
+  description = "The room the camera is in, or `nil` if unknown.",
   get = function()
     local room_num = raw.get_room()
     return room_num and trx.rooms[room_num] or nil
@@ -34,8 +34,8 @@ api.property("camera.target_pos", {
 })
 
 api.property("camera.target_room_num", {
-  type = "integer",
-  description = "0-based number of the room the camera is looking at, or `nil` if unknown.",
+  type = "rooms.Num",
+  description = "The room the camera is looking at, or `nil` if unknown.",
   get = raw.get_target_room,
 })
 
@@ -60,13 +60,17 @@ api.property("camera.is_flyby_active", {
   get = raw.is_flyby_active,
 })
 
+api.number("camera.SequenceNum", {
+  base = 0,
+  description = "Flyby sequence number, as the level numbers them.",
+})
+
 api.define("camera.play_flyby", {
   description = "Starts a flyby camera sequence. Does nothing if another one is already playing.",
   params = {
     {
       name = "sequence_num",
-      type = "integer",
-      description = "0-based sequence number.",
+      type = "camera.SequenceNum",
     },
   },
   returns = {

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -94,8 +94,7 @@ api.define("catalog.to_slot", {
   params = {
     {
       name = "context",
-      type = "integer",
-      enum = "catalog.Context",
+      type = "catalog.Context",
       description = "Which catalog.",
     },
     { name = "id", type = "integer", description = "The TRX id." },
@@ -116,8 +115,7 @@ api.define("catalog.from_slot", {
   params = {
     {
       name = "context",
-      type = "integer",
-      enum = "catalog.Context",
+      type = "catalog.Context",
       description = "Which catalog.",
     },
     { name = "slot", type = "integer", description = "The game's own id." },

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -13,6 +13,16 @@ api.module("catalog", {
     .. "`trx.catalog.to_slot` and `trx.catalog.from_slot` convert between the two.",
 })
 
+api.number("catalog.Id", {
+  description = "A TRX id, in the catalog the context names. It is the same number in every "
+    .. "game TRX ships, which is what lets a script name a thing once.",
+})
+
+api.number("catalog.Slot", {
+  description = "A slot in this game's own files, which is the number a builder reads off Tomb "
+    .. "Editor. It differs from game to game.",
+})
+
 api.enum("catalog.Context", {
   backing = "CATALOG_CONTEXT",
   strip = "CATALOG_",
@@ -89,18 +99,18 @@ api.enum("catalog.weapons", {
 })
 
 api.define("catalog.to_slot", {
-  description = "Converts a TRX id into the slot this game's own files use for it - the number a "
-    .. "builder reads off Tomb Editor.",
+  description = "Converts a `trx.catalog.Id` into the `trx.catalog.Slot` this game's own files "
+    .. "use for it.",
   params = {
     {
       name = "context",
       type = "catalog.Context",
       description = "Which catalog.",
     },
-    { name = "id", type = "integer", description = "The TRX id." },
+    { name = "id", type = "catalog.Id" },
   },
   returns = {
-    type = "integer",
+    type = "catalog.Slot",
     nullable = true,
     description = "`nil` if this game has no slot for it - not every game has every object.",
   },
@@ -111,17 +121,18 @@ api.define("catalog.to_slot", {
 })
 
 api.define("catalog.from_slot", {
-  description = "Converts a slot from this game's own files into the TRX id for it.",
+  description = "Converts a `trx.catalog.Slot` from this game's own files into the "
+    .. "`trx.catalog.Id` for it.",
   params = {
     {
       name = "context",
       type = "catalog.Context",
       description = "Which catalog.",
     },
-    { name = "slot", type = "integer", description = "The game's own id." },
+    { name = "slot", type = "catalog.Slot" },
   },
   returns = {
-    type = "integer",
+    type = "catalog.Id",
     nullable = true,
     description = "`nil` if this game has nothing in that slot.",
   },

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -10,7 +10,7 @@ api.module("catalog", {
     .. "any case, so `trx.catalog.objects.wolf` is the same constant.\n\n"
     .. "The ids in a catalog are TRX's own, and they are the same in all four games. The number a "
     .. "builder reads off Tomb Editor is not: that is the slot the game's own files use. "
-    .. "`to_slot` and `from_slot` convert between the two.",
+    .. "`trx.catalog.to_slot` and `trx.catalog.from_slot` convert between the two.",
 })
 
 api.enum("catalog.Context", {

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -6,9 +6,9 @@ require("trx.locale")
 api.module("config", {
   order = 22,
   description = "Module for reading and changing engine settings.\n\n"
-    .. "These are the player's settings, not the level's. `set` writes to them and keeps the "
+    .. "These are the player's settings, not the level's. `trx.config.set` writes to them and keeps the "
     .. "change: it is remembered across saves and relaunches, exactly as if the player had made "
-    .. "it themselves. A level that wants to tint the water or pull the fog in wants `override` "
+    .. "it themselves. A level that wants to tint the water or pull the fog in wants `trx.config.override` "
     .. "instead, which lasts as long as the script keeps it and leaves the player's own value "
     .. "untouched underneath.",
 })
@@ -41,7 +41,7 @@ end]],
 
 api.define("config.describe", {
   description = "What shape a setting has: how a value is entered and shown, beyond the type "
-    .. "`get` reads back.",
+    .. "`trx.config.get` reads back.",
   params = {
     { name = "key", type = "string", description = "Dotted path." },
   },
@@ -142,7 +142,7 @@ api.define("config.set", {
   description = "Changes the player's setting, and keeps the change. Raises if the key is unknown "
     .. "or the value will not parse.\n\n"
     .. "The old value is not kept anywhere: the new one becomes the active setting as if the "
-    .. "player had chosen it, and is remembered across saves and relaunches. Prefer `override` "
+    .. "player had chosen it, and is remembered across saves and relaunches. Prefer `trx.config.override` "
     .. "for anything a level wants only while it is running.",
   params = {
     { name = "key", type = "string", description = "Dotted path." },
@@ -183,20 +183,20 @@ api.define("config.set", {
 })
 
 api.define("config.reset", {
-  description = "Puts a setting back to its default, and keeps the change, as `set` does.",
+  description = "Puts a setting back to its default, and keeps the change, as `trx.config.set` does.",
   params = {
     { name = "key", type = "string", description = "Dotted path." },
     {
       name = "force",
       type = "boolean",
       optional = true,
-      description = "As for `set`.",
+      description = "As for `trx.config.set`.",
     },
   },
   returns = {
     type = "boolean",
     description = "`false` when a script or the game flow is holding the setting "
-      .. "(see `is_overridden`).",
+      .. "(see `trx.config.is_overridden`).",
   },
   impl = raw.reset,
 })
@@ -204,12 +204,12 @@ api.define("config.reset", {
 api.define("config.override", {
   description = "Changes a setting for as long as the script keeps the override, without touching "
     .. "the player's own value.\n\n"
-    .. "The player's value sits underneath and comes back on `restore`. Nothing is written to "
-    .. "disk. Overrides stack, so one can be pushed over another; each `restore` lifts one off. "
+    .. "The player's value sits underneath and comes back on `trx.config.restore`. Nothing is written to "
+    .. "disk. Overrides stack, so one can be pushed over another; each `trx.config.restore` lifts one off. "
     .. "A setting the game flow enforces cannot be overridden.",
   params = {
     { name = "key", type = "string", description = "Dotted path." },
-    { name = "value", type = "any", description = "As for `set`." },
+    { name = "value", type = "any", description = "As for `trx.config.set`." },
   },
   examples = {
     [[trx.config.override("visuals.water_color", "0080ff")

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -27,7 +27,7 @@ api.define("config.get", {
     {
       name = "key",
       type = "string",
-      description = "Dotted path, e.g. `visuals.water_color`.",
+      description = "Dotted path, e.g. `visuals.water_color`. <!--noref: visuals.water_color-->",
     },
   },
   returns = { type = "any", description = "Raises if no option has that key." },
@@ -53,7 +53,7 @@ api.define("config.describe", {
         name = "kind",
         type = "string",
         description = "One of `boolean`, `integer`, `number`, `color`, `enum`, "
-          .. "`dynamic_enum` or `string`.",
+          .. "`dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
       },
       {
         name = "percent",

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -47,10 +47,26 @@ api.define("config.describe", {
   },
   returns = {
     type = "table",
-    description = "`kind` is one of `boolean`, `integer`, `number`, `color`, `enum`, "
-      .. "`dynamic_enum` or `string`. `percent` marks a number stored 0-1 but entered and "
-      .. "shown as a 0-100 percentage. For the enum kinds, `values` lists what the setting "
-      .. "accepts.",
+    description = "What the setting is and how it is entered.",
+    fields = {
+      {
+        name = "kind",
+        type = "string",
+        description = "One of `boolean`, `integer`, `number`, `color`, `enum`, "
+          .. "`dynamic_enum` or `string`.",
+      },
+      {
+        name = "percent",
+        type = "boolean",
+        description = "Marks a number stored 0-1 but entered and shown as a 0-100 "
+          .. "percentage.",
+      },
+      {
+        name = "values",
+        type = "table",
+        description = "What the setting accepts, for the enum kinds. `nil` for the rest.",
+      },
+    },
   },
   examples = {
     [[for _, value in ipairs(trx.config.describe("visuals.shadow_type").values) do
@@ -72,7 +88,7 @@ api.define("config.format_value", {
   params = {
     { name = "key", type = "string", description = "Dotted path." },
   },
-  returns = { type = "string" },
+  returns = { type = "string", description = "The text, ready to print." },
   examples = { [[trx.console.log(trx.config.format_value("visuals.fov"))]] },
   impl = function(key)
     local desc = raw.describe(key)
@@ -237,7 +253,10 @@ api.define("config.is_overridden", {
   params = {
     { name = "key", type = "string", description = "Dotted path." },
   },
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "True while an override stands, and false once the last is lifted.",
+  },
   impl = raw.is_overridden,
 })
 

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -141,7 +141,7 @@ api.namespace("console.log", {
 api.define("console.log.generic", {
   description = "Logs at a level chosen at runtime.",
   params = {
-    { name = "level", type = "integer", enum = "log.LogLevel" },
+    { name = "level", type = "log.LogLevel" },
     message_param,
   },
   impl = function(level, value)

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -84,7 +84,7 @@ end
 
 local Result = api.enum("console.Result", {
   backing = "COMMAND_RESULT",
-  description = "How a console command went. What a command's `run` gives back.",
+  description = "How a console command went. What a command's `trx.console.register.spec.run` gives back.",
   values = {
     OK = "It worked.",
     FAILURE = "It ran and could not do what was asked.",
@@ -193,7 +193,15 @@ api.define("console.eval", {
       name = "opts",
       type = "table",
       optional = true,
-      description = "`verbose`: show the command's output.",
+      description = "How to run it.",
+      fields = {
+        {
+          name = "verbose",
+          type = "boolean",
+          optional = true,
+          description = "Show the command's output.",
+        },
+      },
     },
   },
   examples = { [[trx.console.eval("play 1", { verbose = true })]] },
@@ -202,25 +210,53 @@ api.define("console.eval", {
 
 api.define("console.register", {
   description = "Registers a console command written in Lua.\n\n"
-    .. "Every command has a `trx.argparse` parser. `args` is an optional function that shapes it - "
+    .. "Every command has a `trx.argparse` parser. `trx.console.register.spec.args` is an optional "
+    .. "function that shapes it - "
     .. "it receives the parser and declares the arguments the command takes. A command that omits "
-    .. "`args` takes none, and reports so when handed one. The console completes the arguments from "
+    .. "`trx.console.register.spec.args` takes none, and reports so when handed one. The console completes the arguments from "
     .. "the parser, and answers `-h`/`--help` from it.\n\n"
-    .. "`run` receives the parsed values, a table keyed by argument name. What it gives back is a "
+    .. "`trx.console.register.spec.run` receives the parsed values, a table keyed by argument name. What it gives back is a "
     .. "`trx.console.Result`, and returning nothing means `OK`. It may return a message after that, "
     .. "which is logged to the console - as an error, for any result but `OK`. A line the parser "
-    .. "rejects is reported with what it expected, without reaching `run`.\n\n"
+    .. "rejects is reported with what it expected, without reaching `trx.console.register.spec.run`.\n\n"
     .. "A command lives for the whole run, so it can only be registered from a global script. A "
     .. "level script raises if it calls this: it runs again every time its level is loaded.",
   params = {
     {
       name = "spec",
       type = "table",
-      description = "`name`: the word the player types. `help`: a game string key for the help "
-        .. "text, optional. `args`: a function that shapes the parser, optional. `run`: the "
-        .. "function, called with the parsed arguments. `aliases`: other words that reach the same "
-        .. "command, optional; they dispatch but stay out of the command listing, and the help for "
-        .. "`name` shows them.",
+      description = "The command.",
+      fields = {
+        {
+          name = "name",
+          type = "string",
+          description = "The word the player types.",
+        },
+        {
+          name = "help",
+          type = "string",
+          optional = true,
+          description = "A game string key for the help text.",
+        },
+        {
+          name = "args",
+          type = "function",
+          optional = true,
+          description = "Shapes the parser.",
+        },
+        {
+          name = "run",
+          type = "function",
+          description = "Called with the parsed arguments.",
+        },
+        {
+          name = "aliases",
+          type = "table",
+          optional = true,
+          description = "Other words that reach the same command. They dispatch but stay out "
+            .. "of the command listing, and the help for the command shows them.",
+        },
+      },
     },
   },
   examples = {
@@ -357,13 +393,30 @@ local function descriptor(cmd)
 end
 
 api.define("console.commands", {
-  description = "Every registered console command, in registration order. Each is "
-    .. "`{ name, aliases, help }`: `name` is the word the player types, `aliases` the other "
-    .. "words that reach it (a list, or absent), and `help` the text the console shows for "
-    .. "`name --help` (absent when the command carries none). The help command is built on this.",
+  description = "Every registered console command, in registration order. The help command is "
+    .. "built on this.",
   returns = {
     type = "table",
-    description = "A list of `{ name, aliases, help }`.",
+    description = "The commands.",
+    list = true,
+    fields = {
+      {
+        name = "name",
+        type = "string",
+        description = "The word the player types.",
+      },
+      {
+        name = "aliases",
+        type = "table",
+        description = "The other words that reach it, or `nil` where it answers to one.",
+      },
+      {
+        name = "help",
+        type = "string",
+        description = "What the console shows for `--help`, or `nil` where the command "
+          .. "carries none.",
+      },
+    },
   },
   impl = function()
     local out = {}

--- a/src/lua/api/creatures.lua
+++ b/src/lua/api/creatures.lua
@@ -16,7 +16,7 @@ api.property("creatures.hostile_allies", {
 api.define("creatures.add_ally", {
   description = "Marks an object as an ally of Lara. Every item of that type becomes an ally.",
   params = {
-    { name = "object_id", type = "integer", enum = "catalog.objects" },
+    { name = "object_id", type = "catalog.objects" },
   },
   examples = { [[trx.creatures.add_ally(trx.catalog.objects.monk_1)]] },
   impl = raw.add_ally,
@@ -26,7 +26,7 @@ api.define("creatures.add_ally_target", {
   description = "Marks an object as one that will fight any of Lara's allies. Every item of that "
     .. "type will target them.",
   params = {
-    { name = "object_id", type = "integer", enum = "catalog.objects" },
+    { name = "object_id", type = "catalog.objects" },
   },
   examples = {
     [[trx.creatures.add_ally_target(trx.catalog.objects.bandit_1)]],

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -44,7 +44,10 @@ api.define("cutscenes.is_played", {
   params = {
     { name = "num", type = "cutscenes.Num" },
   },
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "True once it has run, which is what keeps its trigger from firing again.",
+  },
   impl = raw.is_played,
 })
 

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -12,18 +12,23 @@ api.module("cutscenes", {
   ]],
 })
 
+api.number("cutscenes.Num", {
+  base = 0,
+  description = "Cutscene number, as a cutscene trigger names it.",
+})
+
 api.define("cutscenes.play", {
   description = "Plays a cutscene, fading the scene out first. Does nothing if one is already "
     .. "playing or the game has no cutscene data.",
   params = {
-    { name = "num", type = "integer", description = "Cutscene number." },
+    { name = "num", type = "cutscenes.Num" },
   },
   examples = { [[trx.cutscenes.play(28)]] },
   impl = raw.play,
 })
 
 api.property("cutscenes.current", {
-  type = "integer",
+  type = "cutscenes.Num",
   description = "Number of the cutscene playing, or `nil` if none is.",
   get = raw.get_current,
 })
@@ -37,7 +42,7 @@ api.property("cutscenes.is_playing", {
 api.define("cutscenes.is_played", {
   description = "Whether a cutscene trigger naming this number has already been answered.",
   params = {
-    { name = "num", type = "integer", description = "Cutscene number." },
+    { name = "num", type = "cutscenes.Num" },
   },
   returns = { type = "boolean" },
   impl = raw.is_played,
@@ -55,7 +60,7 @@ api.define("cutscenes.set_played", {
     `play` accepts.
   ]],
   params = {
-    { name = "num", type = "integer", description = "Cutscene number." },
+    { name = "num", type = "cutscenes.Num" },
     {
       name = "played",
       type = "boolean",

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -55,9 +55,9 @@ api.define("cutscenes.set_played", {
 
     A trigger may name a number the game has no cutscene for - TR4 uses 32 to
     ask for a full-motion video - and the engine remembers those the same way,
-    so `on_cutscene_trigger` hears about each of them once. This is what clears
+    so `trx.events.on_cutscene_trigger` hears about each of them once. This is what clears
     that memory, and it takes any number a trigger may carry, not only the ones
-    `play` accepts.
+    `trx.cutscenes.play` accepts.
   ]],
   params = {
     { name = "num", type = "cutscenes.Num" },
@@ -83,7 +83,7 @@ api.define("cutscenes.set_lara_return", {
     afterwards; this says to put her somewhere else instead, as the original
     game does for the scenes that carry her along.
 
-    It holds for one cutscene, whether named before `play` or while the scene
+    It holds for one cutscene, whether named before `trx.cutscenes.play` or while the scene
     runs, and is forgotten once she has been placed.
   ]],
   params = {

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -5,7 +5,7 @@ api.module("cutscenes", {
   order = 13,
   description = [[
     Module for TR4's in-game cutscenes, the animated scenes stored in
-    `cutseq.pak` and started by a cutscene trigger. A cutscene plays once:
+    `cutseq.pak` <!--noref: cutseq.pak--> and started by a cutscene trigger. A cutscene plays once:
     the engine remembers which ones have run, and a script may consult or
     rewrite that memory. The cutscene levels of TR1-TR3, which the game flow
     lists and `/cut` plays, are a different thing: see `trx.game.cutscenes`.

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -93,9 +93,9 @@ api.define("cutscenes.set_lara_return", {
     { name = "pos", type = "vec3", description = "World position." },
     {
       name = "rot",
-      type = "integer",
+      type = "math.Angle",
       optional = true,
-      description = "Facing angle, in the engine's own angle units. Defaults to `0`.",
+      description = "Facing angle. Defaults to `0`.",
     },
   },
   examples = {
@@ -109,9 +109,9 @@ end)]],
 })
 
 api.property("cutscenes.fov", {
-  type = "integer",
-  description = "Field of view a cutscene plays at, in the engine's own angle units. TR4 uses "
-    .. "11488, against 14560 for ordinary play.",
+  type = "math.Angle",
+  description = "Field of view a cutscene plays at. TR4 uses 11488, against 14560 for ordinary "
+    .. "play.",
   get = raw.get_fov,
   set = raw.set_fov,
 })

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -133,8 +133,7 @@ api.define("events.on_pickup", {
       params = {
         {
           name = "item_num",
-          type = "integer",
-          see = "items.num",
+          type = "items.Num",
           description = "The item that was picked up.",
         },
       },
@@ -178,6 +177,7 @@ api.define("events.on_flip_effect", {
     {
       name = "effect_num",
       type = "integer",
+      base = 0,
       description = "The flip effect number to claim, as the level editor numbers them. This is "
         .. "not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` "
         .. "names.",
@@ -194,8 +194,7 @@ api.define("events.on_flip_effect", {
         },
         {
           name = "item_num",
-          type = "integer",
-          see = "items.num",
+          type = "items.Num",
           description = "The item that ran the effect: Lara for a pad trigger, "
             .. "the activating object for a heavy trigger, the animating item for an animation "
             .. "command.",
@@ -225,19 +224,17 @@ api.define("events.on_room_change", {
       params = {
         {
           name = "item",
-          type = "Item",
-          description = "The `trx.items.Item` that changed rooms.",
+          type = "items.Item",
+          description = "The item that changed rooms.",
         },
         {
           name = "old_room_num",
-          type = "integer",
-          see = "rooms.num",
+          type = "rooms.Num",
           description = "-1 if it had none.",
         },
         {
           name = "new_room_num",
-          type = "integer",
-          see = "rooms.num",
+          type = "rooms.Num",
           description = "-1 if it left the world.",
         },
       },
@@ -277,8 +274,8 @@ api.define("events.on_trigger", {
       params = {
         {
           name = "item",
-          type = "Item",
-          description = "The `trx.items.Item` the trigger was aimed at.",
+          type = "items.Item",
+          description = "The item the trigger was aimed at.",
         },
         {
           name = "trigger",
@@ -331,8 +328,8 @@ local function visibility_hook(event_type, method, verb, examples)
         params = {
           {
             name = "item",
-            type = "Item",
-            description = "The `trx.items.Item` that became " .. verb .. ".",
+            type = "items.Item",
+            description = "The item that became " .. verb .. ".",
           },
         },
       },
@@ -364,7 +361,7 @@ local function item_lifecycle_hook(
         params = {
           {
             name = "item",
-            type = "Item",
+            type = "items.Item",
             description = item_desc,
           },
         },
@@ -406,7 +403,7 @@ api.define(
       .. "a one-shot object spent. It is the change that fires, once, and only a live level does, "
       .. "not a cutscene or the attract demo.\n\n"
       .. "`trx.items.Item:on_finish` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that finished.",
+    "The item that finished.",
     {
       [[trx.events.on_finish(function(item)
   trx.log.info(item.object_id .. " finished its run")
@@ -423,7 +420,7 @@ api.define(
       .. "each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a "
       .. "cheat. A trigger also fires `on_activate`, which this does not.\n\n"
       .. "`trx.items.Item:on_enter_sim` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that started being simulated.",
+    "The item that started being simulated.",
     {
       [[trx.events.on_enter_sim(function(item)
   trx.log.info(item.object_id .. " started running")
@@ -439,7 +436,7 @@ api.define(
     "Happens when an item stops being simulated during play - its control routine no longer runs. "
       .. "It keeps its place and its state; it merely stops.\n\n"
       .. "`trx.items.Item:on_leave_sim` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that stopped being simulated.",
+    "The item that stopped being simulated.",
     {
       [[trx.events.on_leave_sim(function(item)
   trx.log.info(item.object_id .. " stopped running")
@@ -456,7 +453,7 @@ api.define(
       .. "level trigger takes. Switches, respawns and cheats start an item without it, firing only "
       .. "`on_enter_sim`; watch that one for a start of any cause.\n\n"
       .. "`trx.items.Item:on_activate` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that was activated.",
+    "The item that was activated.",
     {
       [[trx.events.on_activate(function(item)
   trx.log.info(item.object_id .. " was activated")
@@ -472,7 +469,7 @@ api.define(
     "Happens when a running item is deactivated through the lifecycle front door during play - the "
       .. "path an antitrigger takes. It fires only when the item was actually running.\n\n"
       .. "`trx.items.Item:on_deactivate` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that was deactivated.",
+    "The item that was deactivated.",
     {
       [[trx.events.on_deactivate(function(item)
   trx.log.info(item.object_id .. " was deactivated")
@@ -489,7 +486,7 @@ api.define(
       .. "taken, an object that has run its course. The item can still be read from the handler, "
       .. "which runs before the removal completes, but a handle kept past the handler goes stale.\n\n"
       .. "`trx.items.Item:on_destroy` is this same event, narrowed to one item.",
-    "The `trx.items.Item` being removed. Valid only for the duration of the handler.",
+    "The item being removed. Valid only for the duration of the handler.",
     {
       [[trx.events.on_destroy(function(item)
   trx.log.info(item.object_id .. " was removed")
@@ -506,7 +503,7 @@ api.define(
       .. "emitter releases or an item a script creates. The level's own items do not fire it as "
       .. "they load; only an arrival during a live level counts.\n\n"
       .. "`trx.items.Item:on_enter_world` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that entered the world.",
+    "The item that entered the world.",
     {
       [[trx.events.on_enter_world(function(item)
   trx.log.info(item.object_id .. " entered the world")
@@ -523,7 +520,7 @@ api.define(
       .. "or collidable. It need not be destroyed; a destroyed item leaves the world on its way "
       .. "out, and fires this first.\n\n"
       .. "`trx.items.Item:on_leave_world` is this same event, narrowed to one item.",
-    "The `trx.items.Item` that left the world.",
+    "The item that left the world.",
     {
       [[trx.events.on_leave_world(function(item)
   trx.log.info(item.object_id .. " left the world")
@@ -546,8 +543,8 @@ attacker dealt. A death that does not go through damage - a script writing `hit_
       params = {
         {
           name = "item",
-          type = "Item",
-          description = "The `trx.items.Item` that took the damage.",
+          type = "items.Item",
+          description = "The item that took the damage.",
         },
         {
           name = "damage",
@@ -588,8 +585,8 @@ more for the dagger that ends it.
       params = {
         {
           name = "item",
-          type = "Item",
-          description = "The `trx.items.Item` that was brought down.",
+          type = "items.Item",
+          description = "The item that was brought down.",
         },
       },
     },
@@ -631,8 +628,9 @@ api.define("events.on_cutscene_trigger", {
       params = {
         {
           name = "cutscene_num",
-          type = "integer",
-          description = "Number the trigger names.",
+          type = "cutscenes.Num",
+          description = "The number the trigger names, which the game need not have a cutscene "
+            .. "for.",
         },
       },
     },
@@ -664,8 +662,7 @@ api.define("events.on_cutscene_start", {
       params = {
         {
           name = "cutscene_num",
-          type = "integer",
-          description = "Number of the cutscene starting.",
+          type = "cutscenes.Num",
         },
       },
     },
@@ -684,8 +681,7 @@ api.define("events.on_cutscene_end", {
       params = {
         {
           name = "cutscene_num",
-          type = "integer",
-          description = "Number of the cutscene that ended.",
+          type = "cutscenes.Num",
         },
       },
     },
@@ -710,8 +706,7 @@ A sequence that a cutscene or the player interrupts does not fire it.]],
       params = {
         {
           name = "sequence_num",
-          type = "integer",
-          description = "Number of the flyby sequence that ended.",
+          type = "camera.SequenceNum",
         },
       },
     },

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -134,7 +134,7 @@ api.define("events.on_pickup", {
         {
           name = "item_num",
           type = "integer",
-          see = "items.index",
+          see = "items.num",
           description = "The item that was picked up.",
         },
       },
@@ -195,7 +195,7 @@ api.define("events.on_flip_effect", {
         {
           name = "item_num",
           type = "integer",
-          see = "items.index",
+          see = "items.num",
           description = "The item that ran the effect: Lara for a pad trigger, "
             .. "the activating object for a heavy trigger, the animating item for an animation "
             .. "command.",
@@ -229,29 +229,34 @@ api.define("events.on_room_change", {
           description = "The `trx.items.Item` that changed rooms.",
         },
         {
-          name = "old_room",
+          name = "old_room_num",
           type = "integer",
-          description = "0-based number of the room it left, or -1 if it had none.",
+          see = "rooms.num",
+          description = "-1 if it had none.",
         },
         {
-          name = "new_room",
+          name = "new_room_num",
           type = "integer",
-          description = "0-based number of the room it entered, or -1 if it left the world.",
+          see = "rooms.num",
+          description = "-1 if it left the world.",
         },
       },
     },
   },
   returns = LISTENER,
   examples = {
-    [[trx.events.on_room_change(function(item, old_room, new_room)
-  trx.log.info(item.object_id .. " moved to room " .. new_room)
+    [[trx.events.on_room_change(function(item, old_room_num, new_room_num)
+  trx.log.info(item.object_id .. " moved to room " .. new_room_num)
 end)]],
   },
   impl = function(callback)
     return listener_of(
-      raw.attach(types.ROOM_CHANGE, function(item_num, old_room, new_room)
-        callback(trx.items[item_num], old_room, new_room)
-      end)
+      raw.attach(
+        types.ROOM_CHANGE,
+        function(item_num, old_room_num, new_room_num)
+          callback(trx.items[item_num], old_room_num, new_room_num)
+        end
+      )
     )
   end,
 })
@@ -625,7 +630,7 @@ api.define("events.on_cutscene_trigger", {
       type = "function",
       params = {
         {
-          name = "num",
+          name = "cutscene_num",
           type = "integer",
           description = "Number the trigger names.",
         },
@@ -635,8 +640,8 @@ api.define("events.on_cutscene_trigger", {
   returns = LISTENER,
   examples = {
     [[-- only in the throne room; a flyby stands in for it elsewhere
-trx.events.on_cutscene_trigger(function(num)
-  if num ~= 27 then
+trx.events.on_cutscene_trigger(function(cutscene_num)
+  if cutscene_num ~= 27 then
     return false
   end
   if trx.lara.item.room_num == 55 then
@@ -658,7 +663,7 @@ api.define("events.on_cutscene_start", {
       type = "function",
       params = {
         {
-          name = "num",
+          name = "cutscene_num",
           type = "integer",
           description = "Number of the cutscene starting.",
         },
@@ -678,7 +683,7 @@ api.define("events.on_cutscene_end", {
       type = "function",
       params = {
         {
-          name = "num",
+          name = "cutscene_num",
           type = "integer",
           description = "Number of the cutscene that ended.",
         },
@@ -687,8 +692,8 @@ api.define("events.on_cutscene_end", {
   },
   returns = LISTENER,
   examples = {
-    [[trx.events.on_cutscene_end(function(num)
-  trx.log.info("cutscene " .. num .. " finished")
+    [[trx.events.on_cutscene_end(function(cutscene_num)
+  trx.log.info("cutscene " .. cutscene_num .. " finished")
 end)]],
   },
   impl = hook(types.CUTSCENE_END),
@@ -704,17 +709,17 @@ A sequence that a cutscene or the player interrupts does not fire it.]],
       type = "function",
       params = {
         {
-          name = "sequence",
+          name = "sequence_num",
           type = "integer",
-          description = "Number of the sequence that ended.",
+          description = "Number of the flyby sequence that ended.",
         },
       },
     },
   },
   returns = LISTENER,
   examples = {
-    [[trx.events.on_flyby_end(function(sequence)
-  trx.camera.play_flyby(sequence)
+    [[trx.events.on_flyby_end(function(sequence_num)
+  trx.camera.play_flyby(sequence_num)
 end)]],
   },
   impl = hook(types.FLYBY_END),

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -79,9 +79,9 @@ api.define("events.on_game_start", {
     been applied, so this is where a script sets object properties, declares
     allies, changes room state and plays sound effects. Every kind of level
     fires it: a played level, a cutscene and the attract demo alike. The title
-    screen has `on_title_start` instead.
+    screen has `trx.events.on_title_start` instead.
 
-    Which level is starting is `trx.game.current_level`, whose `num` and `type`
+    Which level is starting is `trx.game.current_level`, whose `trx.game.Level.num` and `trx.game.Level.type`
     say where it counts and what kind it is. A level script already knows both,
     which is why the handler is not handed them.
   ]],
@@ -112,7 +112,7 @@ api.define("events.on_title_start", {
   description = [[
     Happens when the title screen's scene starts playing behind the menu, once
     its level is loaded and its items are set up. The handler takes no
-    arguments. `on_game_start` does not fire for the title level.
+    arguments. `trx.events.on_game_start` does not fire for the title level.
   ]],
   params = { { name = "callback", type = "function" } },
   returns = LISTENER,
@@ -215,7 +215,7 @@ end)]],
 
 api.define("events.on_room_change", {
   description = "Happens when an item changes rooms during play, which a cutscene or the attract "
-    .. "demo is not. `trx.rooms.Room:on_enter` and `:on_exit` are this same event, narrowed to "
+    .. "demo is not. `trx.rooms.Room:on_enter` and `trx.rooms.Room:on_exit` are this same event, narrowed to "
     .. "one room.",
   params = {
     {
@@ -260,7 +260,7 @@ end)]],
 
 api.define("events.on_trigger", {
   description = "Happens every time a trigger is aimed at an item - a floor trigger in the level, "
-    .. "the `/trigger` console command, or `item:trigger` from a script - of any kind, an "
+    .. "the `/trigger` console command, or `trx.items.Item:trigger` from a script - of any kind, an "
     .. "antitrigger included. It is the raw trigger, not a state change: a floor pad fires it every "
     .. "frame Lara stands on it, and a partial trigger fires it too. A cutscene or the attract demo "
     .. "does not.\n\n"
@@ -280,7 +280,7 @@ api.define("events.on_trigger", {
         {
           name = "trigger",
           type = "table",
-          description = "What the trigger carried: `type` (an `items.TriggerType`), `mask` (the "
+          description = "What the trigger carried: `type` (a `trx.items.TriggerType`), `mask` (the "
             .. "code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.",
         },
       },
@@ -418,7 +418,7 @@ api.define(
     types.ENTER_SIM,
     "Happens when an item starts being simulated during play - its control routine begins running "
       .. "each frame. Every path that starts an item fires it: a trigger, a switch, a respawn, a "
-      .. "cheat. A trigger also fires `on_activate`, which this does not.\n\n"
+      .. "cheat. A trigger also fires `trx.events.on_activate`, which this does not.\n\n"
       .. "`trx.items.Item:on_enter_sim` is this same event, narrowed to one item.",
     "The item that started being simulated.",
     {
@@ -451,7 +451,7 @@ api.define(
     types.ACTIVATE,
     "Happens when an item is activated through the lifecycle front door during play - the path a "
       .. "level trigger takes. Switches, respawns and cheats start an item without it, firing only "
-      .. "`on_enter_sim`; watch that one for a start of any cause.\n\n"
+      .. "`trx.events.on_enter_sim`; watch that one for a start of any cause.\n\n"
       .. "`trx.items.Item:on_activate` is this same event, narrowed to one item.",
     "The item that was activated.",
     {
@@ -532,8 +532,8 @@ end)]],
 api.define("events.on_hit", {
   description = [[Happens when an item takes damage, Lara included. It is the raw damage that
 fires, before the item's hit points are clamped, so a fatal blow reports the whole amount the
-attacker dealt. A death that does not go through damage - a script writing `hit_points`, or
-`destroy()` - does not report.
+attacker dealt. A death that does not go through damage - a script writing
+`trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.
 
 `trx.items.Item:on_hit` is this same event, narrowed to one item.]],
   params = {
@@ -569,8 +569,8 @@ end)]],
 
 api.define("events.on_kill", {
   description = [[Happens when damage takes an item's hit points to zero, Lara included. It is the
-same blow `on_hit` reports, which fires first. A death that does not go through damage - a script
-writing `hit_points`, or `destroy()` - does not report.
+same blow `trx.events.on_hit` reports, which fires first. A death that does not go through damage
+- a script writing `trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.
 
 Some bosses fall and get back up: Willard is knocked out, Natla plays dead before her second
 stage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points
@@ -722,7 +722,7 @@ end)]],
 
 api.define("events.detach", {
   description = "Removes a previously attached handler, which stops firing immediately. "
-    .. "`listener:detach()` does the same to one held in hand.",
+    .. "`trx.events.Listener:detach` does the same to one held in hand.",
   params = {
     { name = "listener", type = "events.Listener" },
   },

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -20,6 +20,12 @@ api.module("events", {
     .. "other event ignores what its handlers return.",
 })
 
+api.number("events.FlipEffectNum", {
+  base = 0,
+  description = "A flip effect number, as a level editor numbers them. Not the id space of "
+    .. "`trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` names.",
+})
+
 -- What every hook hands back. The engine keys a listener by a number, and the
 -- number is the module's business rather than a script's: a listener is worth
 -- holding on to, comparing and detaching, and worth nothing else.
@@ -89,6 +95,7 @@ api.define("events.on_game_start", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "is_save",
@@ -114,7 +121,13 @@ api.define("events.on_title_start", {
     its level is loaded and its items are set up. The handler takes no
     arguments. `trx.events.on_game_start` does not fire for the title level.
   ]],
-  params = { { name = "callback", type = "function" } },
+  params = {
+    {
+      name = "callback",
+      type = "function",
+      description = "What to run when it happens.",
+    },
+  },
   returns = LISTENER,
   examples = {
     [[trx.events.on_title_start(function()
@@ -130,6 +143,7 @@ api.define("events.on_pickup", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "item_num",
@@ -151,7 +165,13 @@ end)]],
 api.define("events.before_control", {
   description = "Happens on every logical game frame, before the main game logic runs. The handler "
     .. "takes no arguments.",
-  params = { { name = "callback", type = "function" } },
+  params = {
+    {
+      name = "callback",
+      type = "function",
+      description = "What to run when it happens.",
+    },
+  },
   returns = LISTENER,
   impl = hook(types.BEFORE_CONTROL),
 })
@@ -159,16 +179,22 @@ api.define("events.before_control", {
 api.define("events.after_control", {
   description = "Happens on every logical game frame, after the main game logic runs. The handler "
     .. "takes no arguments.",
-  params = { { name = "callback", type = "function" } },
+  params = {
+    {
+      name = "callback",
+      type = "function",
+      description = "What to run when it happens.",
+    },
+  },
   returns = LISTENER,
   impl = hook(types.AFTER_CONTROL),
 })
 
 api.define("events.on_flip_effect", {
-  description = "Claims a flip effect number and happens whenever a level runs it, whether from a "
-    .. "floor trigger or an animation command. Place an ordinary flipeffect trigger in a level "
-    .. "editor - pad, heavy, switch and antitrigger all work - pick an unused effect number, and "
-    .. "handle it here from the level's script.\n\n"
+  description = "Claims a `trx.events.FlipEffectNum` and happens whenever a level runs it, "
+    .. "whether from a floor trigger or an animation command. Place an ordinary flipeffect "
+    .. "trigger in a level editor - pad, heavy, switch and antitrigger all work - pick one "
+    .. "nothing uses, and handle it here from the level's script.\n\n"
     .. "A claimed number belongs to the script for the rest of the level: its stock engine effect "
     .. "does not run, even if the handler is later detached. Unclaimed numbers are unaffected.\n\n"
     .. "Unlike the other hooks, this happens at effect execution time, in the middle of a game "
@@ -176,15 +202,13 @@ api.define("events.on_flip_effect", {
   params = {
     {
       name = "effect_num",
-      type = "integer",
-      base = 0,
-      description = "The flip effect number to claim, as the level editor numbers them. This is "
-        .. "not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` "
-        .. "names.",
+      type = "events.FlipEffectNum",
+      description = "The one to claim.",
     },
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "timer",
@@ -221,6 +245,7 @@ api.define("events.on_room_change", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "item",
@@ -271,6 +296,7 @@ api.define("events.on_trigger", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "item",
@@ -279,9 +305,8 @@ api.define("events.on_trigger", {
         },
         {
           name = "trigger",
-          type = "table",
-          description = "What the trigger carried: `type` (a `trx.items.TriggerType`), `mask` (the "
-            .. "code bits it set, `1` to `31`), `timer` (in seconds), and `one_shot`.",
+          type = "items.Trigger",
+          description = "What the trigger carried.",
         },
       },
     },
@@ -325,6 +350,7 @@ local function visibility_hook(event_type, method, verb, examples)
       {
         name = "callback",
         type = "function",
+        description = "What to run when it happens.",
         params = {
           {
             name = "item",
@@ -358,6 +384,7 @@ local function item_lifecycle_hook(
       {
         name = "callback",
         type = "function",
+        description = "What to run when it happens.",
         params = {
           {
             name = "item",
@@ -540,6 +567,7 @@ attacker dealt. A death that does not go through damage - a script writing
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "item",
@@ -582,6 +610,7 @@ more for the dagger that ends it.
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "item",
@@ -625,6 +654,7 @@ api.define("events.on_cutscene_trigger", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "cutscene_num",
@@ -659,6 +689,7 @@ api.define("events.on_cutscene_start", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "cutscene_num",
@@ -678,6 +709,7 @@ api.define("events.on_cutscene_end", {
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "cutscene_num",
@@ -703,6 +735,7 @@ A sequence that a cutscene or the player interrupts does not fire it.]],
     {
       name = "callback",
       type = "function",
+      description = "What to run when it happens.",
       params = {
         {
           name = "sequence_num",
@@ -724,7 +757,11 @@ api.define("events.detach", {
   description = "Removes a previously attached handler, which stops firing immediately. "
     .. "`trx.events.Listener:detach` does the same to one held in hand.",
   params = {
-    { name = "listener", type = "events.Listener" },
+    {
+      name = "listener",
+      type = "events.Listener",
+      description = "What the hook handed back when the handler was attached.",
+    },
   },
   returns = {
     type = "boolean",

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -6,6 +6,13 @@ api.module("game", {
   description = "Module for the game flow: which levels there are, and which one is being played.",
 })
 
+api.number("game.LevelNum", {
+  base = 1,
+  description = "The number a level goes by, which is what the player is shown and what a "
+    .. "gameflow names. Not its place in a table: a level the game flow skips does not "
+    .. "count, and a gym level has no number at all and reads 0.",
+})
+
 local LevelTable = api.enum("game.LevelTable", {
   backing = "GF_LEVEL_TABLE_TYPE",
   description = "One of the lists of levels the game flow declares.",
@@ -40,11 +47,8 @@ api.type("game.Level", {
   fields = {
     num = {
       from = "num",
-      type = "integer",
+      type = "game.LevelNum",
       writable = false,
-      base = 1,
-      description = "The number the level goes by. Not its place in the table: levels the game "
-        .. "flow skips do not count, and a gym level has no number at all and reads 0.",
     },
     type = {
       from = "type",
@@ -220,22 +224,33 @@ api.property("game.is_ngplus", {
   get = raw.is_ngplus,
 })
 
+api.number("game.DemoNum", {
+  base = 1,
+  description = "Where a demo sits in the table of demos.",
+})
+
 api.define("game.play_level", {
   description = "Starts a level from `trx.game.levels`.",
   params = {
     {
       name = "level_num",
-      type = "integer",
-      base = 1,
-      description = "Position in `trx.game.levels`.",
+      type = "game.LevelNum",
     },
     {
       name = "opts",
       type = "table",
       optional = true,
-      description = "`select`: start the level as the level-select screen does, rebuilding "
-        .. "Lara's inventory to what she would carry on reaching it. Without it the level "
-        .. "continues from the one in progress.",
+      description = "How to start it.",
+      fields = {
+        {
+          name = "select",
+          type = "boolean",
+          optional = true,
+          description = "Start the level as the level-select screen does, rebuilding Lara's "
+            .. "inventory to what she would carry on reaching it. Without it the level "
+            .. "continues from the one in progress.",
+        },
+      },
     },
   },
   examples = { [[trx.game.play_level(1)]] },
@@ -247,9 +262,7 @@ api.define("game.play_cutscene", {
   params = {
     {
       name = "cutscene_num",
-      type = "integer",
-      base = 1,
-      description = "Position in `trx.game.cutscenes`.",
+      type = "cutscenes.Num",
     },
   },
   impl = raw.play_cutscene,
@@ -260,10 +273,9 @@ api.define("game.play_demo", {
   params = {
     {
       name = "demo_num",
-      type = "integer",
+      type = "game.DemoNum",
       optional = true,
-      base = 1,
-      description = "Position in `trx.game.demos`. Omit to play the next demo in rotation.",
+      description = "Omit to play the next demo in rotation.",
     },
   },
   returns = {

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -225,7 +225,7 @@ api.define("game.play_level", {
   description = "Starts a level from `trx.game.levels`.",
   params = {
     {
-      name = "num",
+      name = "level_num",
       type = "integer",
       description = "1-based position in `trx.game.levels`.",
     },
@@ -246,7 +246,7 @@ api.define("game.play_cutscene", {
   description = "Plays a cutscene.",
   params = {
     {
-      name = "num",
+      name = "cutscene_num",
       type = "integer",
       description = "1-based position in `trx.game.cutscenes`.",
     },
@@ -258,7 +258,7 @@ api.define("game.play_demo", {
   description = "Plays a demo, and returns the one that started.",
   params = {
     {
-      name = "num",
+      name = "demo_num",
       type = "integer",
       optional = true,
       description = "1-based position in `trx.game.demos`. Omit to play the next demo in rotation.",

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -6,6 +6,20 @@ api.module("game", {
   description = "Module for the game flow: which levels there are, and which one is being played.",
 })
 
+api.unit("game.Frames", {
+  description = [[
+    A length of time counted in the frames the engine runs the world at, which
+    is what the engine measures its own timers in.
+  ]],
+  spellings = { "game frames", "in frames" },
+})
+
+api.unit("game.Seconds", {
+  type = "number",
+  description = "A length of time in seconds, as a player would read it off a clock.",
+  spellings = { "in seconds" },
+})
+
 api.number("game.LevelNum", {
   base = 1,
   description = "The number a level goes by, which is what the player is shown and what a "

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -42,14 +42,14 @@ api.type("game.Level", {
       from = "num",
       type = "integer",
       writable = false,
+      base = 1,
       description = "The number the level goes by. Not its place in the table: levels the game "
         .. "flow skips do not count, and a gym level has no number at all and reads 0.",
     },
     type = {
       from = "type",
-      type = "integer",
+      type = "game.LevelType",
       writable = false,
-      enum = "game.LevelType",
       description = "What kind of level it is.",
     },
     title = {
@@ -78,9 +78,8 @@ api.type("game.Level", {
     },
     music_track = {
       from = "music_track",
-      type = "integer",
+      type = "catalog.music",
       writable = false,
-      enum = "catalog.music",
       description = "The track that plays when the level starts.",
     },
     water_particles = {
@@ -118,8 +117,8 @@ api.type("game.Level", {
 
   extensions = {
     inventory = {
-      type = "Inventory",
-      description = "What the level keeps for Lara's return, as a `trx.inventory.Inventory`, or "
+      type = "inventory.Inventory",
+      description = "What the level keeps for Lara's return, or "
         .. "`nil` for a level that keeps nothing: the title screen and the cutscenes. It is what "
         .. "she will arrive there with rather than what she is carrying now, which is "
         .. "`trx.inventory` itself.",
@@ -128,8 +127,8 @@ api.type("game.Level", {
       end,
     },
     stats = {
-      type = "Stats",
-      description = "What the level keeps count of, as a `trx.stats.Stats`, or `nil` for a level "
+      type = "stats.Stats",
+      description = "What the level keeps count of, or `nil` for a level "
         .. "that counts nothing: the title screen and the cutscenes. The level being played is "
         .. "also `trx.stats` itself.",
       impl = function(level)
@@ -173,13 +172,13 @@ api.property("game.demos", {
 })
 
 api.property("game.current_level", {
-  type = "Level",
+  type = "game.Level",
   description = "The level being played, or `nil` if none is.",
   get = raw.get_current_level,
 })
 
 api.property("game.gym", {
-  type = "Level",
+  type = "game.Level",
   description = "The gym level, or `nil` if this game has no gym.",
   get = function()
     local level = raw.get_level(LevelTable.MAIN, 0)
@@ -227,7 +226,8 @@ api.define("game.play_level", {
     {
       name = "level_num",
       type = "integer",
-      description = "1-based position in `trx.game.levels`.",
+      base = 1,
+      description = "Position in `trx.game.levels`.",
     },
     {
       name = "opts",
@@ -248,7 +248,8 @@ api.define("game.play_cutscene", {
     {
       name = "cutscene_num",
       type = "integer",
-      description = "1-based position in `trx.game.cutscenes`.",
+      base = 1,
+      description = "Position in `trx.game.cutscenes`.",
     },
   },
   impl = raw.play_cutscene,
@@ -261,12 +262,13 @@ api.define("game.play_demo", {
       name = "demo_num",
       type = "integer",
       optional = true,
-      description = "1-based position in `trx.game.demos`. Omit to play the next demo in rotation.",
+      base = 1,
+      description = "Position in `trx.game.demos`. Omit to play the next demo in rotation.",
     },
   },
   returns = {
     {
-      type = "Level",
+      type = "game.Level",
       nullable = true,
       description = "The demo that started, or `nil` if the game has no demos.",
     },

--- a/src/lua/api/inventory.lua
+++ b/src/lua/api/inventory.lua
@@ -15,12 +15,12 @@ Every function takes either the pickup lying in the world or the inventory icon
 it goes into. The engine maps one to the other, so a script names whichever it
 has.]],
   instance = raw.get_current,
+  instance_type = "inventory.Inventory",
 })
 
 local object_param = {
   name = "object_id",
-  type = "integer",
-  enum = "catalog.objects",
+  type = "catalog.objects",
   description = "The pickup, or the inventory icon it goes into.",
 }
 
@@ -33,8 +33,7 @@ local count_param = {
 
 local weapon_param = {
   name = "weapon",
-  type = "integer",
-  enum = "catalog.weapons",
+  type = "catalog.weapons",
   description = "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the "
     .. "table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
 }
@@ -51,8 +50,7 @@ is an entry like any other, counting what its rounds come to.]],
   fields = {
     object = {
       from = "object_id",
-      type = "integer",
-      enum = "catalog.objects",
+      type = "catalog.objects",
       writable = false,
       description = "The inventory icon this entry is drawn as.",
     },
@@ -158,19 +156,19 @@ Several pickups share one entry - the scion whether or not she holds it, a
 waterskin at each fill level - so this answers with the one thing they are
 drawn as.]],
       params = { object_param },
-      returns = { type = "Entry", nullable = true },
+      returns = { type = "inventory.Entry", nullable = true },
     },
     entry_at = {
-      description = "The entry at a position, counted from one in the order they are drawn, or "
-        .. "`nil` past the end.",
+      description = "The entry at a position in the order they are drawn, or `nil` past the end.",
       params = {
         {
           name = "entry_num",
           type = "integer",
-          description = "1-based position.",
+          base = 1,
+          description = "Position in the ring.",
         },
       },
-      returns = { type = "Entry", nullable = true },
+      returns = { type = "inventory.Entry", nullable = true },
     },
     entry_count = {
       description = "How many entries there are. `#trx.inventory` is the same number for the "
@@ -187,8 +185,7 @@ from two things. It answers with an object id rather than an entry; `entry` is
 what hands back the entry itself.]],
       params = { object_param },
       returns = {
-        type = "integer",
-        enum = "catalog.objects",
+        type = "catalog.objects",
         nullable = true,
         description = "The icon's object id, or `nil` for a pickup that has none.",
       },
@@ -209,11 +206,10 @@ This asks about the level being played whichever inventory it is called on.]],
 
 api.container("inventory", {
   description = "Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` "
-    .. "is how many kinds of thing she carries. Entries count from one, in the order they are "
-    .. "drawn, and are built one at a time as they are asked for. `pairs()` walks them.",
-  base = 1,
-  key = { type = "integer", description = "1-based position." },
-  value = { type = "Entry", nullable = true },
+    .. "is how many kinds of thing she carries. Entries are keyed by the order they are drawn "
+    .. "in, and are built one at a time as they are asked for. `pairs()` walks them.",
+  key = { type = "integer", base = 1, description = "Position in the ring." },
+  value = { type = "inventory.Entry", nullable = true },
   examples = {
     [[for _, entry in pairs(trx.inventory) do
   trx.log.info(("%d x %s"):format(entry.count, trx.catalog.objects[entry.object]))

--- a/src/lua/api/inventory.lua
+++ b/src/lua/api/inventory.lua
@@ -38,6 +38,11 @@ local weapon_param = {
     .. "table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
 }
 
+api.number("inventory.EntryNum", {
+  base = 1,
+  description = "Where an entry sits in the ring, in the order they are drawn.",
+})
+
 api.type("inventory.Entry", {
   backing = "INVENTORY_ENTRY",
   description = [[
@@ -82,7 +87,7 @@ carrying.]],
       description = "How many of something is in it. A box of ammunition counts what its rounds "
         .. "come to.",
       params = { object_param },
-      returns = { type = "integer" },
+      returns = { type = "integer", description = "0 where there is none." },
     },
     set_count = {
       description = "Sets how many of it there are. Zero takes it away.",
@@ -98,7 +103,10 @@ carrying.]],
     has = {
       description = "Whether there is any of it at all.",
       params = { object_param },
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "True for any count above 0.",
+      },
     },
     give = {
       description = [[
@@ -126,7 +134,10 @@ than an entry of its own, so taking one back takes the rounds a box is worth.]],
       description = "How many shots there are for the weapon. A shot is one pull of the trigger, "
         .. "which is what the counter shows the player; the shotgun spends six rounds on each.",
       params = { weapon_param },
-      returns = { type = "integer" },
+      returns = {
+        type = "integer",
+        description = "0 where she carries no ammunition for it.",
+      },
     },
     set_shots = {
       description = "Sets how many shots there are for it.",
@@ -146,7 +157,10 @@ than an entry of its own, so taking one back takes the rounds a box is worth.]],
       description = "Whether the weapon itself is in it, which is not the same as having "
         .. "ammunition for it.",
       params = { weapon_param },
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "True where the weapon itself is in it.",
+      },
     },
     entry = {
       description = [[
@@ -156,24 +170,33 @@ Several pickups share one entry - the scion whether or not she holds it, a
 waterskin at each fill level - so this answers with the one thing they are
 drawn as.]],
       params = { object_param },
-      returns = { type = "inventory.Entry", nullable = true },
+      returns = {
+        type = "inventory.Entry",
+        nullable = true,
+        description = "The entry, or `nil` where there is none of it.",
+      },
     },
     entry_at = {
       description = "The entry at a position in the order they are drawn, or `nil` past the end.",
       params = {
         {
           name = "entry_num",
-          type = "integer",
-          base = 1,
-          description = "Position in the ring.",
+          type = "inventory.EntryNum",
         },
       },
-      returns = { type = "inventory.Entry", nullable = true },
+      returns = {
+        type = "inventory.Entry",
+        nullable = true,
+        description = "The entry, or `nil` past the last one.",
+      },
     },
     entry_count = {
       description = "How many entries there are. `#trx.inventory` is the same number for the "
         .. "one Lara carries.",
-      returns = { type = "integer" },
+      returns = {
+        type = "integer",
+        description = "Kinds of thing, not counts.",
+      },
     },
     icon_of = {
       description = [[
@@ -199,7 +222,10 @@ lets a cheat hand one over.
 
 This asks about the level being played whichever inventory it is called on.]],
       params = { object_param },
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "True where the level carries the model to draw it with.",
+      },
     },
   },
 })
@@ -208,7 +234,7 @@ api.container("inventory", {
   description = "Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` "
     .. "is how many kinds of thing she carries. Entries are keyed by the order they are drawn "
     .. "in, and are built one at a time as they are asked for. `pairs()` walks them.",
-  key = { type = "integer", base = 1, description = "Position in the ring." },
+  key = { type = "inventory.EntryNum" },
   value = { type = "inventory.Entry", nullable = true },
   examples = {
     [[for _, entry in pairs(trx.inventory) do

--- a/src/lua/api/inventory.lua
+++ b/src/lua/api/inventory.lua
@@ -18,7 +18,7 @@ has.]],
 })
 
 local object_param = {
-  name = "object",
+  name = "object_id",
   type = "integer",
   enum = "catalog.objects",
   description = "The pickup, or the inventory icon it goes into.",
@@ -164,7 +164,11 @@ drawn as.]],
       description = "The entry at a position, counted from one in the order they are drawn, or "
         .. "`nil` past the end.",
       params = {
-        { name = "n", type = "integer", description = "1-based position." },
+        {
+          name = "entry_num",
+          type = "integer",
+          description = "1-based position.",
+        },
       },
       returns = { type = "Entry", nullable = true },
     },

--- a/src/lua/api/inventory.lua
+++ b/src/lua/api/inventory.lua
@@ -109,7 +109,7 @@ flares; a level's simply gains it.]],
       returns = {
         type = "integer",
         description = "How many went in. 0 from Lara's means the level does not carry the icon "
-          .. "for it - see `can_add`.",
+          .. "for it - see `trx.inventory.Inventory:can_add`.",
       },
       examples = { [[trx.inventory:give(trx.catalog.objects.uzi_item, 2)]] },
     },
@@ -117,7 +117,7 @@ flares; a level's simply gains it.]],
       description = [[
 Takes things back out, stopping when there are none left.
 
-This is not the exact opposite of `give`: a box of ammunition is rounds rather
+This is not the exact opposite of `trx.inventory.Inventory:give`: a box of ammunition is rounds rather
 than an entry of its own, so taking one back takes the rounds a box is worth.]],
       params = { object_param, count_param },
       returns = { type = "integer", description = "How many came out." },
@@ -181,7 +181,7 @@ Which inventory icon a pickup is drawn as, whether or not there is any of it.
 
 Several pickups share one icon - the scion whether or not Lara holds it, a
 waterskin at each fill level - so this is what tells two spellings of one thing
-from two things. It answers with an object id rather than an entry; `entry` is
+from two things. It answers with an object id rather than an entry; `trx.inventory.Inventory:entry` is
 what hands back the entry itself.]],
       params = { object_param },
       returns = {
@@ -192,7 +192,7 @@ what hands back the entry itself.]],
     },
     can_add = {
       description = [[
-Whether `give` would do anything in the level being played. The level has to
+Whether `trx.inventory.Inventory:give` would do anything in the level being played. The level has to
 carry the inventory model, which is not the same as the pickup being in it: a
 level with no shotgun lying about still draws one in the ring, which is what
 lets a cheat hand one over.

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -8,10 +8,10 @@ api.module("items", {
   description = "Module for controlling all moveables.",
 })
 
-api.note(
-  "items.num",
-  "0-based item number, matching the numbers level editors show."
-)
+api.number("items.Num", {
+  base = 0,
+  description = "Item number, matching the numbers level editors show.",
+})
 
 api.enum("items.PickupMode", {
   backing = "PICKUP_MODE",
@@ -112,7 +112,7 @@ local function item_lifecycle_method(event_name, description, examples)
         params = {
           {
             name = "item",
-            type = "Item",
+            type = "items.Item",
             description = "This item.",
           },
         },
@@ -145,26 +145,27 @@ api.type("items.Item", {
     anim_num = {
       from = "relative_anim_num",
       type = "integer",
-      description = "The animation's number within the object, counted from 0.",
+      base = 0,
+      description = "The animation's number within the object.",
     },
     frame_num = {
       from = "relative_frame_num",
       type = "integer",
-      description = "The frame's number within the animation, counted from 0. Negative values count "
-        .. "back from the end.",
+      base = 0,
+      description = "The frame's number within the animation. Negative values count back from the "
+        .. "end.",
     },
     num = {
       from = "item_num",
-      type = "integer",
+      type = "items.Num",
       writable = false,
-      see = "items.num",
       description = "An item handed over by a query can say where it lives.",
     },
     room_num = {
       from = "room_num",
-      type = "integer",
+      type = "rooms.Num",
       writable = false,
-      description = "0-based number of the room containing this item. Set `pos` to move the item between rooms.",
+      description = "The room containing this item. Set `pos` to move the item between rooms.",
     },
     hit_points = {
       from = "hit_points",
@@ -184,9 +185,8 @@ api.type("items.Item", {
     },
     object_id = {
       from = "object_id",
-      type = "integer",
+      type = "catalog.objects",
       writable = false,
-      enum = "catalog.objects",
       description = "The item's object type.",
     },
     is_visible = {
@@ -334,8 +334,8 @@ api.type("items.Item", {
 
   extensions = {
     room = {
-      type = "Room",
-      description = "The `trx.rooms.Room` containing this item.",
+      type = "rooms.Room",
+      description = "The room containing this item.",
       impl = function(item)
         return trx.rooms[item.room_num]
       end,
@@ -413,14 +413,13 @@ api.type("items.Item", {
           params = {
             {
               name = "item",
-              type = "Item",
+              type = "items.Item",
               description = "This item.",
             },
             {
               name = "trigger",
               type = "table",
-              description = "What the trigger carried: `type`, `mask`, `timer` and `one_shot`. See "
-                .. "`trx.events.on_trigger`.",
+              description = "What the trigger carried: `type`, `mask`, `timer` and `one_shot`.",
             },
           },
         },
@@ -444,7 +443,7 @@ end)]],
           params = {
             {
               name = "item",
-              type = "Item",
+              type = "items.Item",
               description = "This item.",
             },
             {
@@ -474,7 +473,7 @@ end)]],
           params = {
             {
               name = "item",
-              type = "Item",
+              type = "items.Item",
               description = "This item.",
             },
           },
@@ -701,12 +700,11 @@ api.define("items.get", {
   params = {
     {
       name = "key",
-      type = "any",
-      see = "items.num",
+      type = "items.Num",
       description = "An item's unique name reaches it as well.",
     },
   },
-  returns = { type = "Item", nullable = true },
+  returns = { type = "items.Item", nullable = true },
   examples = {
     [==[local item = trx.items[0]
 item.name = "lara"
@@ -720,8 +718,7 @@ api.define("items.spawn", {
   params = {
     {
       name = "object_id",
-      type = "integer",
-      enum = "catalog.objects",
+      type = "catalog.objects",
       description = "Object type to spawn.",
     },
     {
@@ -744,7 +741,7 @@ api.define("items.spawn", {
     },
   },
   returns = {
-    type = "Item",
+    type = "items.Item",
     nullable = true,
     description = "`nil` if the item pool is exhausted.",
   },
@@ -801,7 +798,7 @@ end
 local function axis_narrowing(field, description)
   return {
     description = description,
-    returns = { type = "Query", description = "The narrowed query." },
+    returns = { type = "query.Query", description = "The narrowed query." },
     impl = trx.query.narrowing(function()
       return function(_i, item)
         return item[field]
@@ -847,7 +844,7 @@ local ItemQuery = api.type("items.ItemQuery", {
           description = "Object id, or a name `trx.objects.query` resolves.",
         },
       },
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       examples = {
         [[trx.items.query:of_object("wolf"):simulated():matches()]],
       },
@@ -864,11 +861,10 @@ local ItemQuery = api.type("items.ItemQuery", {
       params = {
         {
           name = "room_num",
-          type = "integer",
-          see = "rooms.num",
+          type = "rooms.Num",
         },
       },
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       impl = trx.query.narrowing(function(room_num)
         return function(_i, item)
           return item.room_num == room_num
@@ -890,7 +886,7 @@ local ItemQuery = api.type("items.ItemQuery", {
         },
         { name = "max", type = "vec3", description = "The opposite corner." },
       },
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       examples = {
         [[local guards = trx.items.query
   :in_box({ x = 51200, y = -2048, z = 30720 }, { x = 53248, y = 0, z = 32768 })
@@ -917,7 +913,7 @@ local ItemQuery = api.type("items.ItemQuery", {
           description = "How far out it reaches. One sector is 1024.",
         },
       },
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       impl = trx.query.narrowing(function(centre, radius)
         return found_in(raw.in_sphere(centre, radius))
       end),
@@ -933,9 +929,8 @@ local item_query = trx.query.new({
 }, ItemQuery)
 
 api.property("items.query", {
-  type = "ItemQuery",
-  description = "The identity query over every item in the level. Narrow it and read it - see "
-    .. "`trx.items.ItemQuery`.",
+  type = "items.ItemQuery",
+  description = "The identity query over every item in the level. Narrow it and read it.",
   get = function()
     return item_query
   end,
@@ -945,11 +940,10 @@ api.container("items", {
   description = "Indexing the module reaches an item, and `#trx.items` is how many the level has. "
     .. "`pairs()` walks them in order, keyed by the item number.",
   key = {
-    type = "any",
-    see = "items.num",
+    type = { "items.Num", "string" },
     description = "An item's unique name reaches it as well.",
   },
-  value = { type = "Item", nullable = true },
+  value = { type = "items.Item", nullable = true },
   examples = {
     [[for num, item in pairs(trx.items) do
   trx.log.info(item.object_id)

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -40,7 +40,7 @@ api.enum("items.SwitchMode", {
 
 api.enum("items.TriggerType", {
   backing = "ITEM_TRIGGER_KIND",
-  description = "The kind of trigger `item:trigger` fires, matching the trigger types a level editor "
+  description = "The kind of trigger `trx.items.Item:trigger` fires, matching the trigger types a level editor "
     .. "offers. Most are forward triggers that differ only in what trips them in a level; from a "
     .. "script they behave alike, and `TRIGGER` is the one to reach for.",
   values = {
@@ -133,7 +133,7 @@ api.type("items.Item", {
     pos = {
       from = "pos",
       type = "vec3",
-      description = "World position. Updating this also updates `room` and `room_num`.",
+      description = "World position. Updating this also updates `trx.items.Item.room` and `trx.items.Item.room_num`.",
     },
     rot = {
       from = "rot",
@@ -165,18 +165,18 @@ api.type("items.Item", {
       from = "room_num",
       type = "rooms.Num",
       writable = false,
-      description = "The room containing this item. Set `pos` to move the item between rooms.",
+      description = "The room containing this item. Set `trx.items.Item.pos` to move the item between rooms.",
     },
     hit_points = {
       from = "hit_points",
       type = "integer",
-      description = "Current hit points. Raising this above the maximum also raises `properties.max_hit_points`.",
+      description = "Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of `trx.items.Item.properties`.",
     },
     max_hit_points = {
       from = "max_hit_points",
       type = "integer",
       writable = false,
-      description = "Maximum hit points. Set `properties.max_hit_points` to change it.",
+      description = "Maximum hit points. Set the `max_hit_points` entry of `trx.items.Item.properties` to change it.",
     },
     name = {
       from = "name",
@@ -213,7 +213,7 @@ api.type("items.Item", {
       type = "integer",
       description = "How long the item's trigger keeps it going, in game frames. `0` runs it until "
         .. "something takes the trigger back; `-1` means it has run out; anything else counts down. "
-        .. "This is the raw frame count - `trigger()` takes its timer in seconds instead.",
+        .. "This is the raw frame count - `trx.items.Item:trigger` takes its timer in seconds instead.",
     },
     is_triggered = {
       from = "is_triggered",
@@ -222,7 +222,7 @@ api.type("items.Item", {
       description = "Whether the item's trigger currently says go. This is what a door, a switch or "
         .. "an alarm reads to decide whether to act; a creature ignores it and goes by whether it "
         .. "is running.\n\n"
-        .. "It is a verdict on `trigger_mask`, `timer` and `is_reversed` together, not a field of "
+        .. "It is a verdict on `trx.items.Item.trigger_mask`, `trx.items.Item.timer` and `trx.items.Item.is_reversed` together, not a field of "
         .. "its own.",
     },
     trigger_mask = {
@@ -291,7 +291,7 @@ api.type("items.Item", {
       from = "is_simulated",
       type = "boolean",
       writable = false,
-      description = "Whether the item's control routine runs each frame. Call `activate()` to start it.",
+      description = "Whether the item's control routine runs each frame. Call `trx.items.Item:activate` to start it.",
     },
     is_in_play = {
       from = "is_in_play",
@@ -345,7 +345,7 @@ api.type("items.Item", {
       type = "table",
       description = "The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, "
         .. "`max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far "
-        .. "the model reaches around `pos` before `rot` turns it, and they change as the item "
+        .. "the model reaches around `trx.items.Item.pos` before `trx.items.Item.rot` turns it, and they change as the item "
         .. "animates.",
       impl = function(item)
         return raw.get_bounds(item)
@@ -373,15 +373,15 @@ api.type("items.Item", {
     deactivate = {
       description = "Stops the item: its control routine no longer runs, and a creature loses its AI "
         .. "and stands down. The item stays where it is and keeps its hit points, so this is not a "
-        .. "way of getting rid of it - use `destroy()` for that.\n\n"
-        .. "A trigger can still bring it back, and so can `activate()`.",
+        .. "way of getting rid of it - use `trx.items.Item:destroy` for that.\n\n"
+        .. "A trigger can still bring it back, and so can `trx.items.Item:activate`.",
     },
 
     trigger = {
       description = "Fires a trigger at the item, exactly as a floor trigger in the level would: "
         .. "sets the code bits, and once they are all set, starts the item running.\n\n"
         .. "This is the one to reach for on anything a level would trigger - a door, a switch, an "
-        .. "alarm - because those read their trigger before they act, and merely `activate()`-ing "
+        .. "alarm - because those read their trigger before they act, and merely activating "
         .. "one leaves it running but doing nothing. Pass `type = "
         .. "trx.items.TriggerType.ANTITRIGGER` to take the trigger back instead.",
       params = {
@@ -389,7 +389,7 @@ api.type("items.Item", {
           name = "opts",
           type = "table",
           optional = true,
-          description = "`type`: which `items.TriggerType` to fire; a plain `TRIGGER` by default.\n\n"
+          description = "`type`: which `trx.items.TriggerType` to fire; a plain `TRIGGER` by default.\n\n"
             .. "`mask`: which of the five code bits to set, `1` to `31`, all of them by default. "
             .. "Pass fewer to act as one of several triggers a puzzle is waiting on.\n\n"
             .. "`timer`: how long it should keep the item going, in seconds. `0`, the default, means "
@@ -630,7 +630,7 @@ end)]],
         },
       },
       description = "Runs the object's creature death handling: the corpse stays, and `explode` "
-        .. "bursts its meshes as a rocket or grenade would. For creatures; `destroy()` simply removes "
+        .. "bursts its meshes as a rocket or grenade would. For creatures; `trx.items.Item:destroy` simply removes "
         .. "any item from the game.",
     },
 
@@ -642,9 +642,10 @@ end)]],
           description = "Hit points to take.",
         },
       },
-      description = [[Hurts the item the way a weapon does, and reports through `on_hit`, and
-`on_kill` where the blow takes the last hit point. Writing `hit_points` reports neither. The kill
-counts as the environment's rather than Lara's.]],
+      description = [[Hurts the item the way a weapon does, and reports through `trx.events.on_hit`,
+and `trx.events.on_kill` where the blow takes the last hit point. Writing
+`trx.items.Item.hit_points` reports neither. The kill counts as the
+environment's rather than Lara's.]],
       examples = {
         [[local lara = trx.lara.item
 lara:take_damage(lara.hit_points)]],
@@ -661,7 +662,7 @@ lara:take_damage(lara.hit_points)]],
           description = "Splash damage dealt to nearby items.",
         },
       },
-      description = "Bursts the item's meshes into flying debris, the visual `die(true)` produces, "
+      description = "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with `explode`, "
         .. "on its own. It does not kill or remove the item.",
     },
 
@@ -810,7 +811,7 @@ end
 local ItemQuery = api.type("items.ItemQuery", {
   extends = "query.Query",
   description = "A `trx.query.Query` over the items a level holds, with the narrowings below on top "
-    .. "of the ones every query has. Items answer to no names of their own, so `of_object` is how a "
+    .. "of the ones every query has. Items answer to no names of their own, so `trx.items.ItemQuery:of_object` is how a "
     .. "name reaches them.",
 
   methods = {
@@ -899,7 +900,7 @@ local ItemQuery = api.type("items.ItemQuery", {
     },
 
     in_sphere = {
-      description = "The item stands within a radius of a point. As with `in_box`, the item's "
+      description = "The item stands within a radius of a point. As with `trx.items.ItemQuery:in_box`, the item's "
         .. "position is the whole of the test.",
       params = {
         {

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -34,7 +34,7 @@ api.number("items.Num", {
 
 api.enum("items.PickupMode", {
   backing = "PICKUP_MODE",
-  description = " The values the `pickup_mode` item property can take. It selects the animation Lara "
+  description = "<!--noref: pickup_mode--> The values the `pickup_mode` item property can take. It selects the animation Lara "
     .. "plays when collecting the item.",
   values = {
     NORMAL = "Picked up off the floor.",
@@ -47,7 +47,7 @@ api.enum("items.PickupMode", {
 
 api.enum("items.SwitchMode", {
   backing = "SWITCH_MODE",
-  description = " The values the `switch_mode` item property can take. It selects the animation Lara "
+  description = "<!--noref: switch_mode--> The values the `switch_mode` item property can take. It selects the animation Lara "
     .. "plays when interacting with the item.",
   values = {
     NORMAL = "A regular/classic wall lever.",
@@ -211,13 +211,13 @@ api.type("items.Item", {
     hit_points = {
       from = "hit_points",
       type = "integer",
-      description = "Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of `trx.items.Item.properties`.",
+      description = "Current hit points. Raising this above the maximum also raises the `max_hit_points` entry of `trx.items.Item.properties`. <!--noref: max_hit_points-->",
     },
     max_hit_points = {
       from = "max_hit_points",
       type = "integer",
       writable = false,
-      description = "Maximum hit points. Set the `max_hit_points` entry of `trx.items.Item.properties` to change it.",
+      description = "Maximum hit points. Set the `max_hit_points` entry of `trx.items.Item.properties` to change it. <!--noref: max_hit_points-->",
     },
     name = {
       from = "name",
@@ -397,7 +397,7 @@ api.type("items.Item", {
       type = "table",
       description = "Typed, object-specific item properties. Writing here overrides the object's "
         .. "default for this item only; reads fall back to the object. Iterable with `pairs()`. "
-        .. "See [Objects](../../OBJECTS.md).",
+        .. "See [Objects](docs/trx/OBJECTS.md).",
       impl = make_properties,
     },
   },

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -160,8 +160,8 @@ api.type("items.Trigger", {
       description = "The code bits it set, `1` to `31`.",
     },
     timer = {
-      type = "number",
-      description = "How long it keeps the item going, in seconds.",
+      type = "game.Seconds",
+      description = "How long it keeps the item going.",
     },
     one_shot = {
       type = "boolean",
@@ -249,10 +249,10 @@ api.type("items.Item", {
     },
     timer = {
       from = "timer",
-      type = "integer",
-      description = "How long the item's trigger keeps it going, in game frames. `0` runs it until "
-        .. "something takes the trigger back; `-1` means it has run out; anything else counts down. "
-        .. "This is the raw frame count - `trx.items.Item:trigger` takes its timer in seconds instead.",
+      type = "game.Frames",
+      description = "How long the item's trigger keeps it going. `0` runs it until something takes "
+        .. "the trigger back; `-1` means it has run out; anything else counts down. "
+        .. "`trx.items.Item:trigger` takes its own timer as a `trx.game.Seconds`.",
     },
     is_triggered = {
       from = "is_triggered",
@@ -446,12 +446,12 @@ api.type("items.Item", {
             },
             {
               name = "timer",
-              type = "number",
+              type = "game.Seconds",
               optional = true,
               default = 0,
-              description = "How long it should keep the item going, in seconds. `0` means "
-                .. "until something takes the trigger back. A timer of exactly `1` is a single "
-                .. "frame, not a second, matching the level format.",
+              description = "How long it should keep the item going. `0` means until something "
+                .. "takes the trigger back. A timer of exactly `1` is a single frame, not a "
+                .. "second, matching the level format.",
             },
             {
               name = "one_shot",

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -183,9 +183,7 @@ api.type("items.Item", {
     rot = {
       from = "rot",
       type = "vec3",
-      description = "Orientation, in the units `trx.math` counts angles in. An angle counts in "
-        .. "cycles, so one past the end of the turn wraps round to name the same direction rather "
-        .. "than raising: adding a half turn to a rotation always works.",
+      description = "Orientation. Each component is a `trx.math.Angle`.",
     },
     anim_num = {
       from = "relative_anim_num",
@@ -744,8 +742,8 @@ lara:take_damage(lara.hit_points)]],
         { name = "pos", type = "vec3", description = "World position." },
       },
       returns = {
-        type = "integer",
-        description = "In world units, measured between the two positions.",
+        type = "math.Distance",
+        description = "Measured between the two positions.",
       },
       description = "Distance from this item to a world position.",
     },
@@ -830,7 +828,7 @@ api.define("items.spawn", {
     },
     {
       name = "angle_y",
-      type = "integer",
+      type = "math.Angle",
       optional = true,
       default = 0,
       description = "Facing angle.",
@@ -1022,8 +1020,8 @@ local ItemQuery = api.type("items.ItemQuery", {
         },
         {
           name = "radius",
-          type = "integer",
-          description = "How far out it reaches. One sector is 1024.",
+          type = "math.Distance",
+          description = "How far out it reaches.",
         },
       },
       returns = { type = "query.Query", description = "The narrowed query." },

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -1,11 +1,30 @@
 local raw = trxc.items
 local api = trx.api
 
+require("trx.math")
+
+local Box = api.class("math.Box")
 require("trx.query")
 
 api.module("items", {
   order = 2,
   description = "Module for controlling all moveables.",
+})
+
+api.number("items.AnimNum", {
+  base = 0,
+  description = "The animation's number within the object an item is of.",
+})
+
+api.number("items.FrameNum", {
+  base = 0,
+  description = "The frame's number within the animation it belongs to.",
+})
+
+api.number("items.AnimState", {
+  base = 0,
+  description = "An animation state, as the object's own animations number them. What a state "
+    .. "means is the object's business: the numbers of a wolf are not the numbers of a door.",
 })
 
 api.number("items.Num", {
@@ -15,7 +34,7 @@ api.number("items.Num", {
 
 api.enum("items.PickupMode", {
   backing = "PICKUP_MODE",
-  description = "The values the `pickup_mode` item property can take. It selects the animation Lara "
+  description = " The values the `pickup_mode` item property can take. It selects the animation Lara "
     .. "plays when collecting the item.",
   values = {
     NORMAL = "Picked up off the floor.",
@@ -28,7 +47,7 @@ api.enum("items.PickupMode", {
 
 api.enum("items.SwitchMode", {
   backing = "SWITCH_MODE",
-  description = "The values the `switch_mode` item property can take. It selects the animation Lara "
+  description = " The values the `switch_mode` item property can take. It selects the animation Lara "
     .. "plays when interacting with the item.",
   values = {
     NORMAL = "A regular/classic wall lever.",
@@ -109,6 +128,7 @@ local function item_lifecycle_method(event_name, description, examples)
       {
         name = "callback",
         type = "function",
+        description = "What to run when it happens to this item.",
         params = {
           {
             name = "item",
@@ -124,6 +144,31 @@ local function item_lifecycle_method(event_name, description, examples)
     impl = item_hook(event_name),
   }
 end
+
+-- What a trigger carries, which both the hook and the per-item hook hand over.
+-- A plain table the engine builds, so its keys are entries it holds rather than
+-- accessors.
+api.type("items.Trigger", {
+  description = "What a trigger carried when it fired.",
+  fields = {
+    type = {
+      type = "items.TriggerType",
+      description = "The kind of trigger it was.",
+    },
+    mask = {
+      type = "integer",
+      description = "The code bits it set, `1` to `31`.",
+    },
+    timer = {
+      type = "number",
+      description = "How long it keeps the item going, in seconds.",
+    },
+    one_shot = {
+      type = "boolean",
+      description = "Whether it fires only the once.",
+    },
+  },
+})
 
 api.type("items.Item", {
   backing = "ITEM",
@@ -144,16 +189,12 @@ api.type("items.Item", {
     },
     anim_num = {
       from = "relative_anim_num",
-      type = "integer",
-      base = 0,
-      description = "The animation's number within the object.",
+      type = "items.AnimNum",
     },
     frame_num = {
       from = "relative_frame_num",
-      type = "integer",
-      base = 0,
-      description = "The frame's number within the animation. Negative values count back from the "
-        .. "end.",
+      type = "items.FrameNum",
+      description = "Negative values count back from the end.",
     },
     num = {
       from = "item_num",
@@ -319,13 +360,13 @@ api.type("items.Item", {
     },
     anim_state = {
       from = "current_anim_state",
-      type = "integer",
-      description = "Current animation state.",
+      type = "items.AnimState",
+      description = "The state the item is in.",
     },
     goal_anim_state = {
       from = "goal_anim_state",
-      type = "integer",
-      description = "Animation state the item is transitioning towards.",
+      type = "items.AnimState",
+      description = "The state the item is transitioning towards.",
     },
     -- Deliberately not exposed: box_num, floor, next_item, next_simulated, gen,
     -- anim_num, frame_num, prev_frame_num, ai_bits, ai_tag, after_death and the
@@ -342,13 +383,13 @@ api.type("items.Item", {
     },
 
     bounds = {
-      type = "table",
-      description = "The item's bounding box for the frame it is on: `min_x`, `min_y`, `min_z`, "
-        .. "`max_x`, `max_y`, `max_z`. The numbers are in the item's own frame, so they say how far "
-        .. "the model reaches around `trx.items.Item.pos` before `trx.items.Item.rot` turns it, and they change as the item "
-        .. "animates.",
+      type = "math.Box",
+      description = "The item's bounding box for the frame it is on. The numbers are in the "
+        .. "item's own frame, so they say how far the model reaches around "
+        .. "`trx.items.Item.pos` before `trx.items.Item.rot` turns it, and they change as the "
+        .. "item animates.",
       impl = function(item)
-        return raw.get_bounds(item)
+        return setmetatable(raw.get_bounds(item), Box)
       end,
     },
 
@@ -389,13 +430,38 @@ api.type("items.Item", {
           name = "opts",
           type = "table",
           optional = true,
-          description = "`type`: which `trx.items.TriggerType` to fire; a plain `TRIGGER` by default.\n\n"
-            .. "`mask`: which of the five code bits to set, `1` to `31`, all of them by default. "
-            .. "Pass fewer to act as one of several triggers a puzzle is waiting on.\n\n"
-            .. "`timer`: how long it should keep the item going, in seconds. `0`, the default, means "
-            .. "until something takes the trigger back. A timer of exactly `1` is a single frame, "
-            .. "not a second, matching the level format.\n\n"
-            .. "`one_shot`: never let it fire again.",
+          description = "What the trigger carries.",
+          fields = {
+            {
+              name = "type",
+              type = "items.TriggerType",
+              optional = true,
+              description = "A plain `TRIGGER` by default.",
+            },
+            {
+              name = "mask",
+              type = "integer",
+              optional = true,
+              description = "Which of the five code bits to set, `1` to `31`, all of them by "
+                .. "default. Pass fewer to act as one of several triggers a puzzle is waiting "
+                .. "on.",
+            },
+            {
+              name = "timer",
+              type = "number",
+              optional = true,
+              default = 0,
+              description = "How long it should keep the item going, in seconds. `0` means "
+                .. "until something takes the trigger back. A timer of exactly `1` is a single "
+                .. "frame, not a second, matching the level format.",
+            },
+            {
+              name = "one_shot",
+              type = "boolean",
+              optional = true,
+              description = "Never let it fire again.",
+            },
+          },
         },
       },
       examples = {
@@ -410,6 +476,7 @@ api.type("items.Item", {
         {
           name = "callback",
           type = "function",
+          description = "What to run when it happens to this item.",
           params = {
             {
               name = "item",
@@ -418,8 +485,8 @@ api.type("items.Item", {
             },
             {
               name = "trigger",
-              type = "table",
-              description = "What the trigger carried: `type`, `mask`, `timer` and `one_shot`.",
+              type = "items.Trigger",
+              description = "What the trigger carried.",
             },
           },
         },
@@ -440,6 +507,7 @@ end)]],
         {
           name = "callback",
           type = "function",
+          description = "What to run when it happens to this item.",
           params = {
             {
               name = "item",
@@ -470,6 +538,7 @@ end)]],
         {
           name = "callback",
           type = "function",
+          description = "What to run when it happens to this item.",
           params = {
             {
               name = "item",
@@ -605,7 +674,10 @@ end)]],
     },
 
     is_valid = {
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "False once the item it named is gone.",
+      },
       description = "Whether the handle still refers to a live item. Reading or writing a field on a "
         .. "stale handle raises an error rather than silently operating on an unrelated item, so "
         .. "check this for a handle held across time.",
@@ -629,7 +701,7 @@ end)]],
           description = "Whether to burst the meshes as it dies.",
         },
       },
-      description = "Runs the object's creature death handling: the corpse stays, and `explode` "
+      description = "Runs the object's creature death handling: the corpse stays, and `trx.items.Item.die.explode` "
         .. "bursts its meshes as a rocket or grenade would. For creatures; `trx.items.Item:destroy` simply removes "
         .. "any item from the game.",
     },
@@ -662,7 +734,8 @@ lara:take_damage(lara.hit_points)]],
           description = "Splash damage dealt to nearby items.",
         },
       },
-      description = "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with `explode`, "
+      description = "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with "
+        .. "`trx.items.Item.die.explode`, "
         .. "on its own. It does not kill or remove the item.",
     },
 
@@ -670,27 +743,51 @@ lara:take_damage(lara.hit_points)]],
       params = {
         { name = "pos", type = "vec3", description = "World position." },
       },
-      returns = { type = "integer" },
+      returns = {
+        type = "integer",
+        description = "In world units, measured between the two positions.",
+      },
       description = "Distance from this item to a world position.",
     },
 
     get_property = {
-      params = { { name = "name", type = "string" } },
-      returns = { type = "any", nullable = true },
+      params = {
+        {
+          name = "name",
+          type = "string",
+          description = "Which property, as the object declares it.",
+        },
+      },
+      returns = {
+        type = "any",
+        nullable = true,
+        description = "The value, of whatever type the property is declared with.",
+      },
       description = "Reads an object property, falling back to the object's default. "
         .. "Prefer `item.properties.<name>`.",
     },
 
     set_property = {
       params = {
-        { name = "name", type = "string" },
-        { name = "value", type = "any" },
+        {
+          name = "name",
+          type = "string",
+          description = "Which property, as the object declares it.",
+        },
+        {
+          name = "value",
+          type = "any",
+          description = "What to write, of the type the property is declared with.",
+        },
       },
       description = "Overrides an object property for this item. Prefer `item.properties.<name> = ...`.",
     },
 
     get_property_names = {
-      returns = { type = "table" },
+      returns = {
+        type = "table",
+        description = "The names, as a list of strings.",
+      },
       description = "Names of every property this item's object declares.",
     },
   },
@@ -705,7 +802,11 @@ api.define("items.get", {
       description = "An item's unique name reaches it as well.",
     },
   },
-  returns = { type = "items.Item", nullable = true },
+  returns = {
+    type = "items.Item",
+    nullable = true,
+    description = "The item, or `nil` where nothing answers to the key.",
+  },
   examples = {
     [==[local item = trx.items[0]
 item.name = "lara"
@@ -738,7 +839,15 @@ api.define("items.spawn", {
       name = "opts",
       type = "table",
       optional = true,
-      description = "`activate`: bring the item to life, enabling AI for creatures.",
+      description = "How to spawn it.",
+      fields = {
+        {
+          name = "activate",
+          type = "boolean",
+          optional = true,
+          description = "Bring the item to life, enabling AI for creatures.",
+        },
+      },
     },
   },
   returns = {
@@ -755,7 +864,10 @@ api.define("items.spawn", {
 
 api.define("items.count", {
   description = "Returns the total number of allocated items. Same as `#trx.items`.",
-  returns = { type = "integer" },
+  returns = {
+    type = "integer",
+    description = "How many slots the level holds, live or not.",
+  },
   impl = raw.count,
 })
 

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -9,7 +9,7 @@ api.module("items", {
 })
 
 api.note(
-  "items.index",
+  "items.num",
   "0-based item number, matching the numbers level editors show."
 )
 
@@ -142,25 +142,26 @@ api.type("items.Item", {
         .. "cycles, so one past the end of the turn wraps round to name the same direction rather "
         .. "than raising: adding a half turn to a rotation always works.",
     },
-    anim = {
-      from = "anim",
+    anim_num = {
+      from = "relative_anim_num",
       type = "integer",
-      description = "Object-relative animation number, 0-indexed.",
+      description = "The animation's number within the object, counted from 0.",
     },
-    frame = {
-      from = "frame",
+    frame_num = {
+      from = "relative_frame_num",
       type = "integer",
-      description = "Object-relative frame number, 0-indexed. Negative values count back from the end.",
+      description = "The frame's number within the animation, counted from 0. Negative values count "
+        .. "back from the end.",
     },
-    index = {
-      from = "index",
+    num = {
+      from = "item_num",
       type = "integer",
       writable = false,
-      description = "The index `trx.items[i]` takes, counted from 0. An item handed over by a query "
-        .. "can say where it lives.",
+      see = "items.num",
+      description = "An item handed over by a query can say where it lives.",
     },
     room_num = {
-      from = "room_index",
+      from = "room_num",
       type = "integer",
       writable = false,
       description = "0-based number of the room containing this item. Set `pos` to move the item between rooms.",
@@ -696,13 +697,13 @@ lara:take_damage(lara.hit_points)]],
 })
 
 api.define("items.get", {
-  description = "Retrieves an item by index or by name. Items count from zero, matching the "
-    .. "item numbers level editors show.",
+  description = "Retrieves an item by number or by name.",
   params = {
     {
       name = "key",
       type = "any",
-      description = "0-based index, or the item's unique name.",
+      see = "items.num",
+      description = "An item's unique name reaches it as well.",
     },
   },
   returns = { type = "Item", nullable = true },
@@ -942,11 +943,11 @@ api.property("items.query", {
 
 api.container("items", {
   description = "Indexing the module reaches an item, and `#trx.items` is how many the level has. "
-    .. "Items count from zero, matching the item numbers level editors show. `pairs()` walks them "
-    .. "in order, keyed by that number.",
+    .. "`pairs()` walks them in order, keyed by the item number.",
   key = {
     type = "any",
-    description = "0-based index, or the item's unique name.",
+    see = "items.num",
+    description = "An item's unique name reaches it as well.",
   },
   value = { type = "Item", nullable = true },
   examples = {

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -177,15 +177,15 @@ api.type("lara.Lara", {
     },
     dive_timer = {
       from = "dive_timer",
-      type = "integer",
+      type = "game.Frames",
       writable = false,
-      description = "Frames Lara has been diving for.",
+      description = "How long Lara has been diving.",
     },
     death_timer = {
       from = "death_timer",
-      type = "integer",
+      type = "game.Frames",
       writable = false,
-      description = "Frames Lara has been dead for.",
+      description = "How long Lara has been dead.",
     },
     sprint_timer = {
       from = "sprint_timer",
@@ -200,9 +200,9 @@ api.type("lara.Lara", {
     },
     pose_count = {
       from = "pose_count",
-      type = "integer",
+      type = "game.Frames",
       writable = false,
-      description = "Frames Lara has stood still for, which is what starts an idle animation.",
+      description = "How long Lara has stood still, which is what starts an idle animation.",
     },
   },
 })

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -3,6 +3,7 @@ local api = trx.api
 
 -- trx.lara stands for one C struct, so reading trx.lara.air reads Lara's air.
 -- What is reachable is what lara.Lara declares below, and nothing else.
+
 api.module("lara", {
   order = 3,
   description = "Module for reading and nudging Lara's own state.\n\n"
@@ -300,7 +301,7 @@ api.define("lara.teleport", {
 })
 
 api.define("lara.cure_poison", {
-  description = "Cures Lara's poisoning. Not the same as writing `0` to `poison`: the poison has a "
+  description = "Cures Lara's poisoning. Not the same as writing `0` to `trx.lara.poison`: the poison has a "
     .. "target as well as a current value, and clearing only the value lets it climb back.",
   impl = raw.cure_poison,
 })

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -109,7 +109,7 @@ api.type("lara.Lara", {
       from = "exposure_timer",
       type = "integer",
       description = "Warmth remaining in the cold, out of `trx.rules.exposure.max`. Only moves "
-        .. "in a level whose rooms carry the `damaging` flag.",
+        .. "in a level whose rooms carry the `trx.rooms.Room.damaging` flag.",
     },
     poison = {
       from = "poison.value",
@@ -119,7 +119,7 @@ api.type("lara.Lara", {
     poison_target = {
       from = "poison.target",
       type = "integer",
-      description = "The poison reservoir that drains into `poison` over time. TR4 only.",
+      description = "The poison reservoir that drains into `trx.lara.poison` over time. TR4 only.",
     },
     electric = {
       from = "electric",
@@ -247,7 +247,7 @@ api.property("lara.is_flying", {
 
 api.property("lara.is_wet", {
   type = "boolean",
-  description = "Whether Lara is still shedding droplets after a swim. `dry` clears it.",
+  description = "Whether Lara is still shedding droplets after a swim. `trx.lara.dry` clears it.",
   get = raw.is_wet,
 })
 

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -9,6 +9,7 @@ api.module("lara", {
     .. "Her position, room and hit points are not here: she is an item like any other and they "
     .. "live on it, as `trx.lara.item`.",
   instance = raw.state,
+  instance_type = "lara.Lara",
 })
 
 api.enum("lara.Mesh", {
@@ -144,30 +145,26 @@ api.type("lara.Lara", {
     },
     water_status = {
       from = "water_status",
-      type = "integer",
+      type = "lara.WaterState",
       writable = false,
-      enum = "lara.WaterState",
       description = "Where Lara is with respect to water.",
     },
     gun_status = {
       from = "gun_status",
-      type = "integer",
+      type = "lara.GunState",
       writable = false,
-      enum = "lara.GunState",
       description = "What Lara's hands are doing.",
     },
     equipped_gun = {
       from = "gun_type",
-      type = "integer",
+      type = "catalog.weapons",
       writable = false,
-      enum = "catalog.weapons",
       description = "The weapon Lara is holding.",
     },
     requested_gun = {
       from = "request_gun_type",
-      type = "integer",
+      type = "catalog.weapons",
       writable = false,
-      enum = "catalog.weapons",
       description = "The weapon Lara is drawing, while she is drawing it.",
     },
     extra_anim = {
@@ -210,8 +207,8 @@ api.type("lara.Lara", {
 })
 
 api.property("lara.item", {
-  type = "Item",
-  description = "Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit "
+  type = "items.Item",
+  description = "Lara's own item, or `nil` outside a level. Her position, room and hit "
     .. "points are read and written there.",
   get = function()
     return trx.items[raw.get_item()]
@@ -219,7 +216,7 @@ api.property("lara.item", {
 })
 
 api.property("lara.target", {
-  type = "Item",
+  type = "items.Item",
   description = "The item Lara's guns are locked onto, or `nil` if she has none.",
   get = function()
     local target = raw.get_target()
@@ -266,14 +263,12 @@ api.define("lara.set_extra_equipment", {
   params = {
     {
       name = "mesh",
-      type = "integer",
-      enum = "lara.Mesh",
+      type = "lara.Mesh",
       description = "Which of Lara's meshes.",
     },
     {
       name = "extra_mesh",
-      type = "integer",
-      enum = "lara.ExtraMesh",
+      type = "lara.ExtraMesh",
       description = "The mesh to hang on it.",
     },
   },
@@ -292,9 +287,9 @@ api.define("lara.teleport", {
     { name = "pos", type = "vec3", description = "World position." },
     {
       name = "room_num",
-      type = "integer",
+      type = "rooms.Num",
       optional = true,
-      description = "0-based room to look in. Without it, the room is found from the position.",
+      description = "Without it, the room is found from the position.",
     },
   },
   returns = { type = "boolean", description = "Whether she was moved." },
@@ -326,8 +321,7 @@ api.define("lara.clear_equipment", {
   params = {
     {
       name = "mesh",
-      type = "integer",
-      enum = "lara.Mesh",
+      type = "lara.Mesh",
       description = "Which of Lara's meshes.",
     },
   },

--- a/src/lua/api/log.lua
+++ b/src/lua/api/log.lua
@@ -5,6 +5,7 @@ api.module("log", {
   order = 26,
   title = "Logging",
   description = "Logs a message to the terminal and to `TRX.log` in the installation directory. "
+    .. " "
     .. "Each call records the Lua script's filename, function name and line number.",
 })
 
@@ -30,7 +31,7 @@ api.define("log.generic", {
     .. "rather than written literally.",
   params = {
     { name = "level", type = "log.LogLevel" },
-    { name = "message", type = "string" },
+    { name = "message", type = "string", description = "The line to log." },
   },
   examples = {
     [[local level = ok and trx.log.LogLevel.INFO or trx.log.LogLevel.ERROR
@@ -43,31 +44,41 @@ trx.log.generic(level, "finished")]],
 
 api.define("log.info", {
   description = "Logs an informational message.",
-  params = { { name = "message", type = "string" } },
+  params = {
+    { name = "message", type = "string", description = "The line to log." },
+  },
   examples = { [[trx.log.info("hello from lua")]] },
   impl = at(LogLevel.INFO),
 })
 
 api.define("log.warn", {
   description = "Logs a warning.",
-  params = { { name = "message", type = "string" } },
+  params = {
+    { name = "message", type = "string", description = "The line to log." },
+  },
   impl = at(LogLevel.WARNING),
 })
 
 api.define("log.warning", {
   description = "Logs a warning. An alias of `trx.log.warn`.",
-  params = { { name = "message", type = "string" } },
+  params = {
+    { name = "message", type = "string", description = "The line to log." },
+  },
   impl = at(LogLevel.WARNING),
 })
 
 api.define("log.error", {
   description = "Logs an error.",
-  params = { { name = "message", type = "string" } },
+  params = {
+    { name = "message", type = "string", description = "The line to log." },
+  },
   impl = at(LogLevel.ERROR),
 })
 
 api.define("log.debug", {
   description = "Logs a debug message.",
-  params = { { name = "message", type = "string" } },
+  params = {
+    { name = "message", type = "string", description = "The line to log." },
+  },
   impl = at(LogLevel.DEBUG),
 })

--- a/src/lua/api/log.lua
+++ b/src/lua/api/log.lua
@@ -5,7 +5,7 @@ api.module("log", {
   order = 26,
   title = "Logging",
   description = "Logs a message to the terminal and to `TRX.log` in the installation directory. "
-    .. " "
+    .. "<!--noref: TRX.log--> "
     .. "Each call records the Lua script's filename, function name and line number.",
 })
 

--- a/src/lua/api/log.lua
+++ b/src/lua/api/log.lua
@@ -29,7 +29,7 @@ api.define("log.generic", {
   description = "Logs a message at a level chosen at runtime, for when the level is computed "
     .. "rather than written literally.",
   params = {
-    { name = "level", type = "integer", enum = "log.LogLevel" },
+    { name = "level", type = "log.LogLevel" },
     { name = "message", type = "string" },
   },
   examples = {

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -23,9 +23,17 @@ api.define("lua.eval_expr", {
   returns = {
     type = "table",
     nullable = true,
-    description = "`nil` when the code ran to completion. Otherwise a table with `kind` "
-      .. '(`"syntax"` or `"runtime"`) and `message`, the error text. A failure comes back '
-      .. "as a value rather than raising, so the caller decides what it means.",
+    description = "`nil` when the code ran to completion, and what went wrong otherwise. A "
+      .. "failure comes back as a value rather than raising, so the caller decides what it "
+      .. "means.",
+    fields = {
+      {
+        name = "kind",
+        type = "string",
+        description = 'Either `"syntax"` or `"runtime"`.',
+      },
+      { name = "message", type = "string", description = "The error text." },
+    },
   },
   examples = { [[trx.lua.eval_expr("trx.console.log('hello')")]] },
   impl = function(code)

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -42,7 +42,7 @@ api.define("lua.eval_file", {
   returns = {
     type = "table",
     nullable = true,
-    description = "As in `eval_expr`.",
+    description = "As in `trx.lua.eval_expr`.",
   },
   examples = { [[trx.lua.eval_file("data/ship/scripts/extra.lua")]] },
   impl = function(path)

--- a/src/lua/api/math.lua
+++ b/src/lua/api/math.lua
@@ -9,6 +9,20 @@ api.module("math", {
     .. "would.",
 })
 
+api.type("math.Box", {
+  description = "An axis-aligned box, in the units the engine measures the world in. Whether it "
+    .. "is placed in world coordinates or in something's own frame is for whatever hands it "
+    .. "over to say.",
+  fields = {
+    min_x = { type = "integer", description = "West edge." },
+    min_y = { type = "integer", description = "Top edge. Y grows downwards." },
+    min_z = { type = "integer", description = "North edge." },
+    max_x = { type = "integer", description = "East edge." },
+    max_y = { type = "integer", description = "Bottom edge." },
+    max_z = { type = "integer", description = "South edge." },
+  },
+})
+
 api.define("math.sin", {
   description = "Sine of an angle.",
   params = {
@@ -30,10 +44,18 @@ api.define("math.cos", {
 api.define("math.atan", {
   description = "Angle of the vector (x, z), in TRX units.",
   params = {
-    { name = "z", type = "integer" },
-    { name = "x", type = "integer" },
+    {
+      name = "z",
+      type = "integer",
+      description = "How far the vector reaches north.",
+    },
+    {
+      name = "x",
+      type = "integer",
+      description = "How far it reaches east.",
+    },
   },
-  returns = { type = "integer" },
+  returns = { type = "integer", description = "In TRX units." },
   examples = {
     [[-- face an item towards Lara
 local angle = trx.math.atan(lara.pos.z - pos.z, lara.pos.x - pos.x)]],

--- a/src/lua/api/math.lua
+++ b/src/lua/api/math.lua
@@ -3,30 +3,46 @@ local api = trx.api
 
 api.module("math", {
   order = 27,
-  description = "Fixed-point trigonometry, matching the engine's own tables.\n\n"
-    .. "TRX angles are 16-bit units where 65536 is a full turn, not radians. Using these rather "
+  description = "Fixed-point trigonometry, matching the engine's own tables. Using these rather "
     .. "than Lua's `math` library guarantees a script places things exactly where the engine "
-    .. "would.",
+    .. "would. `trx.math.Angle` says what an angle is here.",
+})
+
+api.unit("math.Angle", {
+  description = [[
+    An angle in the engine's own units, where 65536 is a full turn rather than
+    2 pi. An angle counts in cycles, so one past the end of a turn wraps round
+    to name the same direction: adding a half turn to a rotation always works.
+    `trx.math.DEG_1` converts from degrees.
+  ]],
+  spellings = { "TRX units", "angle units" },
+})
+
+api.unit("math.Distance", {
+  description = [[
+    A length in the units the engine measures the world in, where one sector is
+    `trx.math.WALL_L`. Y grows downwards, so a greater Y is further down.
+  ]],
+  spellings = { "world units", "world coordinates" },
 })
 
 api.type("math.Box", {
-  description = "An axis-aligned box, in the units the engine measures the world in. Whether it "
-    .. "is placed in world coordinates or in something's own frame is for whatever hands it "
-    .. "over to say.",
+  description = "An axis-aligned box. Whether it is placed in the world or in something's own "
+    .. "frame is for whatever hands it over to say.",
   fields = {
-    min_x = { type = "integer", description = "West edge." },
-    min_y = { type = "integer", description = "Top edge. Y grows downwards." },
-    min_z = { type = "integer", description = "North edge." },
-    max_x = { type = "integer", description = "East edge." },
-    max_y = { type = "integer", description = "Bottom edge." },
-    max_z = { type = "integer", description = "South edge." },
+    min_x = { type = "math.Distance", description = "West edge." },
+    min_y = { type = "math.Distance", description = "Top edge." },
+    min_z = { type = "math.Distance", description = "North edge." },
+    max_x = { type = "math.Distance", description = "East edge." },
+    max_y = { type = "math.Distance", description = "Bottom edge." },
+    max_z = { type = "math.Distance", description = "South edge." },
   },
 })
 
 api.define("math.sin", {
   description = "Sine of an angle.",
   params = {
-    { name = "angle", type = "integer", description = "Angle in TRX units." },
+    { name = "angle", type = "math.Angle" },
   },
   returns = { type = "number", description = "A value in [-1, 1]." },
   impl = raw.sin,
@@ -35,27 +51,27 @@ api.define("math.sin", {
 api.define("math.cos", {
   description = "Cosine of an angle.",
   params = {
-    { name = "angle", type = "integer", description = "Angle in TRX units." },
+    { name = "angle", type = "math.Angle" },
   },
   returns = { type = "number", description = "A value in [-1, 1]." },
   impl = raw.cos,
 })
 
 api.define("math.atan", {
-  description = "Angle of the vector (x, z), in TRX units.",
+  description = "Angle of the vector (x, z).",
   params = {
     {
       name = "z",
-      type = "integer",
+      type = "math.Distance",
       description = "How far the vector reaches north.",
     },
     {
       name = "x",
-      type = "integer",
+      type = "math.Distance",
       description = "How far it reaches east.",
     },
   },
-  returns = { type = "integer", description = "In TRX units." },
+  returns = { type = "math.Angle" },
   examples = {
     [[-- face an item towards Lara
 local angle = trx.math.atan(lara.pos.z - pos.z, lara.pos.x - pos.x)]],
@@ -65,21 +81,25 @@ local angle = trx.math.atan(lara.pos.z - pos.z, lara.pos.x - pos.x)]],
 
 api.const("math.DEG_1", {
   value = raw.DEG_1,
-  description = "One degree in TRX units. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.",
+  type = "math.Angle",
+  description = "One degree. Multiply by it to say an angle in degrees: `45 * trx.math.DEG_1`.",
 })
 
 api.const("math.DEG_45", {
   value = raw.DEG_45,
-  description = "A 45-degree turn, in TRX units.",
+  type = "math.Angle",
+  description = "A 45-degree turn.",
 })
 
 api.const("math.DEG_90", {
   value = raw.DEG_90,
-  description = "A quarter turn, in TRX units. A full turn is four of these, and wraps to zero.",
+  type = "math.Angle",
+  description = "A quarter turn. A full turn is four of these.",
 })
 
 api.const("math.WALL_L", {
   value = raw.WALL_L,
-  description = "The size of one sector in world units. Level geometry is laid out on this grid, "
-    .. "so it is the step to take to move an item a sector over.",
+  type = "math.Distance",
+  description = "The size of one sector. Level geometry is laid out on this grid, so it is the "
+    .. "step to take to move an item a sector over.",
 })

--- a/src/lua/api/mod.lua
+++ b/src/lua/api/mod.lua
@@ -37,9 +37,8 @@ api.type("mod.Mod", {
     },
     type = {
       from = "mod_type",
-      type = "integer",
+      type = "mod.Type",
       writable = false,
-      enum = "mod.Type",
       description = "What kind of mod it is.",
     },
     engine_version = {
@@ -82,8 +81,8 @@ api.property("mod.list", {
 })
 
 api.property("mod.current", {
-  type = "Mod",
-  description = "The loaded mod, as a `trx.mod.Mod`.",
+  type = "mod.Mod",
+  description = "The loaded mod.",
   get = raw.get_current,
 })
 

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -25,7 +25,7 @@ api.type("music.Stream", {
     .. "stale, so reading a field or calling a method on it raises; check `is_valid()` first.",
 
   fields = {
-    track_id = {
+    track_num = {
       from = "track_id",
       type = "integer",
       writable = false,
@@ -83,11 +83,11 @@ api.type("music.Track", {
     .. "stale, so `is_valid()` answers whether it is still there.",
 
   fields = {
-    id = {
+    num = {
       from = "id",
       type = "integer",
       writable = false,
-      description = "The track's id, in the level's own numbering.",
+      description = "The number the level gives this track.",
     },
   },
 

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -22,7 +22,7 @@ api.type("music.Stream", {
   backing = "MUSIC_STREAM_VIEW",
   description = "One of the soundtrack's playing streams: the main stream, or an overlay. "
     .. "Reach them through `trx.music.streams`. A handle to a slot that is not playing goes "
-    .. "stale, so reading a field or calling a method on it raises; check `is_valid()` first.",
+    .. "stale, so reading a field or calling a method on it raises; check `trx.music.Stream:is_valid` first.",
 
   fields = {
     track_num = {
@@ -79,7 +79,7 @@ api.type("music.Track", {
   backing = "MUSIC_TRACK_VIEW",
   description = "A track the current level carries. Reach them through `trx.music.tracks`, or "
     .. "as `trx.music.current_track`. A handle to a track the loaded level does not carry goes "
-    .. "stale, so `is_valid()` answers whether it is still there.",
+    .. "stale, so `trx.music.Track:is_valid` answers whether it is still there.",
 
   fields = {
     num = {

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -33,9 +33,8 @@ api.type("music.Stream", {
     },
     mode = {
       from = "mode",
-      type = "integer",
+      type = "music.PlayMode",
       writable = false,
-      enum = "music.PlayMode",
       description = "How the track is playing.",
     },
     timestamp = {
@@ -194,8 +193,8 @@ api.property("music.tracks", {
 })
 
 api.property("music.current_track", {
-  type = "Track",
-  description = "The track playing now, as a `trx.music.Track`, or `nil` when nothing plays.",
+  type = "music.Track",
+  description = "The track playing now, or `nil` when nothing plays.",
   get = function()
     local id = raw.get_track()
     return id ~= nil and raw.track_get(id) or nil
@@ -203,9 +202,9 @@ api.property("music.current_track", {
 })
 
 api.property("music.looped_track", {
-  type = "Track",
-  description = "The ambient track that resumes once the current one-shot finishes, as a "
-    .. "`trx.music.Track`, or `nil` when none is set.",
+  type = "music.Track",
+  description = "The ambient track that resumes once the current one-shot finishes, or `nil` "
+    .. "when none is set.",
   get = function()
     local id = raw.get_looped_track()
     return id ~= nil and raw.track_get(id) or nil
@@ -218,8 +217,7 @@ api.define("music.play", {
   params = {
     {
       name = "id",
-      type = "integer",
-      enum = "catalog.music",
+      type = "catalog.music",
       description = "Track to play. To reach a track by the level's own slot, play it through a "
         .. "handle: `trx.music.tracks[slot]:play()`.",
     },

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -6,9 +6,14 @@ api.module("music", {
   description = "Module for playing and controlling the soundtrack.",
 })
 
+api.number("music.TrackNum", {
+  description = "Track number, in the numbering the loaded level carries. Not a "
+    .. "`trx.catalog.music` name, which is the soundtrack's own.",
+})
+
 local PlayMode = api.enum("music.PlayMode", {
   backing = "MUSIC_PLAY_MODE",
-  description = "How a track is played. Pass one as `opts.mode` to `trx.music.play`.",
+  description = "How a track is played. Pass one as `trx.music.play.opts.mode`.",
   values = {
     ONCE = "Plays the track once. When it finishes, any active looped track resumes from its start.",
     LOOP = "Plays the track continuously. It becomes the ambient track.",
@@ -27,9 +32,9 @@ api.type("music.Stream", {
   fields = {
     track_num = {
       from = "track_id",
-      type = "integer",
+      type = "music.TrackNum",
       writable = false,
-      description = "The track this stream is playing, in the level's own numbering.",
+      description = "The track this stream is playing.",
     },
     mode = {
       from = "mode",
@@ -47,7 +52,10 @@ api.type("music.Stream", {
 
   methods = {
     is_valid = {
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "False once the slot has gone quiet.",
+      },
       description = "Whether the slot is still playing. A stream that has finished, or been "
         .. "stopped, leaves its handle stale.",
     },
@@ -84,15 +92,17 @@ api.type("music.Track", {
   fields = {
     num = {
       from = "id",
-      type = "integer",
+      type = "music.TrackNum",
       writable = false,
-      description = "The number the level gives this track.",
     },
   },
 
   methods = {
     is_valid = {
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "False once a level change has replaced the tracks.",
+      },
       description = "Whether the loaded level still carries this track.",
     },
     play = {
@@ -101,7 +111,15 @@ api.type("music.Track", {
           name = "opts",
           type = "table",
           optional = true,
-          description = "`mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.",
+          description = "How to play it.",
+          fields = {
+            {
+              name = "mode",
+              type = "music.PlayMode",
+              optional = true,
+              description = "Plays once by default.",
+            },
+          },
         },
       },
       returns = {
@@ -225,7 +243,15 @@ api.define("music.play", {
       name = "opts",
       type = "table",
       optional = true,
-      description = "`mode`: a `trx.music.PlayMode`. Defaults to `ONCE`.",
+      description = "How to play it.",
+      fields = {
+        {
+          name = "mode",
+          type = "music.PlayMode",
+          optional = true,
+          description = "Plays once by default.",
+        },
+      },
     },
   },
   returns = {

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -44,9 +44,9 @@ api.type("music.Stream", {
     },
     timestamp = {
       from = "timestamp",
-      type = "number",
+      type = "game.Seconds",
       writable = false,
-      description = "How far into the track the stream is, in seconds.",
+      description = "How far into the track the stream is.",
     },
   },
 
@@ -69,8 +69,8 @@ api.type("music.Stream", {
       params = {
         {
           name = "timestamp",
-          type = "number",
-          description = "Where to seek to, in seconds.",
+          type = "game.Seconds",
+          description = "Where to seek to.",
         },
       },
       returns = { type = "boolean", description = "Whether the seek took." },

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -13,6 +13,11 @@ api.module("objects", {
     .. "wolf's. Per-item state lives on the item - see `trx.items`.",
 })
 
+api.number("objects.MeshNum", {
+  base = 0,
+  description = "The mesh's number within the object it belongs to.",
+})
+
 -- Object handles are bare userdata. Their metatable is populated by the
 -- api.type declaration below, and by nothing else: a member of the C OBJECT
 -- struct that is not named here is not reachable from a script at all.
@@ -43,7 +48,7 @@ local function make_properties(object)
   })
 end
 
-api.type("objects.Object", {
+local Object = api.type("objects.Object", {
   backing = "OBJECT",
   description = "An object definition.",
 
@@ -129,29 +134,56 @@ api.type("objects.Object", {
 
   methods = {
     get_names = {
-      returns = { type = "table" },
+      returns = {
+        type = "table",
+        description = "The names, as a list of strings.",
+      },
       description = "Every name the object answers to, in the player's language. Prefer "
         .. "`trx.objects.Object.names`.",
     },
     get_default_names = {
-      returns = { type = "table" },
+      returns = {
+        type = "table",
+        description = "The names, as a list of strings.",
+      },
       description = "The compile-time English names, which a lookup falls back on before a "
         .. "language file is loaded. Prefer `trx.objects.Object.default_names`.",
     },
     get_property = {
-      params = { { name = "name", type = "string" } },
-      returns = { type = "any", nullable = true },
+      params = {
+        {
+          name = "name",
+          type = "string",
+          description = "Which property, as the object declares it.",
+        },
+      },
+      returns = {
+        type = "any",
+        nullable = true,
+        description = "The value, of whatever type the property is declared with.",
+      },
       description = "Reads one of the object's properties. Prefer `object.properties.<name>`.",
     },
     set_property = {
       params = {
-        { name = "name", type = "string" },
-        { name = "value", type = "any" },
+        {
+          name = "name",
+          type = "string",
+          description = "Which property, as the object declares it.",
+        },
+        {
+          name = "value",
+          type = "any",
+          description = "What to write, of the type the property is declared with.",
+        },
       },
       description = "Writes one of the object's properties. Prefer `object.properties.<name> = ...`.",
     },
     get_property_names = {
-      returns = { type = "table" },
+      returns = {
+        type = "table",
+        description = "The names, as a list of strings.",
+      },
       description = "Names of every property this object declares.",
     },
   },
@@ -360,13 +392,13 @@ api.define("objects.swap_mesh", {
     { name = "object_id2", type = "catalog.objects" },
     {
       name = "mesh_num1",
-      type = "integer",
+      type = "objects.MeshNum",
       optional = true,
       description = "Mesh of the first.",
     },
     {
       name = "mesh_num2",
-      type = "integer",
+      type = "objects.MeshNum",
       optional = true,
       description = "Mesh of the second.",
     },

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -121,7 +121,7 @@ api.type("objects.Object", {
     properties = {
       type = "table",
       description = "The object's own typed properties, which every item of the type inherits. "
-        .. "Writing here changes the default for all of them; write to `item.properties` to change "
+        .. "Writing here changes the default for all of them; write to `trx.items.Item.properties` to change "
         .. "one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
       impl = make_properties,
     },
@@ -131,12 +131,12 @@ api.type("objects.Object", {
     get_names = {
       returns = { type = "table" },
       description = "Every name the object answers to, in the player's language. Prefer "
-        .. "`object.names`.",
+        .. "`trx.objects.Object.names`.",
     },
     get_default_names = {
       returns = { type = "table" },
       description = "The compile-time English names, which a lookup falls back on before a "
-        .. "language file is loaded. Prefer `object.default_names`.",
+        .. "language file is loaded. Prefer `trx.objects.Object.default_names`.",
     },
     get_property = {
       params = { { name = "name", type = "string" } },
@@ -325,7 +325,7 @@ local ObjectQuery = api.type("objects.ObjectQuery", {
   description = "A `trx.query.Query` over every object the engine knows, with the narrowings below "
     .. "on top of the ones every query has. Objects answer to names, so it carries the name layer "
     .. "too - see `trx.query.NamedQuery`.\n\n"
-    .. "The families do not cover `pickup` between them: a second state of something Lara already "
+    .. "The families do not cover `trx.objects.ObjectQuery:pickup` between them: a second state of something Lara already "
     .. "carries, such as a part-full waterskin, is in none of them.",
   methods = methods,
 })

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -109,7 +109,7 @@ local Object = api.type("objects.Object", {
     names = {
       type = "table",
       description = "Every name the object answers to, in the player's language. An object has "
-        .. "more than one: a large medipack is also a `medipack` and a `big medi`.",
+        .. "more than one: a large medipack is also a `medipack` and a `big medi`. <!--noref: medipack-->",
       impl = function(object)
         return object:get_names()
       end,
@@ -127,7 +127,7 @@ local Object = api.type("objects.Object", {
       type = "table",
       description = "The object's own typed properties, which every item of the type inherits. "
         .. "Writing here changes the default for all of them; write to `trx.items.Item.properties` to change "
-        .. "one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
+        .. "one item only. Iterable with `pairs()`. See [Objects](docs/trx/OBJECTS.md).",
       impl = make_properties,
     },
   },

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -162,13 +162,12 @@ local get = api.define("objects.get", {
   params = {
     {
       name = "key",
-      type = "any",
-      enum = "catalog.objects",
+      type = "catalog.objects",
       description = 'Object id, or its catalog name: `trx.objects["wolf"]`.',
     },
   },
   returns = {
-    type = "Object",
+    type = "objects.Object",
     nullable = true,
     description = "`nil` if no such object exists.",
   },
@@ -252,7 +251,7 @@ local FAMILIES = {
   },
 }
 
-local QUERY = { type = "Query", description = "The narrowed query." }
+local QUERY = { type = "query.Query", description = "The narrowed query." }
 
 local function family_test(kind)
   return function()
@@ -346,9 +345,8 @@ local object_query = trx.query.new({
 }, ObjectQuery)
 
 api.property("objects.query", {
-  type = "ObjectQuery",
-  description = "The identity query over every object definition. Narrow it and read it - see "
-    .. "`trx.objects.ObjectQuery`.",
+  type = "objects.ObjectQuery",
+  description = "The identity query over every object definition. Narrow it and read it.",
   get = function()
     return object_query
   end,
@@ -358,8 +356,8 @@ api.define("objects.swap_mesh", {
   description = "Swaps meshes between two objects. With no mesh numbers, swaps all of them; with "
     .. "both, swaps just those two. One without the other raises.",
   params = {
-    { name = "object_id1", type = "integer", enum = "catalog.objects" },
-    { name = "object_id2", type = "integer", enum = "catalog.objects" },
+    { name = "object_id1", type = "catalog.objects" },
+    { name = "object_id2", type = "catalog.objects" },
     {
       name = "mesh_num1",
       type = "integer",
@@ -382,8 +380,8 @@ Swaps the sprites of two objects, which is how a pickup looks when 3D pickups
 are turned off. Raises if either object is drawn from meshes rather than a
 sprite.]],
   params = {
-    { name = "object_id1", type = "integer", enum = "catalog.objects" },
-    { name = "object_id2", type = "integer", enum = "catalog.objects" },
+    { name = "object_id1", type = "catalog.objects" },
+    { name = "object_id2", type = "catalog.objects" },
   },
   impl = raw.swap_sprite,
 })
@@ -391,8 +389,11 @@ sprite.]],
 api.container("objects", {
   description = "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf. "
     .. "Keyed by object id or catalog name, not by position.",
-  key = { type = "any", description = "Object id, or its catalog name." },
-  value = { type = "Object", nullable = true },
+  key = {
+    type = { "catalog.objects", "string" },
+    description = "Object id, or its catalog name.",
+  },
+  value = { type = "objects.Object", nullable = true },
   examples = { [[trx.objects.wolf.properties.max_hit_points = 30]] },
   get = get,
 })

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -162,7 +162,7 @@ local Query = api.type("query.Query", {
             {
               name = "handle",
               type = "any",
-              description = "The candidate itself, an `Object` or an `Item`.",
+              description = "The candidate itself, a `trx.objects.Object` or a `trx.items.Item`.",
             },
           },
         },
@@ -233,7 +233,7 @@ end)]],
 api.type("query.NamedQuery", {
   extends = "query.Query",
   description = "A query over a domain whose things answer to names, which adds the name layer to "
-    .. "everything a `Query` has. A domain without names offers none of it.",
+    .. "everything a `trx.query.Query` has. A domain without names offers none of it.",
 
   methods = {
     by_name = {
@@ -255,7 +255,7 @@ api.type("query.NamedQuery", {
         .. "any match belongs to come first, because a completer offers the list in order and a "
         .. "group name that ties on score would otherwise sit behind a thing's own. Which groups "
         .. "answer follows from what the query kept, so one narrowed to what fights offers no "
-        .. "`pickup`.",
+        .. "`trx.objects.ObjectQuery:pickup`.",
       returns = { type = "table", description = "A list of names." },
       impl = function(self)
         local domain = self._domain
@@ -289,8 +289,8 @@ api.type("query.NamedQuery", {
     },
 
     best = {
-      description = "The ids tied for the best `by_name` score: one for a name only one thing "
-        .. "answers to, the whole group for a group name. Without a `by_name`, every matching id.",
+      description = "The ids tied for the best `trx.query.NamedQuery:by_name` score: one for a name only one thing "
+        .. "answers to, the whole group for a group name. Without a `trx.query.NamedQuery:by_name`, every matching id.",
       returns = { type = "table", description = "A list of integers." },
       impl = function(self)
         if self._name == nil then

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -329,7 +329,7 @@ api.define("query.narrowing", {
   },
   returns = {
     type = "function",
-    description = "The method to declare as an `impl`.",
+    description = "The method to declare as an `impl`. <!--noref: impl-->",
   },
   impl = function(make)
     return function(self, ...)

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -110,7 +110,7 @@ local function resolved(self)
   return out
 end
 
-local QUERY = { type = "Query", description = "The narrowed query." }
+local QUERY = { type = "query.Query", description = "The narrowed query." }
 
 local Query = api.type("query.Query", {
   description = "A filter over a domain, read with one of the terminals below once it is narrow "
@@ -355,7 +355,7 @@ api.define("query.new", {
     },
   },
   returns = {
-    type = "Query",
+    type = "query.Query",
     description = "The identity query, matching everything until narrowed.",
   },
   impl = function(domain, class)

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -153,6 +153,7 @@ local Query = api.type("query.Query", {
         {
           name = "predicate",
           type = "function",
+          description = "The test each candidate is put through.",
           params = {
             {
               name = "id",
@@ -222,7 +223,10 @@ end)]],
 
     count = {
       description = "How many candidates match.",
-      returns = { type = "integer" },
+      returns = {
+        type = "integer",
+        description = "The count, without building the list.",
+      },
       impl = function(self)
         return #resolved(self)
       end,
@@ -345,8 +349,36 @@ api.define("query.new", {
     {
       name = "domain",
       type = "table",
-      description = "What the query runs against: `enumerate`, `id_of`, `searchable`, and an "
-        .. "optional `names_of`/`default_names_of` name layer. See the module source.",
+      description = "What the query runs against.",
+      fields = {
+        {
+          name = "enumerate",
+          type = "function",
+          description = "Every id the domain holds.",
+        },
+        {
+          name = "id_of",
+          type = "function",
+          description = "The id of a thing the domain hands out.",
+        },
+        {
+          name = "searchable",
+          type = "function",
+          description = "Whether an id is one a name may reach.",
+        },
+        {
+          name = "names_of",
+          type = "function",
+          optional = true,
+          description = "The names an id answers to, for a domain that has them.",
+        },
+        {
+          name = "default_names_of",
+          type = "function",
+          optional = true,
+          description = "The same names before a language file is loaded.",
+        },
+      },
     },
     {
       name = "class",

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -210,9 +210,9 @@ end)]],
     floor_height = {
       params = { FLOOR_HEIGHT_POS, FLOOR_HEIGHT_OPTS },
       returns = {
-        type = "integer",
+        type = "math.Distance",
         nullable = true,
-        description = "The height, in world units, with `nil` where there is no floor.",
+        description = "The height, with `nil` where there is no floor.",
       },
       description = "As `trx.rooms.floor_height`, looking from this room.",
       impl = function(room, pos, opts)
@@ -232,7 +232,7 @@ end)]],
     },
     bounds = {
       type = "math.Box",
-      description = "Where the room sits, in world coordinates.",
+      description = "Where the room sits in the world.",
       impl = function(room)
         return setmetatable(raw.get_bounds(room), Box)
       end,
@@ -324,9 +324,9 @@ api.define("rooms.floor_height", {
     .. "all: inside solid geometry, or off the edge of the level.",
   params = FLOOR_HEIGHT_PARAMS,
   returns = {
-    type = "integer",
+    type = "math.Distance",
     nullable = true,
-    description = "The height, in world units, with `nil` where there is no floor.",
+    description = "The height, with `nil` where there is no floor.",
   },
   examples = {
     [[local floor = trx.lara.item.room:floor_height(trx.lara.item.pos)]],

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -16,9 +16,9 @@ local function room_hook(pick_room)
       error('watch must be "lara" or "all"', 2)
     end
     local num = room.num
-    return trx.events.on_room_change(function(item, old_room, new_room)
+    return trx.events.on_room_change(function(item, old_room_num, new_room_num)
       if
-        pick_room(old_room, new_room) == num
+        pick_room(old_room_num, new_room_num) == num
         and (watch == "all" or item == trx.lara.item)
       then
         callback(item)
@@ -103,7 +103,7 @@ api.type("rooms.Room", {
 
   fields = {
     num = {
-      from = "room_index",
+      from = "room_num",
       type = "integer",
       writable = false,
       description = "0-based room number, matching the numbers level editors show.",
@@ -156,16 +156,16 @@ api.type("rooms.Room", {
   trx.log.info("entered room 7")
 end)]],
       },
-      impl = room_hook(function(old_room, new_room)
-        return new_room
+      impl = room_hook(function(old_room_num, new_room_num)
+        return new_room_num
       end),
     },
     on_exit = {
       params = ROOM_HOOK_PARAMS,
       returns = ROOM_LISTENER,
       description = "Happens when something changes rooms out of this one.",
-      impl = room_hook(function(old_room, new_room)
-        return old_room
+      impl = room_hook(function(old_room_num, new_room_num)
+        return old_room_num
       end),
     },
     is_valid = {
@@ -234,8 +234,7 @@ api.note(
 )
 
 api.define("rooms.get", {
-  description = "Retrieves a room by number. Rooms count from zero, matching the "
-    .. "room numbers level editors show.",
+  description = "Retrieves a room by number.",
   params = {
     { name = "num", type = "integer", see = "rooms.num" },
   },

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -1,6 +1,10 @@
 local raw = trxc.rooms
 local api = trx.api
 
+require("trx.math")
+
+local Box = api.class("math.Box")
+
 require("trx.log")
 require("trx.query")
 
@@ -31,6 +35,7 @@ local ROOM_HOOK_PARAMS = {
   {
     name = "callback",
     type = "function",
+    description = "What to run when it happens.",
     params = {
       {
         name = "item",
@@ -43,8 +48,17 @@ local ROOM_HOOK_PARAMS = {
     name = "opts",
     type = "table",
     optional = true,
-    description = 'Options. `watch = "lara"` (the default) reacts to Lara alone; `watch = "all"` '
-      .. "to every item.",
+    description = "What to watch for.",
+    fields = {
+      {
+        name = "watch",
+        type = "string",
+        optional = true,
+        default = "lara",
+        description = 'Either `"lara"`, which reacts to Lara alone, or `"all"`, which reacts '
+          .. "to every item.",
+      },
+    },
   },
 }
 
@@ -58,9 +72,18 @@ local FLOOR_HEIGHT_OPTS = {
   name = "opts",
   type = "table",
   optional = true,
-  description = "`fix_tilts`: whether a floor tilt that lies inside a wall is taken into account, "
-    .. "`true` by default. `false` gives the flat height the original games read there, which is "
-    .. "what the geometry glitches of the vanilla levels rest on.",
+  description = "How to read the floor.",
+  fields = {
+    {
+      name = "fix_tilts",
+      type = "boolean",
+      optional = true,
+      default = true,
+      description = "Whether a floor tilt that lies inside a wall is taken into account. "
+        .. "`false` gives the flat height the original games read there, which is what the "
+        .. "geometry glitches of the vanilla levels rest on.",
+    },
+  },
 }
 
 local FLOOR_HEIGHT_PARAMS = {
@@ -167,7 +190,10 @@ end)]],
       end),
     },
     is_valid = {
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "False once the level that held the room has been left.",
+      },
       description = "Whether the handle still refers to a room of the level that is loaded. A level "
         .. "change replaces the rooms, so a handle held across one goes stale rather than naming a "
         .. "different room: reading or writing a field on it raises an error. Check this for a "
@@ -183,7 +209,11 @@ end)]],
     },
     floor_height = {
       params = { FLOOR_HEIGHT_POS, FLOOR_HEIGHT_OPTS },
-      returns = { type = "integer", nullable = true },
+      returns = {
+        type = "integer",
+        nullable = true,
+        description = "The height, in world units, with `nil` where there is no floor.",
+      },
       description = "As `trx.rooms.floor_height`, looking from this room.",
       impl = function(room, pos, opts)
         return raw.get_height(pos, room.num, opts)
@@ -201,26 +231,26 @@ end)]],
       end,
     },
     bounds = {
-      type = "table",
-      description = "World-coordinate bounds of the room: `min_x`, `min_y`, `min_z`, `max_x`, "
-        .. "`max_y`, `max_z`.",
+      type = "math.Box",
+      description = "Where the room sits, in world coordinates.",
       impl = function(room)
-        return raw.get_bounds(room)
+        return setmetatable(raw.get_bounds(room), Box)
       end,
     },
     internal_bounds = {
-      type = "table",
-      description = "As `trx.rooms.Room.bounds`, but excluding the outer ring of sectors, which is solid wall.",
+      type = "math.Box",
+      description = "As `trx.rooms.Room.bounds`, but excluding the outer ring of sectors, which "
+        .. "is solid wall.",
       impl = function(room)
         local b = raw.get_bounds(room)
-        return {
+        return setmetatable({
           min_x = b.min_x + 1024,
           min_y = b.min_y,
           min_z = b.min_z + 1024,
           max_x = b.max_x - 1024,
           max_y = b.max_y,
           max_z = b.max_z - 1024,
-        }
+        }, Box)
       end,
     },
   },
@@ -236,7 +266,11 @@ api.define("rooms.get", {
   params = {
     { name = "num", type = "rooms.Num" },
   },
-  returns = { type = "rooms.Room", nullable = true },
+  returns = {
+    type = "rooms.Room",
+    nullable = true,
+    description = "The room, or `nil` where the level has no such number.",
+  },
   examples = {
     [[local room = trx.rooms[14]
 room.underwater = true]],
@@ -246,7 +280,10 @@ room.underwater = true]],
 
 api.define("rooms.count", {
   description = "Returns the number of rooms in the level. Same as `#trx.rooms`.",
-  returns = { type = "integer" },
+  returns = {
+    type = "integer",
+    description = "How many rooms the loaded level holds.",
+  },
   impl = raw.count,
 })
 
@@ -286,7 +323,11 @@ api.define("rooms.floor_height", {
   description = "The height of the floor under a world position. `nil` where there is no floor at "
     .. "all: inside solid geometry, or off the edge of the level.",
   params = FLOOR_HEIGHT_PARAMS,
-  returns = { type = "integer", nullable = true },
+  returns = {
+    type = "integer",
+    nullable = true,
+    description = "The height, in world units, with `nil` where there is no floor.",
+  },
   examples = {
     [[local floor = trx.lara.item.room:floor_height(trx.lara.item.pos)]],
   },

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -34,8 +34,8 @@ local ROOM_HOOK_PARAMS = {
     params = {
       {
         name = "item",
-        type = "Item",
-        description = "The `trx.items.Item` that changed rooms.",
+        type = "items.Item",
+        description = "The item that changed rooms.",
       },
     },
   },
@@ -67,9 +67,9 @@ local FLOOR_HEIGHT_PARAMS = {
   FLOOR_HEIGHT_POS,
   {
     name = "room_num",
-    type = "integer",
+    type = "rooms.Num",
     optional = true,
-    description = "0-based room to look from. The search crosses portals, so a neighbouring "
+    description = "The search crosses portals, so a neighbouring "
       .. "room's floor is found too. Without it, the room is looked up from the position, which "
       .. "takes the first room that contains it and passes over the flipped-away ones. Where "
       .. "rooms overlap, name the room, or ask the room itself with `room:floor_height`.",
@@ -104,9 +104,8 @@ api.type("rooms.Room", {
   fields = {
     num = {
       from = "room_num",
-      type = "integer",
+      type = "rooms.Num",
       writable = false,
-      description = "0-based room number, matching the numbers level editors show.",
     },
     underwater = {
       from = "flags.underwater",
@@ -136,9 +135,8 @@ api.type("rooms.Room", {
     },
     flip_status = {
       from = "flip_status",
-      type = "integer",
+      type = "rooms.FlipStatus",
       writable = false,
-      enum = "rooms.FlipStatus",
       description = "Current flip status.",
     },
     -- Deliberately not exposed: pos, size, ambient, light and mesh counts,
@@ -195,7 +193,7 @@ end)]],
 
   extensions = {
     flipped_room = {
-      type = "Room",
+      type = "rooms.Room",
       description = "This room's flip pair, or `nil` if it has none.",
       impl = function(room)
         local num = raw.get_flipped_room(room)
@@ -228,17 +226,17 @@ end)]],
   },
 })
 
-api.note(
-  "rooms.num",
-  "0-based room number, matching the numbers level editors show."
-)
+api.number("rooms.Num", {
+  base = 0,
+  description = "Room number, matching the numbers level editors show.",
+})
 
 api.define("rooms.get", {
   description = "Retrieves a room by number.",
   params = {
-    { name = "num", type = "integer", see = "rooms.num" },
+    { name = "num", type = "rooms.Num" },
   },
-  returns = { type = "Room", nullable = true },
+  returns = { type = "rooms.Room", nullable = true },
   examples = {
     [[local room = trx.rooms[14]
 room.underwater = true]],
@@ -268,8 +266,7 @@ api.define("rooms.flip_effect", {
   params = {
     {
       name = "effect_id",
-      type = "integer",
-      enum = "catalog.flip_effects",
+      type = "catalog.flip_effects",
       description = "Use `-1` to clear the current effect.",
     },
     {
@@ -303,8 +300,7 @@ api.define("rooms.find_valid_pos", {
     { name = "pos", type = "vec3", description = "Position to search near." },
     {
       name = "room_num",
-      type = "integer",
-      description = "0-based room to search from.",
+      type = "rooms.Num",
     },
   },
   returns = {
@@ -313,7 +309,10 @@ api.define("rooms.find_valid_pos", {
       nullable = true,
       description = "The valid position, or `nil` if none was found nearby.",
     },
-    { type = "integer", description = "The 0-based room the position is in." },
+    {
+      type = "rooms.Num",
+      description = "The room the position is in.",
+    },
   },
   impl = raw.find_valid_pos,
 })
@@ -334,7 +333,7 @@ end
 local function flag_narrowing(field, description)
   return {
     description = description,
-    returns = { type = "Query", description = "The narrowed query." },
+    returns = { type = "query.Query", description = "The narrowed query." },
     impl = trx.query.narrowing(function()
       return function(_num, room)
         return room[field]
@@ -356,7 +355,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
     swamp = flag_narrowing("swamp", "The room is filled with swamp water."),
     dry = {
       description = "The room holds neither water nor swamp water.",
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       impl = trx.query.narrowing(function()
         return function(_num, room)
           return not room.underwater and not room.swamp
@@ -368,7 +367,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
       description = "The room is part of the level as it stands: an ordinary room, or the half of "
         .. "a flip pair the level is showing. This is what a script asking about the world wants, "
         .. "and what `at` already applies.",
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       examples = { [[trx.rooms.query:reachable():underwater():count()]] },
       impl = trx.query.narrowing(function()
         return function(_num, room)
@@ -379,7 +378,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
     flipped = {
       description = "The room is the half of a flip pair the level is not showing. Its geometry is "
         .. "still there to inspect, but nothing can be in it.",
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       impl = trx.query.narrowing(function()
         return function(_num, room)
           return room.flip_status == trx.rooms.FlipStatus.FLIPPED
@@ -396,7 +395,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
       params = {
         { name = "pos", type = "vec3", description = "World position." },
       },
-      returns = { type = "Query", description = "The narrowed query." },
+      returns = { type = "query.Query", description = "The narrowed query." },
       examples = { [[trx.rooms.query:at(trx.lara.item.pos):first()]] },
       impl = trx.query.narrowing(function(pos)
         return function(_num, room)
@@ -419,9 +418,8 @@ local room_query = trx.query.new({
 }, RoomQuery)
 
 api.property("rooms.query", {
-  type = "RoomQuery",
-  description = "The identity query over every room in the level. Narrow it and read it - see "
-    .. "`trx.rooms.RoomQuery`.",
+  type = "rooms.RoomQuery",
+  description = "The identity query over every room in the level. Narrow it and read it.",
   get = function()
     return room_query
   end,
@@ -429,10 +427,9 @@ api.property("rooms.query", {
 
 api.container("rooms", {
   description = "Indexing the module reaches a room, and `#trx.rooms` is how many the level has. "
-    .. "Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them "
-    .. "in order, keyed by that number.",
-  key = { type = "integer", see = "rooms.num" },
-  value = { type = "Room", nullable = true },
+    .. "`pairs()` walks them in order, keyed by the room number.",
+  key = { type = "rooms.Num" },
+  value = { type = "rooms.Room", nullable = true },
   examples = {
     [[trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[0].num)
 for num, room in pairs(trx.rooms) do

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -72,7 +72,7 @@ local FLOOR_HEIGHT_PARAMS = {
     description = "The search crosses portals, so a neighbouring "
       .. "room's floor is found too. Without it, the room is looked up from the position, which "
       .. "takes the first room that contains it and passes over the flipped-away ones. Where "
-      .. "rooms overlap, name the room, or ask the room itself with `room:floor_height`.",
+      .. "rooms overlap, name the room, or ask the room itself with `trx.rooms.Room:floor_height`.",
   },
   FLOOR_HEIGHT_OPTS,
 }
@@ -89,7 +89,7 @@ api.module("rooms", {
 
 api.enum("rooms.FlipStatus", {
   backing = "ROOM_FLIP_STATUS",
-  description = "The values `room.flip_status` can take.",
+  description = "The values `trx.rooms.Room.flip_status` can take.",
   values = {
     NONE = "This is a normal room.",
     UNFLIPPED = "This room is currently reachable by Lara.",
@@ -210,7 +210,7 @@ end)]],
     },
     internal_bounds = {
       type = "table",
-      description = "As `bounds`, but excluding the outer ring of sectors, which is solid wall.",
+      description = "As `trx.rooms.Room.bounds`, but excluding the outer ring of sectors, which is solid wall.",
       impl = function(room)
         local b = raw.get_bounds(room)
         return {
@@ -366,7 +366,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
     reachable = {
       description = "The room is part of the level as it stands: an ordinary room, or the half of "
         .. "a flip pair the level is showing. This is what a script asking about the world wants, "
-        .. "and what `at` already applies.",
+        .. "and what `trx.rooms.RoomQuery:at` already applies.",
       returns = { type = "query.Query", description = "The narrowed query." },
       examples = { [[trx.rooms.query:reachable():underwater():count()]] },
       impl = trx.query.narrowing(function()

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -32,7 +32,7 @@ end
 rule("exposure.max", {
   type = "integer",
   description = "How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills "
-    .. "to. Warmth only moves in a room carrying the `damaging` flag, such as the cold water of "
+    .. "to. Warmth only moves in a room carrying the `trx.rooms.Room.damaging` flag, such as the cold water of "
     .. "Antarctica.",
 })
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -30,8 +30,8 @@ local function rule(key, spec)
 end
 
 rule("exposure.max", {
-  type = "integer",
-  description = "How much warmth Lara holds, in frames, and what `trx.lara.exposure_bar` fills "
+  type = "game.Frames",
+  description = "How much warmth Lara holds, and what `trx.lara.exposure_bar` fills "
     .. "to. Warmth only moves in a room carrying the `trx.rooms.Room.damaging` flag, such as the cold water of "
     .. "Antarctica.",
 })

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -65,7 +65,10 @@ rule("corpse.fade_speed", {
 api.define("rules.list", {
   description = "Every rule there is, as dotted `group.field` keys.",
   params = {},
-  returns = { type = "table" },
+  returns = {
+    type = "table",
+    description = "The keys, in no particular order.",
+  },
   impl = raw.list,
 })
 
@@ -91,7 +94,11 @@ api.define("rules.set", {
       type = "string",
       description = "Dotted path, e.g. `exposure.damage`.",
     },
-    { name = "value", type = "any" },
+    {
+      name = "value",
+      type = "any",
+      description = "The value to write, of the type the rule declares.",
+    },
   },
   impl = raw.set,
 })
@@ -115,7 +122,7 @@ api.define("rules.format_value", {
   params = {
     { name = "key", type = "string", description = "Dotted path." },
   },
-  returns = { type = "string" },
+  returns = { type = "string", description = "The text, ready to print." },
   impl = raw.format_value,
 })
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -63,7 +63,7 @@ rule("corpse.fade_speed", {
 })
 
 api.define("rules.list", {
-  description = "Every rule there is, as dotted `group.field` keys.",
+  description = "Every rule there is, as dotted `group.field` keys. <!--noref: group.field-->",
   params = {},
   returns = {
     type = "table",
@@ -78,7 +78,7 @@ api.define("rules.get", {
     {
       name = "key",
       type = "string",
-      description = "Dotted path, e.g. `exposure.damage`.",
+      description = "Dotted path, e.g. `exposure.damage`. <!--noref: exposure.damage-->",
     },
   },
   returns = { type = "any", description = "Raises if no rule has that key." },
@@ -92,7 +92,7 @@ api.define("rules.set", {
     {
       name = "key",
       type = "string",
-      description = "Dotted path, e.g. `exposure.damage`.",
+      description = "Dotted path, e.g. `exposure.damage`. <!--noref: exposure.damage-->",
     },
     {
       name = "value",

--- a/src/lua/api/savegame.lua
+++ b/src/lua/api/savegame.lua
@@ -17,16 +17,20 @@ local Pool = api.enum("savegame.Pool", {
 
 local pool_param = {
   name = "pool",
-  type = "integer",
+  type = "savegame.Pool",
   optional = true,
-  enum = "savegame.Pool",
   description = "Which set of slots to look in. Defaults to `NORMAL`.",
 }
 
+api.number("savegame.SlotNum", {
+  base = 1,
+  description = "Slot number within the pool. For the quick pool this is the "
+    .. "on-screen order.",
+})
+
 local slot_param = {
   name = "slot_num",
-  type = "integer",
-  description = "1-based slot number. For the quick pool this is the on-screen order.",
+  type = "savegame.SlotNum",
 }
 
 api.define("savegame.slot_count", {
@@ -66,9 +70,9 @@ api.define("savegame.save", {
   params = {
     {
       name = "slot_num",
-      type = "integer",
+      type = "savegame.SlotNum",
       optional = true,
-      description = "1-based slot number. The quick pool uses the next slot in its rotation "
+      description = "The quick pool uses the next slot in its rotation "
         .. "when it is omitted.",
     },
     pool_param,

--- a/src/lua/api/savegame.lua
+++ b/src/lua/api/savegame.lua
@@ -23,8 +23,8 @@ local pool_param = {
   description = "Which set of slots to look in. Defaults to `NORMAL`.",
 }
 
-local index_param = {
-  name = "index",
+local slot_param = {
+  name = "slot_num",
   type = "integer",
   description = "1-based slot number. For the quick pool this is the on-screen order.",
 }
@@ -41,31 +41,31 @@ api.define("savegame.slot_count", {
 
 api.define("savegame.is_free", {
   description = "Whether a slot holds no save.",
-  params = { index_param, pool_param },
+  params = { slot_param, pool_param },
   returns = {
     { type = "boolean", description = "Whether the slot is empty." },
   },
-  impl = function(index, pool)
-    return raw.is_free(index, pool or Pool.NORMAL)
+  impl = function(slot_num, pool)
+    return raw.is_free(slot_num, pool or Pool.NORMAL)
   end,
 })
 
 api.define("savegame.load", {
   description = "Starts the saved game in a slot. The load happens once the game flow picks it "
     .. "up, not on the call.",
-  params = { index_param, pool_param },
+  params = { slot_param, pool_param },
   examples = { [[trx.savegame.load(1)]] },
-  impl = function(index, pool)
-    raw.load(index, pool or Pool.NORMAL)
+  impl = function(slot_num, pool)
+    raw.load(slot_num, pool or Pool.NORMAL)
   end,
 })
 
 api.define("savegame.save", {
-  description = "Writes a saved game to a slot. A quick save with no index goes to the next "
+  description = "Writes a saved game to a slot. A quick save with no slot number goes to the next "
     .. "slot in the rotation; with one, it saves to the slot named.",
   params = {
     {
-      name = "index",
+      name = "slot_num",
       type = "integer",
       optional = true,
       description = "1-based slot number. The quick pool uses the next slot in its rotation "
@@ -80,7 +80,7 @@ api.define("savegame.save", {
     },
   },
   examples = { [[trx.savegame.save(1)]] },
-  impl = function(index, pool)
-    return raw.save(index, pool or Pool.NORMAL)
+  impl = function(slot_num, pool)
+    return raw.save(slot_num, pool or Pool.NORMAL)
   end,
 })

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -180,8 +180,7 @@ api.define("sound.play", {
   params = {
     {
       name = "id",
-      type = "integer",
-      enum = "catalog.samples",
+      type = "catalog.samples",
       description = "Sample to play. To reach a sample by the level's own slot, play it through a "
         .. "handle: `trx.sound.samples[slot]:play()`.",
     },
@@ -214,8 +213,7 @@ api.define("sound.stop", {
   params = {
     {
       name = "id",
-      type = "integer",
-      enum = "catalog.samples",
+      type = "catalog.samples",
       description = "Sample to stop. To reach a sample by the level's own slot, stop it through a "
         .. "handle: `trx.sound.samples[slot]:stop()`.",
     },

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -6,6 +6,11 @@ api.module("sound", {
   description = "Module for playing sound effects.",
 })
 
+api.number("sound.SampleNum", {
+  description = "Sample number, in the numbering the loaded level carries. Not a "
+    .. "`trx.catalog.samples` name, which is the sound bank's own.",
+})
+
 api.type("sound.Sample", {
   backing = "SOUND_SAMPLE_VIEW",
   description = "A sound sample the current level carries. Reach them through `trx.sound.samples`. "
@@ -15,9 +20,8 @@ api.type("sound.Sample", {
   fields = {
     num = {
       from = "id",
-      type = "integer",
+      type = "sound.SampleNum",
       writable = false,
-      description = "The number the level gives this sample.",
     },
     volume = {
       from = "volume",
@@ -47,7 +51,10 @@ api.type("sound.Sample", {
 
   methods = {
     is_valid = {
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "False once a level change has replaced the samples.",
+      },
       description = "Whether the loaded level still carries this sample.",
     },
     play = {
@@ -56,8 +63,16 @@ api.type("sound.Sample", {
           name = "opts",
           type = "table",
           optional = true,
-          description = "`pos`: a `{ x =, y =, z = }` world position to play from, which applies "
-            .. "pan and volume. Omit to play at full volume.",
+          description = "How to play it.",
+          fields = {
+            {
+              name = "pos",
+              type = "vec3",
+              optional = true,
+              description = "A world position to play from, which applies pan and volume. Omit to "
+                .. "play at full volume.",
+            },
+          },
         },
       },
       returns = {
@@ -81,15 +96,18 @@ api.type("sound.Stream", {
   fields = {
     sample_num = {
       from = "sample_id",
-      type = "integer",
+      type = "sound.SampleNum",
       writable = false,
-      description = "The sample this voice is playing, in the level's own numbering.",
+      description = "The sample this voice is playing.",
     },
   },
 
   methods = {
     is_valid = {
-      returns = { type = "boolean" },
+      returns = {
+        type = "boolean",
+        description = "False once the voice has fallen silent.",
+      },
       description = "Whether this voice is still playing.",
     },
     pause = {
@@ -188,8 +206,16 @@ api.define("sound.play", {
       name = "opts",
       type = "table",
       optional = true,
-      description = "`pos`: a `{ x =, y =, z = }` world position to play from, which applies pan "
-        .. "and volume. Omit to play at full volume.",
+      description = "How to play it.",
+      fields = {
+        {
+          name = "pos",
+          type = "vec3",
+          optional = true,
+          description = "A world position to play from, which applies pan and volume. Omit to "
+            .. "play at full volume.",
+        },
+      },
     },
   },
   returns = {

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -9,7 +9,7 @@ api.module("sound", {
 api.type("sound.Sample", {
   backing = "SOUND_SAMPLE_VIEW",
   description = "A sound sample the current level carries. Reach them through `trx.sound.samples`. "
-    .. "A handle to a sample the loaded level does not carry goes stale, so `is_valid()` answers "
+    .. "A handle to a sample the loaded level does not carry goes stale, so `trx.sound.Sample:is_valid` answers "
     .. "whether it is still there.",
 
   fields = {
@@ -76,7 +76,7 @@ api.type("sound.Sample", {
 api.type("sound.Stream", {
   backing = "SOUND_STREAM_VIEW",
   description = "One of the sound effects playing now. Reach them through `trx.sound.streams`. A "
-    .. "handle to a voice that has fallen silent goes stale, so check `is_valid()` first.",
+    .. "handle to a voice that has fallen silent goes stale, so check `trx.sound.Stream:is_valid` first.",
 
   fields = {
     sample_num = {

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -13,11 +13,11 @@ api.type("sound.Sample", {
     .. "whether it is still there.",
 
   fields = {
-    id = {
+    num = {
       from = "id",
       type = "integer",
       writable = false,
-      description = "The sample's id, in the level's own numbering.",
+      description = "The number the level gives this sample.",
     },
     volume = {
       from = "volume",
@@ -79,7 +79,7 @@ api.type("sound.Stream", {
     .. "handle to a voice that has fallen silent goes stale, so check `is_valid()` first.",
 
   fields = {
-    sample_id = {
+    sample_num = {
       from = "sample_id",
       type = "integer",
       writable = false,

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -109,8 +109,8 @@ api.type("stats.Stats", {
     },
     distance_travelled = {
       from = "distance_travelled",
-      type = "integer",
-      description = "How far Lara has travelled, in world units.",
+      type = "math.Distance",
+      description = "How far Lara has travelled.",
     },
     medipacks_used = {
       from = "medipacks_used",

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -12,6 +12,7 @@ has picked up in it. Any other level's counters are reached the same way through
 `trx.game.Level.stats`. At the title screen there is no level, and everything
 here reads `nil`.]],
   instance = raw.get_current,
+  instance_type = "stats.Stats",
 })
 
 -- The categories are ordered as the engine keeps them, so a name here stands
@@ -61,7 +62,7 @@ api.type("stats.Category", {
 
 local function category(name, description)
   return {
-    type = "Category",
+    type = "stats.Category",
     description = description,
     impl = function(stats)
       return raw.category(stats, CATEGORY[name])
@@ -69,10 +70,14 @@ local function category(name, description)
   }
 end
 
+api.number("stats.SecretNum", {
+  base = 1,
+  description = "The secret's number, as the player counts them.",
+})
+
 local secret_num_param = {
-  name = "num",
-  type = "integer",
-  description = "The secret's number, counted from one.",
+  name = "secret_num",
+  type = "stats.SecretNum",
 }
 
 api.type("stats.Stats", {
@@ -158,7 +163,7 @@ api.type("stats.Stats", {
   methods = {
     secret_list = {
       description = "The level's secrets, in order, as a list of `{ num, found }`. `num` is the "
-        .. "number the player says, counted from one, and `found` is whether Lara has it.",
+        .. "number the player says, and `found` is whether Lara has it.",
       returns = { type = "table", description = "The secrets, one by one." },
       examples = {
         [[for _, secret in ipairs(trx.stats.secret_list()) do

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -162,9 +162,24 @@ api.type("stats.Stats", {
 
   methods = {
     secret_list = {
-      description = "The level's secrets, in order, as a list of `{ num, found }`. `num` is the "
-        .. "number the player says, and `found` is whether Lara has it.",
-      returns = { type = "table", description = "The secrets, one by one." },
+      description = "The level's secrets, in order.",
+      returns = {
+        type = "table",
+        description = "The secrets, one by one.",
+        list = true,
+        fields = {
+          {
+            name = "num",
+            type = "stats.SecretNum",
+            description = "Which secret it is.",
+          },
+          {
+            name = "found",
+            type = "boolean",
+            description = "Whether Lara has it.",
+          },
+        },
+      },
       examples = {
         [[for _, secret in ipairs(trx.stats.secret_list()) do
   trx.log.info(secret.num .. ": " .. tostring(secret.found))

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -26,8 +26,8 @@ local CATEGORY = {
 
 api.type("stats.Category", {
   backing = "STATS_CATEGORY",
-  description = "One thing a level is counted on, which is one row of the statistics screen. `raw` "
-    .. "is `max` plus `unobtainable`: the game flow can declare part of a level out of reach, and "
+  description = "One thing a level is counted on, which is one row of the statistics screen. `trx.stats.Category.raw` "
+    .. "is `trx.stats.Category.max` plus `trx.stats.Category.unobtainable`: the game flow can declare part of a level out of reach, and "
     .. "what it writes off is left out of what counts towards completion while still being in the "
     .. "level.",
 
@@ -36,7 +36,7 @@ api.type("stats.Category", {
       from = "count",
       type = "integer",
       description = "How many of them Lara has. The secrets cannot be set this way: they are held "
-        .. "one by one, so `give_secret` and `take_secret` are how they change.",
+        .. "one by one, so `trx.stats.give_secret` and `trx.stats.take_secret` are how they change.",
     },
     max = {
       from = "max",
@@ -130,7 +130,7 @@ api.type("stats.Stats", {
     ),
     secrets = category(
       "secrets",
-      "The level's secrets. Which ones Lara holds is `secret_list`."
+      "The level's secrets. Which ones Lara holds is `trx.stats.Stats.secret_list`."
     ),
     crystals = category(
       "crystals",
@@ -139,16 +139,16 @@ api.type("stats.Stats", {
 
     max_ally_kills = {
       type = "integer",
-      description = "How many of `kills.max` are allies. The statistics screen holds them against "
-        .. "the player only once `allies_hurt`, so a screen written in Lua wants to do the same: "
-        .. "`max_enemy_kills`, and these as well once she has turned on one.",
+      description = "How many of `trx.stats.Stats.kills.max` are allies. The statistics screen holds them against "
+        .. "the player only once `trx.stats.Stats.allies_hurt`, so a screen written in Lua wants to do the "
+        .. "same: `trx.stats.Stats.max_enemy_kills`, and these as well once she has turned on one.",
       impl = function(stats)
         return (raw.kill_split(stats))
       end,
     },
     max_enemy_kills = {
       type = "integer",
-      description = "How many of `kills.max` are enemies rather than allies.",
+      description = "How many of `trx.stats.Stats.kills.max` are enemies rather than allies.",
       impl = function(stats)
         return select(2, raw.kill_split(stats))
       end,

--- a/src/lua/api/stats.lua
+++ b/src/lua/api/stats.lua
@@ -88,8 +88,8 @@ api.type("stats.Stats", {
   fields = {
     timer = {
       from = "timer",
-      type = "integer",
-      description = "How long the level has been played, in game frames.",
+      type = "game.Frames",
+      description = "How long the level has been played.",
     },
     deaths = {
       from = "death_count",

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -91,7 +91,7 @@ local best = matches[1]]==],
 api.define("strings.parse_bool", {
   description = "Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, "
     .. "`false` or `off` for false, in any case. Anything else is not a boolean. "
-    .. "",
+    .. "<!--noref: on, off-->",
   params = {
     { name = "text", type = "string", description = "The text to read." },
   },

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -11,8 +11,9 @@ api.module("strings", {
 api.define("strings.fuzzy_match", {
   description = "Matches what someone typed against a list of candidates, forgivingly: `big medi` "
     .. "finds `large medipack`.\n\n"
-    .. "Candidates are ranked, best first. Each carries a `value` of the caller's choosing, which "
-    .. "comes back untouched on the match - hang an id off it and read it back.",
+    .. "Candidates are ranked, best first. Each carries a "
+    .. "`trx.strings.fuzzy_match.sources.value` of the caller's choosing, which comes back "
+    .. "untouched on the match - hang an id off it and read it back.",
   params = {
     {
       name = "input",
@@ -22,15 +23,60 @@ api.define("strings.fuzzy_match", {
     {
       name = "sources",
       type = "table",
-      description = "List of `{ key = <the name>, value = <anything>, weight = <integer> }`. "
-        .. "The key is a non-empty string. A heavier candidate wins a tie; weight defaults to 1, "
-        .. "and a weight of zero or less drops the candidate.",
+      description = "The candidates.",
+      list = true,
+      fields = {
+        {
+          name = "key",
+          type = "string",
+          description = "The name to match against. Non-empty.",
+        },
+        {
+          name = "value",
+          type = "any",
+          description = "Anything of the caller's, handed back on the match.",
+        },
+        {
+          name = "weight",
+          type = "integer",
+          optional = true,
+          default = 1,
+          description = "A heavier candidate wins a tie. Zero or less drops it.",
+        },
+      },
     },
   },
   returns = {
     type = "table",
-    description = "The matches, best first: `{ key, value, score, is_full, is_word }`. `is_full` "
-      .. "means the whole candidate matched, `is_word` that a whole word did.",
+    description = "The matches, best first.",
+    list = true,
+    fields = {
+      {
+        name = "key",
+        type = "string",
+        description = "The candidate that matched.",
+      },
+      {
+        name = "value",
+        type = "any",
+        description = "What the candidate carried.",
+      },
+      {
+        name = "score",
+        type = "number",
+        description = "How well it matched.",
+      },
+      {
+        name = "is_full",
+        type = "boolean",
+        description = "Whether the whole candidate matched.",
+      },
+      {
+        name = "is_word",
+        type = "boolean",
+        description = "Whether a whole word matched.",
+      },
+    },
   },
   examples = {
     [==[local matches = trx.strings.fuzzy_match("wolf", {
@@ -44,7 +90,8 @@ local best = matches[1]]==],
 
 api.define("strings.parse_bool", {
   description = "Reads a boolean the way the console does: `1`, `true` or `on` for true, `0`, "
-    .. "`false` or `off` for false, in any case. Anything else is not a boolean.",
+    .. "`false` or `off` for false, in any case. Anything else is not a boolean. "
+    .. "",
   params = {
     { name = "text", type = "string", description = "The text to read." },
   },
@@ -108,14 +155,21 @@ api.define("strings.collapse_ranges", {
 api.define("strings.regex_match", {
   description = "Whether a subject matches a regular expression. Case-insensitive.",
   params = {
-    { name = "subject", type = "string" },
+    {
+      name = "subject",
+      type = "string",
+      description = "The text to search.",
+    },
     {
       name = "pattern",
       type = "string",
       description = "A PCRE regular expression.",
     },
   },
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "True where the pattern matches anywhere in the subject.",
+  },
   examples = { [[if trx.strings.regex_match(args, "^\\d+$") then ... end]] },
   impl = raw.regex_match,
 })

--- a/src/lua/api/weapons.lua
+++ b/src/lua/api/weapons.lua
@@ -13,8 +13,7 @@ has are `trx.inventory`.]],
 
 local weapon_param = {
   name = "weapon",
-  type = "integer",
-  enum = "catalog.weapons",
+  type = "catalog.weapons",
   description = "Which weapon. `UNKNOWN` and `UNARMED` raise, and so does anything outside the "
     .. "table; `FLARE` and `SKIDOO` are taken, being held the way a weapon is.",
 }
@@ -33,8 +32,7 @@ api.define("weapons.object", {
   description = "The pickup the weapon is, for handing it to `trx.inventory:give`.",
   params = { weapon_param },
   returns = {
-    type = "integer",
-    enum = "catalog.objects",
+    type = "catalog.objects",
     description = "The object id, or `nil` if this game has no such weapon.",
   },
   examples = {

--- a/src/lua/api/weapons.lua
+++ b/src/lua/api/weapons.lua
@@ -24,7 +24,10 @@ Whether the game allows this weapon at all. The game flow can keep one out, and
 a cheat that hands it over anyway leaves Lara with a gun the level was built
 without.]],
   params = { weapon_param },
-  returns = { type = "boolean" },
+  returns = {
+    type = "boolean",
+    description = "True where this game has the weapon at all.",
+  },
   impl = raw.is_available,
 })
 
@@ -44,6 +47,6 @@ api.define("weapons.object", {
 api.define("weapons.shots_per_box", {
   description = "How many shots one box of ammunition for it is worth.",
   params = { weapon_param },
-  returns = { type = "integer" },
+  returns = { type = "integer", description = "Shots, not rounds." },
   impl = raw.shots_per_box,
 })

--- a/src/lua/api/weather.lua
+++ b/src/lua/api/weather.lua
@@ -21,8 +21,7 @@ api.define("weather.set", {
   params = {
     {
       name = "type",
-      type = "integer",
-      enum = "weather.Type",
+      type = "weather.Type",
       description = "The weather to show.",
     },
   },
@@ -31,8 +30,7 @@ api.define("weather.set", {
 })
 
 api.property("weather.current", {
-  type = "integer",
-  enum = "weather.Type",
+  type = "weather.Type",
   description = "The active weather.",
   get = raw.get,
 })

--- a/src/lua/commands/load_game.lua
+++ b/src/lua/commands/load_game.lua
@@ -23,44 +23,44 @@ local Pool = trx.savegame.Pool
 -- quick pool, and a number stuck to it (`q2`) is that quick save.
 local function slot(token)
   if token:match("^%d+$") then
-    return { pool = Pool.NORMAL, index = tonumber(token) }, true
+    return { pool = Pool.NORMAL, slot_num = tonumber(token) }, true
   end
-  local index = token:match("^q(%d*)$") or token:match("^quick(%d*)$")
-  if index ~= nil then
+  local slot_num = token:match("^q(%d*)$") or token:match("^quick(%d*)$")
+  if slot_num ~= nil then
     return {
       pool = Pool.QUICK,
-      index = index ~= "" and tonumber(index) or nil,
+      slot_num = slot_num ~= "" and tonumber(slot_num) or nil,
     },
       true
   end
   return nil, false
 end
 
-local function execute(pool, index, has_index)
+local function execute(pool, slot_num, has_slot_num)
   local shown
   if pool == Pool.QUICK then
     -- The quick pool is addressed by its on-screen order, and defaults to the
     -- most recent save.
-    shown = has_index and index or 1
+    shown = has_slot_num and slot_num or 1
     if shown < 1 or shown > trx.savegame.slot_count(Pool.QUICK) then
       return R.FAILURE,
         trx.locale.format("console/cmd/load/fail_invalid_slot", shown)
     end
-    index = shown
+    slot_num = shown
   else
-    if index < 1 or index > trx.savegame.slot_count() then
+    if slot_num < 1 or slot_num > trx.savegame.slot_count() then
       return R.FAILURE,
-        trx.locale.format("console/cmd/load/fail_invalid_slot", index)
+        trx.locale.format("console/cmd/load/fail_invalid_slot", slot_num)
     end
-    shown = index
+    shown = slot_num
   end
 
-  if trx.savegame.is_free(index, pool) then
+  if trx.savegame.is_free(slot_num, pool) then
     return R.FAILURE,
       trx.locale.format("console/cmd/load/fail_unavailable_slot", shown)
   end
 
-  trx.savegame.load(index, pool)
+  trx.savegame.load(slot_num, pool)
   if pool == Pool.QUICK then
     return R.OK, trx.locale.format("console/cmd/load/quick_success", shown)
   end
@@ -77,7 +77,11 @@ trx.console.register({
     )
   end,
   run = function(args)
-    return execute(args.slot.pool, args.slot.index, args.slot.index ~= nil)
+    return execute(
+      args.slot.pool,
+      args.slot.slot_num,
+      args.slot.slot_num ~= nil
+    )
   end,
 })
 
@@ -90,8 +94,9 @@ trx.console.register({
   end,
   run = function(args)
     -- Everything the quickload word takes is a quick save, so the slot's pool
-    -- is ignored and a bare number is read as a quick index (`q2` and `2` alike).
-    local index = args.slot ~= nil and args.slot.index or nil
-    return execute(Pool.QUICK, index, index ~= nil)
+    -- is ignored and a bare number is read as a quick slot number (`q2` and `2`
+    -- alike).
+    local slot_num = args.slot ~= nil and args.slot.slot_num or nil
+    return execute(Pool.QUICK, slot_num, slot_num ~= nil)
   end,
 })

--- a/src/lua/commands/music.lua
+++ b/src/lua/commands/music.lua
@@ -33,7 +33,7 @@ local function overlay_ids()
   local ids = {}
   for _, stream in ipairs(trx.music.streams) do
     if stream:is_valid() and stream.mode == trx.music.PlayMode.OVERLAY then
-      ids[#ids + 1] = stream.track_id
+      ids[#ids + 1] = stream.track_num
     end
   end
   return ids
@@ -58,14 +58,14 @@ local function show_status()
     trx.console.log.info(trx.locale.get("console/cmd/music/current_none"))
   else
     trx.console.log.info(
-      trx.locale.format("console/cmd/music/current", current.id)
+      trx.locale.format("console/cmd/music/current", current.num)
     )
   end
 
   local looped = trx.music.looped_track
-  if current ~= nil and looped ~= nil and current.id ~= looped.id then
+  if current ~= nil and looped ~= nil and current.num ~= looped.num then
     trx.console.log.info(
-      trx.locale.format("console/cmd/music/deferred_ambient", looped.id)
+      trx.locale.format("console/cmd/music/deferred_ambient", looped.num)
     )
   end
 

--- a/src/lua/commands/save_game.lua
+++ b/src/lua/commands/save_game.lua
@@ -22,30 +22,30 @@ local Pool = trx.savegame.Pool
 -- quick pool, and a number stuck to it (`q2`) is that quick save.
 local function slot(token)
   if token:match("^%d+$") then
-    return { pool = Pool.NORMAL, index = tonumber(token) }, true
+    return { pool = Pool.NORMAL, slot_num = tonumber(token) }, true
   end
-  local index = token:match("^q(%d*)$") or token:match("^quick(%d*)$")
-  if index ~= nil then
+  local slot_num = token:match("^q(%d*)$") or token:match("^quick(%d*)$")
+  if slot_num ~= nil then
     return {
       pool = Pool.QUICK,
-      index = index ~= "" and tonumber(index) or nil,
+      slot_num = slot_num ~= "" and tonumber(slot_num) or nil,
     },
       true
   end
   return nil, false
 end
 
-local function quick_save(index)
+local function quick_save(slot_num)
   -- A named quick slot is range-checked the way a normal slot is; the next-slot
-  -- form (no index) leaves it to the save system.
+  -- form (no slot number) leaves it to the save system.
   if
-    index ~= nil
-    and (index < 1 or index > trx.savegame.slot_count(Pool.QUICK))
+    slot_num ~= nil
+    and (slot_num < 1 or slot_num > trx.savegame.slot_count(Pool.QUICK))
   then
     return R.BAD_INVOCATION,
-      trx.locale.format("console/cmd/save/fail_invalid_slot", index)
+      trx.locale.format("console/cmd/save/fail_invalid_slot", slot_num)
   end
-  if not trx.savegame.save(index, Pool.QUICK) then
+  if not trx.savegame.save(slot_num, Pool.QUICK) then
     return R.FAILURE, trx.locale.get("console/cmd/save/quick_fail_no_slots")
   end
   return R.OK, trx.locale.get("console/cmd/save/quick_success")
@@ -65,15 +65,15 @@ trx.console.register({
       return R.UNAVAILABLE
     end
     if args.slot.pool == Pool.QUICK then
-      return quick_save(args.slot.index)
+      return quick_save(args.slot.slot_num)
     end
-    local index = args.slot.index
-    if index < 1 or index > trx.savegame.slot_count() then
+    local slot_num = args.slot.slot_num
+    if slot_num < 1 or slot_num > trx.savegame.slot_count() then
       return R.BAD_INVOCATION,
-        trx.locale.format("console/cmd/save/fail_invalid_slot", index)
+        trx.locale.format("console/cmd/save/fail_invalid_slot", slot_num)
     end
-    trx.savegame.save(index)
-    return R.OK, trx.locale.format("console/cmd/save/success", index)
+    trx.savegame.save(slot_num)
+    return R.OK, trx.locale.format("console/cmd/save/success", slot_num)
   end,
 })
 

--- a/src/lua/commands/trigger.lua
+++ b/src/lua/commands/trigger.lua
@@ -52,7 +52,7 @@ local function targets_from_id(text)
   if not is_targetable(item) then
     return {}, trx.locale.format("console/cmd/trigger/invalid_item", text)
   end
-  return { item.index }
+  return { item.num }
 end
 
 local function targets_from_item_name(text)
@@ -63,7 +63,7 @@ local function targets_from_item_name(text)
   if not is_targetable(item) then
     return {}, trx.locale.format("console/cmd/trigger/invalid_item", text)
   end
-  return { item.index }
+  return { item.num }
 end
 
 local function targets_from_object_name(text)
@@ -81,7 +81,7 @@ local function targets_from_object_name(text)
   for i = 0, #trx.items - 1 do
     local item = trx.items[i]
     if item ~= nil and wanted[item.object_id] and is_targetable(item) then
-      found[#found + 1] = item.index
+      found[#found + 1] = item.num
     end
   end
 

--- a/src/tests/harness/lua_surface.c
+++ b/src/tests/harness/lua_surface.c
@@ -265,7 +265,7 @@ int LuaSurface_Run(const LUA_SURFACE_TEST *const test)
     // From here to the tests, the order is LUA_Init's: seal, then the runtime
     // scripts, then harden.
     if (test->seal) {
-        if (luaL_dostring(L, "trx.api.seal()") != LUA_OK) {
+        if (luaL_dostring(L, "trx.api.seal({ partial = true })") != LUA_OK) {
             M_Fail(L, "sealing");
         }
         lua_pushnil(L);

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1144,6 +1144,74 @@ test("an enum is a type like any other", function()
   assert(declared(api, "things.get").params[1].type == "things.State")
 end)
 
+-- A unit is what a value is measured in, and it answers the same question a
+-- number does: what this is, said once, wherever one turns up.
+test("a unit is written once and named from wherever it is meant", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.unit("things.Angle", {
+    description = "An angle in the engine's own units.",
+    spellings = { "engine's own units" },
+  })
+  api.unit("things.Seconds", { type = "number", description = "Seconds." })
+  api.define("things.turn", {
+    params = { { name = "angle", type = "things.Angle" } },
+    returns = { type = "things.Seconds" },
+    impl = function() end,
+  })
+
+  local dumped = api.describe()
+  assert(#dumped.units == 2, "the units must reach the docs to be linked to")
+  assert(dumped.units[1].path == "things.Angle")
+  assert(dumped.units[1].type == "integer", "a unit is whole unless it says")
+  assert(dumped.units[1].spellings[1] == "engine's own units")
+  assert(dumped.units[2].type == "number")
+
+  local fn = declared(api, "things.turn")
+  assert(fn.params[1].type == "things.Angle")
+  assert(fn.returns.type == "things.Seconds")
+end)
+
+test("a unit measures a whole or a real number, and nothing else", function()
+  local api = fresh_env()
+  assert(
+    not pcall(
+      api.unit,
+      "things.Angle",
+      { type = "string", description = "Not a measurement." }
+    )
+  )
+end)
+
+test("a unit cannot be written twice", function()
+  local api = fresh_env()
+  api.unit("things.Angle", { description = "An angle." })
+  assert(
+    not pcall(api.unit, "things.Angle", { description = "Something else." })
+  )
+end)
+
+-- Strict mode checks a unit as it checks anything else: what a value of it is
+-- is what the unit says it is.
+test("a unit is checked by what it measures", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.unit("things.Seconds", { type = "number", description = "Seconds." })
+  api.unit("things.Angle", { description = "An angle." })
+  api.define("things.wait", {
+    params = {
+      { name = "time", type = "things.Seconds" },
+      { name = "angle", type = "things.Angle" },
+    },
+    impl = function() end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.wait, 1.5, 90), "a real number and a whole one")
+  assert(not pcall(trx.things.wait, 1.5, 1.5), "an angle is whole")
+  api.strict(false)
+end)
+
 test("a number cannot be written twice", function()
   local api = fresh_env()
   api.number("things.Num", { base = 0, description = "A thing number." })

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -959,15 +959,42 @@ test("a Lua type's fields read and write through its accessors", function()
   assert(by_name.size.writable == false, "a field with no set is read-only")
 end)
 
-test("a Lua type's field must carry a get", function()
+test("a Lua type's field with no accessors is an entry it carries", function()
   local api = fresh_env()
-  assert(
-    not pcall(
-      api.type,
-      "things.Widget",
-      { fields = { name = { type = "string" } } }
+  local Box = api.type("things.Box", {
+    description = "...",
+    fields = {
+      min_x = { type = "integer", description = "..." },
+      max_x = { type = "integer", description = "..." },
+    },
+    methods = {
+      width = {
+        description = "...",
+        impl = function(self)
+          return self.max_x - self.min_x
+        end,
+      },
+    },
+  })
+
+  local box = setmetatable({ min_x = 1, max_x = 5 }, Box)
+  assert(box.min_x == 1)
+  assert(box:width() == 4, "a method must still be reachable")
+
+  local entry = api.describe().types[1]
+  for _, field in ipairs(entry.fields) do
+    assert(
+      field.writable == true,
+      "a stored entry is neither getter nor const"
     )
-  )
+  end
+end)
+
+test("a Lua type's field with a set needs a get as well", function()
+  local api = fresh_env()
+  assert(not pcall(api.type, "things.Widget", {
+    fields = { name = { type = "string", set = function() end } },
+  }))
 end)
 
 test("a type is named by the path it was declared under", function()

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -659,7 +659,7 @@ test("a Lua type checks its own values, derived ones included", function()
   })
   local Lever = api.type("things.Lever", { extends = "things.Widget" })
   api.define("things.press", {
-    params = { { name = "widget", type = "Widget" } },
+    params = { { name = "widget", type = "things.Widget" } },
     impl = function()
       return true
     end,
@@ -970,7 +970,7 @@ test("a Lua type's field must carry a get", function()
   )
 end)
 
-test("a type answers to its bare name and to its path", function()
+test("a type is named by the path it was declared under", function()
   local api = fresh_env()
   local Widget = api.type("things.Widget", {})
   api.define("things.press", {
@@ -986,11 +986,25 @@ test("a type answers to its bare name and to its path", function()
   api.strict(false)
 end)
 
--- Two modules with a type of the same name is allowed - music.Stream and
--- sound.Stream are one - but the bare name stops naming either, so a
--- declaration says which by its path instead of checking against whichever
--- module happened to declare last.
-test("a name two modules claim stops naming either", function()
+-- The path is the only name a type has. A bare one used to answer as well,
+-- which meant a declaration could name a type the declaration never chose and
+-- go on meaning it until another module claimed the name.
+test("a bare type name names nothing", function()
+  local api = fresh_env()
+  api.type("things.Widget", {})
+  api.define("things.press", {
+    params = { { name = "thing", type = "Widget" } },
+    impl = function() end,
+  })
+  assert(
+    not pcall(api.seal),
+    "a type nothing declares must be reported, not waved through"
+  )
+end)
+
+-- Two modules may declare a type of the same name - music.Stream and
+-- sound.Stream are one - and each is named by its own path.
+test("two modules may name a type the same", function()
   local api = fresh_env()
   local Widget = api.type("things.Widget", {})
   local Gadget = api.type("others.Widget", {})
@@ -1008,15 +1022,6 @@ test("a name two modules claim stops naming either", function()
     "the path must name one type and not the other"
   )
   api.strict(false)
-
-  assert(
-    not pcall(api.define, "things.poke", {
-        params = { { name = "thing", type = "Widget" } },
-        impl = function() end,
-      }) or not pcall(api.strict, true),
-    "the bare name must no longer check anything"
-  )
-  api.strict(false)
 end)
 
 -- The registry declares functions of its own, so a test finds its own by path.
@@ -1029,69 +1034,95 @@ local function declared(api, path)
   return nil
 end
 
-test("a note is written once and read wherever it is pointed at", function()
+test("a number is written once and named from wherever it is meant", function()
   local api = fresh_env()
   api.module("things", { description = "..." })
-  api.note("things.number", "0-based thing number.")
+  api.number("things.Num", {
+    base = 0,
+    description = "A thing number.",
+  })
   api.define("things.get", {
     params = {
-      { name = "num", type = "integer", see = "things.number" },
+      { name = "num", type = "things.Num" },
       {
         name = "callback",
         type = "function",
-        params = {
-          { name = "num", type = "integer", see = "things.number" },
-        },
+        params = { { name = "num", type = "things.Num" } },
       },
     },
-    returns = { type = "integer", see = "things.number" },
+    returns = { type = "things.Num" },
     impl = function() end,
   })
 
-  local fn = declared(api, "things.get")
-  assert(fn.params[1].description == "0-based thing number.")
+  local dumped = api.describe()
   assert(
-    fn.params[2].params[1].description == "0-based thing number.",
-    "a callback's own arguments read it too"
+    #dumped.numbers == 1,
+    "the number must reach the docs to be linked to"
   )
-  assert(fn.returns.description == "0-based thing number.")
-  assert(fn.params[1].see == nil, "the pointer does not reach the docs")
+  assert(dumped.numbers[1].path == "things.Num")
+  assert(dumped.numbers[1].base == 0)
+
+  -- What a declaration holds is written out as the path it names, so what the
+  -- number says is read from one place.
+  local fn = declared(api, "things.get")
+  assert(fn.params[1].type == "things.Num")
+  assert(fn.params[1].description == nil, "the description is not copied")
+  assert(
+    fn.params[2].params[1].type == "things.Num",
+    "a callback's own arguments name it too"
+  )
+  assert(fn.returns.type == "things.Num")
 end)
 
-test("a note joins what the spec adds of its own", function()
+test("a declaration keeps what it adds of its own", function()
   local api = fresh_env()
-  api.note("things.number", "0-based thing number.")
+  api.number("things.Num", { base = 0, description = "A number." })
   api.define("things.get", {
     params = {
       {
         name = "num",
-        type = "integer",
-        see = "things.number",
+        type = "things.Num",
         description = "The one that broke.",
       },
     },
     impl = function() end,
   })
 
-  assert(
-    declared(api, "things.get").params[1].description
-      == "0-based thing number. The one that broke."
-  )
+  local param = declared(api, "things.get").params[1]
+  assert(param.type == "things.Num")
+  assert(param.description == "The one that broke.")
 end)
 
-test("pointing at a note nobody wrote raises", function()
+test("naming something nobody declares is caught where it is read", function()
   local api = fresh_env()
+  api.module("things", { description = "..." })
   api.define("things.get", {
-    params = { { name = "num", type = "integer", see = "things.nothing" } },
+    params = { { name = "num", type = "things.nothing" } },
     impl = function() end,
   })
   assert(not pcall(api.describe))
 end)
 
-test("a note cannot be written twice", function()
+test("an enum is a type like any other", function()
   local api = fresh_env()
-  api.note("things.number", "0-based thing number.")
-  assert(not pcall(api.note, "things.number", "something else"))
+  api.enum("things.State", {
+    backing = "WIDGET_STATE",
+    description = "A state.",
+    values = { OFF = "off.", ON = "on.", BROKEN = "broken." },
+  })
+  api.define("things.get", {
+    params = { { name = "state", type = "things.State" } },
+    impl = function() end,
+  })
+  assert(declared(api, "things.get").params[1].type == "things.State")
+end)
+
+test("a number cannot be written twice", function()
+  local api = fresh_env()
+  api.number("things.Num", { base = 0, description = "A thing number." })
+  assert(
+    not pcall(api.number, "things.Num", { description = "Something else." })
+  )
 end)
 
 test("a container walks from the index it counts from", function()
@@ -1101,7 +1132,7 @@ test("a container walks from the index it counts from", function()
   api.module("counted", {})
   api.container("counted", {
     description = "Indexing.",
-    key = { type = "integer", description = "0-based." },
+    key = { type = "integer", base = 0, description = "Where it sits." },
     value = { type = "string" },
     get = function(key)
       return zero[key]
@@ -1114,9 +1145,8 @@ test("a container walks from the index it counts from", function()
   api.module("listed", {})
   api.container("listed", {
     description = "Indexing.",
-    key = { type = "integer", description = "1-based." },
+    key = { type = "integer", base = 1, description = "Where it sits." },
     value = { type = "string" },
-    base = 1,
     get = function(key)
       return one[key]
     end,
@@ -1135,6 +1165,151 @@ test("a container walks from the index it counts from", function()
 
   assert(walked(trx.counted) == "0,1", walked(trx.counted))
   assert(walked(trx.listed) == "1,2", walked(trx.listed))
+end)
+
+-- Where a collection counts from is the key's to say, so a container that says
+-- it itself is a declaration left behind by the move.
+test("a container cannot say where it counts from", function()
+  local api = fresh_env()
+  api.module("things", {})
+  assert(not pcall(api.container, "things", {
+    description = "Indexing.",
+    base = 1,
+    key = { type = "integer", description = "Where it sits." },
+    value = { type = "string" },
+    get = function() end,
+  }))
+end)
+
+-- A number need not count from anywhere - a sample number is an identifier and
+-- nothing more - and a key that names one goes on to the next.
+test("a key counts from the first of its numbers that says", function()
+  local api = fresh_env()
+  api.module("things", {})
+  api.number("things.Name", { description = "What it is called." })
+  api.number("things.Num", { base = 1, description = "Where it sits." })
+  api.container("things", {
+    description = "Indexing.",
+    key = { type = { "things.Name", "things.Num" }, description = "Either." },
+    value = { type = "string" },
+    get = function(key)
+      return tostring(key)
+    end,
+    count = function()
+      return 2
+    end,
+  })
+
+  local keys = {}
+  for key in pairs(trx.things) do
+    keys[#keys + 1] = key
+  end
+  assert(table.concat(keys, ",") == "1,2", table.concat(keys, ","))
+end)
+
+test("a declaration naming several types is checked against each", function()
+  local api = fresh_env()
+  api.number("things.Num", { base = 0, description = "A thing number." })
+  api.define("things.get", {
+    params = { { name = "which", type = { "things.Num", "string" } } },
+    impl = function()
+      return true
+    end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.get, 3))
+  assert(pcall(trx.things.get, "hammer"))
+  assert(
+    not pcall(trx.things.get, {}),
+    "a type the declaration does not name must be refused"
+  )
+  api.strict(false)
+end)
+
+test("a property naming several types is checked on write", function()
+  local api = fresh_env()
+  local held
+  api.property("things.size", {
+    type = { "integer", "string" },
+    description = "How big.",
+    get = function()
+      return held
+    end,
+    set = function(value)
+      held = value
+    end,
+  })
+
+  api.strict(true)
+  trx.things.size = "large"
+  assert(held == "large")
+  assert(not pcall(function()
+    trx.things.size = {}
+  end))
+  api.strict(false)
+end)
+
+test("seal names the several types a declaration accepts", function()
+  local api = fresh_env()
+  api.define("things.get", {
+    params = { { name = "which", type = { "things.Gone", "string" } } },
+    impl = function() end,
+  })
+
+  local ok, err = pcall(api.seal)
+  assert(not ok, "a type nothing declares must be reported")
+  assert(
+    err:find("things.Gone or string", 1, true) ~= nil,
+    "the message must name what the declaration wrote: " .. tostring(err)
+  )
+end)
+
+test("a number cannot take the path a type holds", function()
+  local api = fresh_env()
+  api.type("things.Widget", {})
+  assert(
+    not pcall(
+      api.number,
+      "things.Widget",
+      { base = 0, description = "A widget number." }
+    )
+  )
+end)
+
+test("a number belongs to a module", function()
+  local api = fresh_env()
+  assert(not pcall(api.number, "nonsense", { description = "A number." }))
+end)
+
+-- The class is what a module gives a value it hands out, and a module that
+-- hands out another's values has no other way to reach it.
+test("class() hands back the class a type was declared with", function()
+  local api = fresh_env()
+  local Widget = api.type("things.Widget", {
+    methods = { press = { impl = function() end } },
+  })
+
+  assert(api.class("things.Widget") == Widget)
+  assert(not pcall(api.class, "things.Gadget"))
+end)
+
+test("a container names itself where its key names nothing", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.container("things", {
+    description = "Indexing.",
+    key = { type = "things.Gone", description = "A key." },
+    value = { type = "string" },
+    get = function() end,
+  })
+
+  local ok, err = pcall(api.describe)
+  assert(not ok, "a key naming nothing must be reported")
+  assert(
+    err:find("things's type", 1, true) ~= nil,
+    "the message must say which container to look in: " .. tostring(err)
+  )
 end)
 
 -- A suite that registers nothing prints "0 failed" and exits clean, which reads

--- a/src/tests/lua/api/items.lua
+++ b/src/tests/lua/api/items.lua
@@ -73,7 +73,7 @@ test("bounds measure the frame the item is on", function()
   assert(at_rest.min_y == -200 and at_rest.max_y == 0)
   assert(at_rest.min_z == -300 and at_rest.max_z == 300)
 
-  it.frame = 4
+  it.frame_num = 4
   assert(it.bounds.min_x == -104, "the bounds did not follow the animation")
 end)
 
@@ -191,9 +191,9 @@ test("deactivate stops the item and takes a creature's AI away", function()
   )
 end)
 
-test("an item knows its own index, counted from 0", function()
-  assert(trx.items[0].index == 0)
-  assert(trx.items[1].index == 1)
+test("an item knows its own number, counted from 0", function()
+  assert(trx.items[0].num == 0)
+  assert(trx.items[1].num == 1)
 end)
 
 -- A door reads its trigger before it acts, which activate() alone does not set.
@@ -777,8 +777,7 @@ test("undeclared members are unreachable", function()
     "next_item",
     "next_simulated",
     "gen",
-    "anim_num",
-    "frame_num",
+    "prev_frame_num",
     "ai_bits",
     "after_death",
     "shade",
@@ -791,6 +790,13 @@ test("undeclared members are unreachable", function()
   raises(function()
     it.my_own_key = 1
   end)
+end)
+
+test("the names the number fields went by are gone", function()
+  local it = trx.items[0]
+  for _, name in ipairs({ "index", "anim", "frame" }) do
+    assert(it[name] == nil, name .. " must not be reachable")
+  end
 end)
 
 test("query of_object narrows by object, taken by id or by name", function()

--- a/src/tests/lua/api/music.lua
+++ b/src/tests/lua/api/music.lua
@@ -13,7 +13,7 @@ test("a track plays once by default, and hands back its stream", function()
     "the default mode must be ONCE"
   )
   assert(stream ~= nil and stream:is_valid(), "play hands back the stream")
-  assert(stream.track_id == fake.TRACK)
+  assert(stream.track_num == fake.TRACK)
 end)
 
 test("opts.mode selects the play mode", function()
@@ -33,7 +33,7 @@ test("get_track reports what is playing, and nil when nothing is", function()
   assert(trx.music.current_track == nil, "nothing plays to begin with")
 
   trx.music.tracks[fake.TRACK]:play()
-  assert(trx.music.current_track.id == fake.TRACK)
+  assert(trx.music.current_track.num == fake.TRACK)
 
   trx.music.stop()
   assert(
@@ -60,11 +60,11 @@ test("looped_track reports the ambient track, nil when none", function()
   assert(trx.music.looped_track == nil, "no ambient track to begin with")
 
   fake.set_looped(fake.TRACK)
-  assert(trx.music.looped_track.id == fake.TRACK)
+  assert(trx.music.looped_track.num == fake.TRACK)
 end)
 
 test("tracks is keyed by id, nil for a track the level lacks", function()
-  assert(trx.music.tracks[fake.TRACK].id == fake.TRACK)
+  assert(trx.music.tracks[fake.TRACK].num == fake.TRACK)
   assert(trx.music.tracks[fake.MISSING_TRACK] == nil)
   assert(#trx.music.tracks == 1, "the fake soundtrack has exactly one track")
 end)
@@ -72,7 +72,7 @@ end)
 test("iterating tracks walks the available ones by id", function()
   local seen = {}
   for id, track in pairs(trx.music.tracks) do
-    seen[id] = track.id
+    seen[id] = track.num
   end
   assert(seen[fake.TRACK] == fake.TRACK)
   assert(next(seen, next(seen)) == nil, "only one track is available")
@@ -95,7 +95,7 @@ test("a playing stream reports its track, mode and timestamp", function()
   fake.set_stream(0, fake.TRACK, trx.music.PlayMode.LOOP, 12.5)
   local main = trx.music.streams[1]
   assert(main:is_valid(), "slot 0 is playing")
-  assert(main.track_id == fake.TRACK)
+  assert(main.track_num == fake.TRACK)
   assert(main.mode == trx.music.PlayMode.LOOP)
   assert(main.timestamp == 12.5)
 end)
@@ -104,7 +104,7 @@ test("a silent slot is stale, and reading it raises", function()
   local overlay = trx.music.streams[2]
   assert(not overlay:is_valid(), "nothing plays on the first overlay")
   raises(function()
-    return overlay.track_id
+    return overlay.track_num
   end)
 end)
 

--- a/src/tests/lua/api/sound.lua
+++ b/src/tests/lua/api/sound.lua
@@ -4,7 +4,7 @@ local h = require("harness")
 local test, raises = h.test, h.raises
 
 test("samples is keyed by id, nil for a sample the level lacks", function()
-  assert(trx.sound.samples[fake.SAMPLE].id == fake.SAMPLE)
+  assert(trx.sound.samples[fake.SAMPLE].num == fake.SAMPLE)
   assert(trx.sound.samples[fake.MISSING_SAMPLE] == nil)
   assert(#trx.sound.samples == 1, "the fake level has exactly one sample")
 end)
@@ -18,7 +18,7 @@ test("a sample reports its definition and plays itself", function()
   assert(calls.play.count == 1)
   assert(calls.play.sfx_num == fake.SAMPLE)
   assert(voice ~= nil and voice:is_valid(), "play hands back the voice")
-  assert(voice.sample_id == fake.SAMPLE)
+  assert(voice.sample_num == fake.SAMPLE)
 end)
 
 test("play with no position plays at full volume", function()
@@ -62,7 +62,7 @@ test("streams reaches the playing voices and controls them", function()
   fake.set_stream(1, fake.SAMPLE)
   local voice = trx.sound.streams[2]
   assert(voice:is_valid(), "slot 1 is playing")
-  assert(voice.sample_id == fake.SAMPLE)
+  assert(voice.sample_num == fake.SAMPLE)
 
   voice:pause()
   voice:unpause()
@@ -102,7 +102,7 @@ test("a silent voice is stale, and reading it raises", function()
   local voice = trx.sound.streams[1]
   assert(not voice:is_valid(), "nothing plays on the first slot")
   raises(function()
-    return voice.sample_id
+    return voice.sample_num
   end)
 end)
 

--- a/src/tests/lua/seal.lua
+++ b/src/tests/lua/seal.lua
@@ -19,27 +19,14 @@ end)
 -- The declaring half of the registry goes the way trxc goes: a script cannot
 -- reach api.type to re-expose a member the declarations withheld, because there
 -- is nothing left to reach.
+-- Named rather than listed: a list of what goes has to be kept in step with
+-- every declarator added, and one left off it is one nobody notices survived.
 test("sealing takes the declaring half off trx.api", function()
   seal()
 
-  for _, name in ipairs({
-    "seal",
-    "module",
-    "define",
-    "type",
-    "enum",
-    "enum_name",
-    "const",
-    "property",
-    "namespace",
-    "container",
-    "describe",
-    "to_json",
-  }) do
-    assert(
-      trx.api[name] == nil,
-      "trx.api." .. name .. " must not survive the seal"
-    )
+  local kept = { strict = true, is_strict = true }
+  for name in pairs(trx.api) do
+    assert(kept[name], "trx.api." .. name .. " must not survive the seal")
   end
 
   assert(trx.items[0].box_num == nil, "box_num must still be unreachable")

--- a/src/tests/lua/seal.lua
+++ b/src/tests/lua/seal.lua
@@ -8,7 +8,7 @@ local test, raises = h.test, h.raises
 -- something any of them can ask for. It happens once, as it does at boot.
 local function seal()
   if trx.api.seal ~= nil then
-    trx.api.seal()
+    trx.api.seal({ partial = true })
   end
 end
 

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -129,6 +129,13 @@ b_console = {
   'src': ['fakes/console.c', 'fakes/locale.c'],
 }
 
+# The trig bridge. A module that hands back a math.Box needs trx.math loaded,
+# and loading it means its own declarations resolve, so the bridge comes along.
+b_lua_math = {
+  'engine': ['core/math/trig.c', 'game/lua/capi/math.c'],
+  'deps': [dep_mathlibrary],
+}
+
 # One stanza per test. `name` is the test source, minus its .c, and mirrors what
 # the test exercises: src/tests/trx/core/vector.c tests src/trx/core/vector.c,
 # and src/tests/lua/api/music.c stands trx.music up out of src/lua/api/music.lua.
@@ -292,7 +299,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/api/rooms',
-  'bundles': [b_lua_surface],
+  'bundles': [b_lua_surface, b_lua_math],
   'src': ['fakes/rooms.c', 'fakes/items.c'],
   'engine': [
     'game/lua/capi/events.c',
@@ -303,13 +310,13 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/api/items',
-  'bundles': [b_lua_surface, b_lua_strings],
+  'bundles': [b_lua_surface, b_lua_strings, b_lua_math],
   'src': ['fakes/items.c', 'fakes/catalog.c'],
   'engine': [
+    'game/lua/capi/catalog.c',
     'game/lua/capi/events.c',
     'game/lua/capi/items.c',
     'game/lua/capi/objects.c',
-    'game/lua/capi/catalog.c',
   ],
 }
 
@@ -317,7 +324,7 @@ unit_tests += {
 # short of: the seal, and hardening the globals.
 unit_tests += {
   'name': 'lua/boot',
-  'bundles': [b_lua_surface],
+  'bundles': [b_lua_surface, b_lua_math],
   'src': ['fakes/items.c'],
   'engine': ['game/lua/capi/items.c'],
 }
@@ -325,9 +332,7 @@ unit_tests += {
 # No fake engine: the real trig tables are the thing under test.
 unit_tests += {
   'name': 'lua/api/math',
-  'bundles': [b_lua_surface],
-  'engine': ['game/lua/capi/math.c', 'core/math/trig.c'],
-  'deps': [dep_mathlibrary],
+  'bundles': [b_lua_surface, b_lua_math],
 }
 
 unit_tests += {
@@ -340,14 +345,17 @@ unit_tests += {
 # rooms rides along: trx.camera.room hands back a trx.rooms.Room.
 unit_tests += {
   'name': 'lua/api/camera',
-  'bundles': [b_lua_surface],
+  'bundles': [b_lua_surface, b_lua_math],
   'src': [
     'fakes/camera.c',
     'fakes/rooms.c',
     # for Room_GetIndexFromPos, which rooms.c reaches for
     'fakes/items.c',
   ],
-  'engine': ['game/lua/capi/rooms.c', 'game/lua/capi/camera.c'],
+  'engine': [
+    'game/lua/capi/camera.c',
+    'game/lua/capi/rooms.c',
+  ],
 }
 
 unit_tests += {
@@ -444,7 +452,7 @@ unit_tests += {
 # The catalog rides along: the weapons a script names are its enum.
 unit_tests += {
   'name': 'lua/api/inventory',
-  'bundles': [b_lua_surface],
+  'bundles': [b_lua_surface, b_lua_math],
   'src': ['fakes/game.c', 'fakes/lara.c', 'fakes/items.c', 'fakes/catalog.c'],
   'engine': [
     'game/lua/capi/catalog.c',
@@ -456,7 +464,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/api/lara',
-  'bundles': [b_lua_surface],
+  'bundles': [b_lua_surface, b_lua_math],
   'src': ['fakes/lara.c', 'fakes/items.c', 'fakes/catalog.c'],
   'engine': [
     'game/lua/capi/catalog.c',
@@ -505,7 +513,7 @@ unit_tests += {
 # expected.
 unit_tests += {
   'name': 'lua/commands/heal',
-  'bundles': [b_lua_surface, b_console],
+  'bundles': [b_lua_surface, b_console, b_lua_math],
   'src': ['fakes/game.c', 'fakes/items.c', 'fakes/lara.c'],
   'engine': [
     'game/lua/capi/game.c',
@@ -574,7 +582,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/commands/teleport',
-  'bundles': [b_lua_surface, b_console, b_lua_strings],
+  'bundles': [b_lua_surface, b_console, b_lua_strings, b_lua_math],
   'src': [
     'fakes/camera.c',
     'fakes/catalog.c',
@@ -589,7 +597,6 @@ unit_tests += {
     'game/lua/capi/game.c',
     'game/lua/capi/items.c',
     'game/lua/capi/lara.c',
-    'game/lua/capi/math.c',
     'game/lua/capi/objects.c',
     'game/lua/capi/rooms.c',
     'core/math/trig.c',
@@ -631,7 +638,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/seal',
-  'bundles': [b_lua_surface],
+  'bundles': [b_lua_surface, b_lua_math],
   'src': ['fakes/items.c'],
   'engine': ['game/lua/capi/items.c'],
 }

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -29,6 +29,7 @@ def rendered(surface, module=None):
     when the next one renders.
     """
     for table in (
+        docs.ALIASES,
         docs.NUMBERS,
         docs.ANCHORS,
         docs.TYPE_PATHS,
@@ -228,6 +229,66 @@ class TestLuaDocs(unittest.TestCase):
         # A member that points nowhere reads as the type it declares.
         locked = next(line for line in page.splitlines() if "`locked`" in line)
         self.assertIn("**`locked`**: integer.", locked)
+
+    def test_a_reference_reads_short_only_among_members_of_one_thing(self):
+        """A path in prose is written in full and reads as far as it has to.
+
+        Between members of one type or group the name alone is enough, and the
+        module and the path it hangs off are noise. Anywhere else the reader
+        needs the whole path to know what is meant.
+        """
+        surface = copy.deepcopy(SURFACE)
+        surface["types"][0]["fields"][1]["description"] = (
+            "Set `trx.things.Widget.shown` instead, and see `trx.things.spawn`."
+        )
+        surface["functions"][0]["description"] = (
+            "Spawns a thing, of the shape `trx.things.Widget`."
+        )
+        docs.ANCHORS.update(docs.anchors_of(surface))
+        page = rendered(surface)
+
+        locked = next(line for line in page.splitlines() if "`locked`" in line)
+        self.assertIn("[`shown`](#things.Widget.shown)", locked)
+        self.assertIn("[`trx.things.spawn`](#things.spawn)", locked)
+
+        spawn = next(line for line in page.splitlines() if "Spawns a thing" in line)
+        self.assertIn("[`trx.things.Widget`](#things.Widget)", spawn)
+
+    def test_a_method_reference_reads_as_a_call(self):
+        """A method is pointed at the way a script writes it, with a colon."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["description"] = "As `trx.things.Widget:poke`."
+        docs.ANCHORS.update(docs.anchors_of(surface))
+        page = rendered(surface)
+        self.assertIn(
+            "[`trx.things.Widget:poke`](#things.Widget.poke)",
+            page,
+        )
+
+    def test_a_member_reached_through_its_module_links_to_its_declaration(self):
+        """A module that stands for one thing answers for its members.
+
+        A script writes `trx.lara.air` rather than the type's own path, and the
+        anchor is written once, where the type declares the member.
+        """
+        surface = copy.deepcopy(SURFACE)
+        surface["modules"][0]["instance_type"] = "things.Widget"
+        surface["functions"][0]["description"] = "As `trx.things.shown`."
+        docs.ANCHORS.update(docs.anchors_of(surface))
+        docs.ALIASES["things.shown"] = "things.Widget.shown"
+        page = rendered(surface)
+        self.assertIn("[`trx.things.shown`](#things.Widget.shown)", page)
+
+    def test_a_computed_property_links_what_it_names(self):
+        """A computed member's description is prose like any other."""
+        surface = copy.deepcopy(SURFACE)
+        surface["types"][0]["extensions"][0]["description"] = (
+            "Computed from `trx.things.Widget.shown`."
+        )
+        docs.ANCHORS.update(docs.anchors_of(surface))
+        page = rendered(surface)
+        derived = next(line for line in page.splitlines() if "`derived`" in line)
+        self.assertIn("[`shown`](#things.Widget.shown)", derived)
 
     def test_a_number_is_named_rather_than_described_again(self):
         """A declaration that holds a named number names it.
@@ -458,7 +519,7 @@ class TestLuaDocs(unittest.TestCase):
         surface["modules"][0]["title"] = "Thingamabobs"
         page = rendered(surface)
         self.assertIn("title: Thingamabobs", page)
-        self.assertIn("## Thingamabobs module", page)
+        self.assertIn("## " + docs.anchor("things") + "Thingamabobs module", page)
 
     def test_a_namespace_reaches_the_page_whether_or_not_it_is_callable(self):
         """A namespace gets its own bullet either way; only a callable one

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -11,6 +11,37 @@ from helper import load
 
 docs = load("lint/gen/lua_docs")
 
+
+# A catalog as the dump carries one: an enum of names, declared elsewhere.
+CATALOG = {
+    "path": "catalog.objects",
+    "description": "Every object the engine knows.",
+    "bulk": True,
+    "count": 2,
+    "names": ["WOLF", "BEAR"],
+}
+
+
+def rendered(surface, module=None):
+    """A page, rendered the way the tool renders one: dump read in first.
+
+    The tables are cleared first, so one test's surface is not still standing
+    when the next one renders.
+    """
+    for table in (
+        docs.NUMBERS,
+        docs.ANCHORS,
+        docs.TYPE_PATHS,
+        docs.STANDS_FOR,
+        docs.KEYED_BY,
+        docs.CONSTANTS,
+        docs.ENUM_PATHS,
+        docs.ENUM_CONSTANTS,
+    ):
+        table.clear()
+    docs.read(surface)
+    return docs.render_page(module or surface["modules"][0], surface)
+
 # A surface with one of everything, so the renderer has to handle each kind.
 SURFACE = {
     "modules": [{"name": "things", "order": 4, "description": "Things module."}],
@@ -21,10 +52,9 @@ SURFACE = {
             "fields": [
                 {
                     "name": "shown",
-                    "type": "integer",
+                    "type": "things.State",
                     "writable": True,
                     "description": "Visible value.",
-                    "enum": "things.State",
                 },
                 {
                     "name": "locked",
@@ -37,8 +67,14 @@ SURFACE = {
                 {
                     "name": "poke",
                     "description": "Pokes it.",
-                    "params": [{"name": "force", "type": "integer"}],
-                    "returns": {"type": "boolean"},
+                    "params": [
+                        {
+                            "name": "force",
+                            "type": "integer",
+                            "description": "How hard.",
+                        }
+                    ],
+                    "returns": {"type": "boolean", "description": "Whether it gave."},
                 }
             ],
             "extensions": [
@@ -47,6 +83,13 @@ SURFACE = {
         }
     ],
     "enums": [
+        {
+            "path": "catalog.objects",
+            "description": "Every object the engine knows.",
+            "bulk": True,
+            "count": 2,
+            "names": ["WOLF", "BEAR"],
+        },
         {
             "path": "things.State",
             "description": "A state.",
@@ -69,10 +112,9 @@ SURFACE = {
         },
         {
             "path": "things.power",
-            "type": "integer",
+            "type": "things.State",
             "writable": True,
             "description": "How strong it is.",
-            "enum": "things.State",
         },
     ],
     "functions": [
@@ -80,7 +122,7 @@ SURFACE = {
             "path": "things.spawn",
             "description": "Spawns a thing.",
             "params": [
-                {"name": "id", "type": "integer", "enum": "catalog.objects"},
+                {"name": "id", "type": "catalog.objects"},
                 {
                     "name": "angle",
                     "type": "integer",
@@ -89,7 +131,11 @@ SURFACE = {
                     "description": "Facing.",
                 },
             ],
-            "returns": {"type": "Widget", "nullable": True},
+            "returns": {
+                "type": "Widget",
+                "nullable": True,
+                "description": "The thing, or `nil` where none was free.",
+            },
             "examples": ["local w = trx.things.spawn(1)"],
         },
         {
@@ -108,14 +154,13 @@ SURFACE = {
                         },
                         {
                             "name": "id",
-                            "type": "integer",
-                            "enum": "catalog.objects",
+                            "type": "catalog.objects",
                             "description": "What was poked.",
                         },
                     ],
                 }
             ],
-            "returns": {"type": "integer"},
+            "returns": {"type": "integer", "description": "The handler's id."},
         },
     ],
 }
@@ -128,7 +173,7 @@ class TestLuaDocs(unittest.TestCase):
         Fields, computed members and methods all render, so nothing declared in
         the registry can go missing from the reference.
         """
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
 
         for spec in SURFACE["types"]:
             for kind in ("fields", "methods", "extensions"):
@@ -141,7 +186,7 @@ class TestLuaDocs(unittest.TestCase):
         for func in SURFACE["functions"]:
             self.assertIn(func["path"], page)
         for spec in SURFACE["enums"]:
-            for value in spec["values"]:
+            for value in spec.get("values") or []:
                 self.assertIn(
                     value["name"],
                     page,
@@ -154,7 +199,7 @@ class TestLuaDocs(unittest.TestCase):
         An enum reaches the docs only through the registry: the dump cannot see
         one pushed straight onto a module table.
         """
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertIn("### Enums", page)
         self.assertIn("`trx.things.State.OFF` = `0`", page)
         self.assertIn("`trx.things.State.ON` = `1`", page)
@@ -162,39 +207,130 @@ class TestLuaDocs(unittest.TestCase):
         self.assertIn("`trx.things.State.BROKEN` = `7`", page)
         self.assertIn("It is broken.", page)
 
-    def test_enum_cross_references_are_rendered(self):
-        """A field names the enum it accepts by path."""
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
-        shown = next(line for line in page.splitlines() if "`shown`" in line)
-        self.assertIn("Compare against `trx.things.State`.", shown)
-        # Params too, and the target need not be a registry enum: the catalog
-        # tables are CSV-driven, and a pointer at them is still worth rendering.
-        param = next(line for line in page.splitlines() if "**`id`**" in line)
-        self.assertIn("Compare against `trx.catalog.objects`.", param)
+    def test_a_number_that_names_an_enum_reads_as_that_enum(self):
+        """The enum a declaration points at is the type it reads as.
 
-        # A member with no enum must not grow the sentence.
+        `integer` says what the engine passes; the enum says what the value
+        means and lists what it can be, a link away.
+        """
+        surface = copy.deepcopy(SURFACE)
+        surface["enums"].append(CATALOG)
+        page = rendered(surface)
+        shown = next(line for line in page.splitlines() if "`shown`" in line)
+        self.assertIn("**`shown`**: [trx.things.State](#things.State).", shown)
+        # A catalog is an enum too, and the pages it links to sit elsewhere.
+        param = next(line for line in page.splitlines() if "**`id`**" in line)
+        self.assertIn(
+            "**`id`** ([trx.catalog.objects](CATALOG.md#catalog.objects))",
+            param,
+        )
+
+        # A member that points nowhere reads as the type it declares.
         locked = next(line for line in page.splitlines() if "`locked`" in line)
-        self.assertNotIn("Compare against", locked)
+        self.assertIn("**`locked`**: integer.", locked)
+
+    def test_a_number_is_named_rather_than_described_again(self):
+        """A declaration that holds a named number names it.
+
+        What a room number is, and where it counts from, is the number's own
+        business. What holds one says only what is its own, so the sentence is
+        written once however many places mean it.
+        """
+        surface = copy.deepcopy(SURFACE)
+        surface["numbers"] = [
+            {
+                "path": "things.Num",
+                "description": "Thing number, as the level numbers them.",
+                "base": 0,
+            }
+        ]
+        surface["functions"][0]["params"] = [
+            {"name": "num", "type": "things.Num"},
+            {
+                "name": "other",
+                "type": "things.Num",
+                "description": "The one that broke.",
+            },
+        ]
+        page = rendered(surface)
+
+        # The number renders among the structures, and says what it is once.
+        self.assertIn("### Structures", page)
+        self.assertIn(docs.anchor("things.Num"), page)
+        definition = next(
+            line
+            for line in page.splitlines()
+            if "Thing number, as the level numbers them." in line
+        )
+        self.assertIn("Counted from 0.", definition)
+
+        # What holds one names it as its type, and carries neither the
+        # sentence nor the base.
+        num = next(line for line in page.splitlines() if "**`num`**" in line)
+        self.assertIn("**`num`** ([trx.things.Num](#things.Num))", num)
+        self.assertNotIn("Thing number", num)
+        self.assertNotIn("Counted from", num)
+
+        other = next(line for line in page.splitlines() if "**`other`**" in line)
+        self.assertIn("([trx.things.Num](#things.Num)). The one that broke.", other)
+
+    def test_a_number_described_away_from_itself_is_reported(self):
+        """The three ways a named number gets copied instead of named."""
+        surface = copy.deepcopy(SURFACE)
+        surface["numbers"] = [
+            {
+                "path": "things.Num",
+                "description": "Thing number, as the level numbers them.",
+                "base": 0,
+            }
+        ]
+        surface["functions"][0]["params"] = [
+            {"name": "num", "type": "things.Num"},
+        ]
+        docs.read(surface)
+        self.assertEqual(docs.respelled(surface), [])
+
+        # Its words, written somewhere that does not name it.
+        said_again = copy.deepcopy(surface)
+        said_again["functions"][1]["description"] = (
+            "Takes a thing number, as the level numbers them."
+        )
+        report = docs.respelled(said_again)
+        self.assertEqual(len(report), 1, report)
+        self.assertIn("says what `trx.things.Num` says", report[0])
+
+        # A base of its own, beside a number that declares one.
+        rebased = copy.deepcopy(surface)
+        rebased["functions"][0]["params"][0]["base"] = 1
+        self.assertIn("counts from its own base", docs.respelled(rebased)[0])
+
+        # And a number nothing holds at all.
+        unheld = copy.deepcopy(surface)
+        unheld["functions"][0]["params"][0]["type"] = "integer"
+        self.assertIn("a number nothing holds", docs.respelled(unheld)[-1])
 
     def test_a_return_value_cross_references_its_enum(self):
         """A function that hands back an id is as worth cross-referencing as a
         param that takes one."""
         surface = copy.deepcopy(SURFACE)
         surface["functions"][0]["returns"] = {
-            "type": "integer",
-            "enum": "catalog.music",
+            "type": "catalog.music",
             "description": "The track.",
         }
-        page = docs.render_page(surface["modules"][0], surface)
+        surface["enums"].append({**CATALOG, "path": "catalog.music"})
+        page = rendered(surface)
         returns = next(
             line
             for line in page.splitlines()
             if "Returns:" in line and "The track." in line
         )
-        self.assertIn("Compare against `trx.catalog.music`.", returns)
+        self.assertIn(
+            "Returns: [trx.catalog.music](CATALOG.md#catalog.music).",
+            returns,
+        )
 
     def test_read_only_members_are_marked(self):
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         locked = next(
             line for line in page.splitlines() if "`locked`" in line
         )
@@ -203,7 +339,7 @@ class TestLuaDocs(unittest.TestCase):
         self.assertNotIn("read-only", shown)
 
     def test_optional_params_are_bracketed_with_their_default(self):
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertIn("things.spawn(id, [angle])", page)
         self.assertIn("default `0`", page)
 
@@ -212,13 +348,13 @@ class TestLuaDocs(unittest.TestCase):
         the wrapper substitutes. It has to read as the constant."""
         surface = copy.deepcopy(SURFACE)
         surface["functions"][0]["params"][1].update(
-            {"default": 1, "enum": "things.State"}
+            {"default": 1, "type": "things.State"}
         )
         docs.ENUM_CONSTANTS.clear()
         docs.ENUM_CONSTANTS["things.State"] = {0: "OFF", 1: "ON", 7: "BROKEN"}
 
-        page = docs.render_page(surface["modules"][0], surface)
-        self.assertIn("default `trx.things.State.ON`", page)
+        page = rendered(surface)
+        self.assertIn("default [`trx.things.State.ON`](#things.State)", page)
         self.assertNotIn("default `1`", page)
         docs.ENUM_CONSTANTS.clear()
 
@@ -231,7 +367,7 @@ class TestLuaDocs(unittest.TestCase):
             {"type": "integer", "description": "Which room."},
         ]
 
-        page = docs.render_page(surface["modules"][0], surface)
+        page = rendered(surface)
         self.assertIn("vec3 or `nil`. Where.", page)
         self.assertIn("integer. Which room.", page)
 
@@ -249,19 +385,21 @@ class TestLuaDocs(unittest.TestCase):
             }
         ]
 
-        page = docs.render_page(surface["modules"][0], surface)
+        page = rendered(surface)
         self.assertIn("### Indexing", page)
         self.assertIn("**`trx.things[key]`** (Widget or `nil`). 1-based.", page)
         self.assertIn("**`#trx.things`** (integer).", page)
 
     def test_a_module_with_no_container_gets_no_indexing_section(self):
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertNotIn("### Indexing", page)
 
     def test_a_callbacks_own_arguments_are_rendered(self):
         """A function-typed parameter renders the arguments it is called with,
         indented under the parameter itself."""
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        surface = copy.deepcopy(SURFACE)
+        surface["enums"].append(CATALOG)
+        page = rendered(surface)
         self.assertIn("Called with:", page)
         strength = next(
             line for line in page.splitlines() if "**`strength`**" in line
@@ -275,28 +413,31 @@ class TestLuaDocs(unittest.TestCase):
             len(strength) - len(strength.lstrip()),
             len(callback) - len(callback.lstrip()),
         )
-        # A callback argument gets the same enum cross-reference a param does.
+        # A callback argument is typed by the enum it names, as a param is.
         arg = next(line for line in page.splitlines() if "**`id`**" in line)
-        self.assertIn("Compare against `trx.catalog.objects`.", arg)
+        self.assertIn(
+            "**`id`** ([trx.catalog.objects](CATALOG.md#catalog.objects))",
+            arg,
+        )
 
     def test_a_param_with_no_callback_args_stays_flat(self):
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         angle = next(line for line in page.splitlines() if "**`angle`**" in line)
         self.assertNotIn("Called with:", angle)
 
     def test_nullable_returns_say_so(self):
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertIn("Widget or `nil`", page)
 
     def test_examples_are_rendered_as_lua_blocks(self):
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertIn("```lua", page)
         self.assertIn("trx.things.spawn(1)", page)
 
     def test_module_properties_are_rendered(self):
         """A module property reaches the page, marked read-only when it has no
         setter."""
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertIn("### Properties", page)
 
         pos = next(line for line in page.splitlines() if "`trx.things.pos`" in line)
@@ -305,17 +446,17 @@ class TestLuaDocs(unittest.TestCase):
 
         power = next(line for line in page.splitlines() if "`trx.things.power`" in line)
         self.assertNotIn("read-only", power)
-        self.assertIn("Compare against `trx.things.State`.", power)
+        self.assertIn("([trx.things.State](#things.State))", power)
 
     def test_a_module_may_override_its_title(self):
         """Capitalizing the module name gives "Log" and "Assault"; the pages are
         Logging and Assault course."""
-        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        page = rendered(SURFACE)
         self.assertIn("title: Things", page)
 
         surface = copy.deepcopy(SURFACE)
         surface["modules"][0]["title"] = "Thingamabobs"
-        page = docs.render_page(surface["modules"][0], surface)
+        page = rendered(surface)
         self.assertIn("title: Thingamabobs", page)
         self.assertIn("## Thingamabobs module", page)
 
@@ -327,7 +468,7 @@ class TestLuaDocs(unittest.TestCase):
             {"path": "things.log", "description": "Logs it.", "callable": True},
             {"path": "things.stats", "description": "Counts it.", "callable": False},
         ]
-        page = docs.render_page(surface["modules"][0], surface)
+        page = rendered(surface)
         self.assertIn("Logs it.", page)
         self.assertIn("Counts it.", page)
 
@@ -340,7 +481,7 @@ class TestLuaDocs(unittest.TestCase):
         """Every paragraph of a description stays indented inside its list item."""
         surface = copy.deepcopy(SURFACE)
         surface["functions"][0]["description"] = "First para.\n\nSecond para."
-        page = docs.render_page(surface["modules"][0], surface)
+        page = rendered(surface)
         second = next(line for line in page.splitlines() if "Second para." in line)
         self.assertTrue(
             second.startswith("  "), f"paragraph escaped its list item: {second!r}"
@@ -349,10 +490,10 @@ class TestLuaDocs(unittest.TestCase):
     def test_a_bulk_enum_lists_its_names_but_not_its_numbers(self):
         """A bulk enum renders a count and a folded name list, and no values."""
         surface = copy.deepcopy(SURFACE)
-        surface["enums"][0].update(
+        surface["enums"][1].update(
             {"bulk": True, "count": 3, "values": [], "names": ["BROKEN", "OFF", "ON"]}
         )
-        page = docs.render_page(surface["modules"][0], surface)
+        page = rendered(surface)
 
         self.assertIn("`trx.things.State` - 3 names", page)
         self.assertIn("`BROKEN`, `OFF`, `ON`", page)
@@ -363,19 +504,20 @@ class TestLuaDocs(unittest.TestCase):
 
     def test_rendering_is_stable(self):
         """Two runs must agree, or --check would flag spurious drift forever."""
-        a = docs.render_page(SURFACE["modules"][0], SURFACE)
-        b = docs.render_page(SURFACE["modules"][0], SURFACE)
+        a = rendered(SURFACE)
+        b = rendered(SURFACE)
         self.assertEqual(a, b)
 
     def test_a_declared_member_with_no_description_is_reported(self):
         """A member with no description still reaches scripts; it just renders
         blank."""
+        docs.read(SURFACE)
         self.assertEqual(docs.undocumented(SURFACE), [])
 
         cases = [
             (("functions", 0), "things.spawn"),
             (("constants", 0), "things.WALL_L"),
-            (("enums", 0, "values", 1), "things.State.ON"),
+            (("enums", 1, "values", 1), "things.State.ON"),
             (("types", 0, "fields", 0), "things.Widget.shown"),
             (("types", 0, "methods", 0), "things.Widget.poke"),
             (("types", 0, "extensions", 0), "things.Widget.derived"),
@@ -388,7 +530,20 @@ class TestLuaDocs(unittest.TestCase):
                 for key in path:
                     target = target[key]
                 del target["description"]
+                # A member that points somewhere is documented by what it
+                # points at, so only one with nothing at all is reported.
+                if target.get("type") in ("things.State", "catalog.objects"):
+                    target["type"] = "integer"
+                docs.read(surface)
                 self.assertEqual(docs.undocumented(surface), [expected])
+
+    def test_a_member_that_points_somewhere_is_documented(self):
+        """A `ref` says what the member is, so it is not missing prose."""
+        surface = copy.deepcopy(SURFACE)
+        del surface["properties"][0]["description"]
+        surface["properties"][0]["type"] = "things.State"
+        docs.read(surface)
+        self.assertEqual(docs.undocumented(surface), [])
 
     def test_dump_extracts_the_json_from_a_noisy_stream(self):
         """The JSON payload is picked out of a stream that also carries logs."""

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -290,6 +290,23 @@ class TestLuaDocs(unittest.TestCase):
         derived = next(line for line in page.splitlines() if "`derived`" in line)
         self.assertIn("[`shown`](#things.Widget.shown)", derived)
 
+    def test_a_page_of_the_manual_is_named_from_the_root(self):
+        """A description that points at a page names it where it lives.
+
+        Where the link lands is the generated page's business, and a page that
+        is not there is a broken link nobody would notice.
+        """
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["description"] = (
+            "Spawns it. See [Objects](docs/trx/OBJECTS.md)."
+        )
+        page = rendered(surface)
+        self.assertIn("See [Objects](../../OBJECTS.md).", page)
+
+        surface["functions"][0]["description"] = "See [Nope](docs/trx/NOPE.md)."
+        with self.assertRaises(SystemExit):
+            rendered(surface)
+
     def test_a_number_is_named_rather_than_described_again(self):
         """A declaration that holds a named number names it.
 
@@ -583,6 +600,10 @@ class TestLuaDocs(unittest.TestCase):
             (("types", 0, "methods", 0), "things.Widget.poke"),
             (("types", 0, "extensions", 0), "things.Widget.derived"),
             (("properties", 0), "things.pos"),
+            # An argument and a result are as blank as anything else without
+            # words of their own.
+            (("functions", 0, "params", 1), "things.spawn(angle)"),
+            (("types", 0, "methods", 0, "returns"), "things.Widget.poke returns boolean"),
         ]
         for path, expected in cases:
             with self.subTest(member=expected):
@@ -597,6 +618,54 @@ class TestLuaDocs(unittest.TestCase):
                     target["type"] = "integer"
                 docs.read(surface)
                 self.assertEqual(docs.undocumented(surface), [expected])
+
+    def test_a_backticked_name_that_points_nowhere_is_reported(self):
+        """A name in backticks reads as something to go and look at.
+
+        It is either a path the API declares, written in full, or a literal -
+        a file name, a config key, a value a setting takes - and saying which
+        is what the marker is for.
+        """
+        self.assertEqual(docs.unreferenced(SURFACE), [])
+
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["description"] = "Spawns it, as `spawn_thing` does."
+        report = docs.unreferenced(surface)
+        self.assertEqual(len(report), 1, report)
+        self.assertIn("things.spawn: `spawn_thing` names nothing.", report[0])
+
+        # Lua's own words and the types a declaration is written in are not
+        # references, and neither is anything that is not identifier-shaped.
+        for text in (
+            "Comes back as `nil`, or a `table` of `integer`.",
+            "Iterable with `pairs()`.",
+            "Answers `-h` and `--help`, e.g. `{ key, value }` or `1`.",
+            "One of `OFF` or `ON`.",
+        ):
+            with self.subTest(text=text):
+                surface = copy.deepcopy(SURFACE)
+                surface["functions"][0]["description"] = text
+                self.assertEqual(docs.unreferenced(surface), [])
+
+    def test_a_literal_is_marked_rather_than_left_loose(self):
+        """The marker waives the names it lists, and only those."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["description"] = (
+            "Reads `visuals.water_color`, and `other_key` too. "
+            "<!--noref: visuals.water_color-->"
+        )
+        report = docs.unreferenced(surface)
+        self.assertEqual(len(report), 1, report)
+        self.assertIn("`other_key` names nothing", report[0])
+
+        # What the marker waives is the author's business, not the reader's,
+        # so it comes off the page along with the space it sat in.
+        surface["functions"][0]["description"] = (
+            "Reads `visuals.water_color`. <!--noref: visuals.water_color--> Once."
+        )
+        page = rendered(surface)
+        self.assertIn("Reads `visuals.water_color`. Once.", page)
+        self.assertNotIn("noref", page)
 
     def test_a_member_that_points_somewhere_is_documented(self):
         """A `ref` says what the member is, so it is not missing prose."""

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -30,6 +30,7 @@ def rendered(surface, module=None):
     """
     for table in (
         docs.NUMBERS,
+        docs.UNITS,
         docs.ANCHORS,
         docs.TYPE_PATHS,
         docs.STANDS_FOR,
@@ -386,6 +387,52 @@ class TestLuaDocs(unittest.TestCase):
         unheld = copy.deepcopy(surface)
         unheld["functions"][0]["params"][0]["type"] = "integer"
         self.assertIn("a number nothing holds", docs.respelled(unheld)[-1])
+
+    def test_a_unit_written_out_instead_of_named_is_reported(self):
+        """A unit says what a value of it is measured in, once."""
+        surface = copy.deepcopy(SURFACE)
+        surface["units"] = [
+            {
+                "path": "things.Distance",
+                "description": "A length in the units the engine measures the world in.",
+                "type": "integer",
+                "spellings": ["world units"],
+            }
+        ]
+        surface["functions"][0]["params"] = [
+            {"name": "reach", "type": "things.Distance"},
+        ]
+        docs.read(surface)
+        self.assertEqual(docs.respelled(surface), [])
+
+        # The words, written somewhere that does not name the unit.
+        said_again = copy.deepcopy(surface)
+        said_again["functions"][1]["description"] = "How far it reaches, in world units."
+        report = docs.respelled(said_again)
+        self.assertEqual(len(report), 1, report)
+        self.assertIn("writes out what `trx.things.Distance` is", report[0])
+
+        # And a unit nothing is measured in.
+        unheld = copy.deepcopy(surface)
+        unheld["functions"][0]["params"][0]["type"] = "integer"
+        self.assertIn("a unit nothing is measured in", docs.respelled(unheld)[-1])
+
+    def test_a_declaration_typed_by_a_unit_needs_no_words(self):
+        """What it is, and what it is measured in, is what the type says."""
+        self.assertFalse(docs.documented({"name": "reach", "type": "integer"}))
+        docs.read(
+            {
+                **copy.deepcopy(SURFACE),
+                "units": [
+                    {
+                        "path": "things.Distance",
+                        "description": "A length.",
+                        "type": "integer",
+                    }
+                ],
+            }
+        )
+        self.assertTrue(docs.documented({"name": "reach", "type": "things.Distance"}))
 
     def test_a_return_value_cross_references_its_enum(self):
         """A function that hands back an id is as worth cross-referencing as a

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -29,7 +29,6 @@ def rendered(surface, module=None):
     when the next one renders.
     """
     for table in (
-        docs.ALIASES,
         docs.NUMBERS,
         docs.ANCHORS,
         docs.TYPE_PATHS,
@@ -38,6 +37,7 @@ def rendered(surface, module=None):
         docs.CONSTANTS,
         docs.ENUM_PATHS,
         docs.ENUM_CONSTANTS,
+        docs.ALIASES,
     ):
         table.clear()
     docs.read(surface)

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -73,13 +73,6 @@ static const char *M_SetFrame(void *const self, const TRX_VALUE *const in)
     return nullptr;
 }
 
-static bool M_GetRoomIndex(const void *const self, TRX_VALUE *const out)
-{
-    const ITEM *const item = self;
-    *out = (TRX_VALUE) { .type = TVT_S16, .as_int = item->room_num };
-    return true;
-}
-
 static bool M_GetIsAlive(const void *const self, TRX_VALUE *const out)
 {
     *out = (TRX_VALUE) { .type = TVT_BOOL, .as_bool = Item_IsAlive(self) };
@@ -223,16 +216,17 @@ static const char *M_SetName(void *const self, const TRX_VALUE *const in)
 
 // clang-format off
 static const FIELD_DESC m_Fields[] = {
-    // computed / validated
-    FIELD_FN("anim",        TVT_S16,  M_GetAnim,      M_SetAnim),
-    FIELD_FN("frame",       TVT_S16,  M_GetFrame,     M_SetFrame),
-    FIELD_FN("room_index",  TVT_S16,  M_GetRoomIndex, nullptr),
-    FIELD_FN("is_hostile",  TVT_BOOL, M_GetIsHostile, nullptr),
-    FIELD_FN("is_alive",    TVT_BOOL, M_GetIsAlive,   nullptr),
-    FIELD_FN("is_targetable", TVT_BOOL, M_GetIsTargetable, nullptr),
-    FIELD_FN("is_killed",   TVT_BOOL, M_GetIsKilled,  nullptr),
-    FIELD_FN("is_one_shot", TVT_BOOL, M_GetIsOneShot, M_SetIsOneShot),
-    FIELD_FN("index",       TVT_S16,  M_GetIndex,     nullptr),
+    // computed / validated. ITEM counts its animations and frames across the
+    // whole level; these count within the object and within the animation, so
+    // they take names of their own rather than shadowing the members.
+    FIELD_FN("relative_anim_num",  TVT_S16,  M_GetAnim,         M_SetAnim),
+    FIELD_FN("relative_frame_num", TVT_S16,  M_GetFrame,        M_SetFrame),
+    FIELD_FN("item_num",           TVT_S16,  M_GetIndex,        nullptr),
+    FIELD_FN("is_hostile",         TVT_BOOL, M_GetIsHostile,    nullptr),
+    FIELD_FN("is_alive",           TVT_BOOL, M_GetIsAlive,      nullptr),
+    FIELD_FN("is_targetable",      TVT_BOOL, M_GetIsTargetable, nullptr),
+    FIELD_FN("is_killed",          TVT_BOOL, M_GetIsKilled,     nullptr),
+    FIELD_FN("is_one_shot",        TVT_BOOL, M_GetIsOneShot,    M_SetIsOneShot),
 
     // the trigger state a door reads before it acts and a creature ignores
     FIELD_FN("is_triggered", TVT_BOOL, M_GetIsTriggered, nullptr),

--- a/src/trx/game/lua/capi/rooms.c
+++ b/src/trx/game/lua/capi/rooms.c
@@ -23,7 +23,7 @@ static bool M_GetIndex(const void *const self, TRX_VALUE *const out)
 
 // clang-format off
 static const FIELD_DESC m_Fields[] = {
-    FIELD_FN("room_index", TVT_S16, M_GetIndex, nullptr),
+    FIELD_FN("room_num", TVT_S16, M_GetIndex, nullptr),
 
     FIELD(ROOM, flags.underwater),
     FIELD(ROOM, flags.wind),

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -48,16 +49,174 @@ def signature(path: str, params: list[dict] | None) -> str:
     return f"{path}({', '.join(parts)})"
 
 
-def describe(spec: dict) -> str:
-    """The description, plus the enum cross-reference if the spec names one.
+# path -> the number it declares, filled in from the dump before any page is
+# rendered. What holds one is typed by it, and says only what is its own.
+NUMBERS: dict[str, dict] = {}
 
-    `enum` is a fully-qualified path - "items.Status", "catalog.objects" - so a
-    field or param points at the constants it accepts instead of spelling them
-    out in prose that has to be kept in sync by hand.
+
+# The page being written, so a link knows whether it has to cross a file.
+PAGE = ""
+
+# Every path the dump says can be pointed at, and the subset of them that are
+# types. Both come from the dump: what exists is decided where things are
+# declared, and nothing here guesses at a name.
+ANCHORS: set[str] = set()
+TYPE_PATHS: set[str] = set()
+# path -> the declared type it hands back, and module -> the enum its container
+# is keyed by. Both come from the declarations, and both are what lets a written
+# path be walked rather than guessed at.
+STANDS_FOR: dict[str, str] = {}
+KEYED_BY: dict[str, str] = {}
+# enum path -> its constants, upper-cased. A catalog runs to hundreds of them,
+# so they are not anchored one by one and a constant links to its enum.
+CONSTANTS: dict[str, set[str]] = {}
+# Every declared enum, so a declaration that points at one is typed by it.
+ENUM_PATHS: set[str] = set()
+def anchor(path: str) -> str:
+    """The name a declaration is linked to, and the page it lives on.
+
+    A path is 'module.rest', and a module owns one page, so the module names
+    the file and the whole path names the anchor within it. Anchors are written
+    out rather than left to the renderer's heading ids: those move when a
+    heading is reworded, and a link into another page would move with it.
+
+    Both spellings are written. A fragment matches an `id` in HTML5, while
+    `name` is what a renderer that predates it looks for, and which of the two
+    survives depends on what the markdown is put through.
     """
-    desc = spec.get("description") or ""
-    if spec.get("enum"):
-        desc = f"{desc} Compare against `trx.{spec['enum']}`.".lstrip()
+    return f'<a name="{path}"></a>'
+
+
+def link(path: str, text: str) -> str:
+    """A link to a declaration, from a page that may or may not be its own."""
+    module = path.split(".", 1)[0]
+    target = "" if module.upper() == PAGE else f"{module.upper()}.md"
+    return f"[{text}]({target}#{path})"
+
+
+REFERENCE_RE = re.compile(r"(?<!\[)`trx\.([A-Za-z0-9_.]+?)`")
+
+
+def anchors_of(api: dict) -> set[str]:
+    """Every path a declaration can be pointed at by.
+
+    Read off the declarations themselves rather than a list beside them: what
+    exists is what was declared, and a second copy of that is a second thing to
+    keep in step. A module that stands for one thing answers for its members
+    too, since a script writes `trx.lara.air` and not the type's own path.
+    """
+    out = {module["name"] for module in api["modules"]}
+    for group in ("numbers", "enums", "functions", "properties", "namespaces", "constants"):
+        out.update(entry["path"] for entry in api.get(group, []))
+    members: dict[str, list[str]] = {}
+    for spec in api.get("types", []):
+        out.add(spec["path"])
+        members[spec["path"]] = [
+            member["name"]
+            for kind in ("fields", "methods", "extensions")
+            for member in spec.get(kind) or []
+        ]
+        out.update(f"{spec['path']}.{name}" for name in members[spec["path"]])
+    for module in api["modules"]:
+        stands_for = module.get("instance_type")
+        for name in members.get(stands_for, []):
+            out.add(f"{module['name']}.{name}")
+    return out
+
+
+def anchored(path: str) -> str:
+    """Where a written path lands, walked a segment at a time.
+
+    Through the thing itself where it is anchored, through what it hands back
+    where that is a type of its own - `trx.stats.pickups.count` - and through
+    the constants of an enum, whether they are its own or the ones its
+    container is keyed by: `trx.objects.wolf`. Nothing is guessed. A path that
+    lands nowhere has been renamed or was never there, and the engine refuses
+    to dump one, so neither side is the lenient one.
+    """
+    if path in ANCHORS:
+        return path
+    parts = path.split(".")
+    at = parts[0]
+    if at not in ANCHORS:
+        raise SystemExit(unknown(path))
+    for step in parts[1:]:
+        if f"{at}.{step}" in ANCHORS:
+            at = f"{at}.{step}"
+        elif f"{STANDS_FOR.get(at, '')}.{step}" in ANCHORS:
+            at = f"{STANDS_FOR[at]}.{step}"
+        elif step.upper() in CONSTANTS.get(KEYED_BY.get(at, ""), set()):
+            return at
+        elif step.upper() in CONSTANTS.get(at, set()):
+            return at
+        else:
+            raise SystemExit(unknown(path))
+    return at
+
+
+def unknown(path: str) -> str:
+    return (
+        f"error: `trx.{path}` names nothing the API declares.\n"
+        f"  fix the reference in src/lua/api/, or declare what it names"
+    )
+
+
+def linked_prose(text: str) -> str:
+    """Prose with every `trx....` it names turned into a link.
+
+    A description names the thing it is talking about, so the link is already
+    written; it is only missing its destination. Descriptions carry no fenced
+    code, and an example is a field of its own, so nothing inside sample code
+    is reached from here.
+    """
+
+    def one(match: re.Match) -> str:
+        return link(anchored(match.group(1)), match.group(0))
+
+    return REFERENCE_RE.sub(one, text)
+
+
+def typed(spec: dict) -> str:
+    """The type a declaration reads as.
+
+    A number that names an enum is that enum: `trx.assault.Track` says what
+    `integer` does not, and the constants are a link away.
+    """
+    return type_names(spec["type"])
+
+
+def type_names(name) -> str:
+    """What a declaration accepts: one type, or the several a key answers to."""
+    if isinstance(name, list):
+        return " or ".join(type_name(one) for one in name)
+    return type_name(name)
+
+
+def type_name(name: str) -> str:
+    """A type as the reader would write it, linked to where it is declared.
+
+    A declared type is named by its path, and reads as `trx.items.Item`. So is
+    an enum and a number: what a declaration is typed by is what it means. A
+    primitive - integer, table, vec3 - has no declaration and stays as it is.
+    """
+    if name in TYPE_PATHS or name in ENUM_PATHS or name in NUMBERS:
+        return link(name, f"trx.{name}")
+    if "." in name:
+        raise SystemExit(f"error: type `{name}` names no declared type")
+    return name
+
+
+def describe(spec: dict) -> str:
+    """What the spec says, and what it says by what it is typed by.
+
+    A number says what it counts and where it counts from, once, where it is
+    declared. What holds one is typed by it and says only what is its own, so
+    nothing here reaches for someone else's words.
+    """
+    desc = linked_prose(spec.get("description") or "")
+    base = spec.get("base")
+    if base is not None:
+        desc = f"{desc} Counted from {base}.".lstrip()
     return desc
 
 
@@ -75,7 +234,7 @@ def render_callback_args(param: dict, indent: str) -> list[str]:
     for arg in args:
         out.extend(
             render_lead(
-                f"{indent}- **`{arg['name']}`** ({arg['type']}). ",
+                f"{indent}- **`{arg['name']}`** ({typed(arg)}). ",
                 describe(arg),
                 f"{indent}  ",
             )
@@ -90,7 +249,9 @@ def render_prose(text: str, indent: str) -> list[str]:
     would end the list at the blank line and dump the rest at the page's top
     level.
     """
-    return [f"{indent}{line}".rstrip() for line in text.splitlines()]
+    return [
+        f"{indent}{line}".rstrip() for line in linked_prose(text).splitlines()
+    ]
 
 
 def render_lead(head: str, text: str, indent: str) -> list[str]:
@@ -111,18 +272,39 @@ def render_lead(head: str, text: str, indent: str) -> list[str]:
 ENUM_CONSTANTS: dict[str, dict[int, str]] = {}
 
 
-def render_default(param: dict) -> str:
+def render_default(spec: dict) -> str:
     """The default as a script would write it.
 
     A default that names an enum constant is stored as the constant's value,
     since that is what the wrapper substitutes when the argument is omitted. It
-    reads as the constant.
+    reads as the constant, and links to the enum, which is where the constants
+    are listed.
     """
-    default = param.get("default")
-    constants = ENUM_CONSTANTS.get(param.get("enum", ""), {})
-    if default in constants:
-        return f"trx.{param['enum']}.{constants[default]}"
-    return str(default)
+    default = spec.get("default")
+    named = spec.get("type", "")
+    if isinstance(named, list):
+        named = ""
+    constants = ENUM_CONSTANTS.get(named, {})
+    if default in constants and not isinstance(default, bool):
+        return link(named, f"`trx.{named}.{constants[default]}`")
+    if isinstance(default, bool):
+        return "`true`" if default else "`false`"
+    if isinstance(default, str):
+        return f'`"{default}"`'
+    return f"`{default}`"
+
+
+def render_bits(spec: dict) -> str:
+    """The type a member takes, and whether it may be left out."""
+    bits = [typed(spec)]
+    if spec.get("optional"):
+        default = spec.get("default")
+        bits.append(
+            "optional"
+            if default is None
+            else f"optional, default {render_default(spec)}"
+        )
+    return ", ".join(bits)
 
 
 def render_params(params: list[dict] | None, indent: str) -> list[str]:
@@ -130,17 +312,9 @@ def render_params(params: list[dict] | None, indent: str) -> list[str]:
         return []
     out = ["", f"{indent}Parameters:"]
     for param in params:
-        bits = [param["type"]]
-        if param.get("optional"):
-            default = param.get("default")
-            bits.append(
-                "optional"
-                if default is None
-                else f"optional, default `{render_default(param)}`"
-            )
         out.extend(
             render_lead(
-                f"{indent}- **`{param['name']}`** ({', '.join(bits)}). ",
+                f"{indent}- **`{param['name']}`** ({render_bits(param)}). ",
                 describe(param),
                 f"{indent}  ",
             )
@@ -150,7 +324,7 @@ def render_params(params: list[dict] | None, indent: str) -> list[str]:
 
 
 def one_return(spec: dict) -> str:
-    bits = [spec["type"]]
+    bits = [typed(spec)]
     if spec.get("nullable"):
         bits.append("or `nil`")
     return f"{' '.join(bits)}. {describe(spec)}".rstrip()
@@ -161,7 +335,8 @@ def render_returns(returns: dict | list | None, indent: str) -> list[str]:
     if not returns:
         return []
     if isinstance(returns, dict):
-        return ["", *render_lead(f"{indent}Returns: ", one_return(returns), f"{indent}  ")]
+        out = ["", *render_lead(f"{indent}Returns: ", one_return(returns), f"{indent}  ")]
+        return out
     out = ["", f"{indent}Returns:"]
     for spec in returns:
         out.extend(render_lead(f"{indent}- ", one_return(spec), f"{indent}  "))
@@ -180,7 +355,10 @@ def render_examples(examples: list[str] | None, indent: str) -> list[str]:
 
 
 def render_function(func: dict) -> list[str]:
-    out = [f"- [lua]`trx.{signature(func['path'], func.get('params'))}`  "]
+    out = [
+        f"- {anchor(func['path'])}[lua]"
+        f"`trx.{signature(func['path'], func.get('params'))}`  "
+    ]
     if func.get("description"):
         out.extend(render_prose(func["description"], "  "))
     out.extend(render_params(func.get("params"), "  "))
@@ -199,9 +377,12 @@ def render_namespace(spec: dict) -> list[str]:
     called directly.
     """
     if spec.get("callable"):
-        head = f"- [lua]`trx.{signature(spec['path'], spec.get('params'))}`  "
+        head = (
+            f"- {anchor(spec['path'])}[lua]"
+            f"`trx.{signature(spec['path'], spec.get('params'))}`  "
+        )
     else:
-        head = f"- [lua]`trx.{spec['path']}`  "
+        head = f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}`  "
     out = [head]
     if spec.get("description"):
         out.extend(render_prose(spec["description"], "  "))
@@ -213,7 +394,9 @@ def render_namespace(spec: dict) -> list[str]:
 
 
 def render_const(spec: dict) -> list[str]:
-    out = [f"- [lua]`trx.{spec['path']}` = `{spec['value']}`  "]
+    out = [
+        f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}` = `{spec['value']}`  "
+    ]
     if spec.get("description"):
         out.extend(render_prose(spec["description"], "  "))
     out.append("")
@@ -241,7 +424,7 @@ def render_enum(spec: dict) -> list[str]:
     # A bulk enum is described as a whole: a count and a folded list of names,
     # rather than several hundred bullet points. The values stay out.
     if spec.get("bulk"):
-        head = f"- [lua]`trx.{spec['path']}`"
+        head = f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}`"
         count = spec.get("count")
         if count:
             head += f" - {count} names"
@@ -254,7 +437,7 @@ def render_enum(spec: dict) -> list[str]:
         out.append("")
         return out
 
-    out = [f"- [lua]`trx.{spec['path']}`", ""]
+    out = [f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}`", ""]
     if spec.get("description"):
         out.extend(render_prose(spec["description"], INDENT))
         out.append("")
@@ -272,14 +455,15 @@ def render_property(spec: dict) -> list[str]:
     """
     suffix = "" if spec.get("writable") else " *(read-only)*"
     return render_lead(
-        f"- **`trx.{spec['path']}`** ({spec['type']}). ",
-        f"{describe(spec)}{suffix}",
+        f"- {anchor(spec['path'])}**`trx.{spec['path']}`** "
+        f"({typed(spec)}). ",
+        f"{describe(spec)}{suffix}".lstrip(),
         "  ",
     )
 
 
 def render_type(spec: dict) -> list[str]:
-    out = [f"- [lua]`trx.{spec['path']}`", ""]
+    out = [f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}`", ""]
     if spec.get("description"):
         out.extend(render_prose(spec["description"], INDENT))
         out.append("")
@@ -299,8 +483,9 @@ def render_type(spec: dict) -> list[str]:
             suffix = "" if field.get("writable") else " *(read-only)*"
             out.extend(
                 render_lead(
-                    f"{INDENT}- **`{field['name']}`**: {field['type']}. ",
-                    f"{describe(field)}{suffix}",
+                    f"{INDENT}- {anchor(spec['path'] + '.' + field['name'])}"
+                    f"**`{field['name']}`**: {typed(field)}. ",
+                    f"{describe(field)}{suffix}".lstrip(),
                     f"{INDENT}  ",
                 )
             )
@@ -311,7 +496,8 @@ def render_type(spec: dict) -> list[str]:
         for ext in spec["extensions"]:
             out.extend(
                 render_lead(
-                    f"{INDENT}- **`{ext['name']}`**: {ext['type']}. ",
+                    f"{INDENT}- {anchor(spec['path'] + '.' + ext['name'])}"
+                    f"**`{ext['name']}`**: {typed(ext)}. ",
                     ext.get("description") or "",
                     f"{INDENT}  ",
                 )
@@ -338,7 +524,8 @@ def render_type(spec: dict) -> list[str]:
     for method in spec.get("methods") or []:
         name = spec["path"].rsplit(".", 1)[-1].lower()
         out.append(
-            f"{INDENT}- [lua]`{name}:{signature(method['name'], method.get('params'))}`  "
+            f"{INDENT}- {anchor(spec['path'] + '.' + method['name'])}"
+            f"[lua]`{name}:{signature(method['name'], method.get('params'))}`  "
         )
         if method.get("description"):
             out.extend(render_prose(method["description"], f"{INDENT}  "))
@@ -358,7 +545,8 @@ def render_container(name: str, spec: dict) -> list[str]:
         out.append("")
     out.extend(
         render_lead(
-            f"- **`trx.{name}[key]`** ({value['type']}{nullable}). ",
+            f"- {anchor(name + '[]')}**`trx.{name}[key]`** "
+            f"({typed(value)}{nullable}). ",
             describe(key),
             "  ",
         )
@@ -370,8 +558,23 @@ def render_container(name: str, spec: dict) -> list[str]:
     return out
 
 
+def render_number(number: dict) -> list[str]:
+    """A named number: what it counts and where it counts from.
+
+    It is a type like any other - what a room number is is not the business of
+    the thirteen declarations that hold one - so it renders among them, and
+    everything that holds one names it and says only what is its own.
+    """
+    out = [f"- {anchor(number['path'])}[lua]`trx.{number['path']}`", ""]
+    out.extend(render_prose(describe(number), INDENT))
+    out.append("")
+    return out
+
+
 def render_page(module: dict, api: dict) -> str:
+    global PAGE
     name = module["name"]
+    PAGE = name.upper()
     # Declare a title where capitalizing the module name makes a worse one.
     title = module.get("title") or name.capitalize()
     out = [
@@ -391,8 +594,12 @@ def render_page(module: dict, api: dict) -> str:
         "",
     ]
     if module.get("description"):
-        out.append(module["description"])
+        out.extend(render_prose(module["description"], ""))
         out.append("")
+
+    numbers = [
+        n for n in api.get("numbers", []) if n["path"].startswith(f"{name}.")
+    ]
 
     container = next(
         (c for c in api.get("containers", []) if c["module"] == name), None
@@ -431,9 +638,11 @@ def render_page(module: dict, api: dict) -> str:
             out.extend(render_enum(spec))
 
     types = [t for t in api["types"] if t["path"].startswith(f"{name}.")]
-    if types:
+    if types or numbers:
         out.append("### Structures")
         out.append("")
+        for number in numbers:
+            out.extend(render_number(number))
         for spec in types:
             out.extend(render_type(spec))
 
@@ -449,17 +658,78 @@ def render_page(module: dict, api: dict) -> str:
     return "\n".join(out).rstrip() + "\n"
 
 
+def read(api: dict) -> None:
+    """Fill the tables a page is rendered against, from the dump.
+
+    Everything the renderer needs beyond the entry in front of it - what
+    exists, what stands for what, what an enum holds - is read off the dump
+    once, here, so a caller that renders a page renders what the tool does.
+    """
+    ENUM_PATHS.update(enum["path"] for enum in api.get("enums", []))
+    for enum in api.get("enums", []):
+        ENUM_CONSTANTS[enum["path"]] = {
+            value["value"]: value["name"] for value in enum.get("values", [])
+        }
+    for number in api.get("numbers", []):
+        NUMBERS[number["path"]] = number
+    for spec in api.get("types", []):
+        TYPE_PATHS.add(spec["path"])
+        for kind in ("fields", "extensions"):
+            for member in spec.get(kind) or []:
+                STANDS_FOR[f"{spec['path']}.{member['name']}"] = member.get("type")
+    ANCHORS.update(anchors_of(api))
+    for prop in api.get("properties", []):
+        STANDS_FOR[prop["path"]] = prop["type"]
+    for module in api["modules"]:
+        # A module standing for one thing answers for its members, so a path
+        # walked through the module walks on through the type it stands for.
+        stands_for = module.get("instance_type")
+        if stands_for is None:
+            continue
+        spec = next(s for s in api["types"] if s["path"] == stands_for)
+        for kind in ("fields", "extensions"):
+            for member in spec.get(kind) or []:
+                STANDS_FOR[f"{module['name']}.{member['name']}"] = member.get("type")
+    for container in api.get("containers", []):
+        accepted = (container.get("key") or {}).get("type")
+        if isinstance(accepted, list):
+            accepted = next((one for one in accepted if one in ENUM_PATHS), None)
+        if accepted:
+            KEYED_BY[container["module"]] = accepted
+    for enum in api.get("enums", []):
+        ENUM_PATHS.add(enum["path"])
+        CONSTANTS[enum["path"]] = {
+            name.upper()
+            for name in (enum.get("names") or [])
+            + [v["name"] for v in enum.get("values") or []]
+        }
+
+
+def documented(spec: dict) -> bool:
+    """Whether the reader is told anything: its own words, or the type it holds.
+
+    A declaration typed by an enum or a number needs no words of its own: what
+    it is, and what it may be, is what the type says.
+    """
+    if spec.get("description"):
+        return True
+    named = spec.get("type")
+    if isinstance(named, list):
+        return True
+    return named in ENUM_PATHS or named in NUMBERS
+
+
 def undocumented(api: dict) -> list[str]:
-    """Declared names carrying no description - they render as a blank line."""
+    """Declared names that say nothing - they render as a blank line."""
     out = []
     for func in api.get("functions", []):
-        if not func.get("description"):
+        if not documented(func):
             out.append(func["path"])
     for const in api.get("constants", []):
-        if not const.get("description"):
+        if not documented(const):
             out.append(const["path"])
     for prop in api.get("properties", []):
-        if not prop.get("description"):
+        if not documented(prop):
             out.append(prop["path"])
     for space in api.get("namespaces", []):
         # A property group renders as its members, so it has no prose of its own.
@@ -475,8 +745,89 @@ def undocumented(api: dict) -> list[str]:
     for spec in api.get("types", []):
         for kind in ("fields", "methods", "extensions", "operators"):
             for member in spec.get(kind) or []:
-                if not member.get("description"):
+                if not documented(member):
                     out.append(f"{spec['path']}.{member['name']}")
+    return out
+
+
+def respelled(api: dict) -> list[str]:
+    """Where a number's own words are written somewhere other than the number.
+
+    A named number says what it counts and where it counts from, once. A
+    declaration that holds one names it and says only what is its own, so the
+    same sentence written again is a copy that will drift, and a base written
+    again is one that can disagree.
+    """
+    numbers = {number["path"]: number for number in api.get("numbers", [])}
+    # The first clause is the sentence's claim: "Room number", "Cutscene
+    # number". What follows it is detail nobody would repeat by accident.
+    claims = {
+        path: re.split(r"[,.]", number["description"])[0].strip().lower()
+        for path, number in numbers.items()
+    }
+    pointed = set()
+    out = []
+
+    def check(spec: dict, where: str) -> None:
+        if not isinstance(spec, dict):
+            return
+        named = spec.get("type")
+        if isinstance(named, list):
+            named = None
+        if named in numbers:
+            pointed.add(named)
+            if spec.get("base") is not None:
+                out.append(
+                    f"{where}: counts from its own base while naming "
+                    f"`trx.{named}`, which declares one"
+                )
+        text = (spec.get("description") or "").lower()
+        for path, claim in claims.items():
+            if claim and claim in text and named != path:
+                out.append(
+                    f"{where}: says what `trx.{path}` says.\n"
+                    f"    name the number - type it `trx.{path}` - and say only "
+                    f"what is this one's own"
+                )
+
+    for where, spec in walk(api):
+        check(spec, where)
+    for path in numbers:
+        if path not in pointed:
+            out.append(f"{path}: a number nothing holds. Delete it, or type what holds one")
+    return out
+
+
+def walk(api: dict) -> list[tuple[str, dict]]:
+    """Every spec the dump carries, and the declaration it belongs to."""
+    out: list[tuple[str, dict]] = []
+
+    def rec(spec: dict, where: str) -> None:
+        if not isinstance(spec, dict):
+            return
+        out.append((where, spec))
+        for param in spec.get("params") or []:
+            rec(param, f"{where}({param.get('name')})")
+        for field in spec.get("fields") or []:
+            if isinstance(field, dict) and "name" in field:
+                rec(field, f"{where}.{field['name']}")
+        returns = spec.get("returns")
+        for one in (
+            returns if isinstance(returns, list) else [returns] if returns else []
+        ):
+            rec(one, f"{where} returns")
+        for kind in ("methods", "extensions", "values"):
+            for member in spec.get(kind) or []:
+                if isinstance(member, dict):
+                    rec(member, f"{where}.{member.get('name')}")
+
+    for group in ("modules", "functions", "properties", "namespaces", "constants", "enums", "types"):
+        for entry in api.get(group, []):
+            rec(entry, entry.get("path") or entry.get("name"))
+    for container in api.get("containers", []):
+        for side in ("key", "value"):
+            if container.get(side):
+                rec(container[side], f"{container['module']}[{side}]")
     return out
 
 
@@ -532,10 +883,7 @@ def main() -> int:
         )
     api = json.loads(API_JSON.read_text())
 
-    for enum in api.get("enums", []):
-        ENUM_CONSTANTS[enum["path"]] = {
-            value["value"]: value["name"] for value in enum.get("values", [])
-        }
+    read(api)
 
     blank = undocumented(api)
     if blank:
@@ -543,6 +891,14 @@ def main() -> int:
         for path in blank:
             print(f"  {path}", file=sys.stderr)
         print("document it in src/lua/api/, next to the declaration", file=sys.stderr)
+        return 1
+
+
+    copied = respelled(api)
+    if copied:
+        print("error: a number is described away from itself:", file=sys.stderr)
+        for report in copied:
+            print(f"  {report}", file=sys.stderr)
         return 1
 
     stale = []

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -57,6 +57,10 @@ NUMBERS: dict[str, dict] = {}
 # The page being written, so a link knows whether it has to cross a file.
 PAGE = ""
 
+# The declaration being written, so a link to something near it can read as
+# near. A description is written against the thing it belongs to.
+CONTEXT = ""
+
 # Every path the dump says can be pointed at, and the subset of them that are
 # types. Both come from the dump: what exists is decided where things are
 # declared, and nothing here guesses at a name.
@@ -70,6 +74,10 @@ KEYED_BY: dict[str, str] = {}
 # enum path -> its constants, upper-cased. A catalog runs to hundreds of them,
 # so they are not anchored one by one and a constant links to its enum.
 CONSTANTS: dict[str, set[str]] = {}
+# A member reached through a module that stands for one thing -
+# `trx.lara.air` - to where the type it stands for declares it. The anchor is
+# written once, at the declaration, so that is where the link has to go.
+ALIASES: dict[str, str] = {}
 # Every declared enum, so a declaration that points at one is typed by it.
 ENUM_PATHS: set[str] = set()
 def anchor(path: str) -> str:
@@ -84,7 +92,7 @@ def anchor(path: str) -> str:
     `name` is what a renderer that predates it looks for, and which of the two
     survives depends on what the markdown is put through.
     """
-    return f'<a name="{path}"></a>'
+    return f'<a id="{path}" name="{path}"></a>'
 
 
 def link(path: str, text: str) -> str:
@@ -94,7 +102,38 @@ def link(path: str, text: str) -> str:
     return f"[{text}]({target}#{path})"
 
 
-REFERENCE_RE = re.compile(r"(?<!\[)`trx\.([A-Za-z0-9_.]+?)`")
+REFERENCE_RE = re.compile(r"(?<!\[)`trx\.([A-Za-z0-9_.:]+?)`")
+
+
+def segments(path: str) -> list[str]:
+    """A written path split into its parts, each carrying the separator before it.
+
+    A method is written the way it is called, with a colon - `trx.items.Item:num`
+    - so the separator is part of what the reader sees and has to survive being
+    taken apart.
+    """
+    return re.findall(r"[.:]?[A-Za-z0-9_]+", path)
+
+def shortened(path: str) -> str:
+    """How a written path reads from where it is written.
+
+    A declaration names what it points at in full, so the link has somewhere to
+    go and the reference survives a rename. What the reader sees is measured
+    against the declaration being described: a member of the same type or group
+    reads as its own name, anything else as the whole path. Sharing a module is
+    not enough - `trx.game.levels` says what `levels` on its own does not.
+    """
+    written = segments(path)
+    here = segments(CONTEXT)
+    shared = 0
+    while (
+        shared < min(len(written) - 1, len(here))
+        and written[shared].lstrip(".:") == here[shared].lstrip(".:")
+    ):
+        shared += 1
+    if shared < 2:
+        return f"trx.{path}"
+    return "".join(written[shared:]).lstrip(".:")
 
 
 def anchors_of(api: dict) -> set[str]:
@@ -134,8 +173,9 @@ def anchored(path: str) -> str:
     lands nowhere has been renamed or was never there, and the engine refuses
     to dump one, so neither side is the lenient one.
     """
+    path = path.replace(":", ".")
     if path in ANCHORS:
-        return path
+        return ALIASES.get(path, path)
     parts = path.split(".")
     at = parts[0]
     if at not in ANCHORS:
@@ -171,7 +211,8 @@ def linked_prose(text: str) -> str:
     """
 
     def one(match: re.Match) -> str:
-        return link(anchored(match.group(1)), match.group(0))
+        written = match.group(1)
+        return link(anchored(written), f"`{shortened(written)}`")
 
     return REFERENCE_RE.sub(one, text)
 
@@ -204,6 +245,12 @@ def type_name(name: str) -> str:
     if "." in name:
         raise SystemExit(f"error: type `{name}` names no declared type")
     return name
+
+
+def at(path: str) -> None:
+    """Name the declaration the descriptions that follow are written against."""
+    global CONTEXT
+    CONTEXT = path
 
 
 def describe(spec: dict) -> str:
@@ -355,6 +402,7 @@ def render_examples(examples: list[str] | None, indent: str) -> list[str]:
 
 
 def render_function(func: dict) -> list[str]:
+    at(func["path"])
     out = [
         f"- {anchor(func['path'])}[lua]"
         f"`trx.{signature(func['path'], func.get('params'))}`  "
@@ -376,6 +424,7 @@ def render_namespace(spec: dict) -> list[str]:
     the group's own description, and, when it is callable, that the group may be
     called directly.
     """
+    at(spec["path"])
     if spec.get("callable"):
         head = (
             f"- {anchor(spec['path'])}[lua]"
@@ -394,6 +443,7 @@ def render_namespace(spec: dict) -> list[str]:
 
 
 def render_const(spec: dict) -> list[str]:
+    at(spec["path"])
     out = [
         f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}` = `{spec['value']}`  "
     ]
@@ -421,6 +471,7 @@ def render_enum_names(names: list[str] | None, indent: str) -> list[str]:
 
 
 def render_enum(spec: dict) -> list[str]:
+    at(spec["path"])
     # A bulk enum is described as a whole: a count and a folded list of names,
     # rather than several hundred bullet points. The values stay out.
     if spec.get("bulk"):
@@ -442,6 +493,7 @@ def render_enum(spec: dict) -> list[str]:
         out.extend(render_prose(spec["description"], INDENT))
         out.append("")
     for value in spec.get("values") or []:
+        at(f"{spec['path']}.{value['name']}")
         out.append(f"{INDENT}- `trx.{spec['path']}.{value['name']}` = `{value['value']}`  ")
         out.extend(render_prose(value.get("description") or "", f"{INDENT}    "))
     out.append("")
@@ -454,6 +506,7 @@ def render_property(spec: dict) -> list[str]:
     Reading it calls into the engine, so it is neither a function nor a constant.
     """
     suffix = "" if spec.get("writable") else " *(read-only)*"
+    at(spec["path"])
     return render_lead(
         f"- {anchor(spec['path'])}**`trx.{spec['path']}`** "
         f"({typed(spec)}). ",
@@ -463,6 +516,7 @@ def render_property(spec: dict) -> list[str]:
 
 
 def render_type(spec: dict) -> list[str]:
+    at(spec["path"])
     out = [f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}`", ""]
     if spec.get("description"):
         out.extend(render_prose(spec["description"], INDENT))
@@ -480,6 +534,7 @@ def render_type(spec: dict) -> list[str]:
     if spec.get("fields"):
         out.append(f"{INDENT}Properties:")
         for field in spec["fields"]:
+            at(f"{spec['path']}.{field['name']}")
             suffix = "" if field.get("writable") else " *(read-only)*"
             out.extend(
                 render_lead(
@@ -494,11 +549,12 @@ def render_type(spec: dict) -> list[str]:
     if spec.get("extensions"):
         out.append(f"{INDENT}Computed properties (derived, not stored on the object):")
         for ext in spec["extensions"]:
+            at(f"{spec['path']}.{ext['name']}")
             out.extend(
                 render_lead(
                     f"{INDENT}- {anchor(spec['path'] + '.' + ext['name'])}"
                     f"**`{ext['name']}`**: {typed(ext)}. ",
-                    ext.get("description") or "",
+                    describe(ext),
                     f"{INDENT}  ",
                 )
             )
@@ -511,7 +567,7 @@ def render_type(spec: dict) -> list[str]:
             out.extend(
                 render_lead(
                     f"{INDENT}- **`{OPERATORS[operator['name']].format(name)}`**. ",
-                    operator.get("description") or "",
+                    describe(operator),
                     f"{INDENT}  ",
                 )
             )
@@ -522,6 +578,7 @@ def render_type(spec: dict) -> list[str]:
         out.append("")
 
     for method in spec.get("methods") or []:
+        at(f"{spec['path']}.{method['name']}")
         name = spec["path"].rsplit(".", 1)[-1].lower()
         out.append(
             f"{INDENT}- {anchor(spec['path'] + '.' + method['name'])}"
@@ -537,6 +594,7 @@ def render_type(spec: dict) -> list[str]:
 
 
 def render_container(name: str, spec: dict) -> list[str]:
+    at(name)
     key, value = spec["key"], spec["value"]
     nullable = " or `nil`" if value.get("nullable") else ""
     out = ["### Indexing", ""]
@@ -575,6 +633,7 @@ def render_page(module: dict, api: dict) -> str:
     global PAGE
     name = module["name"]
     PAGE = name.upper()
+    at(name)
     # Declare a title where capitalizing the module name makes a worse one.
     title = module.get("title") or name.capitalize()
     out = [
@@ -590,7 +649,7 @@ def render_page(module: dict, api: dict) -> str:
         f"  src/lua/api/{name}.lua. Edit it there.",
         "-->",
         "",
-        f"## {title} module",
+        f"## {anchor(name)}{title} module",
         "",
     ]
     if module.get("description"):
@@ -690,6 +749,16 @@ def read(api: dict) -> None:
         for kind in ("fields", "extensions"):
             for member in spec.get(kind) or []:
                 STANDS_FOR[f"{module['name']}.{member['name']}"] = member.get("type")
+    for module in api["modules"]:
+        stands_for = module.get("instance_type")
+        if stands_for is None:
+            continue
+        spec = next(t for t in api["types"] if t["path"] == stands_for)
+        for kind in ("fields", "methods", "extensions"):
+            for member in spec.get(kind) or []:
+                ALIASES[f"{module['name']}.{member['name']}"] = (
+                    f"{stands_for}.{member['name']}"
+                )
     for container in api.get("containers", []):
         accepted = (container.get("key") or {}).get("type")
         if isinstance(accepted, list):

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -53,6 +53,10 @@ def signature(path: str, params: list[dict] | None) -> str:
 # rendered. What holds one is typed by it, and says only what is its own.
 NUMBERS: dict[str, dict] = {}
 
+# path -> the unit it declares. What is measured in one is typed by it, and
+# says only what is its own.
+UNITS: dict[str, dict] = {}
+
 
 # The page being written, so a link knows whether it has to cross a file.
 PAGE = ""
@@ -173,7 +177,7 @@ def anchors_of(api: dict) -> set[str]:
     too, since a script writes `trx.lara.air` and not the type's own path.
     """
     out = {module["name"] for module in api["modules"]}
-    for group in ("numbers", "enums", "functions", "properties", "namespaces", "constants"):
+    for group in ("numbers", "units", "enums", "functions", "properties", "namespaces", "constants"):
         out.update(entry["path"] for entry in api.get(group, []))
     for group in ("functions", "namespaces"):
         for entry in api.get(group, []):
@@ -298,7 +302,7 @@ def type_name(name: str) -> str:
     an enum and a number: what a declaration is typed by is what it means. A
     primitive - integer, table, vec3 - has no declaration and stays as it is.
     """
-    if name in TYPE_PATHS or name in ENUM_PATHS or name in NUMBERS:
+    if name in TYPE_PATHS or name in ENUM_PATHS or name in NUMBERS or name in UNITS:
         return link(name, f"trx.{name}")
     if "." in name:
         raise SystemExit(f"error: type `{name}` names no declared type")
@@ -541,8 +545,10 @@ def render_namespace(spec: dict) -> list[str]:
 
 def render_const(spec: dict) -> list[str]:
     at(spec["path"])
+    named = f" ({type_name(spec['type'])})" if spec.get("type") else ""
     out = [
-        f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}` = `{spec['value']}`  "
+        f"- {anchor(spec['path'])}[lua]`trx.{spec['path']}` = "
+        f"`{spec['value']}`{named}  "
     ]
     if spec.get("description"):
         out.extend(render_prose(spec["description"], "  "))
@@ -727,6 +733,22 @@ def render_number(number: dict) -> list[str]:
     return out
 
 
+def render_unit(unit: dict) -> list[str]:
+    """A named unit: what a value of it is measured in.
+
+    It renders among the types for the same reason a number does - what a
+    world unit is is not the business of the six declarations measured in one.
+    """
+    at(unit["path"])
+    out = [
+        f"- {anchor(unit['path'])}[lua]`trx.{unit['path']}` ({unit['type']})",
+        "",
+    ]
+    out.extend(render_prose(describe(unit), INDENT))
+    out.append("")
+    return out
+
+
 def render_page(module: dict, api: dict) -> str:
     global PAGE
     name = module["name"]
@@ -757,6 +779,7 @@ def render_page(module: dict, api: dict) -> str:
     numbers = [
         n for n in api.get("numbers", []) if n["path"].startswith(f"{name}.")
     ]
+    units = [u for u in api.get("units", []) if u["path"].startswith(f"{name}.")]
 
     container = next(
         (c for c in api.get("containers", []) if c["module"] == name), None
@@ -795,11 +818,13 @@ def render_page(module: dict, api: dict) -> str:
             out.extend(render_enum(spec))
 
     types = [t for t in api["types"] if t["path"].startswith(f"{name}.")]
-    if types or numbers:
+    if types or numbers or units:
         out.append("### Structures")
         out.append("")
         for number in numbers:
             out.extend(render_number(number))
+        for unit in units:
+            out.extend(render_unit(unit))
         for spec in types:
             out.extend(render_type(spec))
 
@@ -829,6 +854,8 @@ def read(api: dict) -> None:
         }
     for number in api.get("numbers", []):
         NUMBERS[number["path"]] = number
+    for unit in api.get("units", []):
+        UNITS[unit["path"]] = unit
     for spec in api.get("types", []):
         TYPE_PATHS.add(spec["path"])
         for kind in ("fields", "extensions"):
@@ -870,15 +897,15 @@ def read(api: dict) -> None:
 def documented(spec: dict) -> bool:
     """Whether the reader is told anything: its own words, or the type it holds.
 
-    A declaration typed by an enum or a number needs no words of its own: what
-    it is, and what it may be, is what the type says.
+    A declaration typed by an enum, a number or a unit needs no words of its
+    own: what it is, and what it may be, is what the type says.
     """
     if spec.get("description"):
         return True
     named = spec.get("type")
     if isinstance(named, list):
         return True
-    return named in ENUM_PATHS or named in NUMBERS
+    return named in ENUM_PATHS or named in NUMBERS or named in UNITS
 
 
 def undocumented(api: dict) -> list[str]:
@@ -1024,7 +1051,7 @@ def descriptions(api: dict) -> list[tuple[str, str]]:
 
     for module in api.get("modules", []):
         walk(module, module["name"])
-    for group in ("numbers", "enums", "functions", "properties", "namespaces", "constants"):
+    for group in ("numbers", "units", "enums", "functions", "properties", "namespaces", "constants"):
         for entry in api.get(group, []):
             walk(entry, entry["path"])
     for spec in api.get("types", []):
@@ -1065,19 +1092,28 @@ def unreferenced(api: dict) -> list[str]:
 
 
 def respelled(api: dict) -> list[str]:
-    """Where a number's own words are written somewhere other than the number.
+    """Where a number's or a unit's own words are written somewhere else.
 
-    A named number says what it counts and where it counts from, once. A
-    declaration that holds one names it and says only what is its own, so the
-    same sentence written again is a copy that will drift, and a base written
-    again is one that can disagree.
+    A named number says what it counts and where it counts from, once, and a
+    named unit says what a value of it is measured in. A declaration that holds
+    one names it and says only what is its own, so the same sentence written
+    again is a copy that will drift, and a base written again is one that can
+    disagree.
     """
     numbers = {number["path"]: number for number in api.get("numbers", [])}
+    units = {unit["path"]: unit for unit in api.get("units", [])}
     # The first clause is the sentence's claim: "Room number", "Cutscene
     # number". What follows it is detail nobody would repeat by accident.
     claims = {
         path: re.split(r"[,.]", number["description"])[0].strip().lower()
         for path, number in numbers.items()
+    }
+    # A unit is not recognised by its first clause the way a number is - "an
+    # angle in the engine's own units" is not what a declaration holding one
+    # would write. It names the words that mean it instead.
+    spellings = {
+        path: [s.lower() for s in unit.get("spellings") or []]
+        for path, unit in units.items()
     }
     pointed = set()
     out = []
@@ -1095,7 +1131,17 @@ def respelled(api: dict) -> list[str]:
                     f"{where}: counts from its own base while naming "
                     f"`trx.{named}`, which declares one"
                 )
+        if named in units:
+            pointed.add(named)
         text = (spec.get("description") or "").lower()
+        for path, written in spellings.items():
+            for one in written:
+                if one in text and named != path:
+                    out.append(
+                        f"{where}: writes out what `trx.{path}` is.\n"
+                        f"    name the unit - type it `trx.{path}` - and say only "
+                        f"what is this one's own"
+                    )
         for path, claim in claims.items():
             if claim and claim in text and named != path:
                 out.append(
@@ -1109,6 +1155,9 @@ def respelled(api: dict) -> list[str]:
     for path in numbers:
         if path not in pointed:
             out.append(f"{path}: a number nothing holds. Delete it, or type what holds one")
+    for path in units:
+        if path not in pointed:
+            out.append(f"{path}: a unit nothing is measured in. Delete it, or type what is")
     return out
 
 

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -234,6 +234,31 @@ def unknown(path: str) -> str:
     )
 
 
+# A page of the manual, written from the root of the repository so that what it
+# names is checkable, and rewritten to reach it from the page being generated.
+DOC_LINK_RE = re.compile(r"\]\((docs/[\w./-]+\.md)(#[\w.-]+)?\)")
+
+
+def linked_docs(text: str) -> str:
+    """Prose with every page of the manual it names pointed at from here.
+
+    A page is named from the root, which is where it can be looked for; where
+    it lands is this page's business, and depends on which page is being
+    written.
+    """
+
+    def one(match: re.Match) -> str:
+        target = ROOT / match.group(1)
+        if not target.exists():
+            raise SystemExit(
+                f"error: {match.group(1)} names no page of the manual.\n"
+                f"  name it from the root of the repository, as it is on disk"
+            )
+        return f"]({os.path.relpath(target, DOCS_DIR)}{match.group(2) or ''})"
+
+    return DOC_LINK_RE.sub(one, text)
+
+
 def linked_prose(text: str) -> str:
     """Prose with every `trx....` it names turned into a link.
 
@@ -247,7 +272,7 @@ def linked_prose(text: str) -> str:
         written = match.group(1)
         return link(anchored(written), f"`{shortened(written)}`")
 
-    return REFERENCE_RE.sub(one, text)
+    return REFERENCE_RE.sub(one, linked_docs(unmarked(text)))
 
 
 def typed(spec: dict) -> str:
@@ -887,10 +912,155 @@ def undocumented(api: dict) -> list[str]:
     for group in ("functions", "namespaces"):
         for entry in api.get(group, []):
             out.extend(blank_keys(entry, entry["path"]))
+            out.extend(blank_args(entry, entry["path"]))
     for spec in api.get("types", []):
         for method in spec.get("methods") or []:
             path = f"{spec['path']}.{method['name']}"
             out.extend(blank_keys(method, path))
+            out.extend(blank_args(method, path))
+    return out
+
+
+def blank_args(spec: dict, path: str) -> list[str]:
+    """Arguments and results that say nothing.
+
+    A parameter renders as its name and its type, and a result as its type
+    alone, so one with no words leaves the reader to guess what it is for from
+    the name. A `ref` counts as words: it says what the number is.
+    """
+    out = []
+    for param in spec.get("params") or []:
+        if not documented(param):
+            out.append(f"{path}({param['name']})")
+        for arg in param.get("params") or []:
+            if not documented(arg):
+                out.append(f"{path}({param['name']}) -> {arg['name']}")
+    returns = spec.get("returns")
+    for one in returns if isinstance(returns, list) else [returns] if returns else []:
+        if not documented(one):
+            out.append(f"{path} returns {one['type']}")
+    return out
+
+
+# What a description may name in backticks without pointing at a declaration.
+# Everything else identifier-shaped is either a path the API declares, or a
+# literal marked as one - see NOREF.
+LUA_NAMES = {
+    # Lua itself, and the API's own name.
+    "trx",
+    "math",
+    "nil",
+    "true",
+    "false",
+    "pairs()",
+    "ipairs()",
+    "tostring()",
+    "tonumber()",
+    # The types a declaration is written in, which name themselves.
+    "any",
+    "boolean",
+    "function",
+    "integer",
+    "number",
+    "string",
+    "table",
+    "vec3",
+}
+
+# A description says this where a backticked name is not an API path but a
+# literal a player or a file carries: a config key, a file name, a value a
+# setting takes. The marker names them, so what is waived is on the page it is
+# waived from, and it comes off before the text is rendered.
+NOREF_RE = re.compile(r"<!--\s*noref:?\s*(.*?)\s*-->")
+
+# Identifier-shaped, which is what a reference looks like. A number, a quoted
+# string, a flag spelling or anything with a space in it is not one, and an
+# enum constant is reached through the enum rather than by a path of its own.
+NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.:]*(?:\(\))?")
+BACKTICKED_RE = re.compile(r"`([^`]+)`")
+
+
+def unmarked(text: str) -> str:
+    """A description as the reader sees it, with the noref markers taken off.
+
+    The marker is a note to whoever writes the declaration, so it comes off
+    before the page is written, along with the space it sat in.
+    """
+    out = NOREF_RE.sub("", text)
+    out = re.sub(r"[ \t]{2,}", " ", out)
+    return "\n".join(line.rstrip() for line in out.splitlines()).strip()
+
+
+def waived(text: str) -> set[str]:
+    """The names a description marks as literals, and not references."""
+    out: set[str] = set()
+    for marker in NOREF_RE.findall(text):
+        out.update(name.strip(" `") for name in marker.split(",") if name.strip())
+    return out
+
+
+def descriptions(api: dict) -> list[tuple[str, str]]:
+    """Every description the dump carries, and the declaration it belongs to."""
+    out: list[tuple[str, str]] = []
+
+    def walk(spec: dict, path: str) -> None:
+        if not isinstance(spec, dict):
+            return
+        if spec.get("description"):
+            out.append((path, spec["description"]))
+        for param in spec.get("params") or []:
+            walk(param, path)
+        for field in spec.get("fields") or []:
+            if "name" in field:
+                walk(field, path)
+        returns = spec.get("returns")
+        for one in (
+            returns if isinstance(returns, list) else [returns] if returns else []
+        ):
+            walk(one, path)
+        for kind in ("methods", "extensions", "operators", "values"):
+            for member in spec.get(kind) or []:
+                walk(member, f"{path}.{member['name']}")
+
+    for module in api.get("modules", []):
+        walk(module, module["name"])
+    for group in ("numbers", "enums", "functions", "properties", "namespaces", "constants"):
+        for entry in api.get(group, []):
+            walk(entry, entry["path"])
+    for spec in api.get("types", []):
+        walk(spec, spec["path"])
+    for container in api.get("containers", []):
+        walk(container, container["module"])
+        for side in ("key", "value"):
+            if container.get(side):
+                walk(container[side], container["module"])
+    return out
+
+
+def unreferenced(api: dict) -> list[str]:
+    """Names a description writes in backticks that point at nothing.
+
+    A backticked name reads as something the reader can go and look at, so it
+    is either a path the API declares - written in full, and rendered as a link
+    - or a literal, and saying which is what the noref marker is for. A name
+    that is neither is a reference to something renamed, or one the reader
+    cannot follow.
+    """
+    out = []
+    for path, text in descriptions(api):
+        exempt = waived(text)
+        for span in BACKTICKED_RE.findall(NOREF_RE.sub("", text)):
+            if span.startswith("trx."):
+                continue
+            if not NAME_RE.fullmatch(span):
+                continue
+            if span.isupper() or span in LUA_NAMES or span in exempt:
+                continue
+            out.append(
+                f"{path}: `{span}` names nothing.\n"
+                f"    write the whole path, `trx....`, or mark it a literal with "
+                f"<!--noref: {span}-->"
+            )
     return out
 
 
@@ -1056,6 +1226,12 @@ def main() -> int:
         print("document it in src/lua/api/, next to the declaration", file=sys.stderr)
         return 1
 
+    loose = unreferenced(api)
+    if loose:
+        print("error: a description names something unreachable:", file=sys.stderr)
+        for report in loose:
+            print(f"  {report}", file=sys.stderr)
+        return 1
 
     copied = respelled(api)
     if copied:

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -74,12 +74,14 @@ KEYED_BY: dict[str, str] = {}
 # enum path -> its constants, upper-cased. A catalog runs to hundreds of them,
 # so they are not anchored one by one and a constant links to its enum.
 CONSTANTS: dict[str, set[str]] = {}
+# Every declared enum, so a declaration that points at one is typed by it.
+ENUM_PATHS: set[str] = set()
 # A member reached through a module that stands for one thing -
 # `trx.lara.air` - to where the type it stands for declares it. The anchor is
 # written once, at the declaration, so that is where the link has to go.
 ALIASES: dict[str, str] = {}
-# Every declared enum, so a declaration that points at one is typed by it.
-ENUM_PATHS: set[str] = set()
+
+
 def anchor(path: str) -> str:
     """The name a declaration is linked to, and the page it lives on.
 
@@ -114,6 +116,7 @@ def segments(path: str) -> list[str]:
     """
     return re.findall(r"[.:]?[A-Za-z0-9_]+", path)
 
+
 def shortened(path: str) -> str:
     """How a written path reads from where it is written.
 
@@ -136,6 +139,31 @@ def shortened(path: str) -> str:
     return "".join(written[shared:]).lstrip(".:")
 
 
+def keys_of(spec: dict, path: str) -> set[str]:
+    """The keys a call's table argument or result declares.
+
+    A key hangs off the argument that carries it - `opts.mode` under the call
+    it belongs to - and a result's keys off the call itself, since a result has
+    no name of its own.
+    """
+    out = set()
+    for param in spec.get("params") or []:
+        out.add(f"{path}.{param['name']}")
+        for field in param.get("fields") or []:
+            out.add(f"{path}.{param['name']}.{field['name']}")
+        # A hook's callback has one set of arguments, so a table it is handed
+        # hangs off the hook rather than off the callback.
+        for arg in param.get("params") or []:
+            out.add(f"{path}.{arg['name']}")
+            for field in arg.get("fields") or []:
+                out.add(f"{path}.{arg['name']}.{field['name']}")
+    returns = spec.get("returns")
+    for one in returns if isinstance(returns, list) else [returns] if returns else []:
+        for field in one.get("fields") or []:
+            out.add(f"{path}.{field['name']}")
+    return out
+
+
 def anchors_of(api: dict) -> set[str]:
     """Every path a declaration can be pointed at by.
 
@@ -147,6 +175,9 @@ def anchors_of(api: dict) -> set[str]:
     out = {module["name"] for module in api["modules"]}
     for group in ("numbers", "enums", "functions", "properties", "namespaces", "constants"):
         out.update(entry["path"] for entry in api.get(group, []))
+    for group in ("functions", "namespaces"):
+        for entry in api.get(group, []):
+            out.update(keys_of(entry, entry["path"]))
     members: dict[str, list[str]] = {}
     for spec in api.get("types", []):
         out.add(spec["path"])
@@ -156,6 +187,8 @@ def anchors_of(api: dict) -> set[str]:
             for member in spec.get(kind) or []
         ]
         out.update(f"{spec['path']}.{name}" for name in members[spec["path"]])
+        for method in spec.get("methods") or []:
+            out.update(keys_of(method, f"{spec['path']}.{method['name']}"))
     for module in api["modules"]:
         stands_for = module.get("instance_type")
         for name in members.get(stands_for, []):
@@ -278,13 +311,18 @@ def render_callback_args(param: dict, indent: str) -> list[str]:
     if not args:
         return []
     out = [f"{indent}Called with:"]
+    owner = CONTEXT
     for arg in args:
         out.extend(
             render_lead(
-                f"{indent}- **`{arg['name']}`** ({typed(arg)}). ",
+                f"{indent}- {anchor(f'{owner}.{arg['name']}')}"
+                f"**`{arg['name']}`** ({typed(arg)}). ",
                 describe(arg),
                 f"{indent}  ",
             )
+        )
+        out.extend(
+            render_fields(arg, f"{owner}.{arg['name']}", f"{indent}  ")
         )
     return out
 
@@ -354,19 +392,52 @@ def render_bits(spec: dict) -> str:
     return ", ".join(bits)
 
 
+def render_fields(
+    spec: dict, prefix: str, indent: str
+) -> list[str]:
+    """The keys a table argument or result is made of.
+
+    A table declares what it holds where it is declared, so each key has a type
+    and an anchor of its own and is pointed at like anything else. Before this
+    the keys were spelled out in the description, which left them unlinkable
+    and said again in every place that passed the same table. A list says the
+    same of each of its entries.
+    """
+    fields = spec.get("fields")
+    if not fields:
+        return []
+    owner = CONTEXT
+    out = ["", f"{indent}Each entry:" if spec.get("list") else f"{indent}Keys:"]
+    for field in fields:
+        at(f"{prefix}.{field['name']}")
+        out.extend(
+            render_lead(
+                f"{indent}- {anchor(prefix + '.' + field['name'])}"
+                f"**`{field['name']}`** ({render_bits(field)}). ",
+                describe(field),
+                f"{indent}  ",
+            )
+        )
+    at(owner)
+    return out
+
+
 def render_params(params: list[dict] | None, indent: str) -> list[str]:
     if not params:
         return []
     out = ["", f"{indent}Parameters:"]
     for param in params:
+        prefix = f"{CONTEXT}.{param['name']}"
         out.extend(
             render_lead(
-                f"{indent}- **`{param['name']}`** ({render_bits(param)}). ",
+                f"{indent}- {anchor(prefix)}**`{param['name']}`** "
+                f"({render_bits(param)}). ",
                 describe(param),
                 f"{indent}  ",
             )
         )
         out.extend(render_callback_args(param, f"{indent}  "))
+        out.extend(render_fields(param, prefix, f"{indent}  "))
     return out
 
 
@@ -383,10 +454,11 @@ def render_returns(returns: dict | list | None, indent: str) -> list[str]:
         return []
     if isinstance(returns, dict):
         out = ["", *render_lead(f"{indent}Returns: ", one_return(returns), f"{indent}  ")]
-        return out
+        return out + render_fields(returns, CONTEXT, f"{indent}  ")
     out = ["", f"{indent}Returns:"]
     for spec in returns:
         out.extend(render_lead(f"{indent}- ", one_return(spec), f"{indent}  "))
+        out.extend(render_fields(spec, CONTEXT, f"{indent}  "))
     return out
 
 
@@ -505,8 +577,8 @@ def render_property(spec: dict) -> list[str]:
 
     Reading it calls into the engine, so it is neither a function nor a constant.
     """
-    suffix = "" if spec.get("writable") else " *(read-only)*"
     at(spec["path"])
+    suffix = "" if spec.get("writable") else " *(read-only)*"
     return render_lead(
         f"- {anchor(spec['path'])}**`trx.{spec['path']}`** "
         f"({typed(spec)}). ",
@@ -623,6 +695,7 @@ def render_number(number: dict) -> list[str]:
     the thirteen declarations that hold one - so it renders among them, and
     everything that holds one names it and says only what is its own.
     """
+    at(number["path"])
     out = [f"- {anchor(number['path'])}[lua]`trx.{number['path']}`", ""]
     out.extend(render_prose(describe(number), INDENT))
     out.append("")
@@ -749,11 +822,6 @@ def read(api: dict) -> None:
         for kind in ("fields", "extensions"):
             for member in spec.get(kind) or []:
                 STANDS_FOR[f"{module['name']}.{member['name']}"] = member.get("type")
-    for module in api["modules"]:
-        stands_for = module.get("instance_type")
-        if stands_for is None:
-            continue
-        spec = next(t for t in api["types"] if t["path"] == stands_for)
         for kind in ("fields", "methods", "extensions"):
             for member in spec.get(kind) or []:
                 ALIASES[f"{module['name']}.{member['name']}"] = (
@@ -816,6 +884,13 @@ def undocumented(api: dict) -> list[str]:
             for member in spec.get(kind) or []:
                 if not documented(member):
                     out.append(f"{spec['path']}.{member['name']}")
+    for group in ("functions", "namespaces"):
+        for entry in api.get(group, []):
+            out.extend(blank_keys(entry, entry["path"]))
+    for spec in api.get("types", []):
+        for method in spec.get("methods") or []:
+            path = f"{spec['path']}.{method['name']}"
+            out.extend(blank_keys(method, path))
     return out
 
 
@@ -898,6 +973,25 @@ def walk(api: dict) -> list[tuple[str, dict]]:
             if container.get(side):
                 rec(container[side], f"{container['module']}[{side}]")
     return out
+
+
+def blank_keys(spec: dict, path: str) -> list[str]:
+    """Declared keys that say nothing."""
+    return [key for key in sorted(keys_of(spec, path)) if not described_key(spec, key)]
+
+
+def described_key(spec: dict, key: str) -> bool:
+    """Whether the key named by a path carries a description."""
+    name = key.rsplit(".", 1)[-1]
+    everything = []
+    for param in spec.get("params") or []:
+        everything.extend(param.get("fields") or [])
+        for arg in param.get("params") or []:
+            everything.extend(arg.get("fields") or [])
+    returns = spec.get("returns")
+    for one in returns if isinstance(returns, list) else [returns] if returns else []:
+        everything.extend(one.get("fields") or [])
+    return all(documented(f) for f in everything if f["name"] == name)
 
 
 def dump_api(binary: Path) -> str:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Makes the Lua reference say what a value is by naming its type, instead of spelling it out in a sentence beside every declaration that holds one. A room number, an item number, an angle and a length are each declared once, in the module they belong to, and everything that holds one names it.

- `api.number` declares a number: what it counts, and where it counts from. There are nineteen, named by 55 declarations between them.
- `api.unit` declares a unit: what a value is measured in, and whether it arrives as a whole number or a real one. There are four, named by 35 declarations.
- A member, an argument or a return typed by one says only what is its own, and the reference links it to the declaration.
- Every name a description writes in backticks is resolved and rendered as a link. The reference carried one link before this and carries 541 now.
- The dump stops where a description or a type names something nothing declares, so a rename cannot leave a reference pointing at nothing.
- Names say which kind of number they hold: `_num` where a container is what gives it meaning, `_id` where it reads on its own, a bare noun where the thing itself is meant. The rule is written down in `docs/CODING_GUIDELINES.md`.

Before this, the same sentence was written at every declaration that held one. "0-based item number" appeared at thirteen places, "in world units" at five, "in TRX units" at seven. Renaming something left the prose behind, and a description naming a `trx.` path that had since moved went on reading as ordinary text rather than as a broken link, so neither drifting apart was anything a reader or a test would notice.

What a declaration is written against now:

```lua
-- what a number is, said once, in the module that owns it
api.number("rooms.Num", {
  base = 0,
  description = "Room number, matching the numbers level editors show.",
})

-- what a value is measured in, and the words that mean it
api.unit("math.Angle", {
  description = "An angle in the engine's own units, where 65536 is a full turn ...",
  spellings = { "TRX units", "angle units" },
})

-- and a declaration holding one names it, and adds only what is its own
{ name = "room_num", type = "rooms.Num" }
{ name = "angle",    type = "math.Angle" }
{ name = "timer",    type = "game.Seconds", description = "How long it keeps the item going." }
```

A description that writes a unit's words out instead of naming it is reported, as is a number described a second time, a base written beside a number that declares one, and a number or unit nothing holds at all.

Nothing changes for players.

For mod authors, some names a script writes have changed, and the migration notes carry the list. The renames are mechanical:

```
item.index                 item.num
item.anim, item.frame      item.anim_num, item.frame_num
room.room_index            room.room_num
sample.id, stream.sample_id  sample.num, stream.sample_num
track.id, stream.track_id    track.num, stream.track_num
```

The handler arguments follow the same rule - `old_room_num`, `new_room_num`, `sequence_num`, `cutscene_num` - though those are names a script never writes.
