### PR TITLE
ui/keys: accept numpad Enter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - changed the `/give` console command to autocomplete what it can hand over and to reach the savegame crystal by name; `/give keys` now covers the plot items alone, and `/keys`, `/guns` and `/moreguns` are commands of their own
 - changed the `/spawn`, `/kill` and `/tp` console commands to accept a family such as `pickup`, `door` or `enemy` in place of a name, and to offer the families each of them can act on in autocompletion
 - changed the `/tp` console command to place Lara better at whatever she is sent to
+- changed the developer console to accept the numpad Enter key for issuing commands (#6056)
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
 - changed the save crystals option to a mode: crystals can save on the spot, be collected to save from the inventory as on PS1 TR3, heal, or be collectibles (Gameplay → General → Crystal mode) (#5939)
 - changed the Target change option to allow selecting TR4 behavior, where tapping Look switches target and holding it looks around (Gameplay → Controls → Target change)

--- a/src/trx/game/ui/keys.c
+++ b/src/trx/game/ui/keys.c
@@ -20,6 +20,7 @@ static UI_INPUT M_TranslateInput(const uint32_t system_keycode)
     case SDLK_END:       return UI_KEY_END;
     case SDLK_BACKSPACE: return UI_KEY_BACK;
     case SDLK_RETURN:    return UI_KEY_RETURN;
+    case SDLK_KP_ENTER:  return UI_KEY_RETURN;
     case SDLK_ESCAPE:    return UI_KEY_ESCAPE;
     case SDLK_TAB:
         return (SDL_GetModState() & KMOD_SHIFT) != 0 ? UI_KEY_SHIFT_TAB


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Numpad Enter now confirms wherever the UI accepts Return, including issuing commands in the developer console. Before this, only the main Enter key was translated into the UI's Return role.

Resolves #6056 