### PR TITLE
shell/mod: wrap the mixed mod layout error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,7 @@
 - fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)
 - fixed quick saves bypassing the save crystals mode
 - fixed the game displaying a GUI error dialog when it fails to start in headless mode
+- fixed the mixed mod layout error message running off the edge of the screen, leaving the paths it names unreadable (#6048)
 - fixed the body bag trigger to also collect Bacon Lara, Qualopec Mummy and Skidoo Driver's corpses
 - fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -204,9 +204,19 @@ static void M_ValidateNoMixedModLayouts(void)
         const char *const legacy_gameflow =
             String_FormatStatic("%s/%s/gameflow.json5", config_dir, mod->name);
         if (File_Exists(legacy_gameflow)) {
+            // The paths are long enough that the message box cannot fit them
+            // on one line, and it does not wrap.
             Shell_ExitSystemFmt(
-                "Mixed mod layout detected: found legacy mod data at '%s' "
-                "while '%s' is used for mods. Move '%s' to '%s/%s/'.",
+                "Mixed mod layout detected.\n"
+                "\n"
+                "Legacy mod data found at:\n"
+                "    %s\n"
+                "\n"
+                "Mods are read from:\n"
+                "    %s\n"
+                "\n"
+                "Move the '%s' directory to:\n"
+                "    %s/%s/",
                 legacy_gameflow, games_dir, mod->name, games_dir, mod->name);
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The message names three absolute paths, and the message box neither wraps nor scrolls, so most of it sat off the edge of the screen. Each path now sits on a line of its own.

Resolves #6048 / TRX899
