### PR TITLE
Rework the Lua API registry and what a declaration says

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -166,6 +166,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `p`, a global shorthand for `trx.console.log`, and made the console log functions take any value, pretty-printing a table
 - added a new Lua module, `trx.math`, with the engine's own fixed-point trigonometry and the `DEG_1`, `DEG_45`, `DEG_90` and `WALL_L` constants
 - added a new Lua module, `trx.strings`, with `fuzzy_match()` and `regex_match()`
+- added a new Lua module, `trx.json`, to write a value out as JSON
 - added a new Lua module, `trx.rules`, holding the numbers the game plays by
 - added a new Lua module, `trx.argparse`, a declarative argument parser inspired by Python's argparse
 - added a new Lua module, `trx.locale`, for the text the player reads, looked up by key

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -250,7 +250,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed `trx.sound.play`, `trx.sound.stop` and `trx.music.play` to take a sound or track by catalog name, which works across games, rather than the level's own slot; the slot is reached through the `samples`/`tracks` handles, and `play` hands back the stream it starts
 - changed `trx.game.levels` and `trx.game.play_level` to leave out the gym, so numbering no longer shifts and the last level is reachable
 - changed `trx.api` to hold only `strict` and `is_strict` once sealed, and `trx.api.strict()` to check handle method arguments too
-- changed a position table to require all three coordinates, rather than reading a missing one as zero
+- changed a position table to require all three coordinates, rather than reading a missing one as zero; a position is documented as `trx.math.Vec3` and an orientation as `trx.math.Rot`
 - changed `room.idx` to `room.num`
 - changed the Lua level field `name` to `title`
 - changed `item.object_id` to be read-only

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,7 @@
 - changed the `/secret` console command to take a secret number on its own, to offer the numbers it can act on in autocompletion, and to say what it expected when given something else
 - changed the `/give` console command to autocomplete what it can hand over and to reach the savegame crystal by name; `/give keys` now covers the plot items alone, and `/keys`, `/guns` and `/moreguns` are commands of their own
 - changed the `/spawn`, `/kill` and `/tp` console commands to accept a family such as `pickup`, `door` or `enemy` in place of a name, and to offer the families each of them can act on in autocompletion
-- changed the `/tp` console command to place Lara better at whatever she is sent to
+- changed the `/tp` console command to place Lara better at what she is sent to
 - changed the developer console to accept the numpad Enter key for issuing commands (#6056)
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
 - changed the save crystals option to a mode: crystals can save on the spot, be collected to save from the inventory as on PS1 TR3, heal, or be collectibles (Gameplay → General → Crystal mode) (#5939)
@@ -243,7 +243,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed `trx.lara.is_burning` to be writable, so setting it lights Lara or puts her out
 - changed `trx.lara.extra_anim` to a boolean, where it used to be the relative animation number, or -1
 - changed `trx.lara.mesh` and `trx.lara.extra_mesh` to declared enums, `trx.lara.Mesh` and `trx.lara.ExtraMesh`
-- changed `trx.items` and `trx.rooms` to hand out opaque handles rather than `{ idx = ... }` tables, so a handle to a killed item now raises instead of silently addressing whatever took its slot
+- changed `trx.items` and `trx.rooms` to hand out opaque handles rather than `{ idx = ... }` tables, so a handle to a killed item now raises instead of silently addressing the item that took its slot
 - changed handles to compare equal when they name the same thing, so `trx.items[0] == trx.items[0]`
 - changed `trx.items` and `trx.rooms` to count from zero, matching the item and room numbers level editors show, and made `pairs()` walk them keyed by that number
 - changed room handles to go stale at a level change rather than quietly naming a different room

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -165,7 +165,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 
 - added `p`, a global shorthand for `trx.console.log`, and made the console log functions take any value, pretty-printing a table
 - added a new Lua module, `trx.math`, with the engine's own fixed-point trigonometry and the `DEG_1`, `DEG_45`, `DEG_90` and `WALL_L` constants
-- added a new Lua module, `trx.strings`, with `fuzzy_match()` and `regex_match()`
+- added a new Lua module, `trx.strings`, with `fuzzy_match()`, `regex_match()`, `collapse_ranges()` and `dedent()`
 - added a new Lua module, `trx.json`, to write a value out as JSON
 - added a new Lua module, `trx.rules`, holding the numbers the game plays by
 - added a new Lua module, `trx.argparse`, a declarative argument parser inspired by Python's argparse

--- a/docs/trx/COMMANDS.md
+++ b/docs/trx/COMMANDS.md
@@ -96,7 +96,7 @@ whichever key you have bound, and not include it as part of the command itself.
   Turns on infinite sprint. Lara's always been a speedster, but with this, even cheetahs are asking her for running tips!
 
 - `/teatime`  
-  Calls your loyal butler to whatever ends of the world you're exploring right now. Effective immediately.
+  Calls your loyal butler to any end of the world you're exploring right now. Effective immediately.
 
 - `/spawn {object}`  
   Spawn an object of your choice. Not guaranteed to behave, but good for testing and oddly therapeutic for goofing off.

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -24,7 +24,7 @@ order: 3
    - `item.idx` no longer exists, and a handle can no longer carry extra keys of
      your own. Pass the handle itself where you used to pass the index.
    - A handle to a killed or recycled item now raises `stale ITEM handle` when
-     read or written, instead of silently addressing whatever item took over the
+     read or written, instead of silently addressing the item that took over the
      slot. Guard handles held across time with `item:is_valid()`.
    - Two handles are equal when they name the same thing, so
      `trx.items[0] == trx.items[0]` is now true where it used to be false - every
@@ -58,7 +58,7 @@ order: 3
      became `trx.rooms.Room`, `trx.rooms.flip` and `trx.rooms.flip_effect`.
    - A room handle now goes stale when the level changes, as an item handle
      already did: reading or writing a field raises `stale ROOM handle` rather
-     than naming whatever room sits at that number in the new level. Guard a
+     than naming the room that sits at that number in the new level. Guard a
      handle held across time with `room:is_valid()`. Handles compare by identity,
      as item handles do.
    - An unset room flag now reads as `false` rather than `nil`, so
@@ -73,7 +73,7 @@ order: 3
 3. **Update scripts that compare `trx.config.get()` against a string**
    It returns the option's own type now: a boolean option reads as a boolean and
    a number as a number. `trx.config.get("flow.cheat_keys") == "true"` is now
-   false whatever the setting says - drop the comparison and test the value:
+   false regardless of the setting - drop the comparison and test the value:
    `if trx.config.get("flow.cheat_keys") then`. Colors and enums are still
    strings.
 

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2862,7 +2862,6 @@
       ],
       "path": "assault.stats.list_records",
       "returns": {
-        "description": "The records.",
         "list": true,
         "type": "assault.Record"
       }
@@ -3276,7 +3275,6 @@
       "description": "Every registered console command, in registration order. The help command is built on this.",
       "path": "console.commands",
       "returns": {
-        "description": "The commands.",
         "list": true,
         "type": "console.Command"
       }
@@ -4268,7 +4266,7 @@
       ],
       "params": [
         {
-          "description": "The key.",
+          "description": "The key, e.g. `general/misc/off`.",
           "name": "key",
           "type": "string"
         },
@@ -4375,7 +4373,7 @@
       ],
       "params": [
         {
-          "description": "The code.",
+          "description": "Any chunk of Lua, not only an expression.",
           "name": "code",
           "type": "string"
         }
@@ -4401,7 +4399,6 @@
       ],
       "path": "lua.eval_file",
       "returns": {
-        "description": "As in `trx.lua.eval_expr`.",
         "nullable": true,
         "type": "lua.Error"
       }
@@ -4761,11 +4758,10 @@
       ]
     },
     {
-      "description": "Every rule there is, as dotted `group.field` keys. <!--noref: group.field-->",
+      "description": "Every rule there is, as dotted `group.field` keys, in no particular order. <!--noref: group.field-->",
       "params": [],
       "path": "rules.list",
       "returns": {
-        "description": "In no particular order.",
         "list": true,
         "type": "string"
       }
@@ -5001,7 +4997,7 @@
       ],
       "path": "strings.fuzzy_match",
       "returns": {
-        "description": "The matches, best first.",
+        "description": "The best match comes first.",
         "list": true,
         "type": "strings.Match"
       }
@@ -5551,7 +5547,7 @@
       "writable": false
     },
     {
-      "description": "The TRX version string.",
+      "description": "What this build reports as its version: `1.9.3` for a release, and the tag with the commits since it for a development build.",
       "path": "game.trx_version",
       "type": "string",
       "writable": false
@@ -5802,7 +5798,7 @@
             }
           ],
           "returns": {
-            "description": "The parser.",
+            "description": "The same parser, so declarations chain.",
             "type": "argparse.Parser"
           }
         },
@@ -5825,7 +5821,7 @@
           ],
           "returns": [
             {
-              "description": "Best first.",
+              "description": "The best match comes first.",
               "list": true,
               "type": "string"
             },
@@ -5876,7 +5872,7 @@
             }
           ],
           "returns": {
-            "description": "The parser.",
+            "description": "The same parser, so declarations chain.",
             "type": "argparse.Parser"
           }
         },
@@ -5986,7 +5982,7 @@
             }
           ],
           "returns": {
-            "description": "The parser.",
+            "description": "The same parser, so declarations chain.",
             "type": "argparse.Parser"
           }
         },
@@ -6039,7 +6035,7 @@
             }
           ],
           "returns": {
-            "description": "The parser.",
+            "description": "The same parser, so declarations chain.",
             "type": "argparse.Parser"
           }
         },

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3839,7 +3839,7 @@
       }
     },
     {
-      "description": "Happens when an item takes damage, Lara included. It is the raw damage that\nfires, before the item's hit points are clamped, so a fatal blow reports the whole amount the\nattacker dealt. A death that does not go through damage - a script writing\n`trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.\n\n`trx.items.Item:on_hit` is this same event, narrowed to one item.",
+      "description": "Happens when an item takes damage, Lara included. It is the raw damage that\nfires, before the item's hit points are clamped, so a fatal blow reports\nthe whole amount the attacker dealt. A death that does not go through\ndamage - a script writing `trx.items.Item.hit_points`, or\n`trx.items.Item:destroy` - does not report.\n\n`trx.items.Item:on_hit` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_hit(function(item, damage)\n  trx.log.info(item.object_id .. \" lost \" .. damage .. \" hit points\")\nend)"
       ],
@@ -3869,7 +3869,7 @@
       }
     },
     {
-      "description": "Happens when damage takes an item's hit points to zero, Lara included. It is the\nsame blow `trx.events.on_hit` reports, which fires first. A death that does not go through damage\n- a script writing `trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.\n\nSome bosses fall and get back up: Willard is knocked out, Natla plays dead before her second\nstage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points\nto zero, so they report once per stage rather than once per boss, and the dragon reports once\nmore for the dagger that ends it.\n\n`trx.items.Item:on_kill` is this same event, narrowed to one item.",
+      "description": "Happens when damage takes an item's hit points to zero, Lara included. It\nis the same blow `trx.events.on_hit` reports, which fires first. A death\nthat does not go through damage - a script writing\n`trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.\n\nSome bosses fall and get back up: Willard is knocked out, Natla plays dead\nbefore her second stage, and the dragon lies still until Lara takes the\ndagger. Each stage brings their hit points to zero, so they report once per\nstage rather than once per boss, and the dragon reports once more for the\ndagger that ends it.\n\n`trx.items.Item:on_kill` is this same event, narrowed to one item.",
       "examples": [
         "trx.events.on_kill(function(item)\n  trx.log.info(item.object_id .. \" is down\")\nend)"
       ],
@@ -5256,7 +5256,7 @@
       "order": 6
     },
     {
-      "description": "Module for the numbers the engine plays by.\n\nThese are the game's rules: a mechanic that no single item owns. An object's own numbers live on\nthe object, as `trx.objects.<name>.properties`, and the player's own choices live in `trx.config`.\n\nA rule lasts as long as the playthrough: it is saved with the game and restored with it, and a\nnew game starts from the defaults. A level script states what its level wants, and states it\nagain on every entry, so a level that wants the defaults back asks for them.",
+      "description": "Module for the numbers the engine plays by.\n\nThese are the game's rules: a mechanic that no single item owns. An\nobject's own numbers live on the object, as\n`trx.objects.<name>.properties`, and the player's own choices live in\n`trx.config`.\n\nA rule lasts as long as the playthrough: it is saved with the game and\nrestored with it, and a new game starts from the defaults. A level script\nstates what its level wants, and states it again on every entry, so a level\nthat wants the defaults back asks for them.",
       "name": "rules",
       "order": 14
     },
@@ -7174,7 +7174,7 @@
           ]
         },
         {
-          "description": "Hurts the item the way a weapon does, and reports through `trx.events.on_hit`,\nand `trx.events.on_kill` where the blow takes the last hit point. Writing\n`trx.items.Item.hit_points` reports neither. The kill counts as the\nenvironment's rather than Lara's.",
+          "description": "Hurts the item the way a weapon does, and reports through\n`trx.events.on_hit`, and `trx.events.on_kill` where the blow takes the\nlast hit point. Writing `trx.items.Item.hit_points` reports neither.\nThe kill counts as the environment's rather than Lara's.",
           "examples": [
             "local lara = trx.lara.item\nlara:take_damage(lara.hit_points)"
           ],

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -61,6 +61,34 @@
       }
     },
     {
+      "countable": true,
+      "description": "The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle.",
+      "key": {
+        "base": 1,
+        "description": "Which slot.",
+        "type": "integer"
+      },
+      "member": "streams",
+      "module": "music",
+      "value": {
+        "nullable": true,
+        "type": "music.Stream"
+      }
+    },
+    {
+      "countable": true,
+      "description": "The tracks the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.",
+      "key": {
+        "type": "music.TrackNum"
+      },
+      "member": "tracks",
+      "module": "music",
+      "value": {
+        "nullable": true,
+        "type": "music.Track"
+      }
+    },
+    {
       "countable": false,
       "description": "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf. Keyed by object id or catalog name, not by position.",
       "examples": [
@@ -92,6 +120,34 @@
       "value": {
         "nullable": true,
         "type": "rooms.Room"
+      }
+    },
+    {
+      "countable": true,
+      "description": "The samples the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.",
+      "key": {
+        "type": "sound.SampleNum"
+      },
+      "member": "samples",
+      "module": "sound",
+      "value": {
+        "nullable": true,
+        "type": "sound.Sample"
+      }
+    },
+    {
+      "countable": true,
+      "description": "The sound effects playing now. A slot that is silent still answers, with a stale handle.",
+      "key": {
+        "base": 1,
+        "description": "Which voice.",
+        "type": "integer"
+      },
+      "member": "streams",
+      "module": "sound",
+      "value": {
+        "nullable": true,
+        "type": "sound.Stream"
       }
     }
   ],
@@ -5572,18 +5628,6 @@
       "writable": false
     },
     {
-      "description": "The soundtrack's streams as `trx.music.Stream` handles: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle. Indexing and iterating reach one handle at a time.",
-      "path": "music.streams",
-      "type": "table",
-      "writable": false
-    },
-    {
-      "description": "The tracks the current level carries, as `trx.music.Track` handles keyed by id: `trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, iterating walks them, and both reach one handle at a time.",
-      "path": "music.tracks",
-      "type": "table",
-      "writable": false
-    },
-    {
       "description": "The track playing now, or `nil` when nothing plays.",
       "path": "music.current_track",
       "type": "music.Track",
@@ -5648,18 +5692,6 @@
       "path": "rules.corpse.fade_speed",
       "type": "integer",
       "writable": true
-    },
-    {
-      "description": "The samples the current level carries, as `trx.sound.Sample` handles keyed by id: `trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts them, iterating walks them, and both reach one handle at a time.",
-      "path": "sound.samples",
-      "type": "table",
-      "writable": false
-    },
-    {
-      "description": "The sound effects playing now, as `trx.sound.Stream` handles. A slot that is silent still answers, with a stale handle. Indexing and iterating reach one handle at a time.",
-      "path": "sound.streams",
-      "type": "table",
-      "writable": false
     },
     {
       "description": "The active weather.",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3084,7 +3084,7 @@
       "path": "config.override"
     },
     {
-      "description": "Lifts one override off a setting, putting back whatever was underneath it.",
+      "description": "Lifts one override off a setting, putting back the value underneath it.",
       "params": [
         {
           "description": "Dotted path.",
@@ -3894,7 +3894,7 @@
       }
     },
     {
-      "description": "Happens when a cutscene trigger fires, before the engine acts on it. A\nhandler answers the trigger by returning true - having played a cutscene of\nits own, run something else, or decided nothing should run. If no handler\nanswers, the engine plays the cutscene the trigger names.\n\nA trigger Lara stands on fires every frame, so this happens only for a\ncutscene that has not run yet and while none is playing. Asking counts as\nrunning it, whatever came of it, so the same handler is not asked again on\nthe next frame. Clear the mark with `trx.cutscenes.set_played` to hear\nabout one again.\n\nThe number a trigger names need not be one the game has a cutscene for -\nTR4 uses 32 to ask for a full-motion video. Those reach a handler too, and\nthe engine has nothing of its own to do about them.",
+      "description": "Happens when a cutscene trigger fires, before the engine acts on it. A\nhandler answers the trigger by returning true - having played a cutscene of\nits own, run something else, or decided nothing should run. If no handler\nanswers, the engine plays the cutscene the trigger names.\n\nA trigger Lara stands on fires every frame, so this happens only for a\ncutscene that has not run yet and while none is playing. Asking counts as\nrunning it, however it ended, so the same handler is not asked again on\nthe next frame. Clear the mark with `trx.cutscenes.set_played` to hear\nabout one again.\n\nThe number a trigger names need not be one the game has a cutscene for -\nTR4 uses 32 to ask for a full-motion video. Those reach a handler too, and\nthe engine has nothing of its own to do about them.",
       "examples": [
         "-- only in the throne room; a flyby stands in for it elsewhere\ntrx.events.on_cutscene_trigger(function(cutscene_num)\n  if cutscene_num ~= 27 then\n    return false\n  end\n  if trx.lara.item.room_num == 55 then\n    trx.cutscenes.play(27)\n  else\n    trx.camera.play_flyby(3)\n  end\n  return true\nend)"
       ],
@@ -4162,7 +4162,7 @@
       }
     },
     {
-      "description": "Hangs an extra mesh on one of Lara's own, replacing whatever is there.",
+      "description": "Hangs an extra mesh on one of Lara's own, replacing the mesh there.",
       "examples": [
         "trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)"
       ],
@@ -6785,7 +6785,7 @@
             }
           ],
           "returns": {
-            "description": "The value, of whatever type the property is declared with.",
+            "description": "The value, of the type the property is declared with.",
             "nullable": true,
             "type": "any"
           }
@@ -7565,7 +7565,7 @@
       "path": "math.Rot"
     },
     {
-      "description": "An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.",
+      "description": "An axis-aligned box. Whether it is placed in the world or in something's own frame is for the call that hands it over to say.",
       "extensions": [],
       "fields": [
         {
@@ -7882,7 +7882,7 @@
             }
           ],
           "returns": {
-            "description": "The value, of whatever type the property is declared with.",
+            "description": "The value, of the type the property is declared with.",
             "nullable": true,
             "type": "any"
           }

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6089,9 +6089,10 @@
           "type": "boolean"
         },
         {
-          "description": "What the setting accepts, for the enum kinds. `nil` for the rest.",
+          "description": "What the setting accepts, for the enum kinds.",
           "list": true,
           "name": "values",
+          "optional": true,
           "type": "string"
         }
       ],
@@ -6105,14 +6106,16 @@
       "extensions": [],
       "fields": [
         {
-          "description": "The other words that reach it, or `nil` where it answers to one.",
+          "description": "The other words that reach it, where it answers to more than one.",
           "list": true,
           "name": "aliases",
+          "optional": true,
           "type": "string"
         },
         {
-          "description": "What the console shows for `--help`, or `nil` where the command carries none.",
+          "description": "What the console shows for `--help`, where the command carries any.",
           "name": "help",
+          "optional": true,
           "type": "string"
         },
         {
@@ -8762,8 +8765,9 @@
           "type": "number"
         },
         {
-          "description": "What the candidate carried.",
+          "description": "What the candidate carried, where it carried one.",
           "name": "value",
+          "optional": true,
           "type": "any"
         }
       ],

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3204,9 +3204,10 @@
             },
             {
               "description": "Other words that reach the same command. They dispatch but stay out of the command listing, and the help for the command shows them.",
+              "list": true,
               "name": "aliases",
               "optional": true,
-              "type": "table"
+              "type": "string"
             }
           ],
           "name": "spec",
@@ -4712,8 +4713,9 @@
       "params": [],
       "path": "rules.list",
       "returns": {
-        "description": "The keys, in no particular order.",
-        "type": "table"
+        "description": "In no particular order.",
+        "list": true,
+        "type": "string"
       }
     },
     {
@@ -4978,9 +4980,10 @@
       ],
       "params": [
         {
-          "description": "List of integers.",
+          "description": "The numbers to write out.",
+          "list": true,
           "name": "numbers",
-          "type": "table"
+          "type": "integer"
         },
         {
           "description": "What to put between the parts. Defaults to `\", \"`.",
@@ -5445,21 +5448,24 @@
       "writable": true
     },
     {
-      "description": "The levels of the game, in order, as a list of `trx.game.Level` counted from one.",
+      "description": "The levels of the game, in order, counted from one.",
+      "list": true,
       "path": "game.levels",
-      "type": "table",
+      "type": "game.Level",
       "writable": false
     },
     {
-      "description": "The cutscene levels, as a list of `trx.game.Level` counted from one. TR4's in-game cutscenes are a different thing, and live in `trx.cutscenes`.",
+      "description": "The cutscene levels, counted from one. TR4's in-game cutscenes are a different thing, and live in `trx.cutscenes`.",
+      "list": true,
       "path": "game.cutscenes",
-      "type": "table",
+      "type": "game.Level",
       "writable": false
     },
     {
-      "description": "The demos, as a list of `trx.game.Level` counted from one.",
+      "description": "The demos, counted from one.",
+      "list": true,
       "path": "game.demos",
-      "type": "table",
+      "type": "game.Level",
       "writable": false
     },
     {
@@ -5553,9 +5559,10 @@
       "writable": false
     },
     {
-      "description": "The mods the game was built with, as a list of `trx.mod.Mod` counted from one.",
+      "description": "The mods the game was built with, counted from one.",
+      "list": true,
       "path": "mod.list",
-      "type": "table",
+      "type": "mod.Mod",
       "writable": false
     },
     {
@@ -5778,8 +5785,9 @@
           ],
           "returns": [
             {
-              "description": "The candidates, best first.",
-              "type": "table"
+              "description": "Best first.",
+              "list": true,
+              "type": "string"
             },
             {
               "description": "Where the run they replace starts. The run is the token, or the whole tail a greedy argument swallows; in whitespace it is empty, at the caret.",
@@ -6042,8 +6050,9 @@
         },
         {
           "description": "What the setting accepts, for the enum kinds. `nil` for the rest.",
+          "list": true,
           "name": "values",
-          "type": "table"
+          "type": "string"
         }
       ],
       "handle": false,
@@ -6057,8 +6066,9 @@
       "fields": [
         {
           "description": "The other words that reach it, or `nil` where it answers to one.",
+          "list": true,
           "name": "aliases",
-          "type": "table"
+          "type": "string"
         },
         {
           "description": "What the console shows for `--help`, or `nil` where the command carries none.",
@@ -6745,8 +6755,8 @@
           "description": "Names of every property this item's object declares.",
           "name": "get_property_names",
           "returns": {
-            "description": "The names, as a list of strings.",
-            "type": "table"
+            "list": true,
+            "type": "string"
           }
         },
         {
@@ -7760,16 +7770,16 @@
           "description": "The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer `trx.objects.Object.default_names`.",
           "name": "get_default_names",
           "returns": {
-            "description": "The names, as a list of strings.",
-            "type": "table"
+            "list": true,
+            "type": "string"
           }
         },
         {
           "description": "Every name the object answers to, in the player's language. Prefer `trx.objects.Object.names`.",
           "name": "get_names",
           "returns": {
-            "description": "The names, as a list of strings.",
-            "type": "table"
+            "list": true,
+            "type": "string"
           }
         },
         {
@@ -7792,8 +7802,8 @@
           "description": "Names of every property this object declares.",
           "name": "get_property_names",
           "returns": {
-            "description": "The names, as a list of strings.",
-            "type": "table"
+            "list": true,
+            "type": "string"
           }
         },
         {
@@ -8037,16 +8047,19 @@
           "description": "The matching ids. For objects these are object ids; for items, their numbers.",
           "name": "ids",
           "returns": {
-            "description": "A list of integers.",
-            "type": "table"
+            "list": true,
+            "type": "integer"
           }
         },
         {
           "description": "The matching handles.",
           "name": "matches",
           "returns": {
-            "description": "A list of `trx.objects.Object`s or `trx.items.Item`s.",
-            "type": "table"
+            "list": true,
+            "type": [
+              "objects.Object",
+              "items.Item"
+            ]
           }
         },
         {
@@ -8106,8 +8119,8 @@
           "description": "The ids tied for the best `trx.query.NamedQuery:by_name` score: one for a name only one thing answers to, the whole group for a group name. Without a `trx.query.NamedQuery:by_name`, every matching id.",
           "name": "best",
           "returns": {
-            "description": "A list of integers.",
-            "type": "table"
+            "list": true,
+            "type": "integer"
           }
         },
         {
@@ -8132,8 +8145,8 @@
           "description": "Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no `trx.objects.ObjectQuery:pickup`.",
           "name": "names",
           "returns": {
-            "description": "A list of names.",
-            "type": "table"
+            "list": true,
+            "type": "string"
           }
         }
       ],

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5088,6 +5088,24 @@
       }
     },
     {
+      "description": "Takes the shared indentation off a block of text, so that a long string\nwritten inside `[[ ]]` reads as what it says rather than as where it sat in\nthe file. Leading and trailing blank lines go too.\n\nThe deepest lines keep the rest of their indentation, since a block may lay\nsomething out, and four spaces of it is a code block in markdown. Text may\nopen on the line the brackets are on, and that line then sets nothing and\nkeeps what it has, however the ones under it are written.",
+      "examples": [
+        "local help = trx.strings.dedent([[\n      Usage: /give <what>\n        keys   every plot item the level has a place for\n    ]])"
+      ],
+      "params": [
+        {
+          "description": "The text to take in.",
+          "name": "text",
+          "type": "string"
+        }
+      ],
+      "path": "strings.dedent",
+      "returns": {
+        "description": "The text at the left margin.",
+        "type": "string"
+      }
+    },
+    {
       "description": "Whether the game allows this weapon at all. The game flow can keep one out, and\na cheat that hands it over anyway leaves Lara with a gun the level was built\nwithout.",
       "params": [
         {

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -4162,6 +4162,24 @@
       }
     },
     {
+      "description": "Writes a value out as JSON, on one line. Keys come out in sorted order, so\nthe same value encodes the same way twice and a file that is committed and\ndiffed only moves when what it holds does.\n\nA table is written as a list where it holds entry 1, or holds nothing at\nall, and as an object otherwise. A function, a handle and anything else\nwith no JSON of its own is left out.",
+      "examples": [
+        "trx.json.encode({ name = \"wolf\", ids = { 7, 8 } })\n-- {\"ids\":[7,8],\"name\":\"wolf\"}"
+      ],
+      "params": [
+        {
+          "description": "What to write out.",
+          "name": "value",
+          "type": "any"
+        }
+      ],
+      "path": "json.encode",
+      "returns": {
+        "description": "The JSON text.",
+        "type": "string"
+      }
+    },
+    {
       "description": "Hangs an extra mesh on one of Lara's own, replacing the mesh there.",
       "examples": [
         "trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)"
@@ -5136,7 +5154,7 @@
     {
       "description": "Argument checking for the whole of `trx`.",
       "name": "api",
-      "order": 30,
+      "order": 31,
       "title": "API registry"
     },
     {
@@ -5202,6 +5220,12 @@
       "order": 2
     },
     {
+      "description": "Writing Lua values out as JSON. The API dump the reference is generated from goes through this, so what a script writes out is encoded the way the engine's own data is.",
+      "name": "json",
+      "order": 29,
+      "title": "JSON"
+    },
+    {
       "description": "Module for reading and nudging Lara's own state.\n\nHer position, room and hit points are not here: she is an item like any other and they live on it, as `trx.lara.item`.",
       "instance_type": "lara.Lara",
       "name": "lara",
@@ -5221,7 +5245,7 @@
     {
       "description": "Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the same state as every other script.",
       "name": "lua",
-      "order": 29
+      "order": 30
     },
     {
       "description": "Fixed-point trigonometry, matching the engine's own tables. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would. `trx.math.Angle` says what an angle is here.",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -64,9 +64,7 @@
       "countable": true,
       "description": "The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle.",
       "key": {
-        "base": 1,
-        "description": "Which slot.",
-        "type": "integer"
+        "type": "music.StreamNum"
       },
       "member": "streams",
       "module": "music",
@@ -139,9 +137,7 @@
       "countable": true,
       "description": "The sound effects playing now. A slot that is silent still answers, with a stale handle.",
       "key": {
-        "base": 1,
-        "description": "Which voice.",
-        "type": "integer"
+        "type": "sound.StreamNum"
       },
       "member": "streams",
       "module": "sound",
@@ -5402,8 +5398,14 @@
       "path": "items.Num"
     },
     {
+      "base": 0,
       "description": "Track number, in the numbering the loaded level carries. Not a `trx.catalog.music` name, which is the soundtrack's own.",
       "path": "music.TrackNum"
+    },
+    {
+      "base": 1,
+      "description": "Which of the soundtrack's slots: 1 is the main stream, 2 onwards the overlays.",
+      "path": "music.StreamNum"
     },
     {
       "base": 0,
@@ -5421,8 +5423,14 @@
       "path": "savegame.SlotNum"
     },
     {
+      "base": 0,
       "description": "Sample number, in the numbering the loaded level carries. Not a `trx.catalog.samples` name, which is the sound bank's own.",
       "path": "sound.SampleNum"
+    },
+    {
+      "base": 1,
+      "description": "Which of the voices playing now, counted in the order the engine holds them.",
+      "path": "sound.StreamNum"
     },
     {
       "base": 1,

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3379,7 +3379,7 @@
         {
           "description": "World position.",
           "name": "pos",
-          "type": "vec3"
+          "type": "math.Vec3"
         },
         {
           "description": "Facing angle. Defaults to `0`.",
@@ -4122,7 +4122,7 @@
         {
           "description": "World position. Must lie inside the level.",
           "name": "pos",
-          "type": "vec3"
+          "type": "math.Vec3"
         },
         {
           "default": 0,
@@ -4189,7 +4189,7 @@
         {
           "description": "World position.",
           "name": "pos",
-          "type": "vec3"
+          "type": "math.Vec3"
         },
         {
           "description": "Without it, the room is found from the position.",
@@ -4700,7 +4700,7 @@
         {
           "description": "World position.",
           "name": "pos",
-          "type": "vec3"
+          "type": "math.Vec3"
         },
         {
           "description": "The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `trx.rooms.Room:floor_height`.",
@@ -4737,7 +4737,7 @@
         {
           "description": "Position to search near.",
           "name": "pos",
-          "type": "vec3"
+          "type": "math.Vec3"
         },
         {
           "name": "room_num",
@@ -4749,7 +4749,7 @@
         {
           "description": "The valid position, or `nil` if none was found nearby.",
           "nullable": true,
-          "type": "vec3"
+          "type": "math.Vec3"
         },
         {
           "description": "The room the position is in.",
@@ -4928,7 +4928,7 @@
               "description": "A world position to play from, which applies pan and volume. Omit to play at full volume.",
               "name": "pos",
               "optional": true,
-              "type": "vec3"
+              "type": "math.Vec3"
             }
           ],
           "name": "opts",
@@ -5444,7 +5444,7 @@
     {
       "description": "Current camera position.",
       "path": "camera.pos",
-      "type": "vec3",
+      "type": "math.Vec3",
       "writable": false
     },
     {
@@ -5462,7 +5462,7 @@
     {
       "description": "Position the camera is looking at.",
       "path": "camera.target_pos",
-      "type": "vec3",
+      "type": "math.Vec3",
       "writable": false
     },
     {
@@ -6686,7 +6686,7 @@
         {
           "description": "World position. Updating this also updates `trx.items.Item.room` and `trx.items.Item.room_num`.",
           "name": "pos",
-          "type": "vec3",
+          "type": "math.Vec3",
           "writable": true
         },
         {
@@ -6696,9 +6696,9 @@
           "writable": false
         },
         {
-          "description": "Orientation. Each component is a `trx.math.Angle`.",
+          "description": "Orientation.",
           "name": "rot",
-          "type": "vec3",
+          "type": "math.Rot",
           "writable": true
         },
         {
@@ -6766,7 +6766,7 @@
             {
               "description": "World position.",
               "name": "pos",
-              "type": "vec3"
+              "type": "math.Vec3"
             }
           ],
           "returns": {
@@ -7267,12 +7267,12 @@
             {
               "description": "One corner of the box.",
               "name": "min",
-              "type": "vec3"
+              "type": "math.Vec3"
             },
             {
               "description": "The opposite corner.",
               "name": "max",
-              "type": "vec3"
+              "type": "math.Vec3"
             }
           ],
           "returns": {
@@ -7309,7 +7309,7 @@
             {
               "description": "Middle of the sphere.",
               "name": "centre",
-              "type": "vec3"
+              "type": "math.Vec3"
             },
             {
               "description": "How far out it reaches.",
@@ -7513,6 +7513,56 @@
       "methods": [],
       "operators": [],
       "path": "lua.Error"
+    },
+    {
+      "description": "A point or a direction in the world.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "The east-west axis.",
+          "name": "x",
+          "type": "math.Distance"
+        },
+        {
+          "description": "The up-down axis.",
+          "name": "y",
+          "type": "math.Distance"
+        },
+        {
+          "description": "The north-south axis.",
+          "name": "z",
+          "type": "math.Distance"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "math.Vec3"
+    },
+    {
+      "description": "An orientation, as three angles about the world axes.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "Pitch, nose up and down.",
+          "name": "x",
+          "type": "math.Angle"
+        },
+        {
+          "description": "Yaw, the direction it faces.",
+          "name": "y",
+          "type": "math.Angle"
+        },
+        {
+          "description": "Roll, the tilt about its own length.",
+          "name": "z",
+          "type": "math.Angle"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "math.Rot"
     },
     {
       "description": "An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.",
@@ -8263,7 +8313,7 @@
             {
               "description": "World position.",
               "name": "pos",
-              "type": "vec3"
+              "type": "math.Vec3"
             },
             {
               "description": "How to read the floor.",
@@ -8395,7 +8445,7 @@
             {
               "description": "World position.",
               "name": "pos",
-              "type": "vec3"
+              "type": "math.Vec3"
             }
           ],
           "returns": {
@@ -8505,7 +8555,7 @@
                   "description": "A world position to play from, which applies pan and volume. Omit to play at full volume.",
                   "name": "pos",
                   "optional": true,
-                  "type": "vec3"
+                  "type": "math.Vec3"
                 }
               ],
               "name": "opts",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2811,21 +2811,8 @@
       "path": "assault.stats.list_records",
       "returns": {
         "description": "The records.",
-        "fields": [
-          {
-            "description": "The time it took.",
-            "name": "time",
-            "type": "game.Seconds"
-          },
-          {
-            "base": 1,
-            "description": "Which attempt it was.",
-            "name": "attempt_num",
-            "type": "integer"
-          }
-        ],
         "list": true,
-        "type": "table"
+        "type": "assault.Record"
       }
     },
     {
@@ -2946,24 +2933,7 @@
       "path": "config.describe",
       "returns": {
         "description": "What the setting is and how it is entered.",
-        "fields": [
-          {
-            "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
-            "name": "kind",
-            "type": "string"
-          },
-          {
-            "description": "Marks a number stored 0-1 but entered and shown as a 0-100 percentage.",
-            "name": "percent",
-            "type": "boolean"
-          },
-          {
-            "description": "What the setting accepts, for the enum kinds. `nil` for the rest.",
-            "name": "values",
-            "type": "table"
-          }
-        ],
-        "type": "table"
+        "type": "config.Shape"
       }
     },
     {
@@ -3254,29 +3224,12 @@
       "path": "console.commands",
       "returns": {
         "description": "The commands.",
-        "fields": [
-          {
-            "description": "The word the player types.",
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "description": "The other words that reach it, or `nil` where it answers to one.",
-            "name": "aliases",
-            "type": "table"
-          },
-          {
-            "description": "What the console shows for `--help`, or `nil` where the command carries none.",
-            "name": "help",
-            "type": "string"
-          }
-        ],
         "list": true,
-        "type": "table"
+        "type": "console.Command"
       }
     },
     {
-      "description": "The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches. The same `{ name, aliases, help }` as an entry of `trx.console.commands`, or nil when nothing answers to the name.",
+      "description": "The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches.",
       "params": [
         {
           "description": "The word or alias to look up.",
@@ -3286,8 +3239,9 @@
       ],
       "path": "console.command",
       "returns": {
-        "description": "`{ name, aliases, help }`, or nil.",
-        "type": "table"
+        "description": "`nil` when nothing answers to the name.",
+        "nullable": true,
+        "type": "console.Command"
       }
     },
     {
@@ -4376,20 +4330,8 @@
       "path": "lua.eval_expr",
       "returns": {
         "description": "`nil` when the code ran to completion, and what went wrong otherwise. A failure comes back as a value rather than raising, so the caller decides what it means.",
-        "fields": [
-          {
-            "description": "Either `\"syntax\"` or `\"runtime\"`.",
-            "name": "kind",
-            "type": "string"
-          },
-          {
-            "description": "The error text.",
-            "name": "message",
-            "type": "string"
-          }
-        ],
         "nullable": true,
-        "type": "table"
+        "type": "lua.Error"
       }
     },
     {
@@ -4408,7 +4350,7 @@
       "returns": {
         "description": "As in `trx.lua.eval_expr`.",
         "nullable": true,
-        "type": "table"
+        "type": "lua.Error"
       }
     },
     {
@@ -5006,35 +4948,8 @@
       "path": "strings.fuzzy_match",
       "returns": {
         "description": "The matches, best first.",
-        "fields": [
-          {
-            "description": "The candidate that matched.",
-            "name": "key",
-            "type": "string"
-          },
-          {
-            "description": "What the candidate carried.",
-            "name": "value",
-            "type": "any"
-          },
-          {
-            "description": "How well it matched.",
-            "name": "score",
-            "type": "number"
-          },
-          {
-            "description": "Whether the whole candidate matched.",
-            "name": "is_full",
-            "type": "boolean"
-          },
-          {
-            "description": "Whether a whole word matched.",
-            "name": "is_word",
-            "type": "boolean"
-          }
-        ],
         "list": true,
-        "type": "table"
+        "type": "strings.Match"
       }
     },
     {
@@ -5363,6 +5278,11 @@
       "base": 1,
       "description": "Where a time sits in the table of best times, fastest first.",
       "path": "assault.RecordNum"
+    },
+    {
+      "base": 1,
+      "description": "Which attempt at a track it was, counted in the order they were made.",
+      "path": "assault.AttemptNum"
     },
     {
       "base": 0,
@@ -6086,6 +6006,75 @@
       ],
       "operators": [],
       "path": "argparse.Parser"
+    },
+    {
+      "description": "One of a track's best times.",
+      "extensions": [],
+      "fields": [
+        {
+          "name": "attempt_num",
+          "type": "assault.AttemptNum"
+        },
+        {
+          "description": "The time it took.",
+          "name": "time",
+          "type": "game.Seconds"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "assault.Record"
+    },
+    {
+      "description": "How a setting is entered and shown, beyond the type it reads back as.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
+          "name": "kind",
+          "type": "string"
+        },
+        {
+          "description": "Marks a number stored 0-1 but entered and shown as a 0-100 percentage.",
+          "name": "percent",
+          "type": "boolean"
+        },
+        {
+          "description": "What the setting accepts, for the enum kinds. `nil` for the rest.",
+          "name": "values",
+          "type": "table"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "config.Shape"
+    },
+    {
+      "description": "A registered console command, as the help command reads one.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "The other words that reach it, or `nil` where it answers to one.",
+          "name": "aliases",
+          "type": "table"
+        },
+        {
+          "description": "What the console shows for `--help`, or `nil` where the command carries none.",
+          "name": "help",
+          "type": "string"
+        },
+        {
+          "description": "The word the player types.",
+          "name": "name",
+          "type": "string"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "console.Command"
     },
     {
       "description": "An attached handler. Every hook hands one back, and holding it is what makes the handler detachable later. A listener is spent once detached, and a level change spends every one a level script attached.",
@@ -7457,6 +7446,26 @@
       "path": "lara.Lara"
     },
     {
+      "description": "What went wrong while running Lua.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "Either `\"syntax\"` or `\"runtime\"`.",
+          "name": "kind",
+          "type": "string"
+        },
+        {
+          "description": "The error text.",
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "lua.Error"
+    },
+    {
       "description": "An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.",
       "extensions": [],
       "fields": [
@@ -8674,6 +8683,41 @@
       ],
       "operators": [],
       "path": "stats.Stats"
+    },
+    {
+      "description": "A candidate that matched, and how well.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "Whether the whole candidate matched.",
+          "name": "is_full",
+          "type": "boolean"
+        },
+        {
+          "description": "Whether a whole word matched.",
+          "name": "is_word",
+          "type": "boolean"
+        },
+        {
+          "description": "The candidate that matched.",
+          "name": "key",
+          "type": "string"
+        },
+        {
+          "description": "How well it matched.",
+          "name": "score",
+          "type": "number"
+        },
+        {
+          "description": "What the candidate carried.",
+          "name": "value",
+          "type": "any"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "strings.Match"
     }
   ],
   "units": [

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2617,7 +2617,7 @@
   ],
   "functions": [
     {
-      "description": "Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.",
+      "description": "Turns argument checking on or off for every function in `trx`, and for the\nmethods on its handles. Off by default: checking costs a couple of hundred\nnanoseconds a call, which a per-frame handler notices. Turn it on while\nwriting a level, and leave it off in play.",
       "examples": [
         "trx.api.strict(true)"
       ],
@@ -6453,26 +6453,22 @@
         {
           "description": "The code bits it set, `1` to `31`.",
           "name": "mask",
-          "type": "integer",
-          "writable": true
+          "type": "integer"
         },
         {
           "description": "Whether it fires only the once.",
           "name": "one_shot",
-          "type": "boolean",
-          "writable": true
+          "type": "boolean"
         },
         {
           "description": "How long it keeps the item going.",
           "name": "timer",
-          "type": "game.Seconds",
-          "writable": true
+          "type": "game.Seconds"
         },
         {
           "description": "The kind of trigger it was.",
           "name": "type",
-          "type": "items.TriggerType",
-          "writable": true
+          "type": "items.TriggerType"
         }
       ],
       "handle": false,
@@ -7467,38 +7463,32 @@
         {
           "description": "East edge.",
           "name": "max_x",
-          "type": "math.Distance",
-          "writable": true
+          "type": "math.Distance"
         },
         {
           "description": "Bottom edge.",
           "name": "max_y",
-          "type": "math.Distance",
-          "writable": true
+          "type": "math.Distance"
         },
         {
           "description": "South edge.",
           "name": "max_z",
-          "type": "math.Distance",
-          "writable": true
+          "type": "math.Distance"
         },
         {
           "description": "West edge.",
           "name": "min_x",
-          "type": "math.Distance",
-          "writable": true
+          "type": "math.Distance"
         },
         {
           "description": "Top edge.",
           "name": "min_y",
-          "type": "math.Distance",
-          "writable": true
+          "type": "math.Distance"
         },
         {
           "description": "North edge.",
           "name": "min_z",
-          "type": "math.Distance",
-          "writable": true
+          "type": "math.Distance"
         }
       ],
       "handle": false,

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -1,6 +1,6 @@
 ---
 title: API registry
-order: 30
+order: 31
 ---
 
 <!--

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -17,7 +17,10 @@ Argument checking for the whole of `trx`.
 ### Functions
 
 - <a id="api.strict" name="api.strict"></a>[lua]`trx.api.strict(enabled)`  
-  Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.
+  Turns argument checking on or off for every function in `trx`, and for the
+  methods on its handles. Off by default: checking costs a couple of hundred
+  nanoseconds a call, which a per-frame handler notices. Turn it on while
+  writing a level, and leave it off in play.
 
   Parameters:
   - <a id="api.strict.enabled" name="api.strict.enabled"></a>**`enabled`** (boolean). Whether to check.

--- a/docs/trx/lua/reference/ARGPARSE.md
+++ b/docs/trx/lua/reference/ARGPARSE.md
@@ -54,7 +54,7 @@ A choice is either a bare string, where the key and value are the same, or a
 
       Parameters:
       - <a id="argparse.Parser.any_of.name" name="argparse.Parser.any_of.name"></a>**`name`** (string). What the parsed value is keyed by.
-      - <a id="argparse.Parser.any_of.alternatives" name="argparse.Parser.any_of.alternatives"></a>**`alternatives`** (table). The ways the token may read, tried in order.
+      - <a id="argparse.Parser.any_of.alternatives" name="argparse.Parser.any_of.alternatives"></a>**`alternatives`** (a list of table). The ways the token may read, tried in order.
 
         Each entry:
         - <a id="argparse.Parser.any_of.alternatives.type" name="argparse.Parser.any_of.alternatives.type"></a>**`type`** (string, optional). As for [`positional`](#argparse.Parser.positional).
@@ -81,7 +81,7 @@ A choice is either a bare string, where the key and value are the same, or a
       - <a id="argparse.Parser.complete.caret" name="argparse.Parser.complete.caret"></a>**`caret`** (integer, optional). Where the caret sits, as a byte offset. The end of the line by default.
 
       Returns:
-      - table. The candidates, best first.
+      - a list of string. Best first.
       - integer. Where the run they replace starts. The run is the token, or the whole tail a greedy argument swallows; in whitespace it is empty, at the caret.
       - integer. Where that run ends.
 

--- a/docs/trx/lua/reference/ARGPARSE.md
+++ b/docs/trx/lua/reference/ARGPARSE.md
@@ -71,7 +71,7 @@ A choice is either a bare string, where the key and value are the same, or a
         - <a id="argparse.Parser.any_of.opts.suggest" name="argparse.Parser.any_of.opts.suggest"></a>**`suggest`** (function, optional). Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.
         - <a id="argparse.Parser.any_of.opts.help" name="argparse.Parser.any_of.opts.help"></a>**`help`** (string, optional). What the argument is for, shown in the help.
 
-      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+      Returns: [trx.argparse.Parser](#argparse.Parser). The same parser, so declarations chain.
 
     - <a id="argparse.Parser.complete" name="argparse.Parser.complete"></a>[lua]`parser:complete([text], [caret])`  
       The candidate completions for the token the caret sits in. Matching is against the text before the caret.
@@ -81,7 +81,7 @@ A choice is either a bare string, where the key and value are the same, or a
       - <a id="argparse.Parser.complete.caret" name="argparse.Parser.complete.caret"></a>**`caret`** (integer, optional). Where the caret sits, as a byte offset. The end of the line by default.
 
       Returns:
-      - a list of string. Best first.
+      - a list of string. The best match comes first.
       - integer. Where the run they replace starts. The run is the token, or the whole tail a greedy argument swallows; in whitespace it is empty, at the caret.
       - integer. Where that run ends.
 
@@ -97,7 +97,7 @@ A choice is either a bare string, where the key and value are the same, or a
         - <a id="argparse.Parser.flag.opts.long" name="argparse.Parser.flag.opts.long"></a>**`long`** (string, optional). The long spelling, such as `"--force"`.
         - <a id="argparse.Parser.flag.opts.help" name="argparse.Parser.flag.opts.help"></a>**`help`** (string, optional). What the flag is for, shown in the help.
 
-      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+      Returns: [trx.argparse.Parser](#argparse.Parser). The same parser, so declarations chain.
 
     - <a id="argparse.Parser.format_error" name="argparse.Parser.format_error"></a>[lua]`parser:format_error(err)`  
       Turns what a refused line reported into a localized line naming what was wrong and what was expected.
@@ -134,7 +134,7 @@ A choice is either a bare string, where the key and value are the same, or a
         - <a id="argparse.Parser.positional.opts.suggest" name="argparse.Parser.positional.opts.suggest"></a>**`suggest`** (function, optional). Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.
         - <a id="argparse.Parser.positional.opts.help" name="argparse.Parser.positional.opts.help"></a>**`help`** (string, optional). What the argument is for, shown in the help.
 
-      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+      Returns: [trx.argparse.Parser](#argparse.Parser). The same parser, so declarations chain.
 
     - <a id="argparse.Parser.rest" name="argparse.Parser.rest"></a>[lua]`parser:rest(name, [opts])`  
       Adds an argument taking the rest of the line from here on, verbatim as one string, or `nil` where an optional one is absent. Always the last argument.
@@ -150,7 +150,7 @@ A choice is either a bare string, where the key and value are the same, or a
         - <a id="argparse.Parser.rest.opts.suggest" name="argparse.Parser.rest.opts.suggest"></a>**`suggest`** (function, optional). Completions to offer, without restricting what is accepted or being shown in errors. For a free value with a long list behind it, like a setting name.
         - <a id="argparse.Parser.rest.opts.help" name="argparse.Parser.rest.opts.help"></a>**`help`** (string, optional). What the argument is for, shown in the help.
 
-      Returns: [trx.argparse.Parser](#argparse.Parser). The parser.
+      Returns: [trx.argparse.Parser](#argparse.Parser). The same parser, so declarations chain.
 
     - <a id="argparse.Parser.usage" name="argparse.Parser.usage"></a>[lua]`parser:usage()`  
       A short description of what the command accepts.

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -121,7 +121,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Parameters:
   - <a id="assault.stats.list_records.track" name="assault.stats.list_records.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-  Returns: a list of [trx.assault.Record](#assault.Record). The records.
+  Returns: a list of [trx.assault.Record](#assault.Record).
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -35,6 +35,18 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
     Where a time sits in the table of best times, fastest first. Counted from 1.
 
+- <a id="assault.AttemptNum" name="assault.AttemptNum"></a>[lua]`trx.assault.AttemptNum`
+
+    Which attempt at a track it was, counted in the order they were made. Counted from 1.
+
+- <a id="assault.Record" name="assault.Record"></a>[lua]`trx.assault.Record`
+
+    One of a track's best times.
+
+    Properties:
+    - <a id="assault.Record.attempt_num" name="assault.Record.attempt_num"></a>**`attempt_num`**: [trx.assault.AttemptNum](#assault.AttemptNum).
+    - <a id="assault.Record.time" name="assault.Record.time"></a>**`time`**: [trx.game.Seconds](GAME.md#game.Seconds). The time it took.
+
 ### Functions
 
 - <a id="assault.stats" name="assault.stats"></a>[lua]`trx.assault.stats`  
@@ -109,11 +121,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Parameters:
   - <a id="assault.stats.list_records.track" name="assault.stats.list_records.track"></a>**`track`** ([trx.assault.Track](#assault.Track), optional, default [`trx.assault.Track.COURSE`](#assault.Track)).
 
-  Returns: table. The records.
-
-    Each entry:
-    - <a id="assault.stats.list_records.time" name="assault.stats.list_records.time"></a>**`time`** ([trx.game.Seconds](GAME.md#game.Seconds)). The time it took.
-    - <a id="assault.stats.list_records.attempt_num" name="assault.stats.list_records.attempt_num"></a>**`attempt_num`** (integer). Which attempt it was. Counted from 1.
+  Returns: a list of [trx.assault.Record](#assault.Record). The records.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -16,10 +16,10 @@ Module for inspecting the active camera state.
 
 ### Properties
 
-- <a id="camera.pos" name="camera.pos"></a>**`trx.camera.pos`** (vec3). Current camera position. *(read-only)*
+- <a id="camera.pos" name="camera.pos"></a>**`trx.camera.pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). Current camera position. *(read-only)*
 - <a id="camera.room_num" name="camera.room_num"></a>**`trx.camera.room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is in, or `nil` if unknown. *(read-only)*
 - <a id="camera.room" name="camera.room"></a>**`trx.camera.room`** ([trx.rooms.Room](ROOMS.md#rooms.Room)). The room the camera is in, or `nil` if unknown. *(read-only)*
-- <a id="camera.target_pos" name="camera.target_pos"></a>**`trx.camera.target_pos`** (vec3). Position the camera is looking at. *(read-only)*
+- <a id="camera.target_pos" name="camera.target_pos"></a>**`trx.camera.target_pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). Position the camera is looking at. *(read-only)*
 - <a id="camera.target_room_num" name="camera.target_room_num"></a>**`trx.camera.target_room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num)). The room the camera is looking at, or `nil` if unknown. *(read-only)*
 - <a id="camera.is_flyby_active" name="camera.is_flyby_active"></a>**`trx.camera.is_flyby_active`** (boolean). Whether a flyby camera sequence is playing. *(read-only)*
 

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -16,6 +16,17 @@ Module for reading and changing engine settings.
 
 These are the player's settings, not the level's. [`trx.config.set`](#config.set) writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants [`trx.config.override`](#config.override) instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.
 
+### Structures
+
+- <a id="config.Shape" name="config.Shape"></a>[lua]`trx.config.Shape`
+
+    How a setting is entered and shown, beyond the type it reads back as.
+
+    Properties:
+    - <a id="config.Shape.kind" name="config.Shape.kind"></a>**`kind`**: string. One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.
+    - <a id="config.Shape.percent" name="config.Shape.percent"></a>**`percent`**: boolean. Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
+    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: table. What the setting accepts, for the enum kinds. `nil` for the rest.
+
 ### Functions
 
 - <a id="config.get" name="config.get"></a>[lua]`trx.config.get(key)`  
@@ -39,12 +50,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   Parameters:
   - <a id="config.describe.key" name="config.describe.key"></a>**`key`** (string). Dotted path.
 
-  Returns: table. What the setting is and how it is entered.
-
-    Keys:
-    - <a id="config.describe.kind" name="config.describe.kind"></a>**`kind`** (string). One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.
-    - <a id="config.describe.percent" name="config.describe.percent"></a>**`percent`** (boolean). Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
-    - <a id="config.describe.values" name="config.describe.values"></a>**`values`** (table). What the setting accepts, for the enum kinds. `nil` for the rest.
+  Returns: [trx.config.Shape](#config.Shape). What the setting is and how it is entered.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -116,7 +116,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   ```
 
 - <a id="config.restore" name="config.restore"></a>[lua]`trx.config.restore(key)`  
-  Lifts one override off a setting, putting back whatever was underneath it.
+  Lifts one override off a setting, putting back the value underneath it.
 
   Parameters:
   - <a id="config.restore.key" name="config.restore.key"></a>**`key`** (string). Dotted path.

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -25,7 +25,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
     Properties:
     - <a id="config.Shape.kind" name="config.Shape.kind"></a>**`kind`**: string. One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.
     - <a id="config.Shape.percent" name="config.Shape.percent"></a>**`percent`**: boolean. Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
-    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: a list of string. What the setting accepts, for the enum kinds. `nil` for the rest.
+    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: a list of string, optional. What the setting accepts, for the enum kinds.
 
 ### Functions
 

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -25,7 +25,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
     Properties:
     - <a id="config.Shape.kind" name="config.Shape.kind"></a>**`kind`**: string. One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.
     - <a id="config.Shape.percent" name="config.Shape.percent"></a>**`percent`**: boolean. Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
-    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: table. What the setting accepts, for the enum kinds. `nil` for the rest.
+    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: a list of string. What the setting accepts, for the enum kinds. `nil` for the rest.
 
 ### Functions
 

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -148,7 +148,7 @@ Module for interacting with the developer console.
 - <a id="console.commands" name="console.commands"></a>[lua]`trx.console.commands()`  
   Every registered console command, in registration order. The help command is built on this.
 
-  Returns: a list of [trx.console.Command](#console.Command). The commands.
+  Returns: a list of [trx.console.Command](#console.Command).
 
 - <a id="console.command" name="console.command"></a>[lua]`trx.console.command(name)`  
   The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches.

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -31,6 +31,17 @@ Module for interacting with the developer console.
     - `trx.console.Result.BAD_INVOCATION` = `3`  
         The player typed it wrong.
 
+### Structures
+
+- <a id="console.Command" name="console.Command"></a>[lua]`trx.console.Command`
+
+    A registered console command, as the help command reads one.
+
+    Properties:
+    - <a id="console.Command.aliases" name="console.Command.aliases"></a>**`aliases`**: table. The other words that reach it, or `nil` where it answers to one.
+    - <a id="console.Command.help" name="console.Command.help"></a>**`help`**: string. What the console shows for `--help`, or `nil` where the command carries none.
+    - <a id="console.Command.name" name="console.Command.name"></a>**`name`**: string. The word the player types.
+
 ### Functions
 
 - <a id="console.log" name="console.log"></a>[lua]`trx.console.log(message)`  
@@ -137,17 +148,12 @@ Module for interacting with the developer console.
 - <a id="console.commands" name="console.commands"></a>[lua]`trx.console.commands()`  
   Every registered console command, in registration order. The help command is built on this.
 
-  Returns: table. The commands.
-
-    Each entry:
-    - <a id="console.commands.name" name="console.commands.name"></a>**`name`** (string). The word the player types.
-    - <a id="console.commands.aliases" name="console.commands.aliases"></a>**`aliases`** (table). The other words that reach it, or `nil` where it answers to one.
-    - <a id="console.commands.help" name="console.commands.help"></a>**`help`** (string). What the console shows for `--help`, or `nil` where the command carries none.
+  Returns: a list of [trx.console.Command](#console.Command). The commands.
 
 - <a id="console.command" name="console.command"></a>[lua]`trx.console.command(name)`  
-  The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches. The same `{ name, aliases, help }` as an entry of [`trx.console.commands`](#console.commands), or nil when nothing answers to the name.
+  The command a name reaches, by its own name or an alias, matched as the console matches when it dispatches.
 
   Parameters:
   - <a id="console.command.name" name="console.command.name"></a>**`name`** (string). The word or alias to look up.
 
-  Returns: table. `{ name, aliases, help }`, or nil.
+  Returns: [trx.console.Command](#console.Command) or `nil`. `nil` when nothing answers to the name.

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -38,7 +38,7 @@ Module for interacting with the developer console.
     A registered console command, as the help command reads one.
 
     Properties:
-    - <a id="console.Command.aliases" name="console.Command.aliases"></a>**`aliases`**: table. The other words that reach it, or `nil` where it answers to one.
+    - <a id="console.Command.aliases" name="console.Command.aliases"></a>**`aliases`**: a list of string. The other words that reach it, or `nil` where it answers to one.
     - <a id="console.Command.help" name="console.Command.help"></a>**`help`**: string. What the console shows for `--help`, or `nil` where the command carries none.
     - <a id="console.Command.name" name="console.Command.name"></a>**`name`**: string. The word the player types.
 
@@ -126,7 +126,7 @@ Module for interacting with the developer console.
     - <a id="console.register.spec.help" name="console.register.spec.help"></a>**`help`** (string, optional). A game string key for the help text.
     - <a id="console.register.spec.args" name="console.register.spec.args"></a>**`args`** (function, optional). Shapes the parser.
     - <a id="console.register.spec.run" name="console.register.spec.run"></a>**`run`** (function). Called with the parsed arguments.
-    - <a id="console.register.spec.aliases" name="console.register.spec.aliases"></a>**`aliases`** (table, optional). Other words that reach the same command. They dispatch but stay out of the command listing, and the help for the command shows them.
+    - <a id="console.register.spec.aliases" name="console.register.spec.aliases"></a>**`aliases`** (a list of string, optional). Other words that reach the same command. They dispatch but stay out of the command listing, and the help for the command shows them.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -38,8 +38,8 @@ Module for interacting with the developer console.
     A registered console command, as the help command reads one.
 
     Properties:
-    - <a id="console.Command.aliases" name="console.Command.aliases"></a>**`aliases`**: a list of string. The other words that reach it, or `nil` where it answers to one.
-    - <a id="console.Command.help" name="console.Command.help"></a>**`help`**: string. What the console shows for `--help`, or `nil` where the command carries none.
+    - <a id="console.Command.aliases" name="console.Command.aliases"></a>**`aliases`**: a list of string, optional. The other words that reach it, where it answers to more than one.
+    - <a id="console.Command.help" name="console.Command.help"></a>**`help`**: string, optional. What the console shows for `--help`, where the command carries any.
     - <a id="console.Command.name" name="console.Command.name"></a>**`name`**: string. The word the player types.
 
 ### Functions

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -84,7 +84,7 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
   runs, and is forgotten once she has been placed.
 
   Parameters:
-  - <a id="cutscenes.set_lara_return.pos" name="cutscenes.set_lara_return.pos"></a>**`pos`** (vec3). World position.
+  - <a id="cutscenes.set_lara_return.pos" name="cutscenes.set_lara_return.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
   - <a id="cutscenes.set_lara_return.rot" name="cutscenes.set_lara_return.rot"></a>**`rot`** ([trx.math.Angle](MATH.md#math.Angle), optional). Facing angle. Defaults to `0`.
 
   Example:

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -432,7 +432,7 @@ An event that carries a default the script may take over says so in its descript
 
   A trigger Lara stands on fires every frame, so this happens only for a
   cutscene that has not run yet and while none is playing. Asking counts as
-  running it, whatever came of it, so the same handler is not asked again on
+  running it, however it ended, so the same handler is not asked again on
   the next frame. Clear the mark with [`trx.cutscenes.set_played`](CUTSCENES.md#cutscenes.set_played) to hear
   about one again.
 

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -374,9 +374,10 @@ An event that carries a default the script may take over says so in its descript
 
 - <a id="events.on_hit" name="events.on_hit"></a>[lua]`trx.events.on_hit(callback)`  
   Happens when an item takes damage, Lara included. It is the raw damage that
-  fires, before the item's hit points are clamped, so a fatal blow reports the whole amount the
-  attacker dealt. A death that does not go through damage - a script writing
-  [`trx.items.Item.hit_points`](ITEMS.md#items.Item.hit_points), or [`trx.items.Item:destroy`](ITEMS.md#items.Item.destroy) - does not report.
+  fires, before the item's hit points are clamped, so a fatal blow reports
+  the whole amount the attacker dealt. A death that does not go through
+  damage - a script writing [`trx.items.Item.hit_points`](ITEMS.md#items.Item.hit_points), or
+  [`trx.items.Item:destroy`](ITEMS.md#items.Item.destroy) - does not report.
 
   [`trx.items.Item:on_hit`](ITEMS.md#items.Item.on_hit) is this same event, narrowed to one item.
 
@@ -396,14 +397,16 @@ An event that carries a default the script may take over says so in its descript
   ```
 
 - <a id="events.on_kill" name="events.on_kill"></a>[lua]`trx.events.on_kill(callback)`  
-  Happens when damage takes an item's hit points to zero, Lara included. It is the
-  same blow [`trx.events.on_hit`](#events.on_hit) reports, which fires first. A death that does not go through damage
-  - a script writing [`trx.items.Item.hit_points`](ITEMS.md#items.Item.hit_points), or [`trx.items.Item:destroy`](ITEMS.md#items.Item.destroy) - does not report.
+  Happens when damage takes an item's hit points to zero, Lara included. It
+  is the same blow [`trx.events.on_hit`](#events.on_hit) reports, which fires first. A death
+  that does not go through damage - a script writing
+  [`trx.items.Item.hit_points`](ITEMS.md#items.Item.hit_points), or [`trx.items.Item:destroy`](ITEMS.md#items.Item.destroy) - does not report.
 
-  Some bosses fall and get back up: Willard is knocked out, Natla plays dead before her second
-  stage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points
-  to zero, so they report once per stage rather than once per boss, and the dragon reports once
-  more for the dagger that ends it.
+  Some bosses fall and get back up: Willard is knocked out, Natla plays dead
+  before her second stage, and the dragon lies still until Lara takes the
+  dagger. Each stage brings their hit points to zero, so they report once per
+  stage rather than once per boss, and the dragon reports once more for the
+  dagger that ends it.
 
   [`trx.items.Item:on_kill`](ITEMS.md#items.Item.on_kill) is this same event, narrowed to one item.
 

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -22,7 +22,7 @@ Module for the game flow: which levels there are, and which one is being played.
 - <a id="game.current_level" name="game.current_level"></a>**`trx.game.current_level`** ([trx.game.Level](#game.Level)). The level being played, or `nil` if none is. *(read-only)*
 - <a id="game.gym" name="game.gym"></a>**`trx.game.gym`** ([trx.game.Level](#game.Level)). The gym level, or `nil` if this game has no gym. *(read-only)*
 - <a id="game.version" name="game.version"></a>**`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
-- <a id="game.trx_version" name="game.trx_version"></a>**`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
+- <a id="game.trx_version" name="game.trx_version"></a>**`trx.game.trx_version`** (string). What this build reports as its version: `1.9.3` for a release, and the tag with the commits since it for a development build. *(read-only)*
 - <a id="game.is_loaded" name="game.is_loaded"></a>**`trx.game.is_loaded`** (boolean). Whether a level is loaded. *(read-only)*
 - <a id="game.is_playable" name="game.is_playable"></a>**`trx.game.is_playable`** (boolean). Whether the game is loaded and taking input - not in a menu, and not in a cutscene. *(read-only)*
 - <a id="game.is_ngplus" name="game.is_ngplus"></a>**`trx.game.is_ngplus`** (boolean). Whether this is a new game plus run, which is what the passport's bonus start sets. Lara keeps her weapons between levels and her ammunition does not run down. *(read-only)*

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -16,9 +16,9 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Properties
 
-- <a id="game.levels" name="game.levels"></a>**`trx.game.levels`** (table). The levels of the game, in order, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
-- <a id="game.cutscenes" name="game.cutscenes"></a>**`trx.game.cutscenes`** (table). The cutscene levels, as a list of [`trx.game.Level`](#game.Level) counted from one. TR4's in-game cutscenes are a different thing, and live in [`trx.cutscenes`](CUTSCENES.md#cutscenes). *(read-only)*
-- <a id="game.demos" name="game.demos"></a>**`trx.game.demos`** (table). The demos, as a list of [`trx.game.Level`](#game.Level) counted from one. *(read-only)*
+- <a id="game.levels" name="game.levels"></a>**`trx.game.levels`** (a list of [trx.game.Level](#game.Level)). The levels of the game, in order, counted from one. *(read-only)*
+- <a id="game.cutscenes" name="game.cutscenes"></a>**`trx.game.cutscenes`** (a list of [trx.game.Level](#game.Level)). The cutscene levels, counted from one. TR4's in-game cutscenes are a different thing, and live in [`trx.cutscenes`](CUTSCENES.md#cutscenes). *(read-only)*
+- <a id="game.demos" name="game.demos"></a>**`trx.game.demos`** (a list of [trx.game.Level](#game.Level)). The demos, counted from one. *(read-only)*
 - <a id="game.current_level" name="game.current_level"></a>**`trx.game.current_level`** ([trx.game.Level](#game.Level)). The level being played, or `nil` if none is. *(read-only)*
 - <a id="game.gym" name="game.gym"></a>**`trx.game.gym`** ([trx.game.Level](#game.Level)). The gym level, or `nil` if this game has no gym. *(read-only)*
 - <a id="game.version" name="game.version"></a>**`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*

--- a/docs/trx/lua/reference/INVENTORY.md
+++ b/docs/trx/lua/reference/INVENTORY.md
@@ -27,7 +27,7 @@ has.
 
 Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries are keyed by the order they are drawn in, and are built one at a time as they are asked for. `pairs()` walks them.
 
-- <a id="inventory[]" name="inventory[]"></a>**`trx.inventory[key]`** ([trx.inventory.Entry](#inventory.Entry) or `nil`).
+- <a id="inventory[]" name="inventory[]"></a>**`trx.inventory[key]`** (key: [trx.inventory.EntryNum](#inventory.EntryNum), value: [trx.inventory.Entry](#inventory.Entry) or `nil`).
 - **`#trx.inventory`** (integer). How many there are.
 
 Example:

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -191,7 +191,7 @@ end
       Parameters:
       - <a id="items.Item.get_property.name" name="items.Item.get_property.name"></a>**`name`** (string). Which property, as the object declares it.
 
-      Returns: any or `nil`. The value, of whatever type the property is declared with.
+      Returns: any or `nil`. The value, of the type the property is declared with.
 
     - <a id="items.Item.get_property_names" name="items.Item.get_property_names"></a>[lua]`item:get_property_names()`  
       Names of every property this item's object declares.

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -450,10 +450,10 @@ end
       - <a id="items.Item.shatter.damage" name="items.Item.shatter.damage"></a>**`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
 
     - <a id="items.Item.take_damage" name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
-      Hurts the item the way a weapon does, and reports through [`trx.events.on_hit`](EVENTS.md#events.on_hit),
-      and [`trx.events.on_kill`](EVENTS.md#events.on_kill) where the blow takes the last hit point. Writing
-      [`hit_points`](#items.Item.hit_points) reports neither. The kill counts as the
-      environment's rather than Lara's.
+      Hurts the item the way a weapon does, and reports through
+      [`trx.events.on_hit`](EVENTS.md#events.on_hit), and [`trx.events.on_kill`](EVENTS.md#events.on_kill) where the blow takes the
+      last hit point. Writing [`hit_points`](#items.Item.hit_points) reports neither.
+      The kill counts as the environment's rather than Lara's.
 
       Parameters:
       - <a id="items.Item.take_damage.damage" name="items.Item.take_damage.damage"></a>**`damage`** (integer). Hit points to take.

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -196,7 +196,7 @@ end
     - <a id="items.Item.get_property_names" name="items.Item.get_property_names"></a>[lua]`item:get_property_names()`  
       Names of every property this item's object declares.
 
-      Returns: table. The names, as a list of strings.
+      Returns: a list of string.
 
     - <a id="items.Item.is_valid" name="items.Item.is_valid"></a>[lua]`item:is_valid()`  
       Whether the handle still refers to a live item. Reading or writing a field on a stale handle raises an error rather than silently operating on an unrelated item, so check this for a handle held across time.

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -18,7 +18,7 @@ Module for controlling all moveables.
 
 Indexing the module reaches an item, and `#trx.items` is how many the level has. `pairs()` walks them in order, keyed by the item number.
 
-- <a id="items[]" name="items[]"></a>**`trx.items[key]`** ([trx.items.Item](#items.Item) or `nil`). An item's unique name reaches it as well.
+- <a id="items[]" name="items[]"></a>**`trx.items[key]`** (key: [trx.items.Num](#items.Num) or string, value: [trx.items.Item](#items.Item) or `nil`). An item's unique name reaches it as well.
 - **`#trx.items`** (integer). How many there are.
 
 Example:

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -142,9 +142,9 @@ end
     - <a id="items.Item.name" name="items.Item.name"></a>**`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
     - <a id="items.Item.num" name="items.Item.num"></a>**`num`**: [trx.items.Num](#items.Num). An item handed over by a query can say where it lives. *(read-only)*
     - <a id="items.Item.object_id" name="items.Item.object_id"></a>**`object_id`**: [trx.catalog.objects](CATALOG.md#catalog.objects). The item's object type. *(read-only)*
-    - <a id="items.Item.pos" name="items.Item.pos"></a>**`pos`**: vec3. World position. Updating this also updates [`room`](#items.Item.room) and [`room_num`](#items.Item.room_num).
+    - <a id="items.Item.pos" name="items.Item.pos"></a>**`pos`**: [trx.math.Vec3](MATH.md#math.Vec3). World position. Updating this also updates [`room`](#items.Item.room) and [`room_num`](#items.Item.room_num).
     - <a id="items.Item.room_num" name="items.Item.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room containing this item. Set [`pos`](#items.Item.pos) to move the item between rooms. *(read-only)*
-    - <a id="items.Item.rot" name="items.Item.rot"></a>**`rot`**: vec3. Orientation. Each component is a [`trx.math.Angle`](MATH.md#math.Angle).
+    - <a id="items.Item.rot" name="items.Item.rot"></a>**`rot`**: [trx.math.Rot](MATH.md#math.Rot). Orientation.
     - <a id="items.Item.speed" name="items.Item.speed"></a>**`speed`**: integer. Forward speed.
     - <a id="items.Item.timer" name="items.Item.timer"></a>**`timer`**: [trx.game.Frames](GAME.md#game.Frames). How long the item's trigger keeps it going. `0` runs it until something takes the trigger back; `-1` means it has run out; anything else counts down. [`trigger`](#items.Item.trigger) takes its own timer as a [`trx.game.Seconds`](GAME.md#game.Seconds).
     - <a id="items.Item.touch_bits" name="items.Item.touch_bits"></a>**`touch_bits`**: integer. Bitmask of which of the item's meshes Lara is touching. *(read-only)*
@@ -181,7 +181,7 @@ end
       Distance from this item to a world position.
 
       Parameters:
-      - <a id="items.Item.distance_to.pos" name="items.Item.distance_to.pos"></a>**`pos`** (vec3). World position.
+      - <a id="items.Item.distance_to.pos" name="items.Item.distance_to.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
 
       Returns: [trx.math.Distance](MATH.md#math.Distance). Measured between the two positions.
 
@@ -515,8 +515,8 @@ end
       An item is tested by its position, the point it stands at, rather than by the box it fills. Position is all this asks after, so the rest of the query says what else the item must be: `trx.items.query:in_box(min, max):present()` asks for the ones that are in the world as well.
 
       Parameters:
-      - <a id="items.ItemQuery.in_box.min" name="items.ItemQuery.in_box.min"></a>**`min`** (vec3). One corner of the box.
-      - <a id="items.ItemQuery.in_box.max" name="items.ItemQuery.in_box.max"></a>**`max`** (vec3). The opposite corner.
+      - <a id="items.ItemQuery.in_box.min" name="items.ItemQuery.in_box.min"></a>**`min`** ([trx.math.Vec3](MATH.md#math.Vec3)). One corner of the box.
+      - <a id="items.ItemQuery.in_box.max" name="items.ItemQuery.in_box.max"></a>**`max`** ([trx.math.Vec3](MATH.md#math.Vec3)). The opposite corner.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -545,7 +545,7 @@ end
       The item stands within a radius of a point. As with [`in_box`](#items.ItemQuery.in_box), the item's position is the whole of the test.
 
       Parameters:
-      - <a id="items.ItemQuery.in_sphere.centre" name="items.ItemQuery.in_sphere.centre"></a>**`centre`** (vec3). Middle of the sphere.
+      - <a id="items.ItemQuery.in_sphere.centre" name="items.ItemQuery.in_sphere.centre"></a>**`centre`** ([trx.math.Vec3](MATH.md#math.Vec3)). Middle of the sphere.
       - <a id="items.ItemQuery.in_sphere.radius" name="items.ItemQuery.in_sphere.radius"></a>**`radius`** ([trx.math.Distance](MATH.md#math.Distance)). How far out it reaches.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
@@ -605,7 +605,7 @@ end
 
   Parameters:
   - <a id="items.spawn.object_id" name="items.spawn.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). Object type to spawn.
-  - <a id="items.spawn.pos" name="items.spawn.pos"></a>**`pos`** (vec3). World position. Must lie inside the level.
+  - <a id="items.spawn.pos" name="items.spawn.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
   - <a id="items.spawn.angle_y" name="items.spawn.angle_y"></a>**`angle_y`** ([trx.math.Angle](MATH.md#math.Angle), optional, default `0`). Facing angle.
   - <a id="items.spawn.opts" name="items.spawn.opts"></a>**`opts`** (table, optional). How to spawn it.
 

--- a/docs/trx/lua/reference/JSON.md
+++ b/docs/trx/lua/reference/JSON.md
@@ -1,0 +1,37 @@
+---
+title: JSON
+order: 29
+---
+
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  src/lua/api/json.lua. Edit it there.
+-->
+
+## <a id="json" name="json"></a>JSON module
+
+Writing Lua values out as JSON. The API dump the reference is generated from goes through this, so what a script writes out is encoded the way the engine's own data is.
+
+### Functions
+
+- <a id="json.encode" name="json.encode"></a>[lua]`trx.json.encode(value)`  
+  Writes a value out as JSON, on one line. Keys come out in sorted order, so
+  the same value encodes the same way twice and a file that is committed and
+  diffed only moves when what it holds does.
+
+  A table is written as a list where it holds entry 1, or holds nothing at
+  all, and as an object otherwise. A function, a handle and anything else
+  with no JSON of its own is left out.
+
+  Parameters:
+  - <a id="json.encode.value" name="json.encode.value"></a>**`value`** (any). What to write out.
+
+  Returns: string. The JSON text.
+
+  Example:
+  ```lua
+  trx.json.encode({ name = "wolf", ids = { 7, 8 } })
+  -- {"ids":[7,8],"name":"wolf"}
+  ```

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -194,7 +194,7 @@ Her position, room and hit points are not here: she is an item like any other an
   The position is nudged into valid room geometry, so a spot inside a wall lands her beside it rather than in it. Somewhere with no floor within reach moves nothing.
 
   Parameters:
-  - <a id="lara.teleport.pos" name="lara.teleport.pos"></a>**`pos`** (vec3). World position.
+  - <a id="lara.teleport.pos" name="lara.teleport.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
   - <a id="lara.teleport.room_num" name="lara.teleport.room_num"></a>**`room_num`** ([trx.rooms.Num](ROOMS.md#rooms.Num), optional). Without it, the room is found from the position.
 
   Returns: boolean. Whether she was moved.

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -177,7 +177,7 @@ Her position, room and hit points are not here: she is an item like any other an
 ### Functions
 
 - <a id="lara.set_extra_equipment" name="lara.set_extra_equipment"></a>[lua]`trx.lara.set_extra_equipment(mesh, extra_mesh)`  
-  Hangs an extra mesh on one of Lara's own, replacing whatever is there.
+  Hangs an extra mesh on one of Lara's own, replacing the mesh there.
 
   Parameters:
   - <a id="lara.set_extra_equipment.mesh" name="lara.set_extra_equipment.mesh"></a>**`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.

--- a/docs/trx/lua/reference/LOCALE.md
+++ b/docs/trx/lua/reference/LOCALE.md
@@ -52,7 +52,7 @@ The text the player reads, in the player's own language.
   The text behind a key with its placeholders filled in.
 
   Parameters:
-  - <a id="locale.format.key" name="locale.format.key"></a>**`key`** (string). The key.
+  - <a id="locale.format.key" name="locale.format.key"></a>**`key`** (string). The key, e.g. `general/misc/off`.
   - <a id="locale.format...." name="locale.format...."></a>**`...`** (any). What to fill the placeholders with.
 
   Returns: string. The text with the arguments in it. A translation whose placeholders do not line up with the arguments comes back unformatted, with a warning in the log: a player is better served by text they can read than by a script that stops.

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -14,6 +14,16 @@ order: 29
 
 Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the same state as every other script.
 
+### Structures
+
+- <a id="lua.Error" name="lua.Error"></a>[lua]`trx.lua.Error`
+
+    What went wrong while running Lua.
+
+    Properties:
+    - <a id="lua.Error.kind" name="lua.Error.kind"></a>**`kind`**: string. Either `"syntax"` or `"runtime"`.
+    - <a id="lua.Error.message" name="lua.Error.message"></a>**`message`**: string. The error text.
+
 ### Functions
 
 - <a id="lua.eval_expr" name="lua.eval_expr"></a>[lua]`trx.lua.eval_expr(code)`  
@@ -22,11 +32,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   Parameters:
   - <a id="lua.eval_expr.code" name="lua.eval_expr.code"></a>**`code`** (string). The code.
 
-  Returns: table or `nil`. `nil` when the code ran to completion, and what went wrong otherwise. A failure comes back as a value rather than raising, so the caller decides what it means.
-
-    Keys:
-    - <a id="lua.eval_expr.kind" name="lua.eval_expr.kind"></a>**`kind`** (string). Either `"syntax"` or `"runtime"`.
-    - <a id="lua.eval_expr.message" name="lua.eval_expr.message"></a>**`message`** (string). The error text.
+  Returns: [trx.lua.Error](#lua.Error) or `nil`. `nil` when the code ran to completion, and what went wrong otherwise. A failure comes back as a value rather than raising, so the caller decides what it means.
 
   Example:
   ```lua
@@ -39,7 +45,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   Parameters:
   - <a id="lua.eval_file.path" name="lua.eval_file.path"></a>**`path`** (string). Path of the file.
 
-  Returns: table or `nil`. As in [`trx.lua.eval_expr`](#lua.eval_expr).
+  Returns: [trx.lua.Error](#lua.Error) or `nil`. As in [`trx.lua.eval_expr`](#lua.eval_expr).
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -1,6 +1,6 @@
 ---
 title: Lua
-order: 29
+order: 30
 ---
 
 <!--

--- a/docs/trx/lua/reference/LUA.md
+++ b/docs/trx/lua/reference/LUA.md
@@ -30,7 +30,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   Evaluates a string of Lua code, as the `/lua` console command does.
 
   Parameters:
-  - <a id="lua.eval_expr.code" name="lua.eval_expr.code"></a>**`code`** (string). The code.
+  - <a id="lua.eval_expr.code" name="lua.eval_expr.code"></a>**`code`** (string). Any chunk of Lua, not only an expression.
 
   Returns: [trx.lua.Error](#lua.Error) or `nil`. `nil` when the code ran to completion, and what went wrong otherwise. A failure comes back as a value rather than raising, so the caller decides what it means.
 
@@ -45,7 +45,7 @@ Evaluating Lua at runtime: a string of code, or a file on disk. Both run in the 
   Parameters:
   - <a id="lua.eval_file.path" name="lua.eval_file.path"></a>**`path`** (string). Path of the file.
 
-  Returns: [trx.lua.Error](#lua.Error) or `nil`. As in [`trx.lua.eval_expr`](#lua.eval_expr).
+  Returns: [trx.lua.Error](#lua.Error) or `nil`.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -42,6 +42,24 @@ Fixed-point trigonometry, matching the engine's own tables. Using these rather t
     A length in the units the engine measures the world in, where one sector is
     [`trx.math.WALL_L`](#math.WALL_L). Y grows downwards, so a greater Y is further down.
 
+- <a id="math.Vec3" name="math.Vec3"></a>[lua]`trx.math.Vec3`
+
+    A point or a direction in the world.
+
+    Properties:
+    - <a id="math.Vec3.x" name="math.Vec3.x"></a>**`x`**: [trx.math.Distance](#math.Distance). The east-west axis.
+    - <a id="math.Vec3.y" name="math.Vec3.y"></a>**`y`**: [trx.math.Distance](#math.Distance). The up-down axis.
+    - <a id="math.Vec3.z" name="math.Vec3.z"></a>**`z`**: [trx.math.Distance](#math.Distance). The north-south axis.
+
+- <a id="math.Rot" name="math.Rot"></a>[lua]`trx.math.Rot`
+
+    An orientation, as three angles about the world axes.
+
+    Properties:
+    - <a id="math.Rot.x" name="math.Rot.x"></a>**`x`**: [trx.math.Angle](#math.Angle). Pitch, nose up and down.
+    - <a id="math.Rot.y" name="math.Rot.y"></a>**`y`**: [trx.math.Angle](#math.Angle). Yaw, the direction it faces.
+    - <a id="math.Rot.z" name="math.Rot.z"></a>**`z`**: [trx.math.Angle](#math.Angle). Roll, the tilt about its own length.
+
 - <a id="math.Box" name="math.Box"></a>[lua]`trx.math.Box`
 
     An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -62,7 +62,7 @@ Fixed-point trigonometry, matching the engine's own tables. Using these rather t
 
 - <a id="math.Box" name="math.Box"></a>[lua]`trx.math.Box`
 
-    An axis-aligned box. Whether it is placed in the world or in something's own frame is for whatever hands it over to say.
+    An axis-aligned box. Whether it is placed in the world or in something's own frame is for the call that hands it over to say.
 
     Properties:
     - <a id="math.Box.max_x" name="math.Box.max_x"></a>**`max_x`**: [trx.math.Distance](#math.Distance). East edge.

--- a/docs/trx/lua/reference/MOD.md
+++ b/docs/trx/lua/reference/MOD.md
@@ -16,7 +16,7 @@ The mods the game was built with, and which one is loaded.
 
 ### Properties
 
-- <a id="mod.list" name="mod.list"></a>**`trx.mod.list`** (table). The mods the game was built with, as a list of [`trx.mod.Mod`](#mod.Mod) counted from one. *(read-only)*
+- <a id="mod.list" name="mod.list"></a>**`trx.mod.list`** (a list of [trx.mod.Mod](#mod.Mod)). The mods the game was built with, counted from one. *(read-only)*
 - <a id="mod.current" name="mod.current"></a>**`trx.mod.current`** ([trx.mod.Mod](#mod.Mod)). The loaded mod. *(read-only)*
 
 ### Enums

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -14,10 +14,20 @@ order: 18
 
 Module for playing and controlling the soundtrack.
 
+### Indexing
+
+The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle.
+
+- <a id="music.streams[]" name="music.streams[]"></a>**`trx.music.streams[key]`** ([trx.music.Stream](#music.Stream) or `nil`). Which slot. Counted from 1.
+- **`#trx.music.streams`** (integer). How many there are.
+
+The tracks the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.
+
+- <a id="music.tracks[]" name="music.tracks[]"></a>**`trx.music.tracks[key]`** ([trx.music.Track](#music.Track) or `nil`).
+- **`#trx.music.tracks`** (integer). How many there are.
+
 ### Properties
 
-- <a id="music.streams" name="music.streams"></a>**`trx.music.streams`** (table). The soundtrack's streams as [`trx.music.Stream`](#music.Stream) handles: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
-- <a id="music.tracks" name="music.tracks"></a>**`trx.music.tracks`** (table). The tracks the current level carries, as [`trx.music.Track`](#music.Track) handles keyed by id: `trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
 - <a id="music.current_track" name="music.current_track"></a>**`trx.music.current_track`** ([trx.music.Track](#music.Track)). The track playing now, or `nil` when nothing plays. *(read-only)*
 - <a id="music.looped_track" name="music.looped_track"></a>**`trx.music.looped_track`** ([trx.music.Track](#music.Track)). The ambient track that resumes once the current one-shot finishes, or `nil` when none is set. *(read-only)*
 

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -18,12 +18,12 @@ Module for playing and controlling the soundtrack.
 
 The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle.
 
-- <a id="music.streams[]" name="music.streams[]"></a>**`trx.music.streams[key]`** ([trx.music.Stream](#music.Stream) or `nil`).
+- <a id="music.streams[]" name="music.streams[]"></a>**`trx.music.streams[key]`** (key: [trx.music.StreamNum](#music.StreamNum), value: [trx.music.Stream](#music.Stream) or `nil`).
 - **`#trx.music.streams`** (integer). How many there are.
 
 The tracks the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.
 
-- <a id="music.tracks[]" name="music.tracks[]"></a>**`trx.music.tracks[key]`** ([trx.music.Track](#music.Track) or `nil`).
+- <a id="music.tracks[]" name="music.tracks[]"></a>**`trx.music.tracks[key]`** (key: [trx.music.TrackNum](#music.TrackNum), value: [trx.music.Track](#music.Track) or `nil`).
 - **`#trx.music.tracks`** (integer). How many there are.
 
 ### Properties

--- a/docs/trx/lua/reference/MUSIC.md
+++ b/docs/trx/lua/reference/MUSIC.md
@@ -18,7 +18,7 @@ Module for playing and controlling the soundtrack.
 
 The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a stale handle.
 
-- <a id="music.streams[]" name="music.streams[]"></a>**`trx.music.streams[key]`** ([trx.music.Stream](#music.Stream) or `nil`). Which slot. Counted from 1.
+- <a id="music.streams[]" name="music.streams[]"></a>**`trx.music.streams[key]`** ([trx.music.Stream](#music.Stream) or `nil`).
 - **`#trx.music.streams`** (integer). How many there are.
 
 The tracks the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.
@@ -52,7 +52,11 @@ The tracks the current level carries. A level does not carry every number, so in
 
 - <a id="music.TrackNum" name="music.TrackNum"></a>[lua]`trx.music.TrackNum`
 
-    Track number, in the numbering the loaded level carries. Not a [`trx.catalog.music`](CATALOG.md#catalog.music) name, which is the soundtrack's own.
+    Track number, in the numbering the loaded level carries. Not a [`trx.catalog.music`](CATALOG.md#catalog.music) name, which is the soundtrack's own. Counted from 0.
+
+- <a id="music.StreamNum" name="music.StreamNum"></a>[lua]`trx.music.StreamNum`
+
+    Which of the soundtrack's slots: 1 is the main stream, 2 onwards the overlays. Counted from 1.
 
 - <a id="music.Stream" name="music.Stream"></a>[lua]`trx.music.Stream`
 

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -79,7 +79,7 @@ trx.objects.wolf.properties.max_hit_points = 30
       Parameters:
       - <a id="objects.Object.get_property.name" name="objects.Object.get_property.name"></a>**`name`** (string). Which property, as the object declares it.
 
-      Returns: any or `nil`. The value, of whatever type the property is declared with.
+      Returns: any or `nil`. The value, of the type the property is declared with.
 
     - <a id="objects.Object.get_property_names" name="objects.Object.get_property_names"></a>[lua]`object:get_property_names()`  
       Names of every property this object declares.

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -66,12 +66,12 @@ trx.objects.wolf.properties.max_hit_points = 30
     - <a id="objects.Object.get_default_names" name="objects.Object.get_default_names"></a>[lua]`object:get_default_names()`  
       The compile-time English names, which a lookup falls back on before a language file is loaded. Prefer [`default_names`](#objects.Object.default_names).
 
-      Returns: table. The names, as a list of strings.
+      Returns: a list of string.
 
     - <a id="objects.Object.get_names" name="objects.Object.get_names"></a>[lua]`object:get_names()`  
       Every name the object answers to, in the player's language. Prefer [`names`](#objects.Object.names).
 
-      Returns: table. The names, as a list of strings.
+      Returns: a list of string.
 
     - <a id="objects.Object.get_property" name="objects.Object.get_property"></a>[lua]`object:get_property(name)`  
       Reads one of the object's properties. Prefer `object.properties.<name>`.
@@ -84,7 +84,7 @@ trx.objects.wolf.properties.max_hit_points = 30
     - <a id="objects.Object.get_property_names" name="objects.Object.get_property_names"></a>[lua]`object:get_property_names()`  
       Names of every property this object declares.
 
-      Returns: table. The names, as a list of strings.
+      Returns: a list of string.
 
     - <a id="objects.Object.set_property" name="objects.Object.set_property"></a>[lua]`object:set_property(name, value)`  
       Writes one of the object's properties. Prefer `object.properties.<name> = ...`.

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -20,7 +20,7 @@ An object is the pattern every item of that type is cut from: a wolf's radius, n
 
 Indexing the module reaches an object definition, so [`trx.objects.wolf`](#objects) is the wolf. Keyed by object id or catalog name, not by position.
 
-- <a id="objects[]" name="objects[]"></a>**`trx.objects[key]`** ([trx.objects.Object](#objects.Object) or `nil`). Object id, or its catalog name.
+- <a id="objects[]" name="objects[]"></a>**`trx.objects[key]`** (key: [trx.catalog.objects](CATALOG.md#catalog.objects) or string, value: [trx.objects.Object](#objects.Object) or `nil`). Object id, or its catalog name.
 
 Example:
 ```lua

--- a/docs/trx/lua/reference/QUERY.md
+++ b/docs/trx/lua/reference/QUERY.md
@@ -50,12 +50,12 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
     - <a id="query.Query.ids" name="query.Query.ids"></a>[lua]`query:ids()`  
       The matching ids. For objects these are object ids; for items, their numbers.
 
-      Returns: table. A list of integers.
+      Returns: a list of integer.
 
     - <a id="query.Query.matches" name="query.Query.matches"></a>[lua]`query:matches()`  
       The matching handles.
 
-      Returns: table. A list of [`trx.objects.Object`](OBJECTS.md#objects.Object)s or [`trx.items.Item`](ITEMS.md#items.Item)s.
+      Returns: a list of [trx.objects.Object](OBJECTS.md#objects.Object) or [trx.items.Item](ITEMS.md#items.Item).
 
     - <a id="query.Query.where" name="query.Query.where"></a>[lua]`query:where(predicate)`  
       Narrows by a test of the caller's own, for what the domain does not name.
@@ -84,7 +84,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
     - <a id="query.NamedQuery.best" name="query.NamedQuery.best"></a>[lua]`namedquery:best()`  
       The ids tied for the best [`by_name`](#query.NamedQuery.by_name) score: one for a name only one thing answers to, the whole group for a group name. Without a [`by_name`](#query.NamedQuery.by_name), every matching id.
 
-      Returns: table. A list of integers.
+      Returns: a list of integer.
 
     - <a id="query.NamedQuery.by_name" name="query.NamedQuery.by_name"></a>[lua]`namedquery:by_name(name)`  
       Ranks rather than filters: matches the way a player types a name, forgivingly, and orders what survives the rest of the query best first. Some of a domain's narrowings are also searchable groups, so their own name matches every member.
@@ -102,7 +102,7 @@ left to right, combining with AND: `q:spawnable():by_name("wolf")`.
     - <a id="query.NamedQuery.names" name="query.NamedQuery.names"></a>[lua]`namedquery:names()`  
       Every name the matches answer to, for offering completions. The group names any match belongs to come first, because a completer offers the list in order and a group name that ties on score would otherwise sit behind a thing's own. Which groups answer follows from what the query kept, so one narrowed to what fights offers no [`trx.objects.ObjectQuery:pickup`](OBJECTS.md#objects.ObjectQuery.pickup).
 
-      Returns: table. A list of names.
+      Returns: a list of string.
 
 ### Functions
 

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -18,7 +18,7 @@ Module for inspecting and altering the rooms of the current level.
 
 Indexing the module reaches a room, and `#trx.rooms` is how many the level has. `pairs()` walks them in order, keyed by the room number.
 
-- <a id="rooms[]" name="rooms[]"></a>**`trx.rooms[key]`** ([trx.rooms.Room](#rooms.Room) or `nil`).
+- <a id="rooms[]" name="rooms[]"></a>**`trx.rooms[key]`** (key: [trx.rooms.Num](#rooms.Num), value: [trx.rooms.Room](#rooms.Room) or `nil`).
 - **`#trx.rooms`** (integer). How many there are.
 
 Example:

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -81,7 +81,7 @@ end
       As [`trx.rooms.floor_height`](#rooms.floor_height), looking from this room.
 
       Parameters:
-      - <a id="rooms.Room.floor_height.pos" name="rooms.Room.floor_height.pos"></a>**`pos`** (vec3). World position.
+      - <a id="rooms.Room.floor_height.pos" name="rooms.Room.floor_height.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
       - <a id="rooms.Room.floor_height.opts" name="rooms.Room.floor_height.opts"></a>**`opts`** (table, optional). How to read the floor.
 
         Keys:
@@ -149,7 +149,7 @@ end
       The room contains a world position. Rooms overlap, so a position can be in several at once and every one of them matches, in room order. A room claims a point when the point is within its bounds, the outer ring of solid wall aside, and the column it stands in has a floor - the test the engine itself puts a position through. The hidden half of a flip pair is passed over.
 
       Parameters:
-      - <a id="rooms.RoomQuery.at.pos" name="rooms.RoomQuery.at.pos"></a>**`pos`** (vec3). World position.
+      - <a id="rooms.RoomQuery.at.pos" name="rooms.RoomQuery.at.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
 
       Returns: [trx.query.Query](QUERY.md#query.Query). The narrowed query.
 
@@ -228,7 +228,7 @@ end
   The height of the floor under a world position. `nil` where there is no floor at all: inside solid geometry, or off the edge of the level.
 
   Parameters:
-  - <a id="rooms.floor_height.pos" name="rooms.floor_height.pos"></a>**`pos`** (vec3). World position.
+  - <a id="rooms.floor_height.pos" name="rooms.floor_height.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
   - <a id="rooms.floor_height.room_num" name="rooms.floor_height.room_num"></a>**`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with [`trx.rooms.Room:floor_height`](#rooms.Room.floor_height).
   - <a id="rooms.floor_height.opts" name="rooms.floor_height.opts"></a>**`opts`** (table, optional). How to read the floor.
 
@@ -246,9 +246,9 @@ end
   Nudges a position into valid room geometry, e.g. to find somewhere an item can legally be placed.
 
   Parameters:
-  - <a id="rooms.find_valid_pos.pos" name="rooms.find_valid_pos.pos"></a>**`pos`** (vec3). Position to search near.
+  - <a id="rooms.find_valid_pos.pos" name="rooms.find_valid_pos.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). Position to search near.
   - <a id="rooms.find_valid_pos.room_num" name="rooms.find_valid_pos.room_num"></a>**`room_num`** ([trx.rooms.Num](#rooms.Num)).
 
   Returns:
-  - vec3 or `nil`. The valid position, or `nil` if none was found nearby.
+  - [trx.math.Vec3](MATH.md#math.Vec3) or `nil`. The valid position, or `nil` if none was found nearby.
   - [trx.rooms.Num](#rooms.Num). The room the position is in.

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -35,7 +35,7 @@ again on every entry, so a level that wants the defaults back asks for them.
 - <a id="rules.list" name="rules.list"></a>[lua]`trx.rules.list()`  
   Every rule there is, as dotted `group.field` keys.
 
-  Returns: table. The keys, in no particular order.
+  Returns: a list of string. In no particular order.
 
 - <a id="rules.get" name="rules.get"></a>[lua]`trx.rules.get(key)`  
   Reads a rule by its key, for code that does not know which one it wants.

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -14,12 +14,15 @@ order: 14
 
 Module for the numbers the engine plays by.
 
-These are the game's rules: a mechanic that no single item owns. An object's own numbers live on
-the object, as `trx.objects.<name>.properties`, and the player's own choices live in [`trx.config`](CONFIG.md#config).
+These are the game's rules: a mechanic that no single item owns. An
+object's own numbers live on the object, as
+`trx.objects.<name>.properties`, and the player's own choices live in
+[`trx.config`](CONFIG.md#config).
 
-A rule lasts as long as the playthrough: it is saved with the game and restored with it, and a
-new game starts from the defaults. A level script states what its level wants, and states it
-again on every entry, so a level that wants the defaults back asks for them.
+A rule lasts as long as the playthrough: it is saved with the game and
+restored with it, and a new game starts from the defaults. A level script
+states what its level wants, and states it again on every entry, so a level
+that wants the defaults back asks for them.
 
 ### Properties
 

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -33,9 +33,9 @@ again on every entry, so a level that wants the defaults back asks for them.
 ### Functions
 
 - <a id="rules.list" name="rules.list"></a>[lua]`trx.rules.list()`  
-  Every rule there is, as dotted `group.field` keys.
+  Every rule there is, as dotted `group.field` keys, in no particular order.
 
-  Returns: a list of string. In no particular order.
+  Returns: a list of string.
 
 - <a id="rules.get" name="rules.get"></a>[lua]`trx.rules.get(key)`  
   Reads a rule by its key, for code that does not know which one it wants.

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -14,10 +14,17 @@ order: 17
 
 Module for playing sound effects.
 
-### Properties
+### Indexing
 
-- <a id="sound.samples" name="sound.samples"></a>**`trx.sound.samples`** (table). The samples the current level carries, as [`trx.sound.Sample`](#sound.Sample) handles keyed by id: `trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts them, iterating walks them, and both reach one handle at a time. *(read-only)*
-- <a id="sound.streams" name="sound.streams"></a>**`trx.sound.streams`** (table). The sound effects playing now, as [`trx.sound.Stream`](#sound.Stream) handles. A slot that is silent still answers, with a stale handle. Indexing and iterating reach one handle at a time. *(read-only)*
+The samples the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.
+
+- <a id="sound.samples[]" name="sound.samples[]"></a>**`trx.sound.samples[key]`** ([trx.sound.Sample](#sound.Sample) or `nil`).
+- **`#trx.sound.samples`** (integer). How many there are.
+
+The sound effects playing now. A slot that is silent still answers, with a stale handle.
+
+- <a id="sound.streams[]" name="sound.streams[]"></a>**`trx.sound.streams[key]`** ([trx.sound.Stream](#sound.Stream) or `nil`). Which voice. Counted from 1.
+- **`#trx.sound.streams`** (integer). How many there are.
 
 ### Structures
 

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -65,7 +65,7 @@ The sound effects playing now. A slot that is silent still answers, with a stale
       - <a id="sound.Sample.play.opts" name="sound.Sample.play.opts"></a>**`opts`** (table, optional). How to play it.
 
         Keys:
-        - <a id="sound.Sample.play.opts.pos" name="sound.Sample.play.opts.pos"></a>**`pos`** (vec3, optional). A world position to play from, which applies pan and volume. Omit to play at full volume.
+        - <a id="sound.Sample.play.opts.pos" name="sound.Sample.play.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). A world position to play from, which applies pan and volume. Omit to play at full volume.
 
       Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 
@@ -109,7 +109,7 @@ The sound effects playing now. A slot that is silent still answers, with a stale
   - <a id="sound.play.opts" name="sound.play.opts"></a>**`opts`** (table, optional). How to play it.
 
     Keys:
-    - <a id="sound.play.opts.pos" name="sound.play.opts.pos"></a>**`pos`** (vec3, optional). A world position to play from, which applies pan and volume. Omit to play at full volume.
+    - <a id="sound.play.opts.pos" name="sound.play.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). A world position to play from, which applies pan and volume. Omit to play at full volume.
 
   Returns: [trx.sound.Stream](#sound.Stream) or `nil`. The voice it started, or `nil` if none did.
 

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -23,14 +23,18 @@ The samples the current level carries. A level does not carry every number, so i
 
 The sound effects playing now. A slot that is silent still answers, with a stale handle.
 
-- <a id="sound.streams[]" name="sound.streams[]"></a>**`trx.sound.streams[key]`** ([trx.sound.Stream](#sound.Stream) or `nil`). Which voice. Counted from 1.
+- <a id="sound.streams[]" name="sound.streams[]"></a>**`trx.sound.streams[key]`** ([trx.sound.Stream](#sound.Stream) or `nil`).
 - **`#trx.sound.streams`** (integer). How many there are.
 
 ### Structures
 
 - <a id="sound.SampleNum" name="sound.SampleNum"></a>[lua]`trx.sound.SampleNum`
 
-    Sample number, in the numbering the loaded level carries. Not a [`trx.catalog.samples`](CATALOG.md#catalog.samples) name, which is the sound bank's own.
+    Sample number, in the numbering the loaded level carries. Not a [`trx.catalog.samples`](CATALOG.md#catalog.samples) name, which is the sound bank's own. Counted from 0.
+
+- <a id="sound.StreamNum" name="sound.StreamNum"></a>[lua]`trx.sound.StreamNum`
+
+    Which of the voices playing now, counted in the order the engine holds them. Counted from 1.
 
 - <a id="sound.Sample" name="sound.Sample"></a>[lua]`trx.sound.Sample`
 

--- a/docs/trx/lua/reference/SOUND.md
+++ b/docs/trx/lua/reference/SOUND.md
@@ -18,12 +18,12 @@ Module for playing sound effects.
 
 The samples the current level carries. A level does not carry every number, so indexing one it lacks is `nil` and iterating passes it by.
 
-- <a id="sound.samples[]" name="sound.samples[]"></a>**`trx.sound.samples[key]`** ([trx.sound.Sample](#sound.Sample) or `nil`).
+- <a id="sound.samples[]" name="sound.samples[]"></a>**`trx.sound.samples[key]`** (key: [trx.sound.SampleNum](#sound.SampleNum), value: [trx.sound.Sample](#sound.Sample) or `nil`).
 - **`#trx.sound.samples`** (integer). How many there are.
 
 The sound effects playing now. A slot that is silent still answers, with a stale handle.
 
-- <a id="sound.streams[]" name="sound.streams[]"></a>**`trx.sound.streams[key]`** ([trx.sound.Stream](#sound.Stream) or `nil`).
+- <a id="sound.streams[]" name="sound.streams[]"></a>**`trx.sound.streams[key]`** (key: [trx.sound.StreamNum](#sound.StreamNum), value: [trx.sound.Stream](#sound.Stream) or `nil`).
 - **`#trx.sound.streams`** (integer). How many there are.
 
 ### Structures

--- a/docs/trx/lua/reference/STATS.md
+++ b/docs/trx/lua/reference/STATS.md
@@ -83,7 +83,7 @@ here reads `nil`.
     - <a id="stats.Stats.secret_list" name="stats.Stats.secret_list"></a>[lua]`stats:secret_list()`  
       The level's secrets, in order.
 
-      Returns: table. The secrets, one by one.
+      Returns: a list of table. The secrets, one by one.
 
         Each entry:
         - <a id="stats.Stats.secret_list.num" name="stats.Stats.secret_list.num"></a>**`num`** ([trx.stats.SecretNum](#stats.SecretNum)). Which secret it is.

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -98,3 +98,26 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   ```lua
   if trx.strings.regex_match(args, "^\\d+$") then ... end
   ```
+
+- <a id="strings.dedent" name="strings.dedent"></a>[lua]`trx.strings.dedent(text)`  
+  Takes the shared indentation off a block of text, so that a long string
+  written inside `[[ ]]` reads as what it says rather than as where it sat in
+  the file. Leading and trailing blank lines go too.
+
+  The deepest lines keep the rest of their indentation, since a block may lay
+  something out, and four spaces of it is a code block in markdown. Text may
+  open on the line the brackets are on, and that line then sets nothing and
+  keeps what it has, however the ones under it are written.
+
+  Parameters:
+  - <a id="strings.dedent.text" name="strings.dedent.text"></a>**`text`** (string). The text to take in.
+
+  Returns: string. The text at the left margin.
+
+  Example:
+  ```lua
+  local help = trx.strings.dedent([[
+        Usage: /give <what>
+          keys   every plot item the level has a place for
+      ]])
+  ```

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -27,7 +27,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
     - <a id="strings.Match.is_word" name="strings.Match.is_word"></a>**`is_word`**: boolean. Whether a whole word matched.
     - <a id="strings.Match.key" name="strings.Match.key"></a>**`key`**: string. The candidate that matched.
     - <a id="strings.Match.score" name="strings.Match.score"></a>**`score`**: number. How well it matched.
-    - <a id="strings.Match.value" name="strings.Match.value"></a>**`value`**: any. What the candidate carried.
+    - <a id="strings.Match.value" name="strings.Match.value"></a>**`value`**: any, optional. What the candidate carried, where it carried one.
 
 ### Functions
 

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -45,7 +45,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
     - <a id="strings.fuzzy_match.sources.value" name="strings.fuzzy_match.sources.value"></a>**`value`** (any). Anything of the caller's, handed back on the match.
     - <a id="strings.fuzzy_match.sources.weight" name="strings.fuzzy_match.sources.weight"></a>**`weight`** (integer, optional, default `1`). A heavier candidate wins a tie. Zero or less drops it.
 
-  Returns: a list of [trx.strings.Match](#strings.Match). The matches, best first.
+  Returns: a list of [trx.strings.Match](#strings.Match). The best match comes first.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -38,7 +38,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
 
   Parameters:
   - <a id="strings.fuzzy_match.input" name="strings.fuzzy_match.input"></a>**`input`** (string). What the player typed.
-  - <a id="strings.fuzzy_match.sources" name="strings.fuzzy_match.sources"></a>**`sources`** (table). The candidates.
+  - <a id="strings.fuzzy_match.sources" name="strings.fuzzy_match.sources"></a>**`sources`** (a list of table). The candidates.
 
     Each entry:
     - <a id="strings.fuzzy_match.sources.key" name="strings.fuzzy_match.sources.key"></a>**`key`** (string). The name to match against. Non-empty.
@@ -75,7 +75,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   The list is sorted first, and duplicates survive as they are, so the caller need not tidy up before handing it over.
 
   Parameters:
-  - <a id="strings.collapse_ranges.numbers" name="strings.collapse_ranges.numbers"></a>**`numbers`** (table). List of integers.
+  - <a id="strings.collapse_ranges.numbers" name="strings.collapse_ranges.numbers"></a>**`numbers`** (a list of integer). The numbers to write out.
   - <a id="strings.collapse_ranges.separator" name="strings.collapse_ranges.separator"></a>**`separator`** (string, optional). What to put between the parts. Defaults to `", "`.
 
   Returns: string. Empty when the list is.

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -16,6 +16,19 @@ Utilities for working with strings.
 
 Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a player reads: this module is about manipulating strings, that one is about which string the player gets.
 
+### Structures
+
+- <a id="strings.Match" name="strings.Match"></a>[lua]`trx.strings.Match`
+
+    A candidate that matched, and how well.
+
+    Properties:
+    - <a id="strings.Match.is_full" name="strings.Match.is_full"></a>**`is_full`**: boolean. Whether the whole candidate matched.
+    - <a id="strings.Match.is_word" name="strings.Match.is_word"></a>**`is_word`**: boolean. Whether a whole word matched.
+    - <a id="strings.Match.key" name="strings.Match.key"></a>**`key`**: string. The candidate that matched.
+    - <a id="strings.Match.score" name="strings.Match.score"></a>**`score`**: number. How well it matched.
+    - <a id="strings.Match.value" name="strings.Match.value"></a>**`value`**: any. What the candidate carried.
+
 ### Functions
 
 - <a id="strings.fuzzy_match" name="strings.fuzzy_match"></a>[lua]`trx.strings.fuzzy_match(input, sources)`  
@@ -32,14 +45,7 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
     - <a id="strings.fuzzy_match.sources.value" name="strings.fuzzy_match.sources.value"></a>**`value`** (any). Anything of the caller's, handed back on the match.
     - <a id="strings.fuzzy_match.sources.weight" name="strings.fuzzy_match.sources.weight"></a>**`weight`** (integer, optional, default `1`). A heavier candidate wins a tie. Zero or less drops it.
 
-  Returns: table. The matches, best first.
-
-    Each entry:
-    - <a id="strings.fuzzy_match.key" name="strings.fuzzy_match.key"></a>**`key`** (string). The candidate that matched.
-    - <a id="strings.fuzzy_match.value" name="strings.fuzzy_match.value"></a>**`value`** (any). What the candidate carried.
-    - <a id="strings.fuzzy_match.score" name="strings.fuzzy_match.score"></a>**`score`** (number). How well it matched.
-    - <a id="strings.fuzzy_match.is_full" name="strings.fuzzy_match.is_full"></a>**`is_full`** (boolean). Whether the whole candidate matched.
-    - <a id="strings.fuzzy_match.is_word" name="strings.fuzzy_match.is_word"></a>**`is_word`** (boolean). Whether a whole word matched.
+  Returns: a list of [trx.strings.Match](#strings.Match). The matches, best first.
 
   Example:
   ```lua

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -265,45 +265,6 @@ local function as_doc_list(list)
   return out
 end
 
--- A description written as a long-bracket string carries the indentation it was
--- written at, and four spaces is a code block in markdown - which is how a
--- module's own prose came out as one. The text is what the declaration says,
--- not where it sat in the file, so the shared indent comes off. The deepest
--- lines keep the rest of theirs, since a description may lay something out.
---
--- A description may instead open on the line its brackets are on, and that line
--- then carries no indentation, however the ones under it are written. Left in, it
--- makes the shared indent zero and the rest of the description keeps its own,
--- which is what four of them were written flush against the margin to avoid.
-local function dedent(text)
-  local lines = {}
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
-  -- Lua drops the newline that follows `[[`, so what says which of the two
-  -- spellings was written is whether the first line is indented at all: one
-  -- written against the brackets is not, and it neither sets what the rest share
-  -- nor has any of it taken off.
-  local from = text:match("^[ \t]") == nil and 2 or 1
-
-  local shared
-  for i = from, #lines do
-    if lines[i]:match("%S") ~= nil then
-      local indent = #lines[i]:match("^[ \t]*")
-      if shared == nil or indent < shared then
-        shared = indent
-      end
-    end
-  end
-
-  if shared ~= nil and shared > 0 then
-    for i = from, #lines do
-      lines[i] = lines[i]:sub(shared + 1)
-    end
-  end
-  return (table.concat(lines, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
-end
-
 -- Where a path lands, which every declaration asks in one of two ways: what a
 -- path is made of, and what table it names.
 
@@ -1762,7 +1723,7 @@ function api.describe()
     end
     for key, value in pairs(node) do
       if key == "description" and type(value) == "string" then
-        node[key] = dedent(value)
+        node[key] = trx.strings.dedent(value)
       else
         dedent_prose(value)
       end

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -417,8 +417,12 @@ local function write_property(where, prop, value)
     error(where .. " is read-only", 3)
   end
   if strict_enabled then
-    if not once(prop, "write_check", checker, spec)(value) then
-      error(("%s: expected %s"):format(where, check.label_of(spec)), 3)
+    local ok, why = once(prop, "write_check", checker, spec)(value)
+    if not ok then
+      error(
+        ("%s: %s"):format(where, why or "expected " .. check.label_of(spec)),
+        3
+      )
     end
   end
   spec.set(value)
@@ -544,7 +548,7 @@ local function make_checked(fn, path, params)
   local variadic = params[#params].name == "..."
   local fixed = variadic and #params - 1 or #params
 
-  local names, optional, predicates, defaults = {}, {}, {}, {}
+  local names, optional, predicates, defaults, labels = {}, {}, {}, {}, {}
   local fills_a_default = false
   for i = 1, fixed do
     local p = params[i]
@@ -552,6 +556,9 @@ local function make_checked(fn, path, params)
     optional[i] = p.optional == true
     predicates[i] = checker(p)
     defaults[i] = p.default
+    -- What the argument had to be, for a predicate that answers yes or no and
+    -- has nothing of its own to say: a handle, a class, and every primitive.
+    labels[i] = "expected " .. check.label_of(p)
     if p.default ~= nil then
       fills_a_default = true
     end
@@ -562,8 +569,16 @@ local function make_checked(fn, path, params)
     if value == nil and optional[i] then
       return
     end
-    if not predicates[i](value) then
-      error(("%s: invalid argument '%s'"):format(path, names[i]), 3)
+    local ok, why = predicates[i](value)
+    if not ok then
+      error(
+        ("%s: invalid argument '%s' - %s"):format(
+          path,
+          names[i],
+          why or labels[i]
+        ),
+        3
+      )
     end
   end
 
@@ -1017,6 +1032,8 @@ local function declare_lua_class(entry, path, spec, need)
   end
 
   entry.class = class
+  -- A value the registry hands out is checked by identity: it really came from
+  -- us, and an ItemQuery counts as a Query.
   entry.check = check.by_identity(class)
   -- A method of a type written in Lua is the Lua function it declares, and
   -- nothing stands behind it where the declaration names none.
@@ -1025,6 +1042,40 @@ local function declare_lua_class(entry, path, spec, need)
   end
   bind_type_methods(entry)
   return class
+end
+
+-- A record is a plain table with no class on it: one a script writes out as an
+-- options table, or one a call hands back for the caller to own. There is no
+-- identity to check it by, so it is checked by what it holds - every key it
+-- names, no key it does not, and each of the type it was given.
+--
+-- Which of the two a type is, the declaration says. Reading it off the shape -
+-- a type with keys and no methods being a record - is a guess that goes wrong
+-- the moment a record grows a method, or a type the registry hands out has
+-- nothing but keys, as math.Box has.
+local function declare_record(entry, spec, need)
+  need(
+    spec.extends == nil and next(spec.methods or {}) == nil,
+    "a record is a plain table, so it has no methods and no parent"
+  )
+  need(
+    spec.backing == nil
+      and next(spec.operators or {}) == nil
+      and next(spec.extensions or {}) == nil,
+    "a record is a plain table, so it has no C struct, no operators and no extensions"
+  )
+  need(
+    type(spec.fields) == "table" and next(spec.fields) ~= nil,
+    "a record is checked by the keys it names, so it has to name some"
+  )
+  for name, field in pairs(spec.fields) do
+    need(
+      field.get == nil and field.set == nil,
+      "field '%s' has an accessor, which a record has nowhere to keep",
+      name
+    )
+  end
+  entry.check = check.by_keys(spec.fields)
 end
 
 -- A handle stands for something the engine owns and can outlive it. C says how
@@ -1068,6 +1119,9 @@ api.type = declarator("type", "types", {
     -- A type, a number and a unit each belong to the module that hands one out,
     -- and the name a params list writes is that path.
     entry.where = placed(path, need)
+    if spec.record then
+      return declare_record(entry, spec, need)
+    end
     if spec.backing == nil then
       return declare_lua_class(entry, path, spec, need)
     end
@@ -1090,6 +1144,10 @@ api.type = declarator("type", "types", {
           list = doc.list,
           writable = field_writable(spec, field),
           description = doc.description,
+          -- A key of a table a script writes out may be left out, and stand in
+          -- what the declaration says it stands in.
+          optional = doc.optional,
+          default = doc.default,
         }
       end),
       methods = members(spec.methods, function(method)
@@ -1113,12 +1171,15 @@ api.type = declarator("type", "types", {
 -- The class of a type written in Lua, for a module that hands one of its values
 -- out but is not where it is declared: trx.items hands back a math.Box, and a
 -- box carries that class. Everything else names a type by its path.
+--
+-- A record has no class - a plain table is what it is - so asking for one says
+-- so rather than handing back something inert to put on a value.
 local class_needs = complain("api.class")
 
 function api.class(path)
   local entry = at(path)
   local class = entry ~= nil and entry.class or nil
-  class_needs(class ~= nil, "'%s' is not a declared type", path)
+  class_needs(class ~= nil, "'%s' is not a declared type with a class", path)
   return class
 end
 
@@ -1514,9 +1575,10 @@ end
 -- declares is expected to be missing.
 --
 -- What is audited is what checking will call: the arguments of a function, of a
--- callable namespace and of a method, and a property written through. A name in
--- a doc-only position - what a call hands back, what a constant is measured in -
--- is resolved by the docs tool, which walks the dump for exactly that.
+-- callable namespace and of a method, the keys of a table one of those takes,
+-- and a property written through. A name in a doc-only position - what a call
+-- hands back, what a constant is measured in - is resolved by the docs tool,
+-- which walks the dump for exactly that.
 local function audit_types(partial)
   local bad = {}
   local function report(fmt, ...)
@@ -1538,11 +1600,33 @@ local function audit_types(partial)
     return predicate
   end
 
+  -- The keys of a table a script writes out, which are checked as its own
+  -- arguments are and can name a type in the same way.
+  local function audit_keys(where, fields)
+    for key, field in pairs(fields or {}) do
+      local name = field.name or key
+      local predicate = checked_by(where, ("the key '%s'"):format(name), field)
+      if
+        predicate ~= nil
+        and field.default ~= nil
+        and not predicate(field.default)
+      then
+        report(
+          "%s: the default for '%s' is not %s",
+          where,
+          name,
+          check.label_of(field)
+        )
+      end
+    end
+  end
+
   local function audit_params(where, params)
     local optional_seen = false
     for _, p in ipairs(params or {}) do
       if p.name ~= "..." then
         local predicate = checked_by(where, ("'%s'"):format(p.name), p)
+        audit_keys(where .. "." .. p.name, p.fields)
         if
           predicate ~= nil
           and p.default ~= nil
@@ -1585,6 +1669,13 @@ local function audit_types(partial)
   end
   for _, entry in ipairs(each(api.property)) do
     checked_by(entry.path, "the property", entry.spec)
+  end
+  -- A record is checked by the keys it names wherever one is passed in, so the
+  -- names have to answer for the same reason a parameter's does.
+  for _, entry in ipairs(each(api.type)) do
+    if entry.spec.record then
+      audit_keys(entry.path, entry.spec.fields)
+    end
   end
 
   if #bad > 0 then

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -425,13 +425,19 @@ end
 -- the module's own members instead, and iterates raw to reach them.
 local function walk(container, tbl)
   local first = once(container, "base", base_of, container.spec.key)
-  local last = first + container.count() - 1
+  -- How far the keys run, which is not how many there are where a collection
+  -- is sparse: the samples a level carries are a hundred keys spread over
+  -- twice as many numbers. A dense one says nothing and the two agree.
+  local last = first + (container.limit or container.count)() - 1
   return function(_, i)
-    i = i + 1
-    if i > last then
-      return nil
+    while i < last do
+      i = i + 1
+      local value = container.get(i)
+      if value ~= nil then
+        return i, value
+      end
     end
-    return i, container.get(i)
+    return nil
   end,
     tbl,
     first - 1
@@ -752,6 +758,14 @@ api.container = declarator("container", "containers", {
       "count must be a function"
     )
     need(
+      spec.limit == nil or type(spec.limit) == "function",
+      "limit must be a function"
+    )
+    need(
+      spec.limit == nil or spec.count ~= nil,
+      "a limit says how far the keys run, so it needs a count beside it"
+    )
+    need(
       type(spec.key) == "table",
       "key must describe what the module is indexed by"
     )
@@ -777,6 +791,7 @@ api.container = declarator("container", "containers", {
     container.module = name
     container.get = spec.get
     container.count = spec.count
+    container.limit = spec.limit
     container.accepts = function(key)
       local kind = type(key)
       return kind == "number" or (kind == "string" and not by_number_only)

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -372,13 +372,10 @@ local function checker(declared)
   return check.of(declared) or check.anything
 end
 
--- What indexing counts from: the key's own base, or the base of what it points
--- at, since a container keyed by an item number counts as items do. A key that
--- says nothing, and names nothing that does, counts from zero.
+-- What indexing counts from, which is the base of the number the key names: a
+-- container keyed by an item number counts as items do. A key that names no
+-- number, or one with nothing to say, counts from zero.
 local function base_of(key)
-  if key.base ~= nil then
-    return key.base
-  end
   for _, one in ipairs(check.types_of(key.type)) do
     local entry = at(one)
     if made_by(entry, api.number) and entry.spec.base ~= nil then
@@ -785,6 +782,10 @@ api.container = declarator("container", "containers", {
     -- Where a collection counts from is the key's, so that a container keyed by
     -- an item number counts as items do without saying so twice.
     need(spec.base == nil, "where it counts from belongs to the key")
+    need(
+      spec.key.base == nil,
+      "where the keys count from belongs to the number they name"
+    )
 
     -- What the key accepts: one type, or several where a thing answers to a name
     -- as well as to its number. A module keyed only by number leaves a string key
@@ -1089,7 +1090,6 @@ api.type = declarator("type", "types", {
           list = doc.list,
           writable = field_writable(spec, field),
           description = doc.description,
-          base = doc.base,
         }
       end),
       methods = members(spec.methods, function(method)
@@ -1104,7 +1104,6 @@ api.type = declarator("type", "types", {
         return {
           type = computed.type,
           description = computed.description,
-          base = computed.base,
         }
       end),
     }
@@ -1351,7 +1350,6 @@ api.property = declarator("property", "properties", {
       type = doc.type,
       list = doc.list,
       description = doc.description,
-      base = doc.base,
       writable = entry.spec.set ~= nil,
     }
   end,

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -4,159 +4,314 @@
 -- registry is what the docs are generated from, so the reference cannot drift
 -- from the code.
 --
--- On performance: the spec is metadata, not a dispatch layer.
--- `trx.items.spawn` is the raw implementation - calling it costs exactly what
--- calling any Lua function costs. A generic spec-driven wrapper that validated
--- arguments on every call measured 26x slower (416ns vs 16ns), which is
--- untenable for anything a script calls per frame. Argument validation is
--- therefore opt-in: trx.api.strict(true) rebinds every registered function to
--- a code-generated checking wrapper (~108ns overhead), which builders can
--- enable while developing and leave off in play.
+-- The spec is metadata, not a dispatch layer. `trx.items.spawn` is the raw
+-- implementation, and calling it costs what calling any Lua function costs,
+-- because with checking off nothing wraps it at all. Checking is opt-in
+-- instead: api.strict rebinds every registered function to a closure that
+-- checks what it was handed, and its own description says what that costs.
 
 -- Captured at module scope: the raw C bridge is removed from the globals once
 -- the trx.* modules have loaded, so builders cannot reach past the public API.
 local struct = trxc.struct
+
 local enum = trxc.enum
+
 local capi = trxc.api
--- Hardening nils this out of the globals, and api.strict runs long after that.
-local load = load
+
+-- What a declaration accepts, and the predicate that answers for it. The
+-- registry says what is declared where; check.lua says what satisfies one, and
+-- reads the declarations back through the lookup below.
+local check = require("trx.check")
 
 local api = {}
 
--- A registry keyed by path, keeping the paths in declaration order alongside so
--- the docs come out the way the files declare, not the way pairs() happens to
--- iterate. record() is the only writer.
-local function ordered()
-  return { by_path = {}, order = {} }
-end
+-- The module's own state, in one place rather than scattered among the
+-- functions that read it.
 
-local function record(reg, path, spec)
-  if reg.by_path[path] == nil then
-    reg.order[#reg.order + 1] = path
+-- One registry, keyed by the path a declaration was made under and keeping the
+-- paths in declaration order alongside, so the docs come out the way the files
+-- declare rather than the way pairs() happens to iterate.
+--
+-- An entry says what kind of thing was declared and what the declaration said.
+-- What the declaration went on to build is added to the same entry - the
+-- predicate strict mode calls, the class a value carries, the table a module
+-- stands for - so "what is at this path" is one lookup rather than a search
+-- across a table per question.
+local declarations = { by_path = {}, order = {} }
+
+-- Every kind of declaration there is, in the order they were made, and the
+-- same kinds keyed by the declarator that makes one. The dump walks the first;
+-- each() reaches a kind through the second. A kind is the table itself
+-- wherever one is named, so there is nothing to keep a spelling of it in step
+-- with.
+local KINDS = {}
+local KIND_OF = {}
+
+-- Whether declarations are still being made, and whether what a script
+-- calls is the checking wrapper. Both are read by the declarators below.
+local strict_enabled = false
+
+local sealed = false
+
+-- The registry, and what makes a declarator.
+
+-- What a caller of this module got wrong, named by the entry point that caught
+-- it and formatted only where there is something to say. Every complaint the
+-- module makes goes through one of these, so none of them spells its own name
+-- out for itself.
+local function complain(called)
+  return function(ok, fmt, ...)
+    if not ok then
+      error(called .. ": " .. fmt:format(...), 0)
+    end
   end
-  reg.by_path[path] = spec
-  return spec
 end
 
--- Every registry projects to a doc entry the same way: walk it in declaration
--- order, turn each spec into a plain table. Only the projection differs.
-local function collect(reg, project)
+-- The entry for a path, opened on first mention. A table can be reached before
+-- anything declares it - a property names the table it hangs off, and a group
+-- of properties needs no declaration of its own - so an entry may hold what was
+-- built at a path before it holds what was declared there. Until a declarator
+-- claims it, it has no kind, and each() passes it by.
+local function open(path)
+  local entry = declarations.by_path[path]
+  if entry == nil then
+    entry = { path = path }
+    declarations.by_path[path] = entry
+    declarations.order[#declarations.order + 1] = path
+  end
+  return entry
+end
+
+local function at(path)
+  return declarations.by_path[path]
+end
+
+-- What checking asks of the registry: the predicate the declaration at a path
+-- built, and nothing else.
+check.reads_from(function(path)
+  local entry = declarations.by_path[path]
+  return entry ~= nil and entry.check or nil
+end)
+
+-- Which module a declaration lands under is the surface talking; which module
+-- loaded first is not - that is the source list in meson.build, and a module
+-- that requires another pulls it forward. The dump is committed and diffed, so
+-- it groups by module and cannot move when a load order does, the way a type's
+-- members and an enum's values already cannot.
+--
+-- Within a module the order is the order the file declares in, which is a
+-- choice someone made: trx.music reads play, pause, unpause, stop.
+--
+-- The field the module is read out of is named rather than assumed, so a kind
+-- that carries its path under some other name says so.
+local function by_module(field)
+  return function(list)
+    local declared_at = {}
+    for i, entry in ipairs(list) do
+      declared_at[entry] = i
+    end
+    table.sort(list, function(a, b)
+      local mod_a = a[field]:match("^[^.]+")
+      local mod_b = b[field]:match("^[^.]+")
+      if mod_a ~= mod_b then
+        return mod_a < mod_b
+      end
+      return declared_at[a] < declared_at[b]
+    end)
+  end
+end
+
+-- A module and its container carry no path to group on, one of each being all
+-- there is per module, so they read alphabetically.
+local function alphabetically(field)
+  return function(list)
+    table.sort(list, function(a, b)
+      return a[field] < b[field]
+    end)
+  end
+end
+
+-- Every public declarator is made here, so what they share is written once:
+-- declarations are the engine's to make at load time, a spec is a table, and
+-- every one of them opens an entry under the path it was given. What is left
+-- is the part that differs, which the kind supplies as `declare`.
+--
+-- A kind also says where it lands in the dump, how one entry reads there, and
+-- how that list is ordered, so everything about a kind of declaration is in
+-- one call.
+local function declarator(name, key, spec)
+  local kind = {
+    key = key,
+    describe = spec.describe,
+    sort = spec.sort or by_module("path"),
+  }
+  local need = complain("api." .. name)
+
+  -- What a second declaration at one path is told, settled here so nothing is
+  -- built for the declarations that are fine.
+  local taken = "%s is already declared."
+    .. (spec.taken ~= nil and (" " .. spec.taken) or "")
+
+  local function declare(path, declaration)
+    need(
+      not sealed,
+      "the registry is sealed; declarations happen at load time"
+    )
+    need(type(path) == "string", "path must be a string")
+    declaration = declaration or {}
+    need(type(declaration) == "table", "spec must be a table")
+    -- A container is declared as the module it indexes and sits under the name
+    -- the reference gives it, so a kind may name its own path.
+    local entry = open(spec.path and spec.path(path) or path)
+    need(entry.kind == nil, taken, path)
+    entry.kind = kind
+    entry.spec = declaration
+    return spec.declare(entry, path, declaration, need)
+  end
+  KINDS[#KINDS + 1] = kind
+  KIND_OF[declare] = kind
+  return declare
+end
+
+-- Every declaration of one kind, in the order the files made them.
+local function entries_of(kind)
   local list = {}
-  for _, key in ipairs(reg.order) do
-    list[#list + 1] = project(key, reg.by_path[key])
+  for _, path in ipairs(declarations.order) do
+    local entry = declarations.by_path[path]
+    if entry.kind == kind then
+      list[#list + 1] = entry
+    end
   end
   return list
 end
 
-local registry = ordered()
-local modules = ordered()
-local types = ordered()
-local enums = ordered()
-local consts = ordered()
-local properties = ordered()
-local namespaces = ordered()
--- path -> { fn = what calling the namespace runs }. Held apart from the
--- metatable so api.strict can swap the wrapper in.
-local namespace_dispatch = {}
--- Type name -> predicate. Private: reachable, a script could hand strict mode a
--- checker that accepts anything. A declared type answers to the path it was
--- declared under and to nothing else, so nothing names it by a spelling the
--- declaration never chose.
-local checkers
--- What a number is, written once where it belongs: what an item number is is
--- the items module's to say, and everything that holds one is typed by it.
-local numbers = ordered()
--- What a value is measured in, written once where it belongs: a distance is a
--- distance however many declarations hold one.
-local units = ordered()
-local containers = ordered()
--- module -> { get, count, accepts }. What indexing the module table reaches.
-local module_containers = {}
--- container path -> { name -> spec }. What the container's __index dispatches
--- on. A module's path is its name; a namespace's is 'module.namespace'.
-local container_properties = {}
--- module -> function returning the handle it stands for, and the path of the
--- type that handle has: trx.lara.air is a member of lara.Lara, so the docs can
--- say where a script writing trx.lara.<member> lands.
-local module_instances = {}
-local module_instance_types = {}
--- type path -> the class table of a type written in Lua, which is both what a
--- value of that type carries as its metatable and where its methods live.
-local lua_classes = {}
--- class -> the class it extends, for the checker to walk. Held apart from the
--- class table, which a value indexes through.
-local class_parents = {}
-local strict_enabled = false
-local sealed = false
-
--- Every type a spec accepts, in the order it declared them: one, or the
--- several a container key answers to - a number, and the name that reaches the
--- same thing.
-local function types_of(value)
-  return type(value) == "table" and value or { value }
+-- The same, reached by the declarator that makes one rather than by the kind
+-- itself, which is the module's own and not something a caller here holds. The
+-- dump walks KINDS and already has one.
+local function each(maker)
+  return entries_of(KIND_OF[maker])
 end
 
--- What a declaration accepts, as the reader writes it: one type, or the
--- several it answers to. What the errors below name.
-local function type_label(declared)
-  local names = {}
-  for i, one in ipairs(types_of(declared)) do
-    names[i] = tostring(one)
-  end
-  return #names == 0 and tostring(declared) or table.concat(names, " or ")
+-- Whether one entry is of a kind, named the same way.
+local function made_by(entry, maker)
+  return entry ~= nil and entry.kind == KIND_OF[maker]
 end
 
--- The predicate a declaration is checked by, or nil where this surface has no
--- type of that name. One that names several passes on any of them.
-local function checker_for(declared)
-  if type(declared) ~= "table" then
-    return checkers[declared]
+-- What a declaration reads like once it is doc-facing.
+
+-- A spec as the docs read it: a copy, with what it is typed by written out as
+-- the path that names it, so the docs can link to the declaration and a
+-- description several places share is still written once.
+local function as_doc(spec)
+  if type(spec) ~= "table" then
+    return spec
   end
-  local each = {}
-  for i, one in ipairs(declared) do
-    each[i] = checkers[one]
-    if each[i] == nil then
-      return nil
+  local out = {}
+  for key, value in pairs(spec) do
+    out[key] = value
+  end
+  if out.type ~= nil then
+    local accepted = check.types_of(out.type)
+    out.type = #accepted == 1 and accepted[1] or accepted
+  end
+  -- A table argument or result declares the keys it is made of, and each of
+  -- them reads like any other spec.
+  for _, key in ipairs({ "params", "fields" }) do
+    if type(out[key]) == "table" then
+      local list = {}
+      for i, nested in ipairs(out[key]) do
+        list[i] = as_doc(nested)
+      end
+      out[key] = list
     end
   end
-  return function(value)
-    for _, check in ipairs(each) do
-      if check(value) then
-        return true
+  return out
+end
+
+-- A type's members are declared in a table keyed by name, which pairs() walks
+-- in whatever order it likes, so each kind of member comes out sorted by name.
+local function members(declared, read)
+  local list = {}
+  for name, member in pairs(declared or {}) do
+    local one = read(member)
+    one.name = name
+    list[#list + 1] = one
+  end
+  table.sort(list, function(a, b)
+    return a.name < b.name
+  end)
+  return list
+end
+
+-- Params are always a list; what a call hands back is one spec or a list of
+-- them, and a lone one is told apart by carrying a type of its own.
+local function as_doc_list(list)
+  if list == nil or list.type ~= nil then
+    return as_doc(list)
+  end
+  local out = {}
+  for i, spec in ipairs(list) do
+    out[i] = as_doc(spec)
+  end
+  return out
+end
+
+-- A description written as a long-bracket string carries the indentation it was
+-- written at, and four spaces is a code block in markdown - which is how a
+-- module's own prose came out as one. The text is what the declaration says,
+-- not where it sat in the file, so the shared indent comes off. The deepest
+-- lines keep the rest of theirs, since a description may lay something out.
+local function dedent(text)
+  local shared
+  for line in text:gmatch("[^\n]+") do
+    if line:match("%S") ~= nil then
+      local indent = #line:match("^[ \t]*")
+      if shared == nil or indent < shared then
+        shared = indent
       end
     end
-    return false
   end
+  if shared == nil or shared == 0 then
+    return (text:gsub("^%s*\n", ""):gsub("%s+$", ""))
+  end
+  local out = {}
+  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+    out[#out + 1] = line:sub(shared + 1)
+  end
+  return (table.concat(out, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
 end
 
-local function split_path(path)
-  local module, name = path:match("^([%w_]+)%.([%w_]+)$")
-  assert(
-    module ~= nil,
-    "api path must be 'module.name', got: " .. tostring(path)
-  )
-  return module, name
-end
+-- Where a path lands, which every declaration asks in one of two ways: what a
+-- path is made of, and what table it names.
 
--- A path is 'module.name', or 'module.namespace.name' one level deeper.
--- Anything deeper is a sign the module wants splitting.
-local function path_parts(path)
+local function segments(path)
   local parts = {}
   for segment in tostring(path):gmatch("[^.]+") do
     parts[#parts + 1] = segment
   end
-  assert(
-    #parts == 2 or #parts == 3,
-    "api path must be 'module.name' or 'module.namespace.name', got: "
-      .. tostring(path)
-  )
   return parts
 end
 
--- The path of the table a member hangs off: the module, or the namespace
--- inside it.
-local function owner_path(parts)
-  return #parts == 3 and (parts[1] .. "." .. parts[2]) or parts[1]
+-- A path taken apart, which every declarator keeps on its entry as `where`.
+-- `module` is the module it belongs to, `name` the member's own name, and
+-- `owner` the path of the table that member hangs off - the module, or the
+-- namespace inside it. A path is 'module.name', or 'module.namespace.name' where
+-- `deep` allows one; anything further is a sign the module wants splitting.
+local function placed(path, need, deep)
+  local parts = segments(path)
+  local count = #parts
+  need(
+    count == 2 or (deep and count == 3),
+    deep and "path must be 'module.name' or 'module.namespace.name', got: %s"
+      or "path must be 'module.name', got: %s",
+    path
+  )
+  return {
+    module = parts[1],
+    namespace = count == 3 and parts[2] or nil,
+    name = parts[count],
+    owner = count == 3 and (parts[1] .. "." .. parts[2]) or parts[1],
+  }
 end
 
 -- The trx.<module> table, created on first mention. Every declaration hangs its
@@ -166,38 +321,120 @@ local function module_table(module)
   return trx[module]
 end
 
--- The guard every declarator opens with: declarations are the engine's to make
--- at load time, and a spec is a table. `fn` names the caller for the message.
-local function opening(fn, spec)
-  assert(
-    not sealed,
-    "the trx.api registry is sealed; declarations happen at load time"
+-- The table a member hangs off: the module's own, or a namespace's inside it.
+local function table_of(where, need)
+  local tbl = module_table(where.module)
+  if where.namespace == nil then
+    return tbl
+  end
+  local namespace = rawget(tbl, where.namespace)
+  need(
+    type(namespace) == "table",
+    "%s.%s.%s needs api.namespace('%s.%s') declared first",
+    where.module,
+    where.namespace,
+    where.name,
+    where.module,
+    where.namespace
   )
-  if spec ~= nil then
-    assert(type(spec) == "table", fn .. ": spec must be a table")
+  return namespace
+end
+
+-- What a declaration puts on the table a script reaches.
+
+-- What a declaration is worth asking once and keeping, kept on the entry that
+-- was asked about. Asked the first time something needs the answer rather than
+-- as the declaration is made: a declaration may name a type its own file
+-- declares further down, and reading it while the file is still being read
+-- would answer nil.
+local function once(holder, slot, answer, declared)
+  local held = holder[slot]
+  if held == nil then
+    held = answer(declared)
+    holder[slot] = held
+  end
+  return held
+end
+
+-- What checks a value against a declaration, waving it through where nothing
+-- can: a type this surface does not declare is caught by the seal and by the
+-- dump rather than here.
+local function checker(declared)
+  return check.of(declared) or check.anything
+end
+
+-- What indexing counts from: the key's own base, or the base of what it points
+-- at, since a container keyed by an item number counts as items do. A key that
+-- says nothing, and names nothing that does, counts from zero.
+local function base_of(key)
+  if key.base ~= nil then
+    return key.base
+  end
+  for _, one in ipairs(check.types_of(key.type)) do
+    local entry = at(one)
+    if made_by(entry, api.number) and entry.spec.base ~= nil then
+      return entry.spec.base
+    end
+  end
+  return 0
+end
+
+-- What a module standing for a handle reaches on it. A method wants the handle
+-- as its self, and the module is not one, so the handle stands in. A colon call
+-- hands the module over as self and a dot call hands over nothing, so the module
+-- table itself is what tells the two apart - no argument of a script's can be it.
+local function member_of(handle, tbl, key)
+  if handle == nil then
+    return nil
+  end
+  local member = handle[key]
+  if type(member) ~= "function" then
+    return member
+  end
+  return function(first, ...)
+    if first == tbl then
+      return member(handle, ...)
+    end
+    return member(handle, first, ...)
   end
 end
 
--- The module, the table the member hangs off, and the member's own name.
-local function resolve(path)
-  local parts = path_parts(path)
-  local module = parts[1]
-  module_table(module)
-  if #parts == 2 then
-    return module, trx[module], parts[2]
+-- A property is written, not called, so make_checked never sees it. Strict mode
+-- still has to. Three frames up is whoever wrote it.
+--
+-- What checks a write is worked out the first time one is made, as what checks
+-- a collection's key is, and for the same reason: a property may name a type
+-- the same file declares further down.
+local function write_property(where, prop, value)
+  local spec = prop.spec
+  if spec.set == nil then
+    error(where .. " is read-only", 3)
   end
-  local namespace = rawget(trx[module], parts[2])
-  assert(
-    type(namespace) == "table",
-    "api: "
-      .. path
-      .. " needs api.namespace('"
-      .. module
-      .. "."
-      .. parts[2]
-      .. "') declared first"
-  )
-  return module, namespace, parts[3]
+  if strict_enabled then
+    if not once(prop, "write_check", checker, spec)(value) then
+      error(("%s: expected %s"):format(where, check.label_of(spec)), 3)
+    end
+  end
+  spec.set(value)
+end
+
+-- pairs() over the module walks the collection one handle at a time, so a
+-- script iterates without the #..-1 idiom. It walks from whichever index the
+-- collection counts from: the items and the rooms from zero, matching the
+-- numbers level editors show, and a plain list from one. seal()'s audit reads
+-- the module's own members instead, and iterates raw to reach them.
+local function walk(container, tbl)
+  local first = once(container, "base", base_of, container.spec.key)
+  local last = first + container.count() - 1
+  return function(_, i)
+    i = i + 1
+    if i > last then
+      return nil
+    end
+    return i, container.get(i)
+  end,
+    tbl,
+    first - 1
 end
 
 -- A module is a plain table, and api.define rawsets its functions straight into
@@ -209,72 +446,44 @@ end
 -- rather than merely undocumented. That matters most here: neither a metatable
 -- getter nor a struct field ever shows up in pairs(), so seal()'s audit cannot
 -- see one.
--- `owner` is what the errors name, and `tbl` is the table the metatable goes
--- on. For a module the two are the module and trx.<module>; for a namespace,
--- the dotted path and the namespace's own table. Only a module can carry an
--- instance or be a container, so those lookups come back nil for a namespace.
-local function install_meta(owner, tbl)
-  local props = container_properties[owner]
-  local instance = module_instances[owner]
-  local container = module_containers[owner]
-  if props == nil and instance == nil and container == nil then
-    return
-  end
+--
+-- Everything the metatable serves is on the entry: the properties hung off it,
+-- the handle it stands for, the collection it is indexed as. Its path is what
+-- the errors name, and `entry.table` is what the metatable goes on - trx.<name>
+-- for a module, the namespace's own table for a namespace. Only a module can
+-- carry an instance or be a container, so a namespace's entry has neither.
+--
+-- Called by whichever declaration adds one of the three, and again by the next,
+-- so the metatable it leaves serves everything the entry holds by then.
+local NO_PROPERTIES = {}
+
+local function install_meta(entry)
+  local owner, tbl = entry.path, entry.table
+  local props = entry.properties or NO_PROPERTIES
+  local instance, container = entry.instance, entry.container
 
   local meta = {
     __index = function(_, key)
-      local prop = props ~= nil and props[key] or nil
+      local prop = props[key]
       if prop ~= nil then
-        return prop.get()
+        return prop.spec.get()
       end
       if container ~= nil and container.accepts(key) then
         return container.get(key)
       end
       if instance ~= nil then
-        local handle = instance()
-        if handle ~= nil then
-          local member = handle[key]
-          -- A method wants the handle as its self, and the module is not one,
-          -- so the handle stands in. A colon call hands the module over as
-          -- self and a dot call hands over nothing, so the module table itself
-          -- is what tells the two apart - no argument of a script's can be it.
-          if type(member) == "function" then
-            return function(first, ...)
-              if first == tbl then
-                return member(handle, ...)
-              end
-              return member(handle, first, ...)
-            end
-          end
-          return member
-        end
+        return member_of(instance(), tbl, key)
       end
       return nil
     end,
     __newindex = function(_, key, value)
-      local prop = props ~= nil and props[key] or nil
+      local prop = props[key]
       if prop ~= nil then
-        if prop.set == nil then
-          error("trx." .. owner .. "." .. tostring(key) .. " is read-only", 2)
-        end
-        -- A property is written, not called, so make_checked never sees it.
-        -- Strict mode still has to.
-        if strict_enabled then
-          local check = checker_for(prop.type)
-          if check ~= nil and not check(value) then
-            error(
-              "trx."
-                .. owner
-                .. "."
-                .. tostring(key)
-                .. ": expected a "
-                .. type_label(prop.type),
-              2
-            )
-          end
-        end
-        prop.set(value)
-        return
+        return write_property(
+          ("trx.%s.%s"):format(owner, tostring(key)),
+          prop,
+          value
+        )
       end
       if instance ~= nil then
         local handle = instance()
@@ -285,31 +494,18 @@ local function install_meta(owner, tbl)
           return
         end
       end
-      error("Cannot set field '" .. tostring(key) .. "' on trx." .. owner, 2)
+      error(
+        ("Cannot set field '%s' on trx.%s"):format(tostring(key), owner),
+        2
+      )
     end,
   }
   if container ~= nil and container.count ~= nil then
     meta.__len = function()
       return container.count()
     end
-    -- pairs() over the module walks the collection one handle at a time, so a
-    -- script iterates without the #..-1 idiom. It walks from whichever index
-    -- the collection counts from: the items and the rooms from zero, matching
-    -- the numbers level editors show, and a plain list from one. seal()'s
-    -- audit reads the module's own members instead, and iterates raw to reach
-    -- them.
     meta.__pairs = function(t)
-      local first = container.base
-      local last = first + container.count() - 1
-      return function(_, i)
-        i = i + 1
-        if i > last then
-          return nil
-        end
-        return i, container.get(i)
-      end,
-        t,
-        first - 1
+      return walk(container, t)
     end
   end
   -- A namespace declared callable already carries a metatable, and its call
@@ -321,31 +517,13 @@ local function install_meta(owner, tbl)
   setmetatable(tbl, meta)
 end
 
-function api.module(name, spec)
-  opening("api.module", spec)
-  assert(type(name) == "string", "api.module: name must be a string")
-  spec = record(modules, name, spec or {})
+-- Argument checking, which is off until something turns it on.
 
-  -- A module that stands for one C struct reads and writes that struct's fields
-  -- directly: trx.lara.air is Lara's air. `instance` hands back the handle.
-  if spec.instance ~= nil then
-    assert(
-      type(spec.instance) == "function",
-      "api.module: instance must be a function"
-    )
-    assert(
-      type(spec.instance_type) == "string",
-      "api.module: instance_type must name the type the module stands for"
-    )
-    module_instances[name] = spec.instance
-    module_instance_types[name] = spec.instance_type
-    install_meta(name, module_table(name))
-  end
-end
-
--- Builds a specialized validating wrapper by generating Lua source for this
--- exact parameter list. Avoids the per-call table.pack/unpack and spec loop
--- that made the generic approach 26x slower.
+-- Strict mode wraps the implementation in a closure that checks what it was
+-- handed. `select` reads the arguments without copying them, and handing `...`
+-- straight on keeps the count the caller gave: several bridges read
+-- lua_gettop() to tell "not given" from "given nil", so an optional argument
+-- nobody passed has to stay absent rather than arrive as nil.
 local function make_checked(fn, path, params)
   if params == nil or #params == 0 then
     return fn
@@ -354,440 +532,61 @@ local function make_checked(fn, path, params)
   local variadic = params[#params].name == "..."
   local fixed = variadic and #params - 1 or #params
 
-  local names, checks = {}, {}
+  local names, optional, predicates, defaults = {}, {}, {}, {}
+  local fills_a_default = false
   for i = 1, fixed do
     local p = params[i]
-    names[i] = "a" .. i
-    local fail = ("E(%q,%q)"):format(path, p.name)
-    if p.optional then
-      checks[#checks + 1] = ("if a%d==nil then a%d=D[%d] elseif not C[%d](a%d) then %s end"):format(
-        i,
-        i,
-        i,
-        i,
-        i,
-        fail
-      )
-    else
-      checks[#checks + 1] = ("if not C[%d](a%d) then %s end"):format(
-        i,
-        i,
-        fail
-      )
-    end
-  end
-
-  local sig = table.concat(names, ",")
-  if variadic then
-    sig = sig == "" and "..." or (sig .. ",...")
-  end
-
-  -- Several bridges read lua_gettop() to tell "not given" from "given nil", so
-  -- an optional parameter with no default has to stay absent rather than
-  -- arrive as nil. A variadic call carries its own count and needs none of
-  -- this.
-  local body = {}
-  if not variadic then
-    for i = fixed, 1, -1 do
-      local p = params[i]
-      if not (p.optional and p.default == nil) then
-        break
-      end
-      table.insert(
-        body,
-        1,
-        ("if a%d==nil then return fn(%s) end"):format(
-          i,
-          table.concat(names, ",", 1, i - 1)
-        )
-      )
-    end
-  end
-  body[#body + 1] = ("return fn(%s)"):format(sig)
-
-  local src = ("local fn,C,D,E=... return function(%s) %s %s end"):format(
-    sig,
-    table.concat(checks, " "),
-    table.concat(body, " ")
-  )
-
-  local param_checkers, defaults = {}, {}
-  for i = 1, fixed do
-    local p = params[i]
-    -- Strict mode checks what it can. A type this surface does not declare -
-    -- a test standing up a few modules names one - has nothing to check
-    -- against, and is caught where every other name is: the seal, and the dump.
-    local check = checker_for(p.type) or function()
-      return true
-    end
-    param_checkers[i] = check
+    names[i] = p.name
+    optional[i] = p.optional == true
+    predicates[i] = checker(p)
     defaults[i] = p.default
+    if p.default ~= nil then
+      fills_a_default = true
+    end
   end
 
-  local function on_fail(where, arg)
-    error(("%s: invalid argument '%s'"):format(where, arg), 3)
+  -- Three frames down to the caller: here, the wrapper, and whoever called it.
+  local function checked(i, value)
+    if value == nil and optional[i] then
+      return
+    end
+    if not predicates[i](value) then
+      error(("%s: invalid argument '%s'"):format(path, names[i]), 3)
+    end
   end
-  -- Named as an API module is, so LUA_GetCallerInfo walks past this frame too.
-  return load(src, "@trx/api/" .. path .. " (checked)")(
-    fn,
-    param_checkers,
-    defaults,
-    on_fail
-  )
+
+  if not fills_a_default then
+    return function(...)
+      for i = 1, fixed do
+        checked(i, (select(i, ...)))
+      end
+      return fn(...)
+    end
+  end
+
+  -- Substituting a default hands the implementation a different argument list
+  -- than the caller wrote, so this one has to build one. Twelve of the
+  -- surface's parameters declare a default; the rest take the path above.
+  return function(...)
+    local args = table.pack(...)
+    for i = 1, fixed do
+      if args[i] == nil and defaults[i] ~= nil then
+        args[i] = defaults[i]
+        if args.n < i then
+          args.n = i
+        end
+      else
+        checked(i, args[i])
+      end
+    end
+    return fn(table.unpack(args, 1, args.n))
+  end
 end
 
 -- The function a caller reaches: the checking wrapper under strict mode, the
 -- raw one otherwise. api.strict flips every binding through here.
 local function bound(fn, path, params)
   return strict_enabled and make_checked(fn, path, params) or fn
-end
-
--- Doc-facing type names, not Lua type names.
-checkers = {
-  integer = function(v)
-    return math.type(v) == "integer"
-  end,
-  number = function(v)
-    return type(v) == "number"
-  end,
-  string = function(v)
-    return type(v) == "string"
-  end,
-  boolean = function(v)
-    return type(v) == "boolean"
-  end,
-  table = function(v)
-    return type(v) == "table"
-  end,
-  ["function"] = function(v)
-    return type(v) == "function"
-  end,
-  vec3 = function(v)
-    return type(v) == "table" and v.x ~= nil and v.y ~= nil and v.z ~= nil
-  end,
-  any = function()
-    return true
-  end,
-}
-
--- A handle's metatable is its C type name - see LUA_Struct_Register - so one
--- type of handle is told from another. api.type registers one of these per
--- type, which is why Item and Room are absent above.
-local function handle_checker(backing)
-  return function(v)
-    return getmetatable(v) == backing
-  end
-end
-
--- A value of a type written in Lua carries its class as its metatable, and a
--- derived class carries the one it extends. Walking that chain is what lets an
--- ItemQuery satisfy a parameter declared as a Query.
--- A type answers to the path it was declared under. There is no second name to
--- keep in step with it: a declaration that means items.Item says items.Item,
--- and one that means something nobody declared fails the audit rather than
--- waving values through under a name that once meant something else.
---
--- One path, one declaration: a number written over a type's path would leave
--- the type checked for the number instead, and strict mode would report a
--- clean run while a handle's own values went unrecognized.
-local function register_checker(path, check)
-  assert(
-    checkers[path] == nil,
-    "api: '" .. path .. "' is declared twice, and a name answers to one thing"
-  )
-  checkers[path] = check
-end
-
-local function class_checker(class)
-  return function(v)
-    local candidate = getmetatable(v)
-    while candidate ~= nil do
-      if candidate == class then
-        return true
-      end
-      candidate = class_parents[candidate]
-    end
-    return false
-  end
-end
-
--- Called once, from C, after the trx.* modules have loaded. Declarations are
--- the engine's to make; a level script re-opening the surface would defeat the
--- point of declaring it.
---
--- Also audits the finished surface: an assignment straight onto a module table
--- works for scripts, but the docs never see it. Refuse to boot instead.
-function api.seal(spec)
-  local partial = spec ~= nil and spec.partial == true
-  -- The declaring half has done its job, and every one of those functions
-  -- raises from here on. It goes the way trxc goes at this same moment: what a
-  -- script cannot successfully call, it should not be able to reach. Done
-  -- before the audit, so the audit sees the surface a script is left with. C
-  -- keeps the two entrypoints it still needs - see lua/capi/api.c.
-  trx.api = {
-    strict = api.strict,
-    is_strict = api.is_strict,
-  }
-
-  -- container path ("items", or "console.log") -> set of declared member
-  -- names.
-  local declared = {}
-  local function mark(path)
-    local parts = path_parts(path)
-    local container = owner_path(parts)
-    local name = parts[#parts]
-    declared[container] = declared[container] or {}
-    declared[container][name] = true
-  end
-  for _, path in ipairs(registry.order) do
-    mark(path)
-  end
-  for _, path in ipairs(enums.order) do
-    mark(path)
-  end
-  for _, path in ipairs(consts.order) do
-    mark(path)
-  end
-  -- The namespace table itself is a member of its module.
-  for _, path in ipairs(namespaces.order) do
-    mark(path)
-  end
-
-  local undeclared = {}
-  local function audit(container_path, tbl)
-    -- next, not pairs: a container overrides __pairs to walk its collection, so
-    -- the module's own members are only reachable through a raw iteration.
-    for name in next, tbl or {} do
-      if not (declared[container_path] or {})[name] then
-        table.insert(undeclared, "trx." .. container_path .. "." .. name)
-      end
-    end
-  end
-
-  for _, module in ipairs(modules.order) do
-    audit(module, trx[module])
-  end
-  -- A namespace hides its members one level down, where the module audit above
-  -- cannot see them. Audit it as its own container.
-  for _, path in ipairs(namespaces.order) do
-    local module, name = split_path(path)
-    audit(path, rawget(trx[module] or {}, name))
-  end
-
-  if #undeclared > 0 then
-    table.sort(undeclared)
-    error(
-      table.concat(undeclared, ", ")
-        .. ": reachable from scripts but not declared, so the reference cannot describe it. "
-        .. "Declare it with api.define, api.enum, api.const, api.property or api.namespace."
-    )
-  end
-
-  -- A type nothing can check prints a name that means nothing, and waves every
-  -- value through while strict mode reports a clean run over it.
-  local bad = {}
-  local function audit_type(where, what, type_name)
-    if checker_for(type_name) == nil and not partial then
-      table.insert(
-        bad,
-        where
-          .. ": "
-          .. what
-          .. " has an unknown type '"
-          .. type_label(type_name)
-          .. "'"
-      )
-      return false
-    end
-    return true
-  end
-
-  local function audit_params(where, params)
-    local optional_seen = false
-    for _, p in ipairs(params or {}) do
-      if p.name ~= "..." then
-        if
-          audit_type(where, "'" .. tostring(p.name) .. "'", p.type)
-          and p.default ~= nil
-        then
-          if not checker_for(p.type)(p.default) then
-            table.insert(
-              bad,
-              where
-                .. ": the default for '"
-                .. p.name
-                .. "' is not a "
-                .. type_label(p.type)
-            )
-          end
-        end
-        -- Nothing can reach it without passing the optional one too.
-        if p.optional then
-          optional_seen = true
-        elseif optional_seen then
-          table.insert(
-            bad,
-            where
-              .. ": '"
-              .. p.name
-              .. "' is required but follows an optional parameter"
-          )
-        end
-      end
-    end
-  end
-
-  for _, path in ipairs(registry.order) do
-    audit_params(path, registry.by_path[path].params)
-  end
-  for _, path in ipairs(namespaces.order) do
-    audit_params(path, namespaces.by_path[path].params)
-  end
-  -- Strict mode checks a method's arguments too, and make_checked needs a
-  -- checker for each. Without this, a type nobody can check would only surface
-  -- the day a builder turned strict mode on.
-  for _, path in ipairs(types.order) do
-    for name, method in pairs(types.by_path[path].methods or {}) do
-      audit_params(path .. "." .. name, method.params)
-    end
-  end
-  for _, path in ipairs(properties.order) do
-    audit_type(path, "the property", properties.by_path[path].type)
-  end
-
-  if #bad > 0 then
-    table.sort(bad)
-    error(table.concat(bad, "\n"))
-  end
-
-  sealed = true
-end
-
--- Declares a grouping table on a module, holding related members under one
--- name. `call` makes the group itself callable, so calling the group works
--- alongside calling the members inside it.
---
--- A namespace has to be declared before anything inside it: it is the table
--- the members hang off, and seal() audits its contents just as it audits a
--- module's.
-function api.namespace(path, spec)
-  opening("api.namespace", spec)
-  local module, name = split_path(path)
-  -- The table below replaces whatever stands there now, and with it the
-  -- metatable serving any property already declared inside. Those properties
-  -- would go on reading as nil, which seal() cannot see: it audits the members
-  -- a table holds, and a property is never one of them.
-  assert(
-    namespaces.by_path[path] == nil,
-    "api.namespace: "
-      .. path
-      .. " is already declared. Declare it before "
-      .. "anything inside it."
-  )
-
-  local namespace = {}
-  if spec.call ~= nil then
-    assert(
-      type(spec.call) == "function",
-      "api.namespace: call must be a function"
-    )
-    -- Through a holder, so api.strict can swap the wrapper in as it does for
-    -- the members.
-    local dispatch = { fn = bound(spec.call, path, spec.params) }
-    namespace_dispatch[path] = dispatch
-    setmetatable(namespace, {
-      __call = function(_, ...)
-        return dispatch.fn(...)
-      end,
-    })
-  end
-
-  rawset(module_table(module), name, namespace)
-
-  record(namespaces, path, spec)
-  return namespace
-end
-
--- Declares that a module table can be indexed - trx.items[3], trx.objects.wolf
--- - and, if it can be counted, that #trx.items is its length.
---
--- The registry owns the module's metatable, so a module that set its own would
--- lose it to the first property declared on it. And pairs() never sees a
--- metatable, so only a declaration puts the indexing in the reference.
--- What indexing counts from: the key's own base, or the base of whatever it
--- points at, since a container keyed by an item number counts as items do.
-local function key_base(key)
-  if key.base ~= nil then
-    return key.base
-  end
-  for _, one in ipairs(types_of(key.type)) do
-    local number = numbers.by_path[one]
-    if number ~= nil and number.base ~= nil then
-      return number.base
-    end
-  end
-  return nil
-end
-
-function api.container(name, spec)
-  opening("api.container", spec)
-  assert(type(spec.get) == "function", "api.container: get must be a function")
-  assert(
-    spec.count == nil or type(spec.count) == "function",
-    "api.container: count must be a function"
-  )
-  assert(
-    type(spec.key) == "table",
-    "api.container: key must describe what the module is indexed by"
-  )
-  -- Where a collection counts from is the key's, so that a container keyed by
-  -- an item number counts as items do without saying so twice.
-  assert(
-    spec.base == nil,
-    "api.container: where it counts from belongs to the key"
-  )
-
-  -- What the key accepts: one type, or several where a thing answers to a name
-  -- as well as to its number. A module keyed only by number leaves a string key
-  -- to the rest of the metatable, so trx.rooms.nonsense is nil rather than an
-  -- error out of C.
-  local accepted = types_of(spec.key.type)
-  local by_number_only = true
-  for _, one in ipairs(accepted) do
-    if one == "string" or one == "any" then
-      by_number_only = false
-    end
-  end
-  module_containers[name] = {
-    get = spec.get,
-    count = spec.count,
-    -- Where the collection's first entry sits, which is the key's own base: a
-    -- list of its own is counted from one, and what carries an engine number
-    -- keeps it and counts from zero.
-    base = key_base(spec.key) or 0,
-    accepts = function(key)
-      local kind = type(key)
-      return kind == "number" or (kind == "string" and not by_number_only)
-    end,
-  }
-
-  record(containers, name, spec)
-
-  install_meta(name, module_table(name))
-end
-
-function api.define(path, spec)
-  opening("api.define", spec)
-  assert(type(spec.impl) == "function", "api.define: impl must be a function")
-  local _, container, name = resolve(path)
-
-  record(registry, path, spec)
-
-  -- The raw implementation is the public function. No wrapper, no overhead.
-  -- rawset: some module tables guard __newindex, and a declaration is not a
-  -- caller poking at the module.
-  rawset(container, name, bound(spec.impl, path, spec.params))
-  return spec.impl
 end
 
 -- A method is called with the handle as its first argument, which the
@@ -806,20 +605,20 @@ end
 -- `impl`, a Lua function taking the handle first, and is exposed as it stands.
 -- Extensions take nothing but the handle __index hands them, so there is
 -- nothing of the script's to check.
-local function bind_type_methods(path)
-  local spec = types.by_path[path]
+--
+-- What a declaration has to carry is settled where it is made, so this only
+-- binds. api.strict comes back through here every time it is flipped.
+local function bind_type_methods(entry)
+  local path = entry.path
+  local spec = entry.spec
   local backing = spec.backing
-  local class = lua_classes[path]
+  local class = entry.class
 
   -- A type written in Lua keeps its methods in the class table, so binding one
   -- is an assignment and strict mode swaps the wrapper in the same way it does
   -- for a module's functions.
   if class ~= nil then
     for name, method in pairs(spec.methods or {}) do
-      assert(
-        type(method.impl) == "function",
-        "api.type: " .. path .. "." .. name .. " needs an impl"
-      )
       rawset(
         class,
         name,
@@ -848,26 +647,189 @@ local function bind_type_methods(path)
   end
 end
 
--- Rebinds every registered function to (or away from) its checking wrapper.
-function api.strict(enabled)
-  strict_enabled = enabled and true or false
-  for _, path in ipairs(registry.order) do
-    local _, container, name = resolve(path)
-    local spec = registry.by_path[path]
-    rawset(container, name, bound(spec.impl, path, spec.params))
-  end
-  for path, dispatch in pairs(namespace_dispatch) do
-    local spec = namespaces.by_path[path]
-    dispatch.fn = bound(spec.call, path, spec.params)
-  end
-  for _, path in ipairs(types.order) do
-    bind_type_methods(path)
-  end
-end
+-- The public surface. Everything above is written once; everything below
+-- declares one kind of thing and says how it reads in the reference.
 
-function api.is_strict()
-  return strict_enabled
-end
+api.module = declarator("module", "modules", {
+  sort = alphabetically("name"),
+  declare = function(entry, name, spec, need)
+    entry.table = module_table(name)
+
+    -- A module that stands for one C struct reads and writes that struct's fields
+    -- directly: trx.lara.air is Lara's air. `instance` hands back the handle.
+    if spec.instance ~= nil then
+      need(type(spec.instance) == "function", "instance must be a function")
+      need(
+        type(spec.instance_type) == "string",
+        "instance_type must name the type the module stands for"
+      )
+      entry.instance = spec.instance
+      entry.instance_type = spec.instance_type
+      install_meta(entry)
+    end
+  end,
+
+  describe = function(entry)
+    return {
+      name = entry.path,
+      title = entry.spec.title,
+      description = entry.spec.description,
+      order = entry.spec.order,
+      -- What indexing the module reaches, where it stands for one thing:
+      -- trx.lara.air is a member of lara.Lara, and a reference written the way
+      -- a script writes it lands there.
+      instance_type = entry.instance_type,
+    }
+  end,
+})
+
+-- Declares a grouping table on a module, holding related members under one
+-- name. `call` makes the group itself callable, so calling the group works
+-- alongside calling the members inside it.
+--
+-- A namespace has to be declared before anything inside it: it is the table
+-- the members hang off, and seal() audits its contents just as it audits a
+-- module's.
+api.namespace = declarator("namespace", "namespaces", {
+  taken = "Declare it before anything inside it.",
+  declare = function(entry, path, spec, need)
+    local where = placed(path, need)
+    entry.where = where
+    -- The table below stands for the namespace from here on, and replaces
+    -- whatever stands at its path. A property declared inside one is served by
+    -- the metatable on that table, so it would go on reading as nil - which
+    -- seal() cannot see, since it audits the members a table holds and a
+    -- property is never one of them. Declaring the group first is what the
+    -- message above asks for.
+    local namespace = {}
+    entry.table = namespace
+    if spec.call ~= nil then
+      need(type(spec.call) == "function", "call must be a function")
+      -- Read off the entry rather than closed over, so api.strict can swap the
+      -- wrapper in as it does for the members.
+      entry.call = bound(spec.call, path, spec.params)
+      setmetatable(namespace, {
+        __call = function(_, ...)
+          return entry.call(...)
+        end,
+      })
+    end
+
+    rawset(module_table(where.module), where.name, namespace)
+
+    return namespace
+  end,
+
+  describe = function(entry)
+    local spec = entry.spec
+    return {
+      path = entry.path,
+      description = spec.description,
+      params = as_doc_list(spec.params),
+      returns = as_doc_list(spec.returns),
+      examples = spec.examples,
+      callable = spec.call ~= nil,
+      implicit = spec.implicit,
+    }
+  end,
+})
+
+-- Declares that a module table can be indexed - trx.items[3], trx.objects.wolf
+-- - and, if it can be counted, that #trx.items is its length.
+--
+-- The registry owns the module's metatable, so a module that set its own would
+-- lose it to the first property declared on it. And pairs() never sees a
+-- metatable, so only a declaration puts the indexing in the reference.
+api.container = declarator("container", "containers", {
+  path = function(name)
+    return name .. "[]"
+  end,
+  sort = alphabetically("module"),
+  declare = function(entry, name, spec, need)
+    need(type(spec.get) == "function", "get must be a function")
+    need(
+      spec.count == nil or type(spec.count) == "function",
+      "count must be a function"
+    )
+    need(
+      type(spec.key) == "table",
+      "key must describe what the module is indexed by"
+    )
+    -- Where a collection counts from is the key's, so that a container keyed by
+    -- an item number counts as items do without saying so twice.
+    need(spec.base == nil, "where it counts from belongs to the key")
+
+    -- What the key accepts: one type, or several where a thing answers to a name
+    -- as well as to its number. A module keyed only by number leaves a string key
+    -- to the rest of the metatable, so trx.rooms.nonsense is nil rather than an
+    -- error out of C.
+    local accepted = check.types_of(spec.key.type)
+    local by_number_only = true
+    for _, one in ipairs(accepted) do
+      if one == "string" or one == "any" then
+        by_number_only = false
+      end
+    end
+    -- Declared under the name the reference already gives it - `trx.items[]` is
+    -- what the page anchors - so being indexable is a declaration like any
+    -- other, and the module it sits on points at it.
+    local container = entry
+    container.module = name
+    container.get = spec.get
+    container.count = spec.count
+    container.accepts = function(key)
+      local kind = type(key)
+      return kind == "number" or (kind == "string" and not by_number_only)
+    end
+
+    local module = open(name)
+    module.table = module_table(name)
+    module.container = container
+
+    install_meta(module)
+  end,
+
+  describe = function(entry)
+    return {
+      module = entry.module,
+      description = entry.spec.description,
+      key = as_doc(entry.spec.key),
+      value = as_doc(entry.spec.value),
+      countable = entry.spec.count ~= nil,
+      examples = entry.spec.examples,
+    }
+  end,
+})
+
+api.define = declarator("define", "functions", {
+  declare = function(entry, path, spec, need)
+    need(type(spec.impl) == "function", "impl must be a function")
+    local where = placed(path, need, true)
+    entry.where = where
+    local tbl, name = table_of(where, need), where.name
+
+    -- Where the function was put, so strict mode swaps the wrapper in without
+    -- working the path out a second time. rawset: some module tables guard
+    -- __newindex, and a declaration is not a caller poking at the module.
+    entry.expose = function(fn)
+      rawset(tbl, name, fn)
+    end
+
+    -- The raw implementation is the public function. No wrapper, no overhead.
+    entry.expose(bound(spec.impl, path, spec.params))
+    return spec.impl
+  end,
+
+  describe = function(entry)
+    return {
+      path = entry.path,
+      description = entry.spec.description,
+      params = as_doc_list(entry.spec.params),
+      returns = as_doc_list(entry.spec.returns),
+      examples = entry.spec.examples,
+    }
+  end,
+})
 
 -- Declares a handle type: which C members are public, under what name, plus the
 -- methods and computed members that complete the type.
@@ -875,141 +837,239 @@ end
 -- Nothing is reachable from a handle until it is named here. The C table says
 -- how to reach a member; this says whether it is part of the API and what it is
 -- called. A member C can reach but nobody declares simply does not exist.
-function api.type(path, spec)
-  opening("api.type", spec)
+-- A derived class carries the one it extends as its own metatable's __index.
+-- That is what the checker walks to let an ItemQuery satisfy a Query, and what
+-- makes an inherited method reachable. Lua looks a metamethod up raw, so
+-- `__index` on the class is not what reaches one: a derived class carries its
+-- own copy of the operators it inherits.
+local function inherit(class, path, extends, need)
+  local parent = at(extends)
+  local parent_class = parent ~= nil and parent.class or nil
+  need(parent_class ~= nil, "%s extends an undeclared type", path)
+  setmetatable(class, { __index = parent_class })
+  for key, value in pairs(parent_class) do
+    if key:sub(1, 2) == "__" and key ~= "__index" then
+      rawset(class, key, value)
+    end
+  end
+  return parent
+end
 
-  -- A type written in Lua names no C struct. The declaration owns its class
-  -- table and hands it back: the module gives a value that class as its
-  -- metatable, and every method a script can call is one declared here.
-  -- `extends` names a type whose methods this one inherits, for a domain that
-  -- adds its own to a shared base.
-  if spec.backing == nil then
-    local class = {}
-    class.__index = class
-    if spec.extends ~= nil then
-      local parent = lua_classes[spec.extends]
-      assert(
-        parent ~= nil,
-        "api.type: " .. path .. " extends an undeclared type"
+-- A field of a type written in Lua is a pair of accessors, since the value has
+-- no struct behind it to address. A field is writable when it declares a `set`,
+-- and read-only otherwise.
+--
+-- A field with no accessors is an entry the value carries itself, which is what
+-- a plain table of numbers is: the class says what the keys are called and what
+-- they hold, and reading one reaches the entry.
+local function accessors(fields, need)
+  local getters, setters = {}, {}
+  for name, field in pairs(fields or {}) do
+    if field.get == nil then
+      need(field.set == nil, "field '%s' has a set but no get", name)
+    else
+      need(
+        field.set == nil or type(field.set) == "function",
+        "field '%s' has a set that is not a function",
+        name
       )
-      -- The link is held here rather than on the class, which a value indexes
-      -- through: what a script reaches on one is its declared methods and
-      -- nothing else.
-      class_parents[class] = parent
-      setmetatable(class, { __index = parent })
-      -- Lua looks a metamethod up raw, so `__index` on the class is not what
-      -- reaches one: a derived class carries its own copy of the operators it
-      -- inherits.
-      for key, value in pairs(parent) do
-        if key:sub(1, 2) == "__" and key ~= "__index" then
-          rawset(class, key, value)
-        end
+      getters[name], setters[name] = field.get, field.set
+    end
+  end
+  return getters, setters
+end
+
+-- Whether the docs say a field can be written. A handle's field addresses a
+-- struct member and a Lua class's is a pair of accessors, so either may be
+-- read-only. A record a call hands back is a plain table the caller owns, and
+-- has nothing to say either way.
+local function field_writable(spec, field)
+  if spec.backing ~= nil then
+    return field.writable ~= false
+  end
+  if field.get ~= nil then
+    return field.set ~= nil
+  end
+  return nil
+end
+
+-- Declaring an accessor is what puts the type's members under the registry's
+-- control: reading one the declaration does not name comes back nil, and
+-- writing one raises, so a value cannot quietly grow members the docs never
+-- see.
+local function reach_fields(class, path, getters, setters)
+  class.__index = function(self, key)
+    local getter = getters[key]
+    if getter ~= nil then
+      return getter(self)
+    end
+    -- The metamethods sit on the class alongside the methods, and are the
+    -- registry's business rather than a member of the type.
+    if type(key) == "string" and key:sub(1, 2) == "__" then
+      return nil
+    end
+    return class[key]
+  end
+  class.__newindex = function(self, key, value)
+    local setter = setters[key]
+    if setter == nil then
+      if getters[key] ~= nil then
+        error(("%s.%s is read-only"):format(path, tostring(key)), 2)
+      end
+      error(("%s has no member '%s'"):format(path, tostring(key)), 2)
+    end
+    setter(self, value)
+  end
+end
+
+-- A type written in Lua names no C struct. The declaration owns its class table
+-- and hands it back: the module gives a value that class as its metatable, and
+-- every method a script can call is one declared here. `extends` names a type
+-- whose methods this one inherits, for a domain that adds its own to a shared
+-- base.
+local function declare_lua_class(entry, path, spec, need)
+  -- The docs read an extension off the declaration either way, so a class that
+  -- named one would document a member nothing installs.
+  need(
+    next(spec.extensions or {}) == nil,
+    "an extension is computed on a handle; a type written in Lua has none"
+  )
+
+  local class = {}
+  class.__index = class
+
+  local getters, setters = accessors(spec.fields, need)
+  if spec.extends ~= nil then
+    local parent = inherit(class, path, spec.extends, need)
+    -- A field the parent declares reads on this type too. Its accessors sit in
+    -- the parent's __index closure rather than in the class table, so walking
+    -- the metatable chain does not reach one and they are taken over here.
+    for name, getter in pairs(parent.getters) do
+      if getters[name] == nil then
+        getters[name], setters[name] = getter, parent.setters[name]
       end
     end
-
-    for name, operator in pairs(spec.operators or {}) do
-      assert(
-        type(operator.impl) == "function",
-        "api.type: operator '" .. name .. "' needs an impl"
-      )
-      rawset(class, "__" .. name, operator.impl)
-    end
-
-    -- A field of a type written in Lua is a pair of accessors, since the value
-    -- has no struct behind it to address. Declaring any of them is what puts
-    -- the type's members under the registry's control: reading one the
-    -- declaration does not name comes back nil, and writing one raises, so a
-    -- value cannot quietly grow members the docs never see. A field is
-    -- writable when it declares a `set`, and read-only otherwise.
-    local getters, setters = {}, {}
-    local has_fields = false
-    for name, field in pairs(spec.fields or {}) do
-      -- A field with no accessors is an entry the value carries itself, which
-      -- is what a plain table of numbers is: the class says what the keys are
-      -- called and what they hold, and reading one reaches the entry.
-      if field.get == nil then
-        assert(
-          field.set == nil,
-          "api.type: field '" .. name .. "' has a set but no get"
-        )
-        field.writable = field.writable ~= false
-      else
-        assert(
-          field.set == nil or type(field.set) == "function",
-          "api.type: field '" .. name .. "' has a set that is not a function"
-        )
-        getters[name] = field.get
-        setters[name] = field.set
-        field.writable = field.set ~= nil
-        has_fields = true
-      end
-    end
-
-    if has_fields then
-      class.__index = function(self, key)
-        local getter = getters[key]
-        if getter ~= nil then
-          return getter(self)
-        end
-        -- The metamethods sit on the class alongside the methods, and are the
-        -- registry's business rather than a member of the type.
-        if type(key) == "string" and key:sub(1, 2) == "__" then
-          return nil
-        end
-        return class[key]
-      end
-      class.__newindex = function(self, key, value)
-        local setter = setters[key]
-        if setter == nil then
-          if getters[key] ~= nil then
-            error(("%s.%s is read-only"):format(path, tostring(key)), 2)
-          end
-          error(("%s has no member '%s'"):format(path, tostring(key)), 2)
-        end
-        setter(self, value)
-      end
-    end
-
-    lua_classes[path] = class
-    register_checker(path, class_checker(class))
-    record(types, path, spec)
-    bind_type_methods(path)
-    return class
   end
 
-  assert(
-    type(spec.backing) == "string",
-    "api.type: backing must be a C type name"
-  )
-  local backing = spec.backing
+  for name, operator in pairs(spec.operators or {}) do
+    need(
+      type(operator.impl) == "function",
+      "operator '%s' needs an impl",
+      name
+    )
+    rawset(class, "__" .. name, operator.impl)
+  end
 
-  -- Declaring the type is what makes its name checkable in a params list.
-  register_checker(path, handle_checker(backing))
+  entry.getters, entry.setters = getters, setters
+  if next(getters) ~= nil then
+    reach_fields(class, path, getters, setters)
+  end
+
+  entry.class = class
+  entry.check = check.by_identity(class)
+  -- A method of a type written in Lua is the Lua function it declares, and
+  -- nothing stands behind it where the declaration names none.
+  for name, method in pairs(spec.methods or {}) do
+    need(type(method.impl) == "function", "%s.%s needs an impl", path, name)
+  end
+  bind_type_methods(entry)
+  return class
+end
+
+-- A handle stands for something the engine owns and can outlive it. C says how
+-- to reach a member; the declaration says whether it is part of the API and
+-- what it is called, and declaring the type is what makes its name checkable
+-- in a params list.
+local function declare_handle(entry, spec, need)
+  local backing = spec.backing
+  need(type(backing) == "string", "backing must be a C type name")
+  -- A handle carries its C type name as its metatable, and has no class table
+  -- for an operator to go on.
+  need(
+    next(spec.operators or {}) == nil,
+    "an operator goes on a class table; a handle has none"
+  )
+  entry.check = check.by_metatable(backing)
 
   for name, field in pairs(spec.fields or {}) do
-    local from = field.from or name
-    struct.expose_field(backing, name, from, field.writable ~= false)
+    struct.expose_field(
+      backing,
+      name,
+      field.from or name,
+      field.writable ~= false
+    )
   end
 
   for name, computed in pairs(spec.extensions or {}) do
-    assert(
+    need(
       type(computed.impl) == "function",
-      "api.type: extension '" .. name .. "' needs an impl"
+      "extension '%s' needs an impl",
+      name
     )
     struct.expose_computed(backing, name, computed.impl)
   end
 
-  record(types, path, spec)
-
-  bind_type_methods(path)
+  bind_type_methods(entry)
 end
+
+api.type = declarator("type", "types", {
+  declare = function(entry, path, spec, need)
+    -- A type, a number and a unit each belong to the module that hands one out,
+    -- and the name a params list writes is that path.
+    entry.where = placed(path, need)
+    if spec.backing == nil then
+      return declare_lua_class(entry, path, spec, need)
+    end
+    return declare_handle(entry, spec, need)
+  end,
+
+  describe = function(entry)
+    local spec = entry.spec
+    return {
+      path = entry.path,
+      description = spec.description,
+      handle = spec.backing ~= nil,
+      operators = members(spec.operators, function(operator)
+        return { description = operator.description }
+      end),
+      fields = members(spec.fields, function(field)
+        local doc = as_doc(field)
+        return {
+          type = doc.type,
+          list = doc.list,
+          writable = field_writable(spec, field),
+          description = doc.description,
+          base = doc.base,
+        }
+      end),
+      methods = members(spec.methods, function(method)
+        return {
+          description = method.description,
+          params = as_doc_list(method.params),
+          returns = as_doc_list(method.returns),
+          examples = method.examples,
+        }
+      end),
+      extensions = members(spec.extensions, function(computed)
+        return {
+          type = computed.type,
+          description = computed.description,
+          base = computed.base,
+        }
+      end),
+    }
+  end,
+})
 
 -- The class of a type written in Lua, for a module that hands one of its values
 -- out but is not where it is declared: trx.items hands back a math.Box, and a
 -- box carries that class. Everything else names a type by its path.
+local class_needs = complain("api.class")
+
 function api.class(path)
-  local class = lua_classes[path]
-  assert(class ~= nil, "api.class: '" .. path .. "' is not a declared type")
+  local entry = at(path)
+  local class = entry ~= nil and entry.class or nil
+  class_needs(class ~= nil, "'%s' is not a declared type", path)
   return class
 end
 
@@ -1032,197 +1092,245 @@ function api.enum_name(spec, reflected_name)
   return reflected_name
 end
 
-function api.enum(path, spec)
-  opening("api.enum", spec)
-  assert(
-    type(spec.backing) == "string",
-    "api.enum: backing must be a C enum name"
-  )
-  local module, name = split_path(path)
+api.enum = declarator("enum", "enums", {
+  declare = function(entry, path, spec, need)
+    need(type(spec.backing) == "string", "backing must be a C enum name")
+    local where = placed(path, need)
+    entry.where = where
 
-  -- `bulk` is for a catalog-sized enum - every object in the game, say. It is
-  -- described as a whole, and its constants carry no description apiece.
-  local bulk = spec.bulk == true
-  assert(
-    bulk or type(spec.values) == "table",
-    "api.enum: values must be a table"
-  )
+    -- `bulk` is for a catalog-sized enum - every object in the game, say. It is
+    -- described as a whole, and its constants carry no description apiece.
+    local bulk = spec.bulk == true
+    need(bulk or type(spec.values) == "table", "values must be a table")
 
-  local public = {}
-  local reflected = {}
-  for _, constant in ipairs(enum.values(spec.backing)) do
-    local value_name = api.enum_name(spec, constant.name)
-    -- Stripping a prefix can collide two C constants onto one Lua name, and the
-    -- second would quietly take the first one's place.
-    assert(
-      public[value_name] == nil,
-      "api.enum: "
-        .. path
-        .. "."
-        .. value_name
-        .. " is the name of two constants of "
-        .. spec.backing
-    )
-    if not bulk then
-      assert(
-        spec.values[value_name] ~= nil,
-        "api.enum: " .. path .. "." .. value_name .. " is not documented"
+    local public = {}
+    local reflected = {}
+    for _, constant in ipairs(enum.values(spec.backing)) do
+      local value_name = api.enum_name(spec, constant.name)
+      -- Stripping a prefix can collide two C constants onto one Lua name, and the
+      -- second would quietly take the first one's place.
+      need(
+        public[value_name] == nil,
+        "%s.%s is the name of two constants of %s",
+        path,
+        value_name,
+        spec.backing
+      )
+      if not bulk then
+        need(
+          spec.values[value_name] ~= nil,
+          "%s.%s is not documented",
+          path,
+          value_name
+        )
+      end
+      public[value_name] = constant.value
+      reflected[value_name] = true
+    end
+
+    for value_name in pairs(spec.values or {}) do
+      need(
+        reflected[value_name],
+        "%s.%s is not a constant of %s",
+        path,
+        value_name,
+        spec.backing
       )
     end
-    public[value_name] = constant.value
-    reflected[value_name] = true
-  end
 
-  for value_name in pairs(spec.values or {}) do
-    assert(
-      reflected[value_name],
-      "api.enum: "
-        .. path
-        .. "."
-        .. value_name
-        .. " is not a constant of "
-        .. spec.backing
-    )
-  end
+    -- How many constants the enum has, which the declaration did not say and
+    -- the dump reads back off the entry.
+    entry.count = 0
+    for _ in pairs(public) do
+      entry.count = entry.count + 1
+    end
 
-  spec.count = 0
-  for _ in pairs(public) do
-    spec.count = spec.count + 1
-  end
-
-  -- The constants are held behind an empty table rather than in one. Lua only
-  -- calls __newindex for a key the table does not have, so a value sitting in
-  -- the table itself could be overwritten without the metatable seeing it, and
-  -- an enum mirrors C: it is read-only.
-  --
-  -- __index also folds the case, so trx.catalog.objects.wolf and
-  -- trx.catalog.objects.WOLF are the same constant. Upper case is canonical: it
-  -- is what pairs() yields and what the docs list.
-  local face = {}
-  setmetatable(face, {
-    __index = function(_, key)
-      if type(key) ~= "string" then
-        return nil
-      end
-      return public[key] ~= nil and public[key] or public[key:upper()]
-    end,
-    __newindex = function(_, key)
-      error(
-        "trx."
-          .. path
-          .. "."
-          .. tostring(key)
-          .. ": an enum cannot be written to",
-        2
-      )
-    end,
-    -- pairs() hands the caller every value __pairs returns, so returning
-    -- `next, public` would hand out the very table the face is there to keep
-    -- behind __newindex. The iterator closes over it instead.
-    __pairs = function(self)
-      local key
-      return function()
-        local value
-        key, value = next(public, key)
-        return key, value
+    -- The constants are held behind an empty table rather than in one. Lua only
+    -- calls __newindex for a key the table does not have, so a value sitting in
+    -- the table itself could be overwritten without the metatable seeing it, and
+    -- an enum mirrors C: it is read-only.
+    --
+    -- __index also folds the case, so trx.catalog.objects.wolf and
+    -- trx.catalog.objects.WOLF are the same constant. Upper case is canonical: it
+    -- is what pairs() yields and what the docs list.
+    local face = {}
+    setmetatable(face, {
+      __index = function(_, key)
+        if type(key) ~= "string" then
+          return nil
+        end
+        return public[key] or public[key:upper()]
       end,
-        self,
-        nil
-    end,
-  })
+      __newindex = function(_, key)
+        error(
+          ("trx.%s.%s: an enum cannot be written to"):format(
+            path,
+            tostring(key)
+          ),
+          2
+        )
+      end,
+      -- pairs() hands the caller every value __pairs returns, so returning
+      -- `next, public` would hand out the very table the face is there to keep
+      -- behind __newindex. The iterator closes over it instead.
+      __pairs = function(self)
+        local key
+        return function()
+          local value
+          key, value = next(public, key)
+          return key, value
+        end,
+          self,
+          nil
+      end,
+    })
 
-  rawset(module_table(module), name, face)
+    rawset(module_table(where.module), where.name, face)
 
-  -- What the engine passes is a number. Which numbers have names is the
-  -- catalog's business - a bulk enum runs to hundreds, and carries ids no
-  -- constant names - so a declaration typed by an enum checks for the number.
-  register_checker(path, checkers.integer)
+    -- What the engine passes is a number. Which numbers have names is the
+    -- catalog's business - a bulk enum runs to hundreds, and carries ids no
+    -- constant names - so a declaration typed by an enum checks for the number.
+    entry.check = check.primitive("integer")
 
-  record(enums, path, spec)
-  return face
-end
+    return face
+  end,
+
+  describe = function(entry)
+    local path, spec = entry.path, entry.spec
+    local out = {
+      path = path,
+      description = spec.description,
+      examples = spec.examples,
+      bulk = spec.bulk == true,
+      count = entry.count,
+      values = {},
+    }
+    -- A bulk enum reads as names only, and no values: the ids are TRX's own, and
+    -- a script refers to them by name.
+    if out.bulk then
+      out.names = {}
+      for _, constant in ipairs(enum.values(spec.backing)) do
+        table.insert(out.names, api.enum_name(spec, constant.name))
+      end
+      table.sort(out.names)
+    else
+      for _, constant in ipairs(enum.values(spec.backing)) do
+        local value_name = api.enum_name(spec, constant.name)
+        table.insert(out.values, {
+          name = value_name,
+          value = constant.value,
+          description = spec.values[value_name],
+        })
+      end
+      -- Numeric order: the order the constants are meant to be read in, and
+      -- stable across dumps, which the reflected order is not.
+      table.sort(out.values, function(a, b)
+        return a.value < b.value
+      end)
+    end
+    return out
+  end,
+})
 
 -- Declares a lone constant sitting on the module table - an angle unit is a
 -- macro, not a C enum, so api.enum has nothing to reflect. The value still
 -- comes from C, so naming one C does not export fails here rather than quietly
 -- being nil.
-function api.const(path, spec)
-  opening("api.const", spec)
-  assert(
-    spec.value ~= nil,
-    "api.const: " .. path .. " has no value; is it exported from C?"
-  )
-  local module, name = split_path(path)
+api.const = declarator("const", "constants", {
+  declare = function(entry, path, spec, need)
+    need(spec.value ~= nil, "%s has no value; is it exported from C?", path)
+    local where = placed(path, need)
+    entry.where = where
 
-  record(consts, path, spec)
+    rawset(module_table(where.module), where.name, spec.value)
+    return spec.value
+  end,
 
-  rawset(module_table(module), name, spec.value)
-  return spec.value
-end
+  describe = function(entry)
+    local doc = as_doc(entry.spec)
+    return {
+      path = entry.path,
+      value = doc.value,
+      type = doc.type,
+      description = doc.description,
+    }
+  end,
+})
 
 -- Declares a computed member on a module table, or on a namespace inside it.
 -- It is not a function and not a stored field: reading it calls into C, and
 -- writing it calls a setter, or fails if there is none. The registry owns the
 -- container's metatable - see install_meta - so a hand-rolled getter table
 -- would sail past seal().
-function api.property(path, spec)
-  opening("api.property", spec)
-  assert(type(spec.get) == "function", "api.property: get must be a function")
-  assert(
-    spec.set == nil or type(spec.set) == "function",
-    "api.property: set must be a function"
-  )
-  local parts = path_parts(path)
-  local owner = owner_path(parts)
-  -- A group of properties is only the table its members hang off, so it need
-  -- not be declared: trx.rules.exposure.max asks for trx.rules.exposure and
-  -- gets it. api.namespace is for a group that has something of its own to
-  -- say, which is why api.define still insists on one.
-  if #parts == 3 and rawget(module_table(parts[1]), parts[2]) == nil then
-    api.namespace(owner, { implicit = true })
-  end
-  local _, container, name = resolve(path)
+api.property = declarator("property", "properties", {
+  declare = function(entry, path, spec, need)
+    need(type(spec.get) == "function", "get must be a function")
+    need(
+      spec.set == nil or type(spec.set) == "function",
+      "set must be a function"
+    )
+    local where = placed(path, need, true)
+    entry.where = where
+    -- A group of properties is only the table its members hang off, so it need
+    -- not be declared: trx.rules.exposure.max asks for trx.rules.exposure and
+    -- gets it. api.namespace is for a group that has something of its own to
+    -- say, which is why api.define still insists on one.
+    if
+      where.namespace ~= nil
+      and rawget(module_table(where.module), where.namespace) == nil
+    then
+      api.namespace(where.owner, { implicit = true })
+    end
 
-  record(properties, path, spec)
+    -- A property has an entry of its own, and the table it hangs off gathers the
+    -- ones declared on it: what its __index dispatches on is the owner's, not
+    -- each property's.
+    local owner_entry = open(where.owner)
+    owner_entry.table = table_of(where, need)
+    owner_entry.properties = owner_entry.properties or {}
+    owner_entry.properties[where.name] = entry
 
-  local props = container_properties[owner]
-  if props == nil then
-    props = {}
-    container_properties[owner] = props
-  end
-  props[name] = spec
+    install_meta(owner_entry)
+    return spec
+  end,
 
-  install_meta(owner, container)
-  return spec
-end
+  describe = function(entry)
+    local doc = as_doc(entry.spec)
+    return {
+      path = entry.path,
+      type = doc.type,
+      list = doc.list,
+      description = doc.description,
+      base = doc.base,
+      writable = entry.spec.set ~= nil,
+    }
+  end,
+})
 
 -- Declares a number: what it counts, and where it counts from. A room number
 -- is one thing however many declarations hold one, so it is written here and
 -- they name it. Doc-only in the sense that no member of it reaches a script -
 -- what a script gets is the number itself - but it is a type like any other,
 -- and a declaration that holds one says so.
-function api.number(path, spec)
-  opening("api.number", spec)
-  assert(type(path) == "string", "api.number: path must be a string")
-  -- A number belongs to the module that says what it counts, and the docs
-  -- reach it there.
-  split_path(path)
-  assert(
-    type(spec.description) == "string",
-    "api.number: description must be a string"
-  )
-  assert(
-    spec.base == nil or spec.base == 0 or spec.base == 1,
-    "api.number: base counts from 0 or from 1"
-  )
-  assert(
-    numbers.by_path[path] == nil,
-    "api.number: '" .. path .. "' is already written"
-  )
-  record(numbers, path, spec)
+api.number = declarator("number", "numbers", {
+  declare = function(entry, path, spec, need)
+    entry.where = placed(path, need)
+    need(type(spec.description) == "string", "description must be a string")
+    need(
+      spec.base == nil or spec.base == 0 or spec.base == 1,
+      "base counts from 0 or from 1"
+    )
+    entry.check = check.primitive("integer")
+  end,
 
-  register_checker(path, checkers.integer)
-end
+  describe = function(entry)
+    return {
+      path = entry.path,
+      description = entry.spec.description,
+      base = entry.spec.base,
+    }
+  end,
+})
 
 -- Declares a unit: what a value is measured in. An angle is measured the same
 -- way wherever one turns up, so it is written here and the declarations that
@@ -1231,316 +1339,236 @@ end
 -- `type` is what a value of it is: whole where the engine counts in steps of
 -- one, as it does for an angle and a distance, and a real number where it does
 -- not, as for a time in seconds.
-function api.unit(path, spec)
-  opening("api.unit", spec)
-  assert(type(path) == "string", "api.unit: path must be a string")
-  -- A unit belongs to the module that says what it measures, and the docs
-  -- reach it there.
-  split_path(path)
-  assert(
-    type(spec.description) == "string",
-    "api.unit: description must be a string"
-  )
-  local measured = spec.type or "integer"
-  assert(
-    measured == "integer" or measured == "number",
-    "api.unit: a unit measures an integer or a number"
-  )
-  assert(
-    spec.spellings == nil or type(spec.spellings) == "table",
-    "api.unit: spellings must list the words that mean this unit"
-  )
-  assert(
-    units.by_path[path] == nil,
-    "api.unit: '" .. path .. "' is already written"
-  )
-  record(units, path, spec)
+api.unit = declarator("unit", "units", {
+  declare = function(entry, path, spec, need)
+    entry.where = placed(path, need)
+    need(type(spec.description) == "string", "description must be a string")
+    local measured = spec.type or "integer"
+    need(
+      measured == "integer" or measured == "number",
+      "a unit measures an integer or a number"
+    )
+    need(
+      spec.spellings == nil or type(spec.spellings) == "table",
+      "spellings must list the words that mean this unit"
+    )
+    entry.check = check.primitive(measured)
+  end,
 
-  register_checker(path, checkers[measured])
-end
-
--- A spec as the docs read it. What it is typed by is written out as the path
--- that names it, so the docs can link to the declaration and a description
--- several places share is still written once.
-local function noted(spec)
-  if type(spec) ~= "table" then
-    return spec
-  end
-  local out = {}
-  for key, value in pairs(spec) do
-    out[key] = value
-  end
-  if out.type ~= nil then
-    local accepted = types_of(out.type)
-    out.type = #accepted == 1 and accepted[1] or accepted
-  end
-  -- A table argument or result declares the keys it is made of, and each of
-  -- them reads like any other spec.
-  for _, key in ipairs({ "params", "fields" }) do
-    if type(out[key]) == "table" then
-      local list = {}
-      for i, nested in ipairs(out[key]) do
-        list[i] = noted(nested)
-      end
-      out[key] = list
-    end
-  end
-  return out
-end
-
--- Params are a list; returns is one spec or a list of them.
-local function noted_list(list)
-  if list == nil then
-    return nil
-  end
-  local out = {}
-  for i, spec in ipairs(list) do
-    out[i] = noted(spec)
-  end
-  return out
-end
-
-local function noted_returns(returns)
-  if returns == nil or returns.type ~= nil then
-    return noted(returns)
-  end
-  return noted_list(returns)
-end
-
--- A description written as a long-bracket string carries the indentation it was
--- written at, and four spaces is a code block in markdown - which is how a
--- module's own prose came out as one. The text is what the declaration says,
--- not where it sat in the file, so the shared indent comes off. The deepest
--- lines keep the rest of theirs, since a description may lay something out.
-local function dedent(text)
-  local shared
-  for line in text:gmatch("[^\n]+") do
-    if line:match("%S") ~= nil then
-      local indent = #line:match("^[ \t]*")
-      if shared == nil or indent < shared then
-        shared = indent
-      end
-    end
-  end
-  if shared == nil or shared == 0 then
-    return (text:gsub("^%s*\n", ""):gsub("%s+$", ""))
-  end
-  local out = {}
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-    out[#out + 1] = line:sub(shared + 1)
-  end
-  return (table.concat(out, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
-end
-
--- The whole surface as plain data: what the docs generator consumes.
-function api.describe()
-  local out = { types = {}, enums = {} }
-  out.containers = collect(containers, function(name, spec)
+  describe = function(entry)
+    local spec = entry.spec
     return {
-      module = name,
-      description = spec.description,
-      key = noted(spec.key),
-      value = noted(spec.value),
-      countable = spec.count ~= nil,
-      examples = spec.examples,
-    }
-  end)
-  out.numbers = collect(numbers, function(path, spec)
-    return {
-      path = path,
-      description = spec.description,
-      base = spec.base,
-    }
-  end)
-  out.units = collect(units, function(path, spec)
-    return {
-      path = path,
+      path = entry.path,
       description = spec.description,
       -- What a value of it is. Written out even where it is the default, so
       -- the docs need not know what that default is.
       type = spec.type or "integer",
       spellings = spec.spellings,
     }
-  end)
-  out.modules = collect(modules, function(name, spec)
-    return {
-      name = name,
-      title = spec.title,
-      description = spec.description,
-      order = spec.order,
-      -- What indexing the module reaches, where it stands for one thing:
-      -- trx.lara.air is a member of lara.Lara, and a reference written the way
-      -- a script writes it lands there.
-      instance_type = module_instance_types[name],
-    }
-  end)
-  out.functions = collect(registry, function(path, spec)
-    return {
-      path = path,
-      description = spec.description,
-      params = noted_list(spec.params),
-      returns = noted_returns(spec.returns),
-      examples = spec.examples,
-    }
-  end)
-  for _, path in ipairs(types.order) do
-    local spec = types.by_path[path]
-    local entry = {
-      path = path,
-      description = spec.description,
-      -- A handle stands for something the engine owns and can outlive it; a
-      -- type written in Lua is the value itself, so the docs say so only of
-      -- the first.
-      handle = spec.backing ~= nil,
-      fields = {},
-      methods = {},
-      extensions = {},
-      operators = {},
-    }
-    for name, operator in pairs(spec.operators or {}) do
-      table.insert(entry.operators, {
-        name = name,
-        description = operator.description,
-      })
-    end
-    for name, field in pairs(spec.fields or {}) do
-      local noted_field = noted(field)
-      table.insert(entry.fields, {
-        name = name,
-        type = noted_field.type,
-        writable = noted_field.writable ~= false,
-        description = noted_field.description,
-        base = noted_field.base,
-      })
-    end
-    for name, method in pairs(spec.methods or {}) do
-      table.insert(entry.methods, {
-        name = name,
-        description = method.description,
-        params = noted_list(method.params),
-        returns = noted_returns(method.returns),
-        examples = method.examples,
-      })
-    end
-    for name, computed in pairs(spec.extensions or {}) do
-      table.insert(entry.extensions, {
-        name = name,
-        type = computed.type,
-        description = computed.description,
-        base = computed.base,
-      })
-    end
-    local by_name = function(a, b)
-      return a.name < b.name
-    end
-    table.sort(entry.fields, by_name)
-    table.sort(entry.methods, by_name)
-    table.sort(entry.extensions, by_name)
-    table.sort(entry.operators, by_name)
-    table.insert(out.types, entry)
-  end
-  for _, path in ipairs(enums.order) do
-    local spec = enums.by_path[path]
-    local entry = {
-      path = path,
-      description = spec.description,
-      examples = spec.examples,
-      bulk = spec.bulk == true,
-      count = spec.count,
-      values = {},
-    }
-    -- Names only, and no values: the ids are TRX's own, and a script refers to
-    -- them by name.
-    if entry.bulk then
-      entry.names = {}
-      for _, constant in ipairs(enum.values(spec.backing)) do
-        table.insert(entry.names, api.enum_name(spec, constant.name))
-      end
-      table.sort(entry.names)
-    end
-    if not entry.bulk then
-      for _, constant in ipairs(enum.values(spec.backing)) do
-        local value_name = api.enum_name(spec, constant.name)
-        table.insert(entry.values, {
-          name = value_name,
-          value = constant.value,
-          description = spec.values[value_name],
-        })
-      end
-      -- Numeric order: the order the constants are meant to be read in, and
-      -- stable across dumps, which the reflected order is not.
-      table.sort(entry.values, function(a, b)
-        return a.value < b.value
-      end)
-    end
-    table.insert(out.enums, entry)
-  end
-  out.constants = collect(consts, function(path, spec)
-    return {
-      path = path,
-      value = spec.value,
-      type = spec.type,
-      description = spec.description,
-    }
-  end)
-  out.namespaces = collect(namespaces, function(path, spec)
-    return {
-      path = path,
-      description = spec.description,
-      params = spec.params,
-      returns = spec.returns,
-      examples = spec.examples,
-      callable = spec.call ~= nil,
-      implicit = spec.implicit,
-    }
-  end)
-  out.properties = collect(properties, function(path, spec)
-    return {
-      path = path,
-      type = spec.type,
-      description = spec.description,
-      base = spec.base,
-      writable = spec.set ~= nil,
-    }
-  end)
+  end,
+})
 
-  -- Which module a declaration lands under is the surface talking; which module
-  -- loaded first is not - that is the source list in meson.build, and a module
-  -- that requires another pulls it forward. The dump is committed and diffed,
-  -- so it groups by module and cannot move when a load order does, the way a
-  -- type's members and an enum's values already cannot.
-  --
-  -- Within a module the order is the order the file declares in, which is a
-  -- choice someone made: trx.music reads play, pause, unpause, stop.
-  local function by_module(list)
-    local declared_at = {}
-    for i, entry in ipairs(list) do
-      declared_at[entry] = i
-    end
-    table.sort(list, function(a, b)
-      local mod_a = a.path:match("^[^.]+")
-      local mod_b = b.path:match("^[^.]+")
-      if mod_a ~= mod_b then
-        return mod_a < mod_b
-      end
-      return declared_at[a] < declared_at[b]
-    end)
+-- Turning checking on, and closing the registry.
+
+-- Rebinds every registered function to (or away from) its checking wrapper.
+function api.strict(enabled)
+  strict_enabled = enabled and true or false
+  for _, entry in ipairs(each(api.define)) do
+    entry.expose(bound(entry.spec.impl, entry.path, entry.spec.params))
   end
-  by_module(out.functions)
-  by_module(out.types)
-  by_module(out.enums)
-  by_module(out.constants)
-  by_module(out.namespaces)
-  by_module(out.properties)
-  by_module(out.numbers)
-  by_module(out.units)
-  -- Keyed by module, not by path, so by_module has nothing to sort on.
-  table.sort(out.containers, function(a, b)
-    return a.module < b.module
-  end)
-  table.sort(out.modules, function(a, b)
-    return a.name < b.name
-  end)
+  for _, entry in ipairs(each(api.namespace)) do
+    if entry.call ~= nil then
+      entry.call = bound(entry.spec.call, entry.path, entry.spec.params)
+    end
+  end
+  for _, entry in ipairs(each(api.type)) do
+    bind_type_methods(entry)
+  end
+end
+
+function api.is_strict()
+  return strict_enabled
+end
+
+-- Anything a script can reach on a module or a namespace table has to be
+-- declared, or the reference cannot describe it. Neither a metatable getter
+-- nor a struct field ever shows up in pairs(), so this is what catches one.
+local function audit_reachable()
+  -- What a declaration puts on a table a script can index, named by the
+  -- declarator that makes one. A type, a number and a unit put nothing there,
+  -- and a property is served by the metatable rather than held in the table, so
+  -- neither shows up below. The namespace table itself is a member of its
+  -- module.
+  local ON_A_TABLE = {}
+  for _, maker in ipairs({ api.define, api.enum, api.const, api.namespace }) do
+    ON_A_TABLE[KIND_OF[maker]] = true
+  end
+
+  -- table path ("items", or "console.log") -> set of declared member names.
+  local declared = {}
+  for _, path in ipairs(declarations.order) do
+    local entry = declarations.by_path[path]
+    if ON_A_TABLE[entry.kind] then
+      local owner = entry.where.owner
+      declared[owner] = declared[owner] or {}
+      declared[owner][entry.where.name] = true
+    end
+  end
+
+  local undeclared = {}
+  local function audit(table_path, tbl)
+    -- next, not pairs: a container overrides __pairs to walk its collection, so
+    -- the module's own members are only reachable through a raw iteration.
+    for name in next, tbl or {} do
+      if not (declared[table_path] or {})[name] then
+        undeclared[#undeclared + 1] = "trx." .. table_path .. "." .. name
+      end
+    end
+  end
+
+  -- A module is read live rather than off its entry: sealing has just replaced
+  -- trx.api with what survives it, and the audit is of the surface a script is
+  -- left with. A namespace hides its members one level down, where a module's
+  -- own audit cannot see them, so each is audited as the table it is.
+  for _, entry in ipairs(each(api.module)) do
+    audit(entry.path, trx[entry.path])
+  end
+  for _, entry in ipairs(each(api.namespace)) do
+    audit(entry.path, entry.table)
+  end
+
+  if #undeclared > 0 then
+    table.sort(undeclared)
+    error(
+      table.concat(undeclared, ", ")
+        .. ": reachable from scripts but not declared, so the reference "
+        .. "cannot describe it. Declare it with api.define, api.enum, "
+        .. "api.const, api.property, api.namespace or api.container."
+    )
+  end
+end
+
+-- A type nothing can check prints a name that means nothing, and waves every
+-- value through while strict mode reports a clean run over it. `partial` is for
+-- a test that stands up part of the surface, where a name the rest of it
+-- declares is expected to be missing.
+--
+-- What is audited is what checking will call: the arguments of a function, of a
+-- callable namespace and of a method, and a property written through. A name in
+-- a doc-only position - what a call hands back, what a constant is measured in -
+-- is resolved by the docs tool, which walks the dump for exactly that.
+local function audit_types(partial)
+  local bad = {}
+  local function report(fmt, ...)
+    bad[#bad + 1] = fmt:format(...)
+  end
+
+  -- The predicate a declaration is checked by, or nil where nothing can check
+  -- it, which is itself worth reporting.
+  local function checked_by(where, what, spec)
+    local predicate = check.of(spec)
+    if predicate == nil and not partial then
+      report(
+        "%s: %s has an unknown type '%s'",
+        where,
+        what,
+        check.label_of(spec)
+      )
+    end
+    return predicate
+  end
+
+  local function audit_params(where, params)
+    local optional_seen = false
+    for _, p in ipairs(params or {}) do
+      if p.name ~= "..." then
+        local predicate = checked_by(where, ("'%s'"):format(p.name), p)
+        if
+          predicate ~= nil
+          and p.default ~= nil
+          and not predicate(p.default)
+        then
+          report(
+            "%s: the default for '%s' is not %s",
+            where,
+            p.name,
+            check.label_of(p)
+          )
+        end
+        -- Nothing can reach it without passing the optional one too.
+        if p.optional then
+          optional_seen = true
+        elseif optional_seen then
+          report(
+            "%s: '%s' is required but follows an optional parameter",
+            where,
+            p.name
+          )
+        end
+      end
+    end
+  end
+
+  -- The two that take arguments a script writes.
+  for _, maker in ipairs({ api.define, api.namespace }) do
+    for _, entry in ipairs(each(maker)) do
+      audit_params(entry.path, entry.spec.params)
+    end
+  end
+  -- Strict mode checks a method's arguments too, and make_checked needs a
+  -- checker for each. Without this, a type nobody can check would only surface
+  -- the day a builder turned strict mode on.
+  for _, entry in ipairs(each(api.type)) do
+    for name, method in pairs(entry.spec.methods or {}) do
+      audit_params(entry.path .. "." .. name, method.params)
+    end
+  end
+  for _, entry in ipairs(each(api.property)) do
+    checked_by(entry.path, "the property", entry.spec)
+  end
+
+  if #bad > 0 then
+    table.sort(bad)
+    error(table.concat(bad, "\n"))
+  end
+end
+
+-- Called once, from C, after the trx.* modules have loaded. Declarations are
+-- the engine's to make; a level script re-opening the surface would defeat the
+-- point of declaring it.
+function api.seal(spec)
+  -- The declaring half has done its job, and every one of those functions
+  -- raises from here on. It goes the way trxc goes at this same moment: what a
+  -- script cannot successfully call, it should not be able to reach. Done
+  -- before the audits, so they see the surface a script is left with. C keeps
+  -- the two entrypoints it still needs - see lua/capi/api.c.
+  trx.api = {
+    strict = api.strict,
+    is_strict = api.is_strict,
+  }
+  -- The checking layer goes the same way. Nothing declares it, so the audit
+  -- below never sees it, and reads_from is a way into what strict mode holds a
+  -- script to.
+  trx.check = nil
+
+  audit_reachable()
+  audit_types(spec ~= nil and spec.partial == true)
+
+  sealed = true
+end
+
+-- The whole surface as plain data, and as JSON.
+
+function api.describe()
+  local out = {}
+  for _, kind in ipairs(KINDS) do
+    local list = {}
+    for i, entry in ipairs(entries_of(kind)) do
+      list[i] = kind.describe(entry)
+    end
+    kind.sort(list)
+    out[kind.key] = list
+  end
 
   -- Every kind of entry carries prose under the same key, so the indentation
   -- comes off in one pass rather than at each place one is collected. An
@@ -1559,254 +1587,8 @@ function api.describe()
   end
   dedent_prose(out)
 
-  -- Everything a declaration can be pointed at by, which is the path it was
-  -- declared under and nothing else. A member is reachable as its type's path
-  -- and its own name; a module standing for an instance also answers for that
-  -- type's members, since a script writes trx.lara.air rather than the type.
-  local anchors = {}
-  local function claim(path)
-    if type(path) == "string" then
-      anchors[path] = true
-    end
-  end
-  for _, group in ipairs({
-    out.numbers,
-    out.units,
-    out.enums,
-    out.functions,
-    out.properties,
-    out.namespaces,
-    out.constants,
-  }) do
-    for _, entry in ipairs(group) do
-      claim(entry.path)
-    end
-  end
-  for _, module in ipairs(out.modules) do
-    claim(module.name)
-  end
-  -- What a call declares of its own: the arguments it takes, the keys of a
-  -- table among them, and the keys of what it hands back. A result has no name
-  -- of its own, so its keys hang off the call.
-  local function claim_call(entry, path)
-    for _, param in ipairs(entry.params or {}) do
-      claim(path .. "." .. param.name)
-      for _, field in ipairs(param.fields or {}) do
-        claim(path .. "." .. param.name .. "." .. field.name)
-      end
-      -- A hook has one callback, so what it is called with reads as the hook's.
-      for _, arg in ipairs(param.params or {}) do
-        claim(path .. "." .. arg.name)
-        for _, field in ipairs(arg.fields or {}) do
-          claim(path .. "." .. arg.name .. "." .. field.name)
-        end
-      end
-    end
-    local returns = entry.returns
-    for _, one in
-      ipairs(
-        returns ~= nil and returns.type ~= nil and { returns } or returns or {}
-      )
-    do
-      for _, field in ipairs(one.fields or {}) do
-        claim(path .. "." .. field.name)
-      end
-    end
-  end
-
-  for _, group in ipairs({ out.functions, out.namespaces }) do
-    for _, entry in ipairs(group) do
-      claim_call(entry, entry.path)
-    end
-  end
-
-  local members = {}
-  for _, entry in ipairs(out.types) do
-    claim(entry.path)
-    members[entry.path] = {}
-    for _, kind in ipairs({ entry.fields, entry.methods, entry.extensions }) do
-      for _, member in ipairs(kind) do
-        claim(entry.path .. "." .. member.name)
-        table.insert(members[entry.path], member.name)
-      end
-    end
-    for _, method in ipairs(entry.methods) do
-      claim_call(method, entry.path .. "." .. method.name)
-    end
-  end
-  for module, type_path in pairs(module_instance_types) do
-    assert(
-      members[type_path] ~= nil,
-      "api: module '"
-        .. module
-        .. "' stands for '"
-        .. type_path
-        .. "', which nothing declares"
-    )
-    for _, name in ipairs(members[type_path]) do
-      claim(module .. "." .. name)
-    end
-  end
-
-  -- What a declared member hands back, where that is a declared type too, so
-  -- a path can be walked through it: stats.pickups is a stats.Category, and
-  -- its count is that type's own member.
-  -- A container keyed by an enum is indexed by its constants, which is how
-  -- trx.objects.wolf is written; the key says which enum, so the constant is
-  -- checked against it rather than waved through.
-  local constants = {}
-  for _, entry in ipairs(out.enums) do
-    constants[entry.path] = {}
-    for _, value in ipairs(entry.values or {}) do
-      constants[entry.path][value.name:upper()] = true
-    end
-    for _, name in ipairs(entry.names or {}) do
-      constants[entry.path][name:upper()] = true
-    end
-  end
-
-  local keyed_by = {}
-  for _, entry in ipairs(out.containers) do
-    -- What a key accepts may be several things; the enum among them is what a
-    -- name indexes through.
-    local accepted = entry.key ~= nil and entry.key.type or nil
-    if type(accepted) == "table" then
-      for _, one in ipairs(accepted) do
-        if constants[one] ~= nil then
-          accepted = one
-          break
-        end
-      end
-    end
-    keyed_by[entry.module] = type(accepted) == "string" and accepted or nil
-  end
-
-  local stands_for = {}
-  for _, entry in ipairs(out.types) do
-    for _, member in ipairs(entry.fields) do
-      stands_for[entry.path .. "." .. member.name] = member.type
-    end
-    for _, member in ipairs(entry.extensions) do
-      stands_for[entry.path .. "." .. member.name] = member.type
-    end
-  end
-  for _, entry in ipairs(out.properties) do
-    stands_for[entry.path] = entry.type
-  end
-  for module, type_path in pairs(module_instance_types) do
-    for _, name in ipairs(members[type_path] or {}) do
-      stands_for[module .. "." .. name] = stands_for[type_path .. "." .. name]
-    end
-  end
-
-  -- The path a reference names, walked a segment at a time: through the thing
-  -- itself where it is anchored, and through what it hands back where that is
-  -- a type of its own. Nothing is guessed - a name one segment off used to
-  -- resolve to the module it sat under, which is how a reference to something
-  -- renamed went on looking fine.
-  local function resolve(path)
-    if anchors[path] then
-      return path
-    end
-    local parts = {}
-    for part in path:gmatch("[^.]+") do
-      parts[#parts + 1] = part
-    end
-    local at = parts[1]
-    if not anchors[at] then
-      return nil
-    end
-    for i = 2, #parts do
-      local step = parts[i]
-      if anchors[at .. "." .. step] then
-        at = at .. "." .. step
-      elseif
-        stands_for[at] ~= nil and anchors[stands_for[at] .. "." .. step]
-      then
-        at = stands_for[at] .. "." .. step
-      elseif
-        keyed_by[at] ~= nil
-        and constants[keyed_by[at]] ~= nil
-        and constants[keyed_by[at]][step:upper()]
-      then
-        -- Indexing a container by one of the names its key accepts.
-        return at
-      elseif constants[at] ~= nil and constants[at][step:upper()] then
-        -- An enum's constants are not anchored one by one - a catalog runs to
-        -- hundreds - so the enum that holds it is where the link lands.
-        return at
-      else
-        return nil
-      end
-    end
-    return at
-  end
-
-  -- A path that resolves to nothing is a reference to something that has been
-  -- renamed or was never there: a silent broken link in the reference, and a
-  -- description that quietly goes missing. It stops the dump instead.
-  local function must_resolve(where, what, path, exact)
-    local hit = resolve(path)
-    assert(
-      hit ~= nil and (not exact or hit == path),
-      "api: "
-        .. tostring(where)
-        .. "'s "
-        .. what
-        .. " names '"
-        .. path
-        .. "', which nothing declares"
-    )
-  end
-
-  local function check_refs(node, where)
-    if type(node) ~= "table" then
-      return
-    end
-    -- A container is named by the module it is indexed on, which is what a
-    -- reader has to be told to find the declaration.
-    local here = node.path or node.name or node.module or where
-    for _, one in ipairs(types_of(node.type)) do
-      if type(one) == "string" then
-        if numbers.by_path[one] ~= nil then
-          assert(
-            node.base == nil,
-            "api: "
-              .. tostring(here)
-              .. " is a '"
-              .. one
-              .. "' and declares a base of its own"
-          )
-        end
-        if one:find("%.") ~= nil then
-          must_resolve(here, "type", one, true)
-        end
-      end
-    end
-    -- Prose names things the same way a script does, and the reference links
-    -- every one of them, so a name that has moved has to be caught here too.
-    for path in (node.description or ""):gmatch("`trx%.([%w_.]+)`") do
-      must_resolve(here, "description", path, false)
-    end
-    for _, value in pairs(node) do
-      check_refs(value, here)
-    end
-  end
-  check_refs(out, "api")
-
   return out
 end
-
-trx.api = api
-
--- api.type reports members nobody exposed, so the logger must exist by the time
--- any module declares one, and modules load in source-list order, which puts
--- log after items. Force it here rather than depend on that ordering.
---
--- It has to come after `trx.api` is set, not before: log.lua declares itself
--- through the registry, so requiring it any earlier would hand it a half-built
--- api table.
-require("trx.log")
 
 -- Minimal JSON encoder. The dump is consumed by tools/update_lua_docs; keeping
 -- the encoding here means the whole API surface - C field tables included - is
@@ -1875,9 +1657,12 @@ api.module("api", {
 })
 
 api.define("api.strict", {
-  description = "Turns argument checking on or off for every function in `trx`, and for the methods "
-    .. "on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler "
-    .. "notices. Turn it on while writing a level, and leave it off in play.",
+  description = [[
+    Turns argument checking on or off for every function in `trx`, and for the
+    methods on its handles. Off by default: checking costs a couple of hundred
+    nanoseconds a call, which a per-frame handler notices. Turn it on while
+    writing a level, and leave it off in play.
+  ]],
   params = {
     {
       name = "enabled",
@@ -1897,6 +1682,19 @@ api.define("api.is_strict", {
   },
   impl = api.is_strict,
 })
+
+-- The registry, handed to scripts and to C, declaring itself last of all.
+
+trx.api = api
+
+-- api.type reports members nobody exposed, so the logger must exist by the time
+-- any module declares one, and modules load in source-list order, which puts
+-- log after items. Force it here rather than depend on that ordering.
+--
+-- It has to come after `trx.api` is set, not before: log.lua declares itself
+-- through the registry, so requiring it any earlier would hand it a half-built
+-- api table.
+require("trx.log")
 
 -- Sealing and dumping the surface stay C's to call, and the dump runs after the
 -- seal has taken them off trx.api. Hand them over while they are still here.

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -238,7 +238,7 @@ local function as_doc(spec)
 end
 
 -- A type's members are declared in a table keyed by name, which pairs() walks
--- in whatever order it likes, so each kind of member comes out sorted by name.
+-- in any order, so each kind of member comes out sorted by name.
 local function members(declared, read)
   local list = {}
   for name, member in pairs(declared or {}) do
@@ -272,7 +272,7 @@ end
 -- lines keep the rest of theirs, since a description may lay something out.
 --
 -- A description may instead open on the line its brackets are on, and that line
--- then carries no indentation whatever the ones under it carry. Left in, it
+-- then carries no indentation, however the ones under it are written. Left in, it
 -- makes the shared indent zero and the rest of the description keeps its own,
 -- which is what four of them were written flush against the margin to avoid.
 local function dedent(text)
@@ -750,7 +750,7 @@ api.namespace = declarator("namespace", "namespaces", {
     local where = placed(path, need)
     entry.where = where
     -- The table below stands for the namespace from here on, and would replace
-    -- whatever stands at its path: the table a collection is read through, or
+    -- what stands at its path: the table a collection is read through, or
     -- the one a group of properties hangs off. Either goes on reading as nil,
     -- which seal() cannot see - it audits the members a table holds, and
     -- neither indexing nor a property is ever one of them.
@@ -1571,7 +1571,7 @@ local function audit_reachable()
   -- left with. A namespace hides its members one level down, where a module's
   -- own audit cannot see them, so each is audited as the table it is. So is the
   -- table a collection is read through, which is a member of its module and
-  -- holds whatever was declared inside it.
+  -- holds what was declared inside it.
   for _, entry in ipairs(each(api.module)) do
     audit(entry.path, trx[entry.path])
   end
@@ -1823,7 +1823,7 @@ local function encode(value, out)
   return out
 end
 
--- The complete public API surface. One registry, one source: whatever is not
+-- The complete public API surface. One registry, one source: what is not
 -- declared here is not reachable from a script, so the dump cannot omit
 -- anything that exists.
 function api.to_json()

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -121,12 +121,21 @@ local function by_module(field)
   end
 end
 
--- A module and its container carry no path to group on, one of each being all
--- there is per module, so they read alphabetically.
-local function alphabetically(field)
+-- A module and a container carry no path to group on, so they read
+-- alphabetically. A module may hand out several collections, so the member
+-- settles the order between them and the dump cannot move when a declaration
+-- somewhere else is added.
+local function alphabetically(...)
+  local fields = { ... }
   return function(list)
     table.sort(list, function(a, b)
-      return a[field] < b[field]
+      for _, field in ipairs(fields) do
+        local x, y = a[field] or "", b[field] or ""
+        if x ~= y then
+          return x < y
+        end
+      end
+      return false
     end)
   end
 end
@@ -701,12 +710,16 @@ api.namespace = declarator("namespace", "namespaces", {
   declare = function(entry, path, spec, need)
     local where = placed(path, need)
     entry.where = where
-    -- The table below stands for the namespace from here on, and replaces
-    -- whatever stands at its path. A property declared inside one is served by
-    -- the metatable on that table, so it would go on reading as nil - which
-    -- seal() cannot see, since it audits the members a table holds and a
-    -- property is never one of them. Declaring the group first is what the
-    -- message above asks for.
+    -- The table below stands for the namespace from here on, and would replace
+    -- whatever stands at its path: the table a collection is read through, or
+    -- the one a group of properties hangs off. Either goes on reading as nil,
+    -- which seal() cannot see - it audits the members a table holds, and
+    -- neither indexing nor a property is ever one of them.
+    need(
+      entry.table == nil,
+      "%s already stands for a table - a collection, or a group of properties.",
+      path
+    )
     local namespace = {}
     entry.table = namespace
     if spec.call ~= nil then
@@ -750,7 +763,7 @@ api.container = declarator("container", "containers", {
   path = function(name)
     return name .. "[]"
   end,
-  sort = alphabetically("module"),
+  sort = alphabetically("module", "member"),
   declare = function(entry, name, spec, need)
     need(type(spec.get) == "function", "get must be a function")
     need(
@@ -788,7 +801,6 @@ api.container = declarator("container", "containers", {
     -- what the page anchors - so being indexable is a declaration like any
     -- other, and the module it sits on points at it.
     local container = entry
-    container.module = name
     container.get = spec.get
     container.count = spec.count
     container.limit = spec.limit
@@ -797,16 +809,39 @@ api.container = declarator("container", "containers", {
       return kind == "number" or (kind == "string" and not by_number_only)
     end
 
-    local module = open(name)
-    module.table = module_table(name)
-    module.container = container
+    -- A collection is declared as the module that is indexed, or as the member
+    -- of it the collection is read through: one segment or two, where every
+    -- other declaration names a member and so has one more.
+    local parts = segments(name)
+    need(
+      #parts == 1 or #parts == 2,
+      "a collection is declared as 'module' or 'module.member', got: %s",
+      name
+    )
+    container.module = parts[1]
+    container.member = parts[2]
 
-    install_meta(module)
+    -- The table the collection is indexed on: the module's own where the module
+    -- is indexed, and a member of it where the module hands a collection out.
+    -- Either way the entry at that path owns the table and its metatable, as it
+    -- does for the properties declared on one, so a later declaration there
+    -- finds the indexing rather than replacing it.
+    local owner = open(name)
+    if container.member == nil then
+      owner.table = module_table(name)
+    else
+      owner.table = owner.table or {}
+      rawset(module_table(container.module), container.member, owner.table)
+    end
+    owner.container = container
+    install_meta(owner)
+    return owner.table
   end,
 
   describe = function(entry)
     return {
       module = entry.module,
+      member = entry.member,
       description = entry.spec.description,
       key = as_doc(entry.spec.key),
       value = as_doc(entry.spec.value),
@@ -1427,6 +1462,10 @@ local function audit_reachable()
       local owner = entry.where.owner
       declared[owner] = declared[owner] or {}
       declared[owner][entry.where.name] = true
+    elseif made_by(entry, api.container) and entry.member ~= nil then
+      -- The table a collection is read through is a member of its module.
+      declared[entry.module] = declared[entry.module] or {}
+      declared[entry.module][entry.member] = true
     end
   end
 
@@ -1444,12 +1483,20 @@ local function audit_reachable()
   -- A module is read live rather than off its entry: sealing has just replaced
   -- trx.api with what survives it, and the audit is of the surface a script is
   -- left with. A namespace hides its members one level down, where a module's
-  -- own audit cannot see them, so each is audited as the table it is.
+  -- own audit cannot see them, so each is audited as the table it is. So is the
+  -- table a collection is read through, which is a member of its module and
+  -- holds whatever was declared inside it.
   for _, entry in ipairs(each(api.module)) do
     audit(entry.path, trx[entry.path])
   end
   for _, entry in ipairs(each(api.namespace)) do
     audit(entry.path, entry.table)
+  end
+  for _, entry in ipairs(each(api.container)) do
+    if entry.member ~= nil then
+      local owner = at(entry.module .. "." .. entry.member)
+      audit(owner.path, owner.table)
+    end
   end
 
   if #undeclared > 0 then

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -1773,68 +1773,18 @@ function api.describe()
   return out
 end
 
--- Minimal JSON encoder. The dump is consumed by tools/update_lua_docs; keeping
--- the encoding here means the whole API surface - C field tables included - is
--- serialized from one place.
-local function encode(value, out)
-  local kind = type(value)
-  if value == nil then
-    out[#out + 1] = "null"
-  elseif kind == "boolean" then
-    out[#out + 1] = tostring(value)
-  elseif kind == "number" then
-    out[#out + 1] = tostring(value)
-  elseif kind == "string" then
-    out[#out + 1] = '"'
-      .. value
-        :gsub("\\", "\\\\")
-        :gsub('"', '\\"')
-        :gsub("\n", "\\n")
-        :gsub("\t", "\\t")
-      .. '"'
-  elseif kind == "table" then
-    if value[1] ~= nil or next(value) == nil then
-      out[#out + 1] = "["
-      for i, v in ipairs(value) do
-        if i > 1 then
-          out[#out + 1] = ","
-        end
-        encode(v, out)
-      end
-      out[#out + 1] = "]"
-    else
-      local keys = {}
-      for k in pairs(value) do
-        keys[#keys + 1] = k
-      end
-      table.sort(keys)
-      out[#out + 1] = "{"
-      for i, k in ipairs(keys) do
-        if i > 1 then
-          out[#out + 1] = ","
-        end
-        encode(tostring(k), out)
-        out[#out + 1] = ":"
-        encode(value[k], out)
-      end
-      out[#out + 1] = "}"
-    end
-  end
-  return out
-end
-
 -- The complete public API surface. One registry, one source: what is not
 -- declared here is not reachable from a script, so the dump cannot omit
 -- anything that exists.
 function api.to_json()
-  return table.concat(encode(api.describe(), {}))
+  return trx.json.encode(api.describe())
 end
 
 -- The registry declares itself, last of all. What is left of it once seal() has
 -- run is what a script can use: strict mode, and the question of whether it is
 -- on. The rest declared the surface and is gone by the time any script runs.
 api.module("api", {
-  order = 30,
+  order = 31,
   title = "API registry",
   description = "Argument checking for the whole of `trx`.",
 })

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -270,24 +270,38 @@ end
 -- module's own prose came out as one. The text is what the declaration says,
 -- not where it sat in the file, so the shared indent comes off. The deepest
 -- lines keep the rest of theirs, since a description may lay something out.
+--
+-- A description may instead open on the line its brackets are on, and that line
+-- then carries no indentation whatever the ones under it carry. Left in, it
+-- makes the shared indent zero and the rest of the description keeps its own,
+-- which is what four of them were written flush against the margin to avoid.
 local function dedent(text)
+  local lines = {}
+  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+    lines[#lines + 1] = line
+  end
+  -- Lua drops the newline that follows `[[`, so what says which of the two
+  -- spellings was written is whether the first line is indented at all: one
+  -- written against the brackets is not, and it neither sets what the rest share
+  -- nor has any of it taken off.
+  local from = text:match("^[ \t]") == nil and 2 or 1
+
   local shared
-  for line in text:gmatch("[^\n]+") do
-    if line:match("%S") ~= nil then
-      local indent = #line:match("^[ \t]*")
+  for i = from, #lines do
+    if lines[i]:match("%S") ~= nil then
+      local indent = #lines[i]:match("^[ \t]*")
       if shared == nil or indent < shared then
         shared = indent
       end
     end
   end
-  if shared == nil or shared == 0 then
-    return (text:gsub("^%s*\n", ""):gsub("%s+$", ""))
+
+  if shared ~= nil and shared > 0 then
+    for i = from, #lines do
+      lines[i] = lines[i]:sub(shared + 1)
+    end
   end
-  local out = {}
-  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-    out[#out + 1] = line:sub(shared + 1)
-  end
-  return (table.concat(out, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
+  return (table.concat(lines, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
 end
 
 -- Where a path lands, which every declaration asks in one of two ways: what a

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -421,10 +421,6 @@ end
 
 -- A property is written, not called, so make_checked never sees it. Strict mode
 -- still has to. Three frames up is whoever wrote it.
---
--- What checks a write is worked out the first time one is made, as what checks
--- a collection's key is, and for the same reason: a property may name a type
--- the same file declares further down.
 local function write_property(where, prop, value)
   local spec = prop.spec
   if spec.set == nil then
@@ -440,6 +436,13 @@ local function write_property(where, prop, value)
     end
   end
   spec.set(value)
+end
+
+-- What a script may index a collection with. The key declares a type and the
+-- reference documents it, so strict mode holds a script to it: `trx.rooms[1.5]`
+-- says so here rather than reaching C with a number no room answers to.
+local function key_accepted(container, key)
+  return once(container, "key_check", checker, container.spec.key)(key)
 end
 
 -- pairs() over the module walks the collection one handle at a time, so a
@@ -499,6 +502,16 @@ local function install_meta(entry)
         return prop.spec.get()
       end
       if container ~= nil and container.accepts(key) then
+        if strict_enabled and not key_accepted(container, key) then
+          error(
+            ("trx.%s[%s]: expected %s"):format(
+              owner,
+              tostring(key),
+              check.label_of(container.spec.key)
+            ),
+            2
+          )
+        end
         return container.get(key)
       end
       if instance ~= nil then
@@ -1683,6 +1696,11 @@ local function audit_types(partial)
   end
   for _, entry in ipairs(each(api.property)) do
     checked_by(entry.path, "the property", entry.spec)
+  end
+  -- Strict mode holds a script to what a collection is indexed with, so the key
+  -- has to answer for the same reason a parameter does.
+  for _, entry in ipairs(each(api.container)) do
+    checked_by(entry.path, "the key", entry.spec.key)
   end
   -- A record is checked by the keys it names wherever one is passed in, so the
   -- names have to answer for the same reason a parameter's does.

--- a/src/lua/api/argparse.lua
+++ b/src/lua/api/argparse.lua
@@ -815,7 +815,10 @@ Parser = api.type("argparse.Parser", {
           fields = positional_opts(),
         },
       },
-      returns = { type = "argparse.Parser", description = "The parser." },
+      returns = {
+        type = "argparse.Parser",
+        description = "The same parser, so declarations chain.",
+      },
       impl = P.positional,
     },
 
@@ -875,7 +878,10 @@ Parser = api.type("argparse.Parser", {
           fields = ARG_OPTS,
         },
       },
-      returns = { type = "argparse.Parser", description = "The parser." },
+      returns = {
+        type = "argparse.Parser",
+        description = "The same parser, so declarations chain.",
+      },
       impl = P.any_of,
     },
 
@@ -896,7 +902,10 @@ Parser = api.type("argparse.Parser", {
           fields = ARG_OPTS,
         },
       },
-      returns = { type = "argparse.Parser", description = "The parser." },
+      returns = {
+        type = "argparse.Parser",
+        description = "The same parser, so declarations chain.",
+      },
       impl = P.rest,
     },
 
@@ -935,7 +944,10 @@ Parser = api.type("argparse.Parser", {
           },
         },
       },
-      returns = { type = "argparse.Parser", description = "The parser." },
+      returns = {
+        type = "argparse.Parser",
+        description = "The same parser, so declarations chain.",
+      },
       impl = P.flag,
     },
 
@@ -1000,7 +1012,11 @@ Parser = api.type("argparse.Parser", {
         },
       },
       returns = {
-        { type = "string", list = true, description = "Best first." },
+        {
+          type = "string",
+          list = true,
+          description = "The best match comes first.",
+        },
         {
           type = "integer",
           description = "Where the run they replace starts. The run is the token, or the "

--- a/src/lua/api/argparse.lua
+++ b/src/lua/api/argparse.lua
@@ -1000,7 +1000,7 @@ Parser = api.type("argparse.Parser", {
         },
       },
       returns = {
-        { type = "table", description = "The candidates, best first." },
+        { type = "string", list = true, description = "Best first." },
         {
           type = "integer",
           description = "Where the run they replace starts. The run is the token, or the "

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -18,6 +18,7 @@ api.number("assault.AttemptNum", {
 })
 
 api.type("assault.Record", {
+  record = true,
   description = "One of a track's best times.",
   fields = {
     time = { type = "game.Seconds", description = "The time it took." },

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -143,7 +143,6 @@ api.define("assault.stats.list_records", {
   returns = {
     type = "assault.Record",
     list = true,
-    description = "The records.",
   },
   examples = {
     [[for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -12,6 +12,19 @@ api.number("assault.RecordNum", {
   description = "Where a time sits in the table of best times, fastest first.",
 })
 
+api.number("assault.AttemptNum", {
+  base = 1,
+  description = "Which attempt at a track it was, counted in the order they were made.",
+})
+
+api.type("assault.Record", {
+  description = "One of a track's best times.",
+  fields = {
+    time = { type = "game.Seconds", description = "The time it took." },
+    attempt_num = { type = "assault.AttemptNum" },
+  },
+})
+
 local Track = api.enum("assault.Track", {
   backing = "GYM_TRACK_TYPE",
   description = "A timed gym track.",
@@ -127,22 +140,9 @@ api.define("assault.stats.list_records", {
   description = "The records, fastest first.",
   params = { track_param() },
   returns = {
-    type = "table",
-    description = "The records.",
+    type = "assault.Record",
     list = true,
-    fields = {
-      {
-        name = "time",
-        type = "game.Seconds",
-        description = "The time it took.",
-      },
-      {
-        name = "attempt_num",
-        type = "integer",
-        base = 1,
-        description = "Which attempt it was.",
-      },
-    },
+    description = "The records.",
   },
   examples = {
     [[for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do

--- a/src/lua/api/camera.lua
+++ b/src/lua/api/camera.lua
@@ -7,7 +7,7 @@ api.module("camera", {
 })
 
 api.property("camera.pos", {
-  type = "vec3",
+  type = "math.Vec3",
   description = "Current camera position.",
   get = raw.get_pos,
 })
@@ -28,7 +28,7 @@ api.property("camera.room", {
 })
 
 api.property("camera.target_pos", {
-  type = "vec3",
+  type = "math.Vec3",
   description = "Position the camera is looking at.",
   get = raw.get_target_pos,
 })

--- a/src/lua/api/check.lua
+++ b/src/lua/api/check.lua
@@ -23,15 +23,12 @@ function M.reads_from(lookup)
   declared_check = lookup
 end
 
--- The eight names a declaration may write without declaring them. Every other
--- name is a path. Doc-facing names, not Lua ones.
+-- The names a declaration may write without declaring them. Every other name is
+-- a path. Doc-facing names, not Lua ones.
 local PRIMITIVES = {
   -- A whole number, which type() alone does not tell from a fractional one.
   integer = function(v)
     return math.type(v) == "integer"
-  end,
-  vec3 = function(v)
-    return type(v) == "table" and v.x ~= nil and v.y ~= nil and v.z ~= nil
   end,
   any = function()
     return true

--- a/src/lua/api/check.lua
+++ b/src/lua/api/check.lua
@@ -1,0 +1,167 @@
+-- What a value has to be to satisfy a declaration.
+--
+-- The registry next door says what is declared and where; this says what a
+-- declaration accepts, and hands back the predicate that answers for it. The
+-- two meet at a path: api.lua passes the lookup it owns to `reads_from`, and
+-- nothing else crosses between them.
+--
+-- There are three ways a value is recognised. A handle is told by its
+-- metatable, which is the C type name it was registered under. A value the
+-- registry hands out is told by the class it carries, so a derived one counts
+-- as the type it extends. A table a script writes out has no identity to go on
+-- and is told by what it holds.
+
+local M = {}
+
+-- Where a name that is not a primitive is looked up. Set by api.lua, which owns
+-- the declarations; this only asks what one is checked by.
+local declared_check = function()
+  return nil
+end
+
+function M.reads_from(lookup)
+  declared_check = lookup
+end
+
+-- The eight names a declaration may write without declaring them. Every other
+-- name is a path. Doc-facing names, not Lua ones.
+local PRIMITIVES = {
+  -- A whole number, which type() alone does not tell from a fractional one.
+  integer = function(v)
+    return math.type(v) == "integer"
+  end,
+  vec3 = function(v)
+    return type(v) == "table" and v.x ~= nil and v.y ~= nil and v.z ~= nil
+  end,
+  any = function()
+    return true
+  end,
+}
+
+-- The rest are the Lua type of the same name.
+for _, name in ipairs({ "number", "string", "boolean", "table", "function" }) do
+  PRIMITIVES[name] = function(v)
+    return type(v) == name
+  end
+end
+
+-- A type this surface does not declare has nothing to check against, and what
+-- a caller wrote goes through. Strict mode reaches for this where a name means
+-- nothing to it; the seal reports the name itself.
+M.anything = PRIMITIVES.any
+
+function M.primitive(name)
+  return PRIMITIVES[name]
+end
+
+-- Every type a spec accepts, in the order it declared them: one, or the several
+-- a container key answers to - a number, and the name that reaches the same
+-- thing.
+function M.types_of(value)
+  return type(value) == "table" and value or { value }
+end
+
+-- What a declaration accepts, as the reader writes it: one type, or the several
+-- it answers to.
+function M.label(declared)
+  local names = {}
+  for i, one in ipairs(M.types_of(declared)) do
+    names[i] = tostring(one)
+  end
+  return #names == 0 and "any" or table.concat(names, " or ")
+end
+
+-- What a declaration accepts, as the messages below name it: what it is typed
+-- by, or the keys it names where it is typed by nothing, and the many it holds
+-- folded in.
+function M.label_of(spec)
+  local named = spec.type ~= nil and M.label(spec.type)
+    or (spec.fields ~= nil and "table" or "any")
+  return spec.list and ("list of " .. named) or named
+end
+
+-- A type answers to the path it was declared under. There is no second name to
+-- keep in step with it: a declaration that means items.Item says items.Item,
+-- and one that means something nobody declared fails the audit rather than
+-- waving values through under a name that once meant something else.
+local function by_name(name)
+  return PRIMITIVES[name] or declared_check(name)
+end
+
+-- The predicate one value is checked by, or nil where this surface has no type
+-- of that name. One that names several passes on any of them.
+local function by_type(declared)
+  if type(declared) ~= "table" then
+    return by_name(declared)
+  end
+  local checks = {}
+  for i, one in ipairs(declared) do
+    checks[i] = by_name(one)
+    if checks[i] == nil then
+      return nil
+    end
+  end
+  return function(value)
+    for _, check in ipairs(checks) do
+      if check(value) then
+        return true
+      end
+    end
+    return false
+  end
+end
+
+-- A handle's metatable is its C type name - see LUA_Struct_Register - so one
+-- type of handle is told from another. api.type registers one of these per
+-- type, which is why Item and Room are absent from the primitives.
+function M.by_metatable(backing)
+  return function(v)
+    return getmetatable(v) == backing
+  end
+end
+
+-- A derived class carries the one it extends as its own metatable's __index,
+-- which is what makes an inherited method reachable, so the chain to walk is
+-- already there.
+function M.by_identity(class)
+  return function(v)
+    local candidate = getmetatable(v)
+    while candidate ~= nil do
+      if candidate == class then
+        return true
+      end
+      local meta = getmetatable(candidate)
+      candidate = meta ~= nil and meta.__index or nil
+    end
+    return false
+  end
+end
+
+-- The predicate a whole declaration is checked by. One that holds several of
+-- something is checked as the list it is: a list of integers is a table of
+-- integers, not an integer.
+function M.of(spec)
+  local one = by_type(spec.type)
+  if one == nil or not spec.list then
+    return one
+  end
+  return function(value)
+    if type(value) ~= "table" then
+      return false, "not a list"
+    end
+    for i, held in ipairs(value) do
+      if not one(held) then
+        return false, ("entry %d: expected %s"):format(i, M.label(spec.type))
+      end
+    end
+    return true
+  end
+end
+
+-- On the global, so a module reaches this one the way it reaches any other.
+-- It is the registry's own and no part of the surface a script gets: reads_from
+-- is a way into what strict mode checks against, so the seal takes it off again
+-- as it takes trxc off.
+trx.check = M
+
+return M

--- a/src/lua/api/check.lua
+++ b/src/lua/api/check.lua
@@ -137,11 +137,57 @@ function M.by_identity(class)
   end
 end
 
--- The predicate a whole declaration is checked by. One that holds several of
--- something is checked as the list it is: a list of integers is a table of
--- integers, not an integer.
+-- What a table a script writes out has to hold: every key the declaration
+-- names, no key it does not, and each one of the type it was given. A typo in
+-- an options table reads as nothing at all otherwise, whether checking is on or
+-- off.
+function M.by_keys(fields)
+  local declared = {}
+  for key, field in pairs(fields) do
+    -- Declared as a list where a call writes them out, and keyed by name where
+    -- a type does.
+    declared[field.name or key] = field
+  end
+  -- What checks a key is resolved the first time it is asked for, as the
+  -- registry resolves its own. A name that resolves to nothing is asked again:
+  -- a suite that stands up part of the surface declares the rest of it after.
+  local resolved = {}
+  return function(value)
+    if type(value) ~= "table" then
+      return false, "not a table"
+    end
+    for key in pairs(value) do
+      if declared[key] == nil then
+        return false, ("no such key '%s'"):format(tostring(key))
+      end
+    end
+    for name, field in pairs(declared) do
+      local held = value[name]
+      if held == nil then
+        if not field.optional then
+          return false, ("'%s' is missing"):format(name)
+        end
+      else
+        local one = resolved[name]
+        if one == nil then
+          one = M.of(field)
+          resolved[name] = one
+        end
+        if one ~= nil and not one(held) then
+          return false, ("'%s': expected %s"):format(name, M.label_of(field))
+        end
+      end
+    end
+    return true
+  end
+end
+
+-- The predicate a whole declaration is checked by: the keys it names, or what it
+-- is typed by. One that holds several of something is checked as the list it is:
+-- a list of integers is a table of integers, not an integer.
 function M.of(spec)
-  local one = by_type(spec.type)
+  local one = spec.fields ~= nil and M.by_keys(spec.fields)
+    or by_type(spec.type)
   if one == nil or not spec.list then
     return one
   end
@@ -150,8 +196,10 @@ function M.of(spec)
       return false, "not a list"
     end
     for i, held in ipairs(value) do
-      if not one(held) then
-        return false, ("entry %d: expected %s"):format(i, M.label(spec.type))
+      local ok, why = one(held)
+      if not ok then
+        return false,
+          ("entry %d: %s"):format(i, why or "expected " .. M.label(spec.type))
       end
     end
     return true

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -240,7 +240,7 @@ trx.config.restore("visuals.water_color")]],
 })
 
 api.define("config.restore", {
-  description = "Lifts one override off a setting, putting back whatever was underneath it.",
+  description = "Lifts one override off a setting, putting back the value underneath it.",
   params = {
     { name = "key", type = "string", description = "Dotted path." },
   },

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -21,6 +21,7 @@ trx.locale.declare({
 })
 
 api.type("config.Shape", {
+  record = true,
   description = "How a setting is entered and shown, beyond the type it reads back as.",
   fields = {
     kind = {
@@ -36,7 +37,8 @@ api.type("config.Shape", {
     values = {
       type = "string",
       list = true,
-      description = "What the setting accepts, for the enum kinds. `nil` for the rest.",
+      optional = true,
+      description = "What the setting accepts, for the enum kinds.",
     },
   },
 })

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -20,6 +20,26 @@ trx.locale.declare({
   ["console/config/accepted_percent"] = "[integer]",
 })
 
+api.type("config.Shape", {
+  description = "How a setting is entered and shown, beyond the type it reads back as.",
+  fields = {
+    kind = {
+      type = "string",
+      description = "One of `boolean`, `integer`, `number`, `color`, `enum`, "
+        .. "`dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
+    },
+    percent = {
+      type = "boolean",
+      description = "Marks a number stored 0-1 but entered and shown as a 0-100 "
+        .. "percentage.",
+    },
+    values = {
+      type = "table",
+      description = "What the setting accepts, for the enum kinds. `nil` for the rest.",
+    },
+  },
+})
+
 api.define("config.get", {
   description = "Reads a setting. The value comes back as the type the option is declared with, so "
     .. "a boolean option reads as a boolean. Colors and enums read as strings.",
@@ -46,27 +66,8 @@ api.define("config.describe", {
     { name = "key", type = "string", description = "Dotted path." },
   },
   returns = {
-    type = "table",
+    type = "config.Shape",
     description = "What the setting is and how it is entered.",
-    fields = {
-      {
-        name = "kind",
-        type = "string",
-        description = "One of `boolean`, `integer`, `number`, `color`, `enum`, "
-          .. "`dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
-      },
-      {
-        name = "percent",
-        type = "boolean",
-        description = "Marks a number stored 0-1 but entered and shown as a 0-100 "
-          .. "percentage.",
-      },
-      {
-        name = "values",
-        type = "table",
-        description = "What the setting accepts, for the enum kinds. `nil` for the rest.",
-      },
-    },
   },
   examples = {
     [[for _, value in ipairs(trx.config.describe("visuals.shadow_type").values) do

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -34,7 +34,8 @@ api.type("config.Shape", {
         .. "percentage.",
     },
     values = {
-      type = "table",
+      type = "string",
+      list = true,
       description = "What the setting accepts, for the enum kinds. `nil` for the rest.",
     },
   },

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -143,7 +143,8 @@ api.type("console.Command", {
   fields = {
     name = { type = "string", description = "The word the player types." },
     aliases = {
-      type = "table",
+      type = "string",
+      list = true,
       description = "The other words that reach it, or `nil` where it answers to one.",
     },
     help = {
@@ -267,7 +268,8 @@ api.define("console.register", {
         },
         {
           name = "aliases",
-          type = "table",
+          type = "string",
+          list = true,
           optional = true,
           description = "Other words that reach the same command. They dispatch but stay out "
             .. "of the command listing, and the help for the command shows them.",

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -138,6 +138,22 @@ api.namespace("console.log", {
   call = at(LogLevel.INFO),
 })
 
+api.type("console.Command", {
+  description = "A registered console command, as the help command reads one.",
+  fields = {
+    name = { type = "string", description = "The word the player types." },
+    aliases = {
+      type = "table",
+      description = "The other words that reach it, or `nil` where it answers to one.",
+    },
+    help = {
+      type = "string",
+      description = "What the console shows for `--help`, or `nil` where the command "
+        .. "carries none.",
+    },
+  },
+})
+
 api.define("console.log.generic", {
   description = "Logs at a level chosen at runtime.",
   params = {
@@ -396,27 +412,9 @@ api.define("console.commands", {
   description = "Every registered console command, in registration order. The help command is "
     .. "built on this.",
   returns = {
-    type = "table",
-    description = "The commands.",
+    type = "console.Command",
     list = true,
-    fields = {
-      {
-        name = "name",
-        type = "string",
-        description = "The word the player types.",
-      },
-      {
-        name = "aliases",
-        type = "table",
-        description = "The other words that reach it, or `nil` where it answers to one.",
-      },
-      {
-        name = "help",
-        type = "string",
-        description = "What the console shows for `--help`, or `nil` where the command "
-          .. "carries none.",
-      },
-    },
+    description = "The commands.",
   },
   impl = function()
     local out = {}
@@ -429,8 +427,7 @@ api.define("console.commands", {
 
 api.define("console.command", {
   description = "The command a name reaches, by its own name or an alias, matched as the console "
-    .. "matches when it dispatches. The same `{ name, aliases, help }` as an entry of "
-    .. "`trx.console.commands`, or nil when nothing answers to the name.",
+    .. "matches when it dispatches.",
   params = {
     {
       name = "name",
@@ -439,8 +436,9 @@ api.define("console.command", {
     },
   },
   returns = {
-    type = "table",
-    description = "`{ name, aliases, help }`, or nil.",
+    type = "console.Command",
+    nullable = true,
+    description = "`nil` when nothing answers to the name.",
   },
   impl = function(name)
     local cmd = raw.command(name)

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -418,7 +418,6 @@ api.define("console.commands", {
   returns = {
     type = "console.Command",
     list = true,
-    description = "The commands.",
   },
   impl = function()
     local out = {}

--- a/src/lua/api/console.lua
+++ b/src/lua/api/console.lua
@@ -139,18 +139,20 @@ api.namespace("console.log", {
 })
 
 api.type("console.Command", {
+  record = true,
   description = "A registered console command, as the help command reads one.",
   fields = {
     name = { type = "string", description = "The word the player types." },
     aliases = {
       type = "string",
       list = true,
-      description = "The other words that reach it, or `nil` where it answers to one.",
+      optional = true,
+      description = "The other words that reach it, where it answers to more than one.",
     },
     help = {
       type = "string",
-      description = "What the console shows for `--help`, or `nil` where the command "
-        .. "carries none.",
+      optional = true,
+      description = "What the console shows for `--help`, where the command carries any.",
     },
   },
 })

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -90,7 +90,7 @@ api.define("cutscenes.set_lara_return", {
     runs, and is forgotten once she has been placed.
   ]],
   params = {
-    { name = "pos", type = "vec3", description = "World position." },
+    { name = "pos", type = "math.Vec3", description = "World position." },
     {
       name = "rot",
       type = "math.Angle",

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -649,7 +649,7 @@ api.define("events.on_cutscene_trigger", {
 
     A trigger Lara stands on fires every frame, so this happens only for a
     cutscene that has not run yet and while none is playing. Asking counts as
-    running it, whatever came of it, so the same handler is not asked again on
+    running it, however it ended, so the same handler is not asked again on
     the next frame. Clear the mark with `trx.cutscenes.set_played` to hear
     about one again.
 

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -557,12 +557,15 @@ end)]],
 )
 
 api.define("events.on_hit", {
-  description = [[Happens when an item takes damage, Lara included. It is the raw damage that
-fires, before the item's hit points are clamped, so a fatal blow reports the whole amount the
-attacker dealt. A death that does not go through damage - a script writing
-`trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.
+  description = [[
+    Happens when an item takes damage, Lara included. It is the raw damage that
+    fires, before the item's hit points are clamped, so a fatal blow reports
+    the whole amount the attacker dealt. A death that does not go through
+    damage - a script writing `trx.items.Item.hit_points`, or
+    `trx.items.Item:destroy` - does not report.
 
-`trx.items.Item:on_hit` is this same event, narrowed to one item.]],
+    `trx.items.Item:on_hit` is this same event, narrowed to one item.
+  ]],
   params = {
     {
       name = "callback",
@@ -596,16 +599,20 @@ end)]],
 })
 
 api.define("events.on_kill", {
-  description = [[Happens when damage takes an item's hit points to zero, Lara included. It is the
-same blow `trx.events.on_hit` reports, which fires first. A death that does not go through damage
-- a script writing `trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.
+  description = [[
+    Happens when damage takes an item's hit points to zero, Lara included. It
+    is the same blow `trx.events.on_hit` reports, which fires first. A death
+    that does not go through damage - a script writing
+    `trx.items.Item.hit_points`, or `trx.items.Item:destroy` - does not report.
 
-Some bosses fall and get back up: Willard is knocked out, Natla plays dead before her second
-stage, and the dragon lies still until Lara takes the dagger. Each stage brings their hit points
-to zero, so they report once per stage rather than once per boss, and the dragon reports once
-more for the dagger that ends it.
+    Some bosses fall and get back up: Willard is knocked out, Natla plays dead
+    before her second stage, and the dragon lies still until Lara takes the
+    dagger. Each stage brings their hit points to zero, so they report once per
+    stage rather than once per boss, and the dragon reports once more for the
+    dagger that ends it.
 
-`trx.items.Item:on_kill` is this same event, narrowed to one item.]],
+    `trx.items.Item:on_kill` is this same event, narrowed to one item.
+  ]],
   params = {
     {
       name = "callback",

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -165,25 +165,28 @@ local function level_list(table_type)
 end
 
 api.property("game.levels", {
-  type = "table",
-  description = "The levels of the game, in order, as a list of `trx.game.Level` counted from one.",
+  type = "game.Level",
+  list = true,
+  description = "The levels of the game, in order, counted from one.",
   get = function()
     return level_list(LevelTable.MAIN)
   end,
 })
 
 api.property("game.cutscenes", {
-  type = "table",
-  description = "The cutscene levels, as a list of `trx.game.Level` counted from one. TR4's "
-    .. "in-game cutscenes are a different thing, and live in `trx.cutscenes`.",
+  type = "game.Level",
+  list = true,
+  description = "The cutscene levels, counted from one. TR4's in-game cutscenes are a different "
+    .. "thing, and live in `trx.cutscenes`.",
   get = function()
     return level_list(LevelTable.CUTSCENES)
   end,
 })
 
 api.property("game.demos", {
-  type = "table",
-  description = "The demos, as a list of `trx.game.Level` counted from one.",
+  type = "game.Level",
+  list = true,
+  description = "The demos, counted from one.",
   get = function()
     return level_list(LevelTable.DEMOS)
   end,

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -218,7 +218,8 @@ api.property("game.version", {
 
 api.property("game.trx_version", {
   type = "string",
-  description = "The TRX version string.",
+  description = "What this build reports as its version: `1.9.3` for a release, and the tag with "
+    .. "the commits since it for a development build.",
   get = raw.get_trx_version,
 })
 

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -150,6 +150,7 @@ end
 -- A plain table the engine builds, so its keys are entries it holds rather than
 -- accessors.
 api.type("items.Trigger", {
+  record = true,
   description = "What a trigger carried when it fired.",
   fields = {
     type = {

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -784,8 +784,8 @@ lara:take_damage(lara.hit_points)]],
 
     get_property_names = {
       returns = {
-        type = "table",
-        description = "The names, as a list of strings.",
+        type = "string",
+        list = true,
       },
       description = "Names of every property this item's object declares.",
     },

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -714,10 +714,12 @@ end)]],
           description = "Hit points to take.",
         },
       },
-      description = [[Hurts the item the way a weapon does, and reports through `trx.events.on_hit`,
-and `trx.events.on_kill` where the blow takes the last hit point. Writing
-`trx.items.Item.hit_points` reports neither. The kill counts as the
-environment's rather than Lara's.]],
+      description = [[
+        Hurts the item the way a weapon does, and reports through
+        `trx.events.on_hit`, and `trx.events.on_kill` where the blow takes the
+        last hit point. Writing `trx.items.Item.hit_points` reports neither.
+        The kill counts as the environment's rather than Lara's.
+      ]],
       examples = {
         [[local lara = trx.lara.item
 lara:take_damage(lara.hit_points)]],

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -763,7 +763,7 @@ lara:take_damage(lara.hit_points)]],
       returns = {
         type = "any",
         nullable = true,
-        description = "The value, of whatever type the property is declared with.",
+        description = "The value, of the type the property is declared with.",
       },
       description = "Reads an object property, falling back to the object's default. "
         .. "Prefer `item.properties.<name>`.",

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -179,13 +179,13 @@ api.type("items.Item", {
   fields = {
     pos = {
       from = "pos",
-      type = "vec3",
+      type = "math.Vec3",
       description = "World position. Updating this also updates `trx.items.Item.room` and `trx.items.Item.room_num`.",
     },
     rot = {
       from = "rot",
-      type = "vec3",
-      description = "Orientation. Each component is a `trx.math.Angle`.",
+      type = "math.Rot",
+      description = "Orientation.",
     },
     anim_num = {
       from = "relative_anim_num",
@@ -743,7 +743,7 @@ lara:take_damage(lara.hit_points)]],
 
     distance_to = {
       params = {
-        { name = "pos", type = "vec3", description = "World position." },
+        { name = "pos", type = "math.Vec3", description = "World position." },
       },
       returns = {
         type = "math.Distance",
@@ -827,7 +827,7 @@ api.define("items.spawn", {
     },
     {
       name = "pos",
-      type = "vec3",
+      type = "math.Vec3",
       description = "World position. Must lie inside the level.",
     },
     {
@@ -996,10 +996,14 @@ local ItemQuery = api.type("items.ItemQuery", {
       params = {
         {
           name = "min",
-          type = "vec3",
+          type = "math.Vec3",
           description = "One corner of the box.",
         },
-        { name = "max", type = "vec3", description = "The opposite corner." },
+        {
+          name = "max",
+          type = "math.Vec3",
+          description = "The opposite corner.",
+        },
       },
       returns = { type = "query.Query", description = "The narrowed query." },
       examples = {
@@ -1019,7 +1023,7 @@ local ItemQuery = api.type("items.ItemQuery", {
       params = {
         {
           name = "centre",
-          type = "vec3",
+          type = "math.Vec3",
           description = "Middle of the sphere.",
         },
         {

--- a/src/lua/api/json.lua
+++ b/src/lua/api/json.lua
@@ -1,0 +1,93 @@
+local api = trx.api
+
+api.module("json", {
+  order = 29,
+  title = "JSON",
+  description = "Writing Lua values out as JSON. The API dump the reference is generated from "
+    .. "goes through this, so what a script writes out is encoded the way the engine's own data "
+    .. "is.",
+})
+
+local ESCAPED = {
+  ["\\"] = "\\\\",
+  ['"'] = '\\"',
+  ["\n"] = "\\n",
+  ["\t"] = "\\t",
+  ["\r"] = "\\r",
+}
+
+local function quoted(text)
+  return '"'
+    .. text:gsub('[%c"\\]', function(c)
+      return ESCAPED[c] or ("\\u%04x"):format(c:byte())
+    end)
+    .. '"'
+end
+
+-- A table with no keys at all is written as an empty list: a declaration that
+-- holds none of something reads as none of it rather than as an object with
+-- nothing in it.
+local function is_list(value)
+  return value[1] ~= nil or next(value) == nil
+end
+
+local function write(value, out)
+  local kind = type(value)
+  if value == nil then
+    out[#out + 1] = "null"
+  elseif kind == "boolean" or kind == "number" then
+    out[#out + 1] = tostring(value)
+  elseif kind == "string" then
+    out[#out + 1] = quoted(value)
+  elseif kind == "table" and is_list(value) then
+    out[#out + 1] = "["
+    for i, held in ipairs(value) do
+      if i > 1 then
+        out[#out + 1] = ","
+      end
+      write(held, out)
+    end
+    out[#out + 1] = "]"
+  elseif kind == "table" then
+    local keys = {}
+    for key in pairs(value) do
+      keys[#keys + 1] = key
+    end
+    table.sort(keys)
+    out[#out + 1] = "{"
+    for i, key in ipairs(keys) do
+      if i > 1 then
+        out[#out + 1] = ","
+      end
+      out[#out + 1] = quoted(tostring(key))
+      out[#out + 1] = ":"
+      write(value[key], out)
+    end
+    out[#out + 1] = "}"
+  end
+end
+
+api.define("json.encode", {
+  description = [[
+    Writes a value out as JSON, on one line. Keys come out in sorted order, so
+    the same value encodes the same way twice and a file that is committed and
+    diffed only moves when what it holds does.
+
+    A table is written as a list where it holds entry 1, or holds nothing at
+    all, and as an object otherwise. A function, a handle and anything else
+    with no JSON of its own is left out.
+  ]],
+  params = {
+    { name = "value", type = "any", description = "What to write out." },
+  },
+  returns = { type = "string", description = "The JSON text." },
+  examples = {
+    [[trx.json.encode({ name = "wolf", ids = { 7, 8 } })
+-- {"ids":[7,8],"name":"wolf"}]],
+  },
+  impl = function(value)
+    local out = {}
+    write(value, out)
+    return table.concat(out)
+  end,
+})

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -260,7 +260,7 @@ api.property("lara.has_pistol_weapon", {
 })
 
 api.define("lara.set_extra_equipment", {
-  description = "Hangs an extra mesh on one of Lara's own, replacing whatever is there.",
+  description = "Hangs an extra mesh on one of Lara's own, replacing the mesh there.",
   params = {
     {
       name = "mesh",

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -285,7 +285,7 @@ api.define("lara.teleport", {
     .. "The position is nudged into valid room geometry, so a spot inside a wall lands her beside "
     .. "it rather than in it. Somewhere with no floor within reach moves nothing.",
   params = {
-    { name = "pos", type = "vec3", description = "World position." },
+    { name = "pos", type = "math.Vec3", description = "World position." },
     {
       name = "room_num",
       type = "rooms.Num",

--- a/src/lua/api/locale.lua
+++ b/src/lua/api/locale.lua
@@ -65,7 +65,11 @@ api.define("locale.get", {
 api.define("locale.format", {
   description = "The text behind a key with its placeholders filled in.",
   params = {
-    { name = "key", type = "string", description = "The key." },
+    {
+      name = "key",
+      type = "string",
+      description = "The key, e.g. `general/misc/off`.",
+    },
     {
       name = "...",
       type = "any",

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -2,7 +2,7 @@ local raw = trxc.lua
 local api = trx.api
 
 api.module("lua", {
-  order = 29,
+  order = 30,
   description = "Evaluating Lua at runtime: a string of code, or a file on disk. "
     .. "Both run in the same state as every other script.",
 })

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -15,25 +15,28 @@ local function wrap(kind, message)
   return { kind = kind, message = message }
 end
 
+api.type("lua.Error", {
+  description = "What went wrong while running Lua.",
+  fields = {
+    kind = {
+      type = "string",
+      description = 'Either `"syntax"` or `"runtime"`.',
+    },
+    message = { type = "string", description = "The error text." },
+  },
+})
+
 api.define("lua.eval_expr", {
   description = "Evaluates a string of Lua code, as the `/lua` console command does.",
   params = {
     { name = "code", type = "string", description = "The code." },
   },
   returns = {
-    type = "table",
+    type = "lua.Error",
     nullable = true,
     description = "`nil` when the code ran to completion, and what went wrong otherwise. A "
       .. "failure comes back as a value rather than raising, so the caller decides what it "
       .. "means.",
-    fields = {
-      {
-        name = "kind",
-        type = "string",
-        description = 'Either `"syntax"` or `"runtime"`.',
-      },
-      { name = "message", type = "string", description = "The error text." },
-    },
   },
   examples = { [[trx.lua.eval_expr("trx.console.log('hello')")]] },
   impl = function(code)
@@ -48,7 +51,7 @@ api.define("lua.eval_file", {
     { name = "path", type = "string", description = "Path of the file." },
   },
   returns = {
-    type = "table",
+    type = "lua.Error",
     nullable = true,
     description = "As in `trx.lua.eval_expr`.",
   },

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -16,6 +16,7 @@ local function wrap(kind, message)
 end
 
 api.type("lua.Error", {
+  record = true,
   description = "What went wrong while running Lua.",
   fields = {
     kind = {

--- a/src/lua/api/lua.lua
+++ b/src/lua/api/lua.lua
@@ -30,7 +30,11 @@ api.type("lua.Error", {
 api.define("lua.eval_expr", {
   description = "Evaluates a string of Lua code, as the `/lua` console command does.",
   params = {
-    { name = "code", type = "string", description = "The code." },
+    {
+      name = "code",
+      type = "string",
+      description = "Any chunk of Lua, not only an expression.",
+    },
   },
   returns = {
     type = "lua.Error",
@@ -54,7 +58,6 @@ api.define("lua.eval_file", {
   returns = {
     type = "lua.Error",
     nullable = true,
-    description = "As in `trx.lua.eval_expr`.",
   },
   examples = { [[trx.lua.eval_file("data/ship/scripts/extra.lua")]] },
   impl = function(path)

--- a/src/lua/api/math.lua
+++ b/src/lua/api/math.lua
@@ -26,6 +26,29 @@ api.unit("math.Distance", {
   spellings = { "world units", "world coordinates" },
 })
 
+api.type("math.Vec3", {
+  record = true,
+  description = "A point or a direction in the world.",
+  fields = {
+    x = { type = "math.Distance", description = "The east-west axis." },
+    y = { type = "math.Distance", description = "The up-down axis." },
+    z = { type = "math.Distance", description = "The north-south axis." },
+  },
+})
+
+api.type("math.Rot", {
+  record = true,
+  description = "An orientation, as three angles about the world axes.",
+  fields = {
+    x = { type = "math.Angle", description = "Pitch, nose up and down." },
+    y = { type = "math.Angle", description = "Yaw, the direction it faces." },
+    z = {
+      type = "math.Angle",
+      description = "Roll, the tilt about its own length.",
+    },
+  },
+})
+
 api.type("math.Box", {
   description = "An axis-aligned box. Whether it is placed in the world or in something's own "
     .. "frame is for whatever hands it over to say.",

--- a/src/lua/api/math.lua
+++ b/src/lua/api/math.lua
@@ -51,7 +51,7 @@ api.type("math.Rot", {
 
 api.type("math.Box", {
   description = "An axis-aligned box. Whether it is placed in the world or in something's own "
-    .. "frame is for whatever hands it over to say.",
+    .. "frame is for the call that hands it over to say.",
   fields = {
     min_x = { type = "math.Distance", description = "West edge." },
     min_y = { type = "math.Distance", description = "Top edge." },

--- a/src/lua/api/mod.lua
+++ b/src/lua/api/mod.lua
@@ -69,8 +69,9 @@ api.type("mod.Mod", {
 })
 
 api.property("mod.list", {
-  type = "table",
-  description = "The mods the game was built with, as a list of `trx.mod.Mod` counted from one.",
+  type = "mod.Mod",
+  list = true,
+  description = "The mods the game was built with, counted from one.",
   get = function()
     local mods = {}
     for i = 1, raw.count() do

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -24,6 +24,21 @@ local PlayMode = api.enum("music.PlayMode", {
   },
 })
 
+local PLAY_OPTS = {
+  name = "opts",
+  type = "table",
+  optional = true,
+  description = "How to play it.",
+  fields = {
+    {
+      name = "mode",
+      type = "music.PlayMode",
+      optional = true,
+      description = "Plays once by default.",
+    },
+  },
+}
+
 api.number("music.StreamNum", {
   base = 1,
   description = "Which of the soundtrack's slots: 1 is the main stream, 2 onwards the overlays.",
@@ -112,22 +127,7 @@ api.type("music.Track", {
       description = "Whether the loaded level still carries this track.",
     },
     play = {
-      params = {
-        {
-          name = "opts",
-          type = "table",
-          optional = true,
-          description = "How to play it.",
-          fields = {
-            {
-              name = "mode",
-              type = "music.PlayMode",
-              optional = true,
-              description = "Plays once by default.",
-            },
-          },
-        },
-      },
+      params = { PLAY_OPTS },
       returns = {
         type = "music.Stream",
         nullable = true,
@@ -198,20 +198,7 @@ api.define("music.play", {
       description = "Track to play. To reach a track by the level's own slot, play it through a "
         .. "handle: `trx.music.tracks[slot]:play()`.",
     },
-    {
-      name = "opts",
-      type = "table",
-      optional = true,
-      description = "How to play it.",
-      fields = {
-        {
-          name = "mode",
-          type = "music.PlayMode",
-          optional = true,
-          description = "Plays once by default.",
-        },
-      },
-    },
+    PLAY_OPTS,
   },
   returns = {
     type = "music.Stream",

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -142,72 +142,25 @@ api.type("music.Track", {
 
 -- One lazy view apiece: indexing and iterating reach into C a handle at a time,
 -- so neither builds a list up front.
-local streams = setmetatable({}, {
-  __index = function(_, n)
-    if type(n) ~= "number" then
-      return nil
-    end
+api.container("music.streams", {
+  description = "The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay "
+    .. "slots. A slot that is not playing still answers, with a stale handle.",
+  key = { type = "integer", base = 1, description = "Which slot." },
+  value = { type = "music.Stream", nullable = true },
+  get = function(n)
     return raw.stream_get(n - 1)
   end,
-  __len = function()
-    return raw.stream_count()
-  end,
-  __pairs = function()
-    local count = raw.stream_count()
-    local i = 0
-    return function()
-      i = i + 1
-      if i <= count then
-        return i, raw.stream_get(i - 1)
-      end
-    end
-  end,
+  count = raw.stream_count,
 })
 
-local tracks = setmetatable({}, {
-  __index = function(_, id)
-    if type(id) ~= "number" then
-      return nil
-    end
-    return raw.track_get(id)
-  end,
-  __len = function()
-    return raw.track_available_count()
-  end,
-  __pairs = function()
-    local limit = raw.track_limit()
-    local id = -1
-    return function()
-      id = id + 1
-      while id < limit do
-        local track = raw.track_get(id)
-        if track ~= nil then
-          return id, track
-        end
-        id = id + 1
-      end
-    end
-  end,
-})
-
-api.property("music.streams", {
-  type = "table",
-  description = "The soundtrack's streams as `trx.music.Stream` handles: `[1]` is the main "
-    .. "stream, `[2]` onwards the overlay slots. A slot that is not playing still answers, with a "
-    .. "stale handle. Indexing and iterating reach one handle at a time.",
-  get = function()
-    return streams
-  end,
-})
-
-api.property("music.tracks", {
-  type = "table",
-  description = "The tracks the current level carries, as `trx.music.Track` handles keyed by id: "
-    .. "`trx.music.tracks[5]` is track 5, or `nil` if the level has no such track. `#` counts them, "
-    .. "iterating walks them, and both reach one handle at a time.",
-  get = function()
-    return tracks
-  end,
+local tracks = api.container("music.tracks", {
+  description = "The tracks the current level carries. A level does not carry every number, so "
+    .. "indexing one it lacks is `nil` and iterating passes it by.",
+  key = { type = "music.TrackNum" },
+  value = { type = "music.Track", nullable = true },
+  get = raw.track_get,
+  count = raw.track_available_count,
+  limit = raw.track_limit,
 })
 
 api.property("music.current_track", {

--- a/src/lua/api/music.lua
+++ b/src/lua/api/music.lua
@@ -7,6 +7,7 @@ api.module("music", {
 })
 
 api.number("music.TrackNum", {
+  base = 0,
   description = "Track number, in the numbering the loaded level carries. Not a "
     .. "`trx.catalog.music` name, which is the soundtrack's own.",
 })
@@ -21,6 +22,11 @@ local PlayMode = api.enum("music.PlayMode", {
     DELAY = "Marks the track for later playback rather than starting it now.",
     OVERLAY = "Plays the track on top of the current one.",
   },
+})
+
+api.number("music.StreamNum", {
+  base = 1,
+  description = "Which of the soundtrack's slots: 1 is the main stream, 2 onwards the overlays.",
 })
 
 api.type("music.Stream", {
@@ -145,7 +151,7 @@ api.type("music.Track", {
 api.container("music.streams", {
   description = "The soundtrack's streams: `[1]` is the main stream, `[2]` onwards the overlay "
     .. "slots. A slot that is not playing still answers, with a stale handle.",
-  key = { type = "integer", base = 1, description = "Which slot." },
+  key = { type = "music.StreamNum" },
   value = { type = "music.Stream", nullable = true },
   get = function(n)
     return raw.stream_get(n - 1)

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -160,7 +160,7 @@ local Object = api.type("objects.Object", {
       returns = {
         type = "any",
         nullable = true,
-        description = "The value, of whatever type the property is declared with.",
+        description = "The value, of the type the property is declared with.",
       },
       description = "Reads one of the object's properties. Prefer `object.properties.<name>`.",
     },

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -135,16 +135,16 @@ local Object = api.type("objects.Object", {
   methods = {
     get_names = {
       returns = {
-        type = "table",
-        description = "The names, as a list of strings.",
+        type = "string",
+        list = true,
       },
       description = "Every name the object answers to, in the player's language. Prefer "
         .. "`trx.objects.Object.names`.",
     },
     get_default_names = {
       returns = {
-        type = "table",
-        description = "The names, as a list of strings.",
+        type = "string",
+        list = true,
       },
       description = "The compile-time English names, which a lookup falls back on before a "
         .. "language file is loaded. Prefer `trx.objects.Object.default_names`.",
@@ -181,8 +181,8 @@ local Object = api.type("objects.Object", {
     },
     get_property_names = {
       returns = {
-        type = "table",
-        description = "The names, as a list of strings.",
+        type = "string",
+        list = true,
       },
       description = "Names of every property this object declares.",
     },

--- a/src/lua/api/query.lua
+++ b/src/lua/api/query.lua
@@ -183,7 +183,7 @@ end)]],
 
     ids = {
       description = "The matching ids. For objects these are object ids; for items, their numbers.",
-      returns = { type = "table", description = "A list of integers." },
+      returns = { type = "integer", list = true },
       impl = function(self)
         local out = {}
         for _, pair in ipairs(resolved(self)) do
@@ -195,10 +195,7 @@ end)]],
 
     matches = {
       description = "The matching handles.",
-      returns = {
-        type = "table",
-        description = "A list of `trx.objects.Object`s or `trx.items.Item`s.",
-      },
+      returns = { type = { "objects.Object", "items.Item" }, list = true },
       impl = function(self)
         local out = {}
         for _, pair in ipairs(resolved(self)) do
@@ -260,7 +257,7 @@ api.type("query.NamedQuery", {
         .. "group name that ties on score would otherwise sit behind a thing's own. Which groups "
         .. "answer follows from what the query kept, so one narrowed to what fights offers no "
         .. "`trx.objects.ObjectQuery:pickup`.",
-      returns = { type = "table", description = "A list of names." },
+      returns = { type = "string", list = true },
       impl = function(self)
         local domain = self._domain
         local kept = kept_pairs(self)
@@ -295,7 +292,7 @@ api.type("query.NamedQuery", {
     best = {
       description = "The ids tied for the best `trx.query.NamedQuery:by_name` score: one for a name only one thing "
         .. "answers to, the whole group for a group name. Without a `trx.query.NamedQuery:by_name`, every matching id.",
-      returns = { type = "table", description = "A list of integers." },
+      returns = { type = "integer", list = true },
       impl = function(self)
         if self._name == nil then
           return self:ids()

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -64,7 +64,7 @@ local ROOM_HOOK_PARAMS = {
 
 local FLOOR_HEIGHT_POS = {
   name = "pos",
-  type = "vec3",
+  type = "math.Vec3",
   description = "World position.",
 }
 
@@ -338,7 +338,11 @@ api.define("rooms.find_valid_pos", {
   description = "Nudges a position into valid room geometry, e.g. to find somewhere an item can "
     .. "legally be placed.",
   params = {
-    { name = "pos", type = "vec3", description = "Position to search near." },
+    {
+      name = "pos",
+      type = "math.Vec3",
+      description = "Position to search near.",
+    },
     {
       name = "room_num",
       type = "rooms.Num",
@@ -346,7 +350,7 @@ api.define("rooms.find_valid_pos", {
   },
   returns = {
     {
-      type = "vec3",
+      type = "math.Vec3",
       nullable = true,
       description = "The valid position, or `nil` if none was found nearby.",
     },
@@ -434,7 +438,7 @@ local RoomQuery = api.type("rooms.RoomQuery", {
         .. "column it stands in has a floor - the test the engine itself puts a position through. "
         .. "The hidden half of a flip pair is passed over.",
       params = {
-        { name = "pos", type = "vec3", description = "World position." },
+        { name = "pos", type = "math.Vec3", description = "World position." },
       },
       returns = { type = "query.Query", description = "The narrowed query." },
       examples = { [[trx.rooms.query:at(trx.lara.item.pos):first()]] },

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -63,13 +63,10 @@ rule("corpse.fade_speed", {
 })
 
 api.define("rules.list", {
-  description = "Every rule there is, as dotted `group.field` keys. <!--noref: group.field-->",
+  description = "Every rule there is, as dotted `group.field` keys, in no particular order. "
+    .. "<!--noref: group.field-->",
   params = {},
-  returns = {
-    type = "string",
-    list = true,
-    description = "In no particular order.",
-  },
+  returns = { type = "string", list = true },
   impl = raw.list,
 })
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -66,8 +66,9 @@ api.define("rules.list", {
   description = "Every rule there is, as dotted `group.field` keys. <!--noref: group.field-->",
   params = {},
   returns = {
-    type = "table",
-    description = "The keys, in no particular order.",
+    type = "string",
+    list = true,
+    description = "In no particular order.",
   },
   impl = raw.list,
 })

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -3,14 +3,19 @@ local api = trx.api
 
 api.module("rules", {
   order = 14,
-  description = [[Module for the numbers the engine plays by.
+  description = [[
+    Module for the numbers the engine plays by.
 
-These are the game's rules: a mechanic that no single item owns. An object's own numbers live on
-the object, as `trx.objects.<name>.properties`, and the player's own choices live in `trx.config`.
+    These are the game's rules: a mechanic that no single item owns. An
+    object's own numbers live on the object, as
+    `trx.objects.<name>.properties`, and the player's own choices live in
+    `trx.config`.
 
-A rule lasts as long as the playthrough: it is saved with the game and restored with it, and a
-new game starts from the defaults. A level script states what its level wants, and states it
-again on every entry, so a level that wants the defaults back asks for them.]],
+    A rule lasts as long as the playthrough: it is saved with the game and
+    restored with it, and a new game starts from the defaults. A level script
+    states what its level wants, and states it again on every entry, so a level
+    that wants the defaults back asks for them.
+  ]],
 })
 
 -- Every rule is reachable two ways: as a member here, and by the dotted key

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -12,6 +12,22 @@ api.number("sound.SampleNum", {
     .. "`trx.catalog.samples` name, which is the sound bank's own.",
 })
 
+local PLAY_OPTS = {
+  name = "opts",
+  type = "table",
+  optional = true,
+  description = "How to play it.",
+  fields = {
+    {
+      name = "pos",
+      type = "vec3",
+      optional = true,
+      description = "A world position to play from, which applies pan and volume. Omit to "
+        .. "play at full volume.",
+    },
+  },
+}
+
 api.number("sound.StreamNum", {
   base = 1,
   description = "Which of the voices playing now, counted in the order the engine holds them.",
@@ -64,23 +80,7 @@ api.type("sound.Sample", {
       description = "Whether the loaded level still carries this sample.",
     },
     play = {
-      params = {
-        {
-          name = "opts",
-          type = "table",
-          optional = true,
-          description = "How to play it.",
-          fields = {
-            {
-              name = "pos",
-              type = "vec3",
-              optional = true,
-              description = "A world position to play from, which applies pan and volume. Omit to "
-                .. "play at full volume.",
-            },
-          },
-        },
-      },
+      params = { PLAY_OPTS },
       returns = {
         type = "sound.Stream",
         nullable = true,
@@ -159,21 +159,7 @@ api.define("sound.play", {
       description = "Sample to play. To reach a sample by the level's own slot, play it through a "
         .. "handle: `trx.sound.samples[slot]:play()`.",
     },
-    {
-      name = "opts",
-      type = "table",
-      optional = true,
-      description = "How to play it.",
-      fields = {
-        {
-          name = "pos",
-          type = "vec3",
-          optional = true,
-          description = "A world position to play from, which applies pan and volume. Omit to "
-            .. "play at full volume.",
-        },
-      },
-    },
+    PLAY_OPTS,
   },
   returns = {
     type = "sound.Stream",

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -7,8 +7,14 @@ api.module("sound", {
 })
 
 api.number("sound.SampleNum", {
+  base = 0,
   description = "Sample number, in the numbering the loaded level carries. Not a "
     .. "`trx.catalog.samples` name, which is the sound bank's own.",
+})
+
+api.number("sound.StreamNum", {
+  base = 1,
+  description = "Which of the voices playing now, counted in the order the engine holds them.",
 })
 
 api.type("sound.Sample", {
@@ -135,7 +141,7 @@ local samples = api.container("sound.samples", {
 api.container("sound.streams", {
   description = "The sound effects playing now. A slot that is silent still answers, with a "
     .. "stale handle.",
-  key = { type = "integer", base = 1, description = "Which voice." },
+  key = { type = "sound.StreamNum" },
   value = { type = "sound.Stream", nullable = true },
   get = function(n)
     return raw.stream_get(n - 1)

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -20,7 +20,7 @@ local PLAY_OPTS = {
   fields = {
     {
       name = "pos",
-      type = "vec3",
+      type = "math.Vec3",
       optional = true,
       description = "A world position to play from, which applies pan and volume. Omit to "
         .. "play at full volume.",

--- a/src/lua/api/sound.lua
+++ b/src/lua/api/sound.lua
@@ -122,74 +122,25 @@ api.type("sound.Stream", {
   },
 })
 
--- One lazy view apiece: indexing and iterating reach into C a handle at a time,
--- so neither builds a list up front.
-local samples = setmetatable({}, {
-  __index = function(_, id)
-    if type(id) ~= "number" then
-      return nil
-    end
-    return raw.sample_get(id)
-  end,
-  __len = function()
-    return raw.sample_available_count()
-  end,
-  __pairs = function()
-    local limit = raw.sample_limit()
-    local id = -1
-    return function()
-      id = id + 1
-      while id < limit do
-        local sample = raw.sample_get(id)
-        if sample ~= nil then
-          return id, sample
-        end
-        id = id + 1
-      end
-    end
-  end,
+local samples = api.container("sound.samples", {
+  description = "The samples the current level carries. A level does not carry every number, "
+    .. "so indexing one it lacks is `nil` and iterating passes it by.",
+  key = { type = "sound.SampleNum" },
+  value = { type = "sound.Sample", nullable = true },
+  get = raw.sample_get,
+  count = raw.sample_available_count,
+  limit = raw.sample_limit,
 })
 
-local streams = setmetatable({}, {
-  __index = function(_, n)
-    if type(n) ~= "number" then
-      return nil
-    end
+api.container("sound.streams", {
+  description = "The sound effects playing now. A slot that is silent still answers, with a "
+    .. "stale handle.",
+  key = { type = "integer", base = 1, description = "Which voice." },
+  value = { type = "sound.Stream", nullable = true },
+  get = function(n)
     return raw.stream_get(n - 1)
   end,
-  __len = function()
-    return raw.stream_count()
-  end,
-  __pairs = function()
-    local count = raw.stream_count()
-    local i = 0
-    return function()
-      i = i + 1
-      if i <= count then
-        return i, raw.stream_get(i - 1)
-      end
-    end
-  end,
-})
-
-api.property("sound.samples", {
-  type = "table",
-  description = "The samples the current level carries, as `trx.sound.Sample` handles keyed by id: "
-    .. "`trx.sound.samples[99]` is sample 99, or `nil` if the level has no such sample. `#` counts "
-    .. "them, iterating walks them, and both reach one handle at a time.",
-  get = function()
-    return samples
-  end,
-})
-
-api.property("sound.streams", {
-  type = "table",
-  description = "The sound effects playing now, as `trx.sound.Stream` handles. A slot that is "
-    .. "silent still answers, with a stale handle. Indexing and iterating reach one handle at a "
-    .. "time.",
-  get = function()
-    return streams
-  end,
+  count = raw.stream_count,
 })
 
 api.define("sound.play", {

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -71,7 +71,7 @@ api.define("strings.fuzzy_match", {
   returns = {
     type = "strings.Match",
     list = true,
-    description = "The matches, best first.",
+    description = "The best match comes first.",
   },
   examples = {
     [==[local matches = trx.strings.fuzzy_match("wolf", {

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -173,3 +173,53 @@ api.define("strings.regex_match", {
   examples = { [[if trx.strings.regex_match(args, "^\\d+$") then ... end]] },
   impl = raw.regex_match,
 })
+
+api.define("strings.dedent", {
+  description = [=[
+    Takes the shared indentation off a block of text, so that a long string
+    written inside `[[ ]]` reads as what it says rather than as where it sat in
+    the file. Leading and trailing blank lines go too.
+
+    The deepest lines keep the rest of their indentation, since a block may lay
+    something out, and four spaces of it is a code block in markdown. Text may
+    open on the line the brackets are on, and that line then sets nothing and
+    keeps what it has, however the ones under it are written.
+  ]=],
+  params = {
+    { name = "text", type = "string", description = "The text to take in." },
+  },
+  returns = { type = "string", description = "The text at the left margin." },
+  examples = {
+    [==[local help = trx.strings.dedent([[
+      Usage: /give <what>
+        keys   every plot item the level has a place for
+    ]])]==],
+  },
+  impl = function(text)
+    local lines = {}
+    for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+      lines[#lines + 1] = line
+    end
+    -- Lua drops the newline that follows `[[`, so what says which of the two
+    -- spellings was written is whether the first line is indented at all: one
+    -- written against the brackets is not.
+    local from = text:match("^[ \t]") == nil and 2 or 1
+
+    local shared
+    for i = from, #lines do
+      if lines[i]:match("%S") ~= nil then
+        local indent = #lines[i]:match("^[ \t]*")
+        if shared == nil or indent < shared then
+          shared = indent
+        end
+      end
+    end
+
+    if shared ~= nil and shared > 0 then
+      for i = from, #lines do
+        lines[i] = lines[i]:sub(shared + 1)
+      end
+    end
+    return (table.concat(lines, "\n"):gsub("^%s*\n", ""):gsub("%s+$", ""))
+  end,
+})

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -8,6 +8,23 @@ api.module("strings", {
     .. "about manipulating strings, that one is about which string the player gets.",
 })
 
+api.type("strings.Match", {
+  description = "A candidate that matched, and how well.",
+  fields = {
+    key = { type = "string", description = "The candidate that matched." },
+    value = { type = "any", description = "What the candidate carried." },
+    score = { type = "number", description = "How well it matched." },
+    is_full = {
+      type = "boolean",
+      description = "Whether the whole candidate matched.",
+    },
+    is_word = {
+      type = "boolean",
+      description = "Whether a whole word matched.",
+    },
+  },
+})
+
 api.define("strings.fuzzy_match", {
   description = "Matches what someone typed against a list of candidates, forgivingly: `big medi` "
     .. "finds `large medipack`.\n\n"
@@ -47,36 +64,9 @@ api.define("strings.fuzzy_match", {
     },
   },
   returns = {
-    type = "table",
-    description = "The matches, best first.",
+    type = "strings.Match",
     list = true,
-    fields = {
-      {
-        name = "key",
-        type = "string",
-        description = "The candidate that matched.",
-      },
-      {
-        name = "value",
-        type = "any",
-        description = "What the candidate carried.",
-      },
-      {
-        name = "score",
-        type = "number",
-        description = "How well it matched.",
-      },
-      {
-        name = "is_full",
-        type = "boolean",
-        description = "Whether the whole candidate matched.",
-      },
-      {
-        name = "is_word",
-        type = "boolean",
-        description = "Whether a whole word matched.",
-      },
-    },
+    description = "The matches, best first.",
   },
   examples = {
     [==[local matches = trx.strings.fuzzy_match("wolf", {

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -9,10 +9,15 @@ api.module("strings", {
 })
 
 api.type("strings.Match", {
+  record = true,
   description = "A candidate that matched, and how well.",
   fields = {
     key = { type = "string", description = "The candidate that matched." },
-    value = { type = "any", description = "What the candidate carried." },
+    value = {
+      type = "any",
+      optional = true,
+      description = "What the candidate carried, where it carried one.",
+    },
     score = { type = "number", description = "How well it matched." },
     is_full = {
       type = "boolean",

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -109,7 +109,12 @@ api.define("strings.collapse_ranges", {
     .. "The list is sorted first, and duplicates survive as they are, so the caller need not tidy "
     .. "up before handing it over.",
   params = {
-    { name = "numbers", type = "table", description = "List of integers." },
+    {
+      name = "numbers",
+      type = "integer",
+      list = true,
+      description = "The numbers to write out.",
+    },
     {
       name = "separator",
       type = "string",

--- a/src/lua/commands/give.lua
+++ b/src/lua/commands/give.lua
@@ -5,7 +5,7 @@
 --   /give 5 flare    five of them
 --   /give keys       every plot item the level has a place for
 --   /give guns       every weapon the level allows, with ammunition
---   /give moreguns   every weapon, whatever the level allows
+--   /give moreguns   every weapon, even one the level does not carry
 --   /give all        one of everything, with the counts a cheat gives
 --
 -- /keys, /guns and /moreguns reach the last three on their own.
@@ -31,8 +31,8 @@ local KEYWORDS = { "all", "keys", "guns", "moreguns" }
 
 -- Every weapon a cheat hands over, in the order it hands them over, and how
 -- much ammunition each comes with. A new game plus run tops every one of them
--- up instead. The pistols are not here: they come whatever the level says, and
--- never run down.
+-- up instead. The pistols are not here: they come regardless of what the level
+-- says, and never run down.
 local NGPLUS_AMMO = 10001
 local ARSENAL = {
   { trx.catalog.weapons.SHOTGUN, 300 },

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,7 @@ trx_lua_api_sources = files(
   'lua/api/game.lua',
   'lua/api/inventory.lua',
   'lua/api/items.lua',
+  'lua/api/json.lua',
   'lua/api/lara.lua',
   'lua/api/locale.lua',
   'lua/api/log.lua',

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,6 +43,7 @@ trx_lua_api_sources = files(
   'lua/api/assault.lua',
   'lua/api/camera.lua',
   'lua/api/catalog.lua',
+  'lua/api/check.lua',
   'lua/api/config.lua',
   'lua/api/console.lua',
   'lua/api/creatures.lua',

--- a/src/tests/fakes/locale.c
+++ b/src/tests/fakes/locale.c
@@ -1,6 +1,6 @@
 // The game string table, reduced to what a surface test needs: the fixtures
 // below - one plain, one with a placeholder, one with two, and one a translator
-// wrote a bare percent sign into - plus whatever the scripts under test declare
+// wrote a bare percent sign into - plus the keys the scripts under test declare
 // through trx.locale.declare(). The real one starts from
 // game_strings/entries.def and has cfg/base_strings.json5 and its translations
 // layered over it.

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -80,9 +80,20 @@ local function fresh_env()
       set_entrypoint = function() end,
     },
   }
-  _G.trx = { log = { debug = function() end, warn = function() end } }
-  -- The registry requires the checking layer and stubs nothing else, so this
-  -- runs the real one: what a declaration accepts is half of what is under test.
+  -- What describe() runs a description through. The real one is declared as
+  -- trx.strings.dedent and tested where it is written, so this stands in as
+  -- the identity; the test that cares which keys reach it swaps in its own.
+  _G.trx = {
+    log = { debug = function() end, warn = function() end },
+    strings = {
+      dedent = function(text)
+        return text
+      end,
+    },
+  }
+  -- The registry requires the checking layer and the logger. This runs the
+  -- real checker, because what a declaration accepts is half of what is under
+  -- test; the logger declares an enum out of C and is left stubbed.
   _G.require = function(name)
     if name == "trx.check" then
       return dofile(ROOT .. "src/lua/api/check.lua")
@@ -185,76 +196,48 @@ test("type() passes the declaration to the C binder", function()
   assert(exposed.fields.secret == nil, "an undeclared member was exposed")
 end)
 
--- A long-bracket description is written at the indentation of the declaration
--- around it, and four spaces of it would read as a code block.
-test("describe() takes the indentation off a description", function()
-  local api = fresh_env()
-  api.module("things", {
-    description = [[
-      A module.
-
-      Written at the indentation the declaration sits at, with a line that
-        lays something out under it.
-    ]],
-  })
-  api.define("things.poke", {
-    description = [[
-      Pokes it.
-    ]],
-    impl = function() end,
-  })
-
-  local dumped = api.describe()
-  local module
-  for _, entry in ipairs(dumped.modules) do
-    if entry.name == "things" then
-      module = entry
+-- Which of the keys describe() collects are prose. The dedenting itself is
+-- trx.strings.dedent's, and is tested where that is written.
+test(
+  "describe() takes the indentation off prose and leaves code alone",
+  function()
+    local api = fresh_env()
+    trx.strings.dedent = function(text)
+      return "dedented: " .. text
     end
-  end
-  assert(
-    module.description
-      == "A module.\n\nWritten at the indentation the declaration sits at, "
-        .. "with a line that\n  lays something out under it.",
-    "shared indent must go and the deeper line must keep the rest: "
-      .. module.description
-  )
+    api.module("things", { description = "A module." })
+    api.define("things.poke", {
+      description = "Pokes it.",
+      params = { { name = "how", type = "string", description = "How hard." } },
+      examples = { "trx.things.poke('gently')" },
+      impl = function() end,
+    })
 
-  local poke
-  for _, fn in ipairs(dumped.functions) do
-    if fn.path == "things.poke" then
-      poke = fn
+    local dumped = api.describe()
+    local module, poke
+    for _, entry in ipairs(dumped.modules) do
+      if entry.name == "things" then
+        module = entry
+      end
     end
-  end
-  assert(poke.description == "Pokes it.")
-end)
-
--- The other way one is written: the first line against the brackets, and the
--- rest at the indentation of the declaration. Left to set what the lines share,
--- that first line would hold the whole description at its own indentation, and
--- four spaces of it reads as a code block.
-test("describe() dedents a description opened against its brackets", function()
-  local api = fresh_env()
-  api.module("things", {
-    description = [[A module.
-
-    Written against the brackets, with a line that
-      lays something out under it.]],
-  })
-
-  local module
-  for _, entry in ipairs(api.describe().modules) do
-    if entry.name == "things" then
-      module = entry
+    for _, entry in ipairs(dumped.functions) do
+      if entry.path == "things.poke" then
+        poke = entry
+      end
     end
+
+    assert(module.description == "dedented: A module.")
+    assert(poke.description == "dedented: Pokes it.")
+    assert(
+      poke.params[1].description == "dedented: How hard.",
+      "a parameter carries prose too"
+    )
+    assert(
+      poke.examples[1] == "trx.things.poke('gently')",
+      "an example is code, and its own indentation is the point"
+    )
   end
-  assert(
-    module.description
-      == "A module.\n\nWritten against the brackets, with a line that\n"
-        .. "  lays something out under it.",
-    "the opening line must survive and the rest must be dedented: "
-      .. module.description
-  )
-end)
+)
 
 test("describe() reports fields, methods and extensions", function()
   local api = fresh_env()

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1288,6 +1288,42 @@ test("describe() gives the same answer twice", function()
   assert(api.to_json() == first, "describe() rewrote what it read")
 end)
 
+-- A table a script writes out is checked by what it holds. A key it does not
+-- name reads as nothing at all otherwise, whether checking is on or off.
+test("strict mode checks the keys a table declares", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.type("things.Options", {
+    record = true,
+    description = "How to do it.",
+    fields = {
+      mode = { type = "integer", optional = true, description = "." },
+    },
+  })
+  api.define("things.play", {
+    description = "...",
+    params = {
+      { name = "opts", type = "things.Options", optional = true },
+      {
+        name = "inline",
+        type = "table",
+        optional = true,
+        description = ".",
+        fields = { { name = "pos", type = "integer", description = "." } },
+      },
+    },
+    impl = function() end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.play, { mode = 1 }), "a plain table a script wrote")
+  assert(not pcall(trx.things.play, { moed = 1 }), "a key nothing names")
+  assert(not pcall(trx.things.play, { mode = "x" }), "a key of the wrong type")
+  assert(pcall(trx.things.play, nil, { pos = 1 }), "keys declared inline")
+  assert(not pcall(trx.things.play, nil, {}), "one of them missing")
+  api.strict(false)
+end)
+
 -- A declaration that holds several of something is checked as the list it is.
 -- Checking the element type against the list itself rejects every valid call.
 test("strict mode checks a list by what it holds", function()
@@ -1296,6 +1332,19 @@ test("strict mode checks a list by what it holds", function()
   api.define("things.collapse", {
     description = "...",
     params = { { name = "numbers", type = "integer", list = true } },
+    impl = function() end,
+  })
+  api.define("things.match", {
+    description = "...",
+    params = {
+      {
+        name = "sources",
+        type = "table",
+        list = true,
+        description = ".",
+        fields = { { name = "key", type = "string", description = "." } },
+      },
+    },
     impl = function() end,
   })
 
@@ -1307,6 +1356,8 @@ test("strict mode checks a list by what it holds", function()
     not pcall(trx.things.collapse, { 1, "x" }),
     "an entry of the wrong type"
   )
+  assert(pcall(trx.things.match, { { key = "a" } }), "keys declared inline")
+  assert(not pcall(trx.things.match, { { kye = "a" } }), "a key nothing names")
   api.strict(false)
 end)
 
@@ -1677,6 +1728,117 @@ test("class() hands back the class a type was declared with", function()
 
   assert(api.class("things.Widget") == Widget)
   assert(not pcall(api.class, "things.Gadget"))
+end)
+
+-- Which of the two a type is, the declaration says. Read off the shape, a type
+-- the registry hands out but that carries nothing except keys - math.Box - would
+-- be taken for a table a script writes, and its class would go on a value
+-- nothing checks by it.
+test("a type says whether it is a record or a value with a class", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  local Box = api.type("things.Box", {
+    description = "...",
+    fields = {
+      min_x = { type = "integer", description = "..." },
+      max_x = { type = "integer", description = "..." },
+    },
+  })
+  api.type("things.Options", {
+    record = true,
+    description = "...",
+    fields = { mode = { type = "integer", description = "." } },
+  })
+  api.define("things.fit", {
+    description = "...",
+    params = {
+      { name = "box", type = "things.Box" },
+      { name = "opts", type = "things.Options" },
+    },
+    impl = function() end,
+  })
+
+  api.strict(true)
+  local written = { min_x = 1, max_x = 5 }
+  assert(
+    not pcall(trx.things.fit, written, { mode = 1 }),
+    "a box the registry did not hand out"
+  )
+  assert(
+    pcall(trx.things.fit, setmetatable(written, Box), { mode = 1 }),
+    "one that carries the class"
+  )
+  api.strict(false)
+
+  -- A record is a plain table, so there is no class to put on one.
+  assert(api.class("things.Box") == Box)
+  assert(
+    not pcall(api.class, "things.Options"),
+    "a record must not hand out a class"
+  )
+end)
+
+test("a record is checked by the keys it names", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  assert(
+    not pcall(api.type, "things.Empty", { record = true, description = "." }),
+    "a record with no keys has nothing to be checked by"
+  )
+  assert(not pcall(api.type, "things.Method", {
+    record = true,
+    description = ".",
+    fields = { mode = { type = "integer", description = "." } },
+    methods = { poke = { impl = function() end } },
+  }), "a record is a plain table, so it has no methods")
+  assert(not pcall(api.type, "things.Accessor", {
+    record = true,
+    description = ".",
+    fields = {
+      mode = {
+        type = "integer",
+        description = ".",
+        get = function()
+          return 1
+        end,
+      },
+    },
+  }), "a record has nowhere to keep an accessor")
+end)
+
+test("a type declares only what its own shape can hold", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  local computed = { derived = { description = ".", impl = function() end } }
+  local operators = { band = { description = ".", impl = function() end } }
+
+  assert(not pcall(api.type, "things.Class", { extensions = computed }))
+  assert(not pcall(api.type, "things.Handle", {
+    backing = "WIDGET",
+    operators = operators,
+  }))
+  assert(not pcall(api.type, "things.Record", {
+    record = true,
+    description = ".",
+    fields = { mode = { type = "integer", description = "." } },
+    extensions = computed,
+  }))
+end)
+
+test("strict mode says what an argument had to be", function()
+  local api = fresh_env()
+  api.define("things.spawn", {
+    params = { { name = "id", type = "integer" } },
+    impl = function() end,
+  })
+
+  api.strict(true)
+  local ok, why = pcall(trx.things.spawn, "wolf")
+  assert(not ok)
+  assert(
+    why:find("expected integer", 1, true) ~= nil,
+    "the message names the parameter but not what it wanted: " .. why
+  )
 end)
 
 -- A suite that registers nothing prints "0 failed" and exits clean, which reads

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1584,7 +1584,7 @@ test(
   end
 )
 
--- The table a collection is read through holds whatever was declared inside it,
+-- The table a collection is read through holds what was declared inside it,
 -- the way a namespace's does, so the audit has to read it as well.
 test("seal audits the table a collection is read through", function()
   local api = fresh_env()

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -81,7 +81,13 @@ local function fresh_env()
     },
   }
   _G.trx = { log = { debug = function() end, warn = function() end } }
-  _G.require = function() end
+  -- The registry requires the checking layer and stubs nothing else, so this
+  -- runs the real one: what a declaration accepts is half of what is under test.
+  _G.require = function(name)
+    if name == "trx.check" then
+      return dofile(ROOT .. "src/lua/api/check.lua")
+    end
+  end
 
   dofile(ROOT .. "src/lua/api/api.lua")
   return trx.api, exposed
@@ -640,6 +646,43 @@ test("a derived Lua type inherits methods and operators", function()
   assert(getmetatable(Widget) == nil, "the base class gained a metatable")
 end)
 
+test("a derived Lua type inherits its parent's fields", function()
+  local api = fresh_env()
+  api.type("things.Widget", {
+    fields = {
+      name = {
+        type = "string",
+        description = "...",
+        get = function(self)
+          return rawget(self, "held")
+        end,
+        set = function(self, value)
+          rawset(self, "held", value)
+        end,
+      },
+    },
+  })
+  local Lever = api.type("things.Lever", {
+    extends = "things.Widget",
+    methods = {
+      pull = {
+        description = "...",
+        impl = function(self)
+          return self.name .. " pulled"
+        end,
+      },
+    },
+  })
+
+  -- The accessors sit in the parent's __index closure, so the metatable chain
+  -- does not reach one and the derived type has to take them over.
+  local lever = setmetatable({ held = "lever" }, Lever)
+  assert(lever.name == "lever", "an inherited field is unreadable")
+  lever.name = "pulled lever"
+  assert(lever.name == "pulled lever", "an inherited field is unwritable")
+  assert(lever:pull() == "pulled lever pulled")
+end)
+
 test("extending a type nobody declared raises", function()
   local api = fresh_env()
   assert(not pcall(api.type, "things.Lever", { extends = "things.Widget" }))
@@ -984,8 +1027,8 @@ test("a Lua type's field with no accessors is an entry it carries", function()
   local entry = api.describe().types[1]
   for _, field in ipairs(entry.fields) do
     assert(
-      field.writable == true,
-      "a stored entry is neither getter nor const"
+      field.writable == nil,
+      "a plain table the caller owns has no writability to report"
     )
   end
 end)
@@ -1120,16 +1163,6 @@ test("a declaration keeps what it adds of its own", function()
   assert(param.description == "The one that broke.")
 end)
 
-test("naming something nobody declares is caught where it is read", function()
-  local api = fresh_env()
-  api.module("things", { description = "..." })
-  api.define("things.get", {
-    params = { { name = "num", type = "things.nothing" } },
-    impl = function() end,
-  })
-  assert(not pcall(api.describe))
-end)
-
 test("an enum is a type like any other", function()
   local api = fresh_env()
   api.enum("things.State", {
@@ -1209,6 +1242,71 @@ test("a unit is checked by what it measures", function()
   api.strict(true)
   assert(pcall(trx.things.wait, 1.5, 90), "a real number and a whole one")
   assert(not pcall(trx.things.wait, 1.5, 1.5), "an angle is whole")
+  api.strict(false)
+end)
+
+-- Partial is for a suite that stands up a few modules, where a name the rest
+-- of the surface declares is expected to be missing. It used to reach for the
+-- checker it had just found nothing for.
+test("a partial seal tolerates a default it cannot check", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.define("things.get", {
+    description = "...",
+    params = {
+      {
+        name = "num",
+        type = "elsewhere.Num",
+        optional = true,
+        default = 0,
+        description = "...",
+      },
+    },
+    impl = function() end,
+  })
+
+  assert(
+    pcall(api.seal, { partial = true }),
+    "a partial seal must tolerate it"
+  )
+end)
+
+-- describe() is read twice by the tests and once by the dump, and a projection
+-- that handed out its own registry entry would rewrite it the first time.
+test("describe() gives the same answer twice", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.namespace("things.log", {
+    description = [[
+      Indented, so the dedent has something to take off.
+    ]],
+    params = { { name = "message", type = "any", description = "..." } },
+    call = function() end,
+  })
+
+  local first = api.to_json()
+  assert(api.to_json() == first, "describe() rewrote what it read")
+end)
+
+-- A declaration that holds several of something is checked as the list it is.
+-- Checking the element type against the list itself rejects every valid call.
+test("strict mode checks a list by what it holds", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.define("things.collapse", {
+    description = "...",
+    params = { { name = "numbers", type = "integer", list = true } },
+    impl = function() end,
+  })
+
+  api.strict(true)
+  assert(pcall(trx.things.collapse, { 1, 2, 3 }), "a list of what it holds")
+  assert(pcall(trx.things.collapse, {}), "an empty one")
+  assert(not pcall(trx.things.collapse, 1), "the element on its own")
+  assert(
+    not pcall(trx.things.collapse, { 1, "x" }),
+    "an entry of the wrong type"
+  )
   api.strict(false)
 end)
 
@@ -1387,24 +1485,6 @@ test("class() hands back the class a type was declared with", function()
 
   assert(api.class("things.Widget") == Widget)
   assert(not pcall(api.class, "things.Gadget"))
-end)
-
-test("a container names itself where its key names nothing", function()
-  local api = fresh_env()
-  api.module("things", { description = "..." })
-  api.container("things", {
-    description = "Indexing.",
-    key = { type = "things.Gone", description = "A key." },
-    value = { type = "string" },
-    get = function() end,
-  })
-
-  local ok, err = pcall(api.describe)
-  assert(not ok, "a key naming nothing must be reported")
-  assert(
-    err:find("things's type", 1, true) ~= nil,
-    "the message must say which container to look in: " .. tostring(err)
-  )
 end)
 
 -- A suite that registers nothing prints "0 failed" and exits clean, which reads

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1362,6 +1362,52 @@ end)
 
 -- Where a collection counts from is the key's to say, so a container that says
 -- it itself is a declaration left behind by the move.
+-- A sparse collection runs its keys further than it has entries: the samples a
+-- level carries are a hundred spread over twice as many numbers.
+test("a sparse container walks its keys and skips the gaps", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  local held = { [0] = "a", [3] = "b", [4] = "c" }
+  api.container("things", {
+    description = "Indexing.",
+    key = { type = "integer", base = 0, description = "A key." },
+    value = { type = "string", nullable = true },
+    get = function(i)
+      return held[i]
+    end,
+    count = function()
+      return 3
+    end,
+    limit = function()
+      return 5
+    end,
+  })
+
+  assert(#trx.things == 3, "# is how many there are")
+  local seen = {}
+  for i, value in pairs(trx.things) do
+    seen[#seen + 1] = i .. "=" .. value
+  end
+  assert(
+    table.concat(seen, ",") == "0=a,3=b,4=c",
+    "the gaps must not come out as nil: " .. table.concat(seen, ",")
+  )
+end)
+
+test("a limit needs a count beside it", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  assert(not pcall(api.container, "things", {
+    description = "Indexing.",
+    key = { type = "integer", description = "A key." },
+    value = { type = "string" },
+    get = function() end,
+    limit = function()
+      return 5
+    end,
+  }))
+end)
+
 test("a container cannot say where it counts from", function()
   local api = fresh_env()
   api.module("things", {})

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1323,9 +1323,10 @@ test("a container walks from the index it counts from", function()
   local zero, one = { [0] = "a", [1] = "b" }, { "a", "b" }
 
   api.module("counted", {})
+  api.number("counted.Num", { base = 0, description = "Where it sits." })
   api.container("counted", {
     description = "Indexing.",
-    key = { type = "integer", base = 0, description = "Where it sits." },
+    key = { type = "counted.Num" },
     value = { type = "string" },
     get = function(key)
       return zero[key]
@@ -1336,9 +1337,10 @@ test("a container walks from the index it counts from", function()
   })
 
   api.module("listed", {})
+  api.number("listed.Num", { base = 1, description = "Where it sits." })
   api.container("listed", {
     description = "Indexing.",
-    key = { type = "integer", base = 1, description = "Where it sits." },
+    key = { type = "listed.Num" },
     value = { type = "string" },
     get = function(key)
       return one[key]
@@ -1365,10 +1367,11 @@ end)
 test("a sparse container walks its keys and skips the gaps", function()
   local api = fresh_env()
   api.module("things", { description = "..." })
+  api.number("things.Num", { base = 0, description = "Where it sits." })
   local held = { [0] = "a", [3] = "b", [4] = "c" }
   api.container("things", {
     description = "Indexing.",
-    key = { type = "integer", base = 0, description = "A key." },
+    key = { type = "things.Num" },
     value = { type = "string", nullable = true },
     get = function(i)
       return held[i]
@@ -1535,6 +1538,17 @@ test("a limit needs a count beside it", function()
     limit = function()
       return 5
     end,
+  }))
+end)
+
+test("a container key cannot say where it counts from either", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  assert(not pcall(api.container, "things", {
+    description = "Indexing.",
+    key = { type = "integer", base = 1, description = "A key." },
+    value = { type = "string" },
+    get = function() end,
   }))
 end)
 

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -90,6 +90,12 @@ local function fresh_env()
   end
 
   dofile(ROOT .. "src/lua/api/api.lua")
+
+  -- What to_json() writes the dump out with. It declares itself through the
+  -- registry like anything else, so it loads after, and it is the real one:
+  -- there is no C behind it, and how the dump comes out is under test here.
+  dofile(ROOT .. "src/lua/api/json.lua")
+
   return trx.api, exposed
 end
 

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -213,6 +213,34 @@ test("describe() takes the indentation off a description", function()
   assert(poke.description == "Pokes it.")
 end)
 
+-- The other way one is written: the first line against the brackets, and the
+-- rest at the indentation of the declaration. Left to set what the lines share,
+-- that first line would hold the whole description at its own indentation, and
+-- four spaces of it reads as a code block.
+test("describe() dedents a description opened against its brackets", function()
+  local api = fresh_env()
+  api.module("things", {
+    description = [[A module.
+
+    Written against the brackets, with a line that
+      lays something out under it.]],
+  })
+
+  local module
+  for _, entry in ipairs(api.describe().modules) do
+    if entry.name == "things" then
+      module = entry
+    end
+  end
+  assert(
+    module.description
+      == "A module.\n\nWritten against the brackets, with a line that\n"
+        .. "  lays something out under it.",
+    "the opening line must survive and the rest must be dedented: "
+      .. module.description
+  )
+end)
+
 test("describe() reports fields, methods and extensions", function()
   local api = fresh_env()
   api.module("things", { description = "..." })

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1397,6 +1397,42 @@ test("a number cannot be written twice", function()
   )
 end)
 
+-- A collection declares what its key is, and the reference says so, so strict
+-- mode holds a script to it rather than handing C a number nothing answers to.
+test("strict mode checks what a collection is indexed with", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.number("things.Num", { base = 0, description = "Where it sits." })
+  api.container("things", {
+    description = "Indexing.",
+    key = { type = "things.Num" },
+    value = { type = "string", nullable = true },
+    get = function(i)
+      return "held " .. i
+    end,
+    count = function()
+      return 2
+    end,
+  })
+
+  assert(trx.things[1.5] == "held 1.5", "unchecked while checking is off")
+
+  api.strict(true)
+  assert(trx.things[1] == "held 1", "a key of the declared type")
+  local ok, err = pcall(function()
+    return trx.things[1.5]
+  end)
+  assert(not ok, "a fractional key must be refused")
+  assert(
+    tostring(err):find("things[1.5]", 1, true),
+    "the message must name what was written: " .. tostring(err)
+  )
+  -- A key of a kind the collection never accepts is left to the rest of the
+  -- metatable, so it is nil rather than an error.
+  assert(trx.things.nonsense == nil, "a string key is not indexing")
+  api.strict(false)
+end)
+
 test("a container walks from the index it counts from", function()
   local api = fresh_env()
   local zero, one = { [0] = "a", [1] = "b" }, { "a", "b" }
@@ -1867,6 +1903,21 @@ test("strict mode says what an argument had to be", function()
     why:find("expected integer", 1, true) ~= nil,
     "the message names the parameter but not what it wanted: " .. why
   )
+end)
+
+test("seal refuses a collection key nothing can check", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.container("things", {
+    description = ".",
+    key = { type = "things.Nothing", description = "." },
+    value = { type = "integer", description = "." },
+    get = function() end,
+  })
+
+  local ok, why = pcall(api.seal)
+  assert(not ok, "strict mode would wave every key through")
+  assert(why:find("things.Nothing", 1, true) ~= nil, why)
 end)
 
 -- A suite that registers nothing prints "0 failed" and exits clean, which reads

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -110,10 +110,19 @@ end)
 
 test("strict mode rejects bad args and accepts good ones", function()
   local api = fresh_env()
+  api.type("things.Pos", {
+    record = true,
+    description = "Where.",
+    fields = {
+      x = { type = "integer", description = "." },
+      y = { type = "integer", description = "." },
+      z = { type = "integer", description = "." },
+    },
+  })
   api.define("things.spawn", {
     params = {
       { name = "id", type = "integer" },
-      { name = "pos", type = "vec3" },
+      { name = "pos", type = "things.Pos" },
       { name = "angle", type = "integer", optional = true, default = 0 },
     },
     impl = function(id, pos, angle)
@@ -125,7 +134,7 @@ test("strict mode rejects bad args and accepts good ones", function()
   assert(
     not pcall(trx.things.spawn, "not an integer", { x = 1, y = 1, z = 1 })
   )
-  assert(not pcall(trx.things.spawn, 1, "not a vec3"))
+  assert(not pcall(trx.things.spawn, 1, "not a position"))
   assert(pcall(trx.things.spawn, 1, { x = 1, y = 1, z = 1 }))
 
   -- An omitted optional argument takes its declared default.
@@ -378,7 +387,7 @@ test(
       end,
     })
     api.property("things.pos", {
-      type = "vec3",
+      type = "table",
       description = "Where.",
       get = function()
         return { x = 1, y = 2, z = 3 }
@@ -422,7 +431,7 @@ test("properties reach describe()", function()
   })
   api.property(
     "things.pos",
-    { type = "vec3", description = "Where.", get = function() end }
+    { type = "table", description = "Where.", get = function() end }
   )
 
   local out = api.describe()

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1360,8 +1360,6 @@ test("a container walks from the index it counts from", function()
   assert(walked(trx.listed) == "1,2", walked(trx.listed))
 end)
 
--- Where a collection counts from is the key's to say, so a container that says
--- it itself is a declaration left behind by the move.
 -- A sparse collection runs its keys further than it has entries: the samples a
 -- level carries are a hundred spread over twice as many numbers.
 test("a sparse container walks its keys and skips the gaps", function()
@@ -1394,6 +1392,138 @@ test("a sparse container walks its keys and skips the gaps", function()
   )
 end)
 
+-- A module may hand out a collection under a name of its own as well as being
+-- indexed itself, and the table that collection sits on is the registry's in
+-- the same way a module's is.
+test("a collection a module hands out is indexed on its own table", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  local held = { [1] = "a", [2] = "b" }
+  local samples = api.container("things.samples", {
+    description = "Indexing.",
+    key = { type = "integer", description = "A key." },
+    value = { type = "string" },
+    get = function(i)
+      return held[i]
+    end,
+    count = function()
+      return 2
+    end,
+  })
+
+  assert(samples == trx.things.samples, "the table it is indexed on")
+  assert(trx.things.samples[2] == "b")
+  assert(#trx.things.samples == 2)
+
+  -- The collection and anything else declared on it answer off one entry, so
+  -- the property does not arrive with a metatable of its own and take the
+  -- indexing with it.
+  api.property("things.samples.total", {
+    type = "integer",
+    description = "...",
+    get = function()
+      return 2
+    end,
+  })
+  assert(trx.things.samples.total == 2, "the property must answer")
+  assert(trx.things.samples[1] == "a", "and the indexing must survive it")
+end)
+
+-- A namespace declares the table it stands for, and would put it where the
+-- collection is read through. Nothing about the surface afterwards says the
+-- indexing went: it reads as nil, and the audit sees only what a table holds.
+test(
+  "a namespace cannot replace the table a collection is read through",
+  function()
+    local api = fresh_env()
+    api.module("things", { description = "..." })
+    api.container("things.samples", {
+      description = "Indexing.",
+      key = { type = "integer", description = "A key." },
+      value = { type = "string" },
+      get = function()
+        return "a"
+      end,
+    })
+
+    local ok, err =
+      pcall(api.namespace, "things.samples", { description = "Samples." })
+    assert(not ok, "the collection already stands there")
+    assert(
+      tostring(err):find("already stands for a table", 1, true),
+      "the message must say what stands there: " .. tostring(err)
+    )
+    assert(trx.things.samples[1] == "a", "the indexing must survive it")
+  end
+)
+
+-- The table a collection is read through holds whatever was declared inside it,
+-- the way a namespace's does, so the audit has to read it as well.
+test("seal audits the table a collection is read through", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.container("things.samples", {
+    description = "Indexing.",
+    key = { type = "integer", description = "A key." },
+    value = { type = "string" },
+    get = function() end,
+  })
+  rawset(trx.things.samples, "sneaky", function() end)
+
+  local ok, err = pcall(api.seal)
+  assert(not ok, "an undeclared member on the collection must fail the seal")
+  assert(
+    tostring(err):find("trx.things.samples.sneaky", 1, true),
+    "the audit must name it: " .. tostring(err)
+  )
+end)
+
+test("a collection is declared as a module or a member of one", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  local ok, err = pcall(api.container, "things.a.b", {
+    description = "Indexing.",
+    key = { type = "integer", description = "A key." },
+    value = { type = "string" },
+    get = function() end,
+  })
+  assert(not ok, "three segments deep")
+  -- The path the message names is the one that was written, not one with a
+  -- segment added to borrow another declaration's parser.
+  assert(
+    tostring(err):find("got: things.a.b", 1, true),
+    "the message must name the path as written: " .. tostring(err)
+  )
+end)
+
+-- Several collections on one module tie on the module they sit under, and the
+-- dump is committed and diffed, so the member has to settle the order.
+test("the containers of a module come out in a fixed order", function()
+  local api = fresh_env()
+  local function collection(path)
+    api.container(path, {
+      description = "Indexing.",
+      key = { type = "integer", description = "A key." },
+      value = { type = "string" },
+      get = function() end,
+    })
+  end
+  api.module("things", { description = "..." })
+  api.module("others", { description = "..." })
+  collection("things.tracks")
+  collection("others")
+  collection("things.samples")
+
+  local seen = {}
+  for _, one in ipairs(api.describe().containers) do
+    seen[#seen + 1] = one.module .. (one.member and "." .. one.member or "")
+  end
+  assert(
+    table.concat(seen, ",") == "others,things.samples,things.tracks",
+    "the order must not follow the declarations: " .. table.concat(seen, ",")
+  )
+end)
+
 test("a limit needs a count beside it", function()
   local api = fresh_env()
   api.module("things", { description = "..." })
@@ -1408,6 +1538,8 @@ test("a limit needs a count beside it", function()
   }))
 end)
 
+-- Where a collection counts from is the key's to say, so a container that says
+-- it itself is a declaration left behind by the move.
 test("a container cannot say where it counts from", function()
   local api = fresh_env()
   api.module("things", {})

--- a/src/tests/lua/api/argparse.lua
+++ b/src/tests/lua/api/argparse.lua
@@ -142,7 +142,7 @@ test("suggest completes but does not restrict or hint", function()
   local p = trx.argparse.new()
   p:positional("option", { suggest = { "fov", "gamma" } })
   -- Any token is taken; suggest never rejects.
-  assert(p:parse("whatever").option == "whatever")
+  assert(p:parse("anything").option == "anything")
   -- It offers completions...
   assert(p:complete("f")[1] == "fov")
   -- ...but stays out of the error: a missing option carries no "expected" hint.

--- a/src/tests/lua/api/console.lua
+++ b/src/tests/lua/api/console.lua
@@ -146,7 +146,7 @@ test("the arguments are trimmed", function()
   assert(seen == "spaced", "the handler was handed untrimmed arguments")
 end)
 
-test("a command answers to whatever case the player typed", function()
+test("a command answers to any case the player typed", function()
   local seen = nil
   trx.console.register({
     name = "shout",

--- a/src/tests/lua/api/events.lua
+++ b/src/tests/lua/api/events.lua
@@ -57,7 +57,7 @@ test(
       listener.id = 1
     end, "read-only")
     raises(function()
-      listener.whatever = 1
+      listener.nonsense = 1
     end)
   end
 )

--- a/src/tests/lua/api/game.lua
+++ b/src/tests/lua/api/game.lua
@@ -129,7 +129,7 @@ test("play_level rejects a level that is not there", function()
     trx.game.play_level(0)
   end)
   -- A number too wide for the engine's would otherwise wrap into range and
-  -- start whatever level it landed on.
+  -- start the level it landed on.
   raises(function()
     trx.game.play_level(4294967297)
   end)

--- a/src/tests/lua/api/inventory.lua
+++ b/src/tests/lua/api/inventory.lua
@@ -40,7 +40,7 @@ test("a count below one is refused, and neither gives nor takes", function()
   assert(trx.inventory:count(KEY) == 0)
 end)
 
--- Inv_AddItem reaches the object table with whatever it is handed, so the
+-- Inv_AddItem reaches the object table with what it is handed, so the
 -- bridge turns an id the engine does not know into a raise of its own.
 test("an object the engine does not know is refused", function()
   for _, name in ipairs({ "give", "take", "count", "icon_of", "can_add" }) do
@@ -65,7 +65,7 @@ test("a weapon knows its pickup", function()
   assert(trx.weapons.object(UZIS) ~= nil)
 end)
 
-test("ammunition is counted in shots, whatever a shot costs", function()
+test("ammunition is counted in shots, however much a shot costs", function()
   local SHOTGUN = trx.catalog.weapons.SHOTGUN
 
   assert(trx.inventory:shots(UZIS) == 0)
@@ -128,7 +128,7 @@ test("the module counts and walks what she carries", function()
   assert(#trx.inventory == 0, "she starts with nothing")
 
   trx.inventory:give(KEY, 2)
-  assert(#trx.inventory == 1, "one kind of thing, whatever the count")
+  assert(#trx.inventory == 1, "one kind of thing, not one entry per key")
 
   local entry = trx.inventory[1]
   assert(entry.object == KEY)

--- a/src/tests/lua/api/items.lua
+++ b/src/tests/lua/api/items.lua
@@ -516,7 +516,7 @@ test(
   end
 )
 
--- An index alone would rebind to whatever item recycled the slot; the
+-- An index alone would rebind to the item that recycled the slot; the
 -- generation counter is what makes the handle go stale instead.
 test("a handle to a destroyed item goes stale", function()
   local it = trx.items[0]
@@ -526,7 +526,7 @@ test("a handle to a destroyed item goes stale", function()
   assert(not it:is_valid(), "the handle should be stale after destroy()")
   assert(fake.calls().destroy.count == 1)
 
-  -- Reading a stale handle raises rather than addressing whatever took over.
+  -- Reading a stale handle raises rather than addressing the item that took over.
   raises(function()
     return it.hit_points
   end, "stale")
@@ -552,7 +552,7 @@ test("two handles to the same item are equal", function()
   assert(it ~= fresh, "a stale handle must not equal a live one")
 end)
 
--- pairs() hands the iterator to the script, so it is reachable with whatever
+-- pairs() hands the iterator to the script, so it is reachable with any
 -- the script cares to pass it.
 test("the field iterator refuses a value that is not an item", function()
   local it = trx.items[0]
@@ -757,7 +757,7 @@ test("strict mode checks a method's arguments", function()
 end)
 
 -- The handle is the method's first argument, and a dot where a colon was meant
--- passes whatever came first instead.
+-- passes the one that came first instead.
 test("strict mode catches a method called with a dot", function()
   local it = trx.items[0]
   trx.api.strict(true)

--- a/src/tests/lua/api/json.c
+++ b/src/tests/lua/api/json.c
@@ -1,0 +1,18 @@
+// The JSON encoder. The assertions live in json.lua; this stands up the world
+// they run against.
+
+#include <harness/lua_surface.h>
+
+static void M_PushFake(lua_State *const L)
+{
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "json",
+        .tests = "api/json",
+        .push_fake = M_PushFake,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/tests/lua/api/json.lua
+++ b/src/tests/lua/api/json.lua
@@ -1,0 +1,56 @@
+-- The JSON encoder as a script actually sees it. The API dump goes through
+-- this, so what it writes is what the committed reference is generated from.
+
+local h = require("harness")
+local test = h.test
+
+test("a scalar writes as itself", function()
+  local encode = trx.json.encode
+
+  assert(encode(true) == "true")
+  assert(encode(false) == "false")
+  assert(encode(7) == "7")
+  assert(encode("wolf") == '"wolf"')
+end)
+
+test("a table with entries writes as a list", function()
+  local encode = trx.json.encode
+
+  assert(encode({ 1, 2, 3 }) == "[1,2,3]")
+  assert(encode({ "a", "b" }) == '["a","b"]')
+  assert(encode({}) == "[]", "nothing at all reads as none of it")
+end)
+
+test("a table with keys writes as an object, in sorted order", function()
+  -- pairs() walks a table in any order, and the dump is committed and diffed.
+  local written = trx.json.encode({ name = "wolf", ids = { 7, 8 }, hp = 6 })
+  assert(
+    written == '{"hp":6,"ids":[7,8],"name":"wolf"}',
+    "keys must come out sorted: " .. written
+  )
+end)
+
+test(
+  "a string carries its quotes and its control characters through",
+  function()
+    local encode = trx.json.encode
+
+    assert(encode('say "hi"') == '"say \\"hi\\""')
+    assert(encode("back\\slash") == '"back\\\\slash"')
+    assert(encode("two\nlines") == '"two\\nlines"')
+    assert(encode("a\tb") == '"a\\tb"')
+    assert(
+      encode("bell\a") == '"bell\\u0007"',
+      "a control character with no escape of its own still has to be escaped"
+    )
+  end
+)
+
+test("nesting comes out nested", function()
+  local written = trx.json.encode({
+    rooms = { { num = 0 }, { num = 1 } },
+  })
+  assert(written == '{"rooms":[{"num":0},{"num":1}]}', written)
+end)
+
+return h.report()

--- a/src/tests/lua/api/strings.lua
+++ b/src/tests/lua/api/strings.lua
@@ -118,4 +118,44 @@ test("collapse_ranges sorts, and takes a separator", function()
   assert(collapse({ 1, 2, 5 }, " | ") == "1-2 | 5")
 end)
 
+-- A block written at the indentation of the code around it, where four spaces
+-- of it would read as a code block in markdown.
+test("dedent takes off what the lines share", function()
+  local text = trx.strings.dedent([[
+      A block.
+
+      Written at the indentation the code sits at, with a line that
+        lays something out under it.
+    ]])
+  assert(
+    text
+      == "A block.\n\nWritten at the indentation the code sits at, "
+        .. "with a line that\n  lays something out under it.",
+    "the shared indent must go and the deeper line must keep the rest: "
+      .. text
+  )
+end)
+
+-- The other way one is written: the first line against the brackets, and the
+-- rest at the indentation of the code. Left to set what the lines share, that
+-- first line would hold the whole block at its own indentation.
+test("dedent leaves a block opened against its brackets standing", function()
+  local text = trx.strings.dedent([[A block.
+
+    Written against the brackets, with a line that
+      lays something out under it.]])
+  assert(
+    text
+      == "A block.\n\nWritten against the brackets, with a line that\n"
+        .. "  lays something out under it.",
+    "the opening line must survive and the rest must be dedented: " .. text
+  )
+end)
+
+test("dedent leaves a block that shares no indent alone", function()
+  assert(trx.strings.dedent("One line.") == "One line.")
+  assert(trx.strings.dedent("A.\nB.") == "A.\nB.")
+  assert(trx.strings.dedent("\n\n  Padded.\n\n") == "Padded.")
+end)
+
 return h.report()

--- a/src/tests/lua/boot.lua
+++ b/src/tests/lua/boot.lua
@@ -16,9 +16,10 @@ test("the loader and the globals it feeds are gone", function()
   assert(string.dump == nil, "string.dump feeds the loader")
 end)
 
--- Strict mode compiles its wrappers with load(), which api.lua captures at
--- module scope because hardening nils the global. Every other strict test runs
--- unhardened and would not notice if that capture went.
+-- Strict mode rebinds every registered function, and api.lua reaches the C
+-- bridge to do it through the reference it captured at module scope, because
+-- hardening nils the global. Every other strict test runs unhardened and would
+-- not notice if that capture went.
 test("strict mode still works once the globals are hardened", function()
   trx.api.strict(true)
 

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -370,6 +370,12 @@ unit_tests += {
   'bundles': [b_lua_surface, b_lua_strings],
 }
 
+# Pure Lua, with no bridge under it: the encoder is the whole module.
+unit_tests += {
+  'name': 'lua/api/json',
+  'bundles': [b_lua_surface],
+}
+
 # The parser is pure Lua, but it leans on the real fuzzy matcher out of
 # trx.strings, so the two are stood up together.
 unit_tests += {

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -512,7 +512,11 @@ class TestLuaDocs(unittest.TestCase):
 
         page = rendered(surface)
         self.assertIn("### Indexing", page)
-        self.assertIn("**`trx.things[key]`** (Widget or `nil`). 1-based.", page)
+        self.assertIn(
+            "**`trx.things[key]`** (key: integer, value: Widget or `nil`). "
+            "1-based.",
+            page,
+        )
         self.assertIn("**`#trx.things`** (integer).", page)
 
     def test_a_module_with_no_container_gets_no_indexing_section(self):

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -666,6 +666,32 @@ class TestLuaDocs(unittest.TestCase):
                 docs.read(surface)
                 self.assertEqual(docs.undocumented(surface), [expected])
 
+    def test_a_type_naming_nothing_stops_the_run(self):
+        """The engine emits what it was told; resolving it is this tool's job."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["params"] = [
+            {"name": "num", "type": "things.nothing", "description": "A number."}
+        ]
+        docs.read(surface)
+        with self.assertRaises(SystemExit) as caught:
+            for module in surface["modules"]:
+                docs.render_page(module, surface)
+        report = str(caught.exception)
+        self.assertIn("things.nothing", report)
+        self.assertIn(surface["functions"][0]["path"], report)
+
+    def test_a_reference_says_which_declaration_it_was_read_from(self):
+        """The same path is written in a dozen places; only one has to move."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][1]["description"] = "See `trx.things.gone`."
+        docs.read(surface)
+        with self.assertRaises(SystemExit) as caught:
+            for module in surface["modules"]:
+                docs.render_page(module, surface)
+        report = str(caught.exception)
+        self.assertIn("`trx.things.gone`", report)
+        self.assertIn(surface["functions"][1]["path"], report)
+
     def test_a_backticked_name_that_points_nowhere_is_reported(self):
         """A name in backticks reads as something to go and look at.
 

--- a/src/tests/tools/update_lua_docs.py
+++ b/src/tests/tools/update_lua_docs.py
@@ -666,6 +666,22 @@ class TestLuaDocs(unittest.TestCase):
                 docs.read(surface)
                 self.assertEqual(docs.undocumented(surface), [expected])
 
+    def test_a_result_holding_several_is_named_by_the_call(self):
+        """A parameter still says what it is for; only a result is let off."""
+        surface = copy.deepcopy(SURFACE)
+        returns = surface["types"][0]["methods"][0]["returns"]
+        del returns["description"]
+        returns["list"] = True
+        docs.read(surface)
+        self.assertEqual(docs.undocumented(surface), [])
+
+        surface = copy.deepcopy(SURFACE)
+        param = surface["functions"][0]["params"][1]
+        del param["description"]
+        param["list"] = True
+        docs.read(surface)
+        self.assertEqual(docs.undocumented(surface), ["things.spawn(angle)"])
+
     def test_a_type_naming_nothing_stops_the_run(self):
         """The engine emits what it was told; resolving it is this tool's job."""
         surface = copy.deepcopy(SURFACE)

--- a/src/tests/trx/core/enum_map.c
+++ b/src/tests/trx/core/enum_map.c
@@ -49,7 +49,7 @@ TEST(get_name_reports_the_c_identifier)
 }
 
 // This is what trxc.enum.values() reflects. Every constant must come back,
-// whatever its numeric value - M_WIDGET_BROKEN is 7, not 2, so nothing here may
+// however it is numbered - M_WIDGET_BROKEN is 7, not 2, so nothing here may
 // assume the values are contiguous.
 TEST(list_values_returns_every_constant)
 {

--- a/src/tests/trx/core/hash.c
+++ b/src/tests/trx/core/hash.c
@@ -3,7 +3,7 @@
 #include <trx/core/hash.h>
 
 // FNV-1a. Savegames and caches key off these, so the values are a wire format:
-// changing them silently invalidates whatever was hashed with the old ones.
+// changing them silently invalidates what was hashed with the old ones.
 
 TEST(the_empty_hash_is_the_fnv_offset_basis)
 {

--- a/src/tests/trx/core/vector.c
+++ b/src/tests/trx/core/vector.c
@@ -173,7 +173,7 @@ TEST(expanding_reserves_room_the_caller_can_write_into)
 
 TEST(a_vector_of_structs_moves_whole_items_not_bytes)
 {
-    // item_size is whatever the caller says, so a shift that used the wrong
+    // item_size is the caller's to set, so a shift that used the wrong
     // stride would corrupt every element after the one removed.
     typedef struct {
         int32_t id;

--- a/src/tests/trx/game/cutseq/decoder.c
+++ b/src/tests/trx/game/cutseq/decoder.c
@@ -342,8 +342,9 @@ TEST(build_pose_clears_the_meshes_the_actor_does_not_carry)
     CHECK(CutSeq_Decoder_InitNodes(buf, size, nodes, 2) > 0);
     CutSeq_Decoder_Reset(nodes, 2);
 
-    // Lara is posed to the full LM_NUMBER_OF whatever her actor declares, so
-    // a pose reused across cutscenes may not keep the last one's tail.
+    // Lara is posed to the full LM_NUMBER_OF regardless of how many meshes her
+    // actor declares, so a pose reused across cutscenes may not keep the last
+    // one's tail.
     CUTSEQ_POSE pose;
     for (int32_t i = 0; i < CUTSEQ_MAX_MESHES; i++) {
         pose.rots[i] = (XYZ_16) { .x = 999, .y = 999, .z = 999 };

--- a/src/tests/trx/game/cutseq/pak.c
+++ b/src/tests/trx/game/cutseq/pak.c
@@ -295,7 +295,7 @@ TEST(a_missing_file_is_not_a_loaded_pak)
     m_FileExists = true;
 }
 
-// The loader's view of the outside world: a file that is whatever the test
+// The loader's view of the outside world: a file that holds what the test
 // last published, and object ids it does not act on here.
 
 #include <trx/core/memory.h>

--- a/src/tests/trx/game/lua/capi/struct.c
+++ b/src/tests/trx/game/lua/capi/struct.c
@@ -262,7 +262,7 @@ TEST(declaring_a_nonexistent_member_raises)
     lua_close(L);
 }
 
-// A handle held across a kill must raise, not silently rebind to whatever
+// A handle held across a kill must raise, not silently rebind to what
 // reused the slot. This is what the generation counter buys.
 TEST(a_stale_handle_raises_rather_than_rebinding)
 {

--- a/src/tests/trx/game/ui.c
+++ b/src/tests/trx/game/ui.c
@@ -122,7 +122,7 @@ static void M_CheckNode(
     }
 
     // Nothing in this UI clips, so text wider than the box it was given spills
-    // over whatever is beside it - the frame it sits in, or the row below.
+    // over what is beside it - the frame it sits in, or the row below.
     const float outside_box = node->measure_w - node->w;
     if (outside_box > *worst_box) {
         *worst_box = outside_box;

--- a/src/trx/config/override.h
+++ b/src/trx/config/override.h
@@ -10,7 +10,7 @@
 //
 // Overrides are runtime-only: they never reach the settings file.
 
-// Applies `value` to the option, remembering whatever is currently there.
+// Applies `value` to the option, remembering the value currently there.
 bool ConfigOverride_Push(const CONFIG_OPTION *option, const void *value);
 
 // Applies a value parsed from a string. Fails on an option the game flow

--- a/src/trx/config/value.h
+++ b/src/trx/config/value.h
@@ -24,7 +24,7 @@ typedef union {
 void ConfigValue_Copy(
     const CONFIG_OPTION *option, CONFIG_VALUE *dst, const void *src);
 
-// Releases whatever the value owns. Only string-typed values own anything.
+// Releases what the value owns. Only string-typed values own anything.
 void ConfigValue_Free(const CONFIG_OPTION *option, CONFIG_VALUE *value);
 
 // The value as a raw pointer of the option's own type, which is what the rest

--- a/src/trx/core/completion.h
+++ b/src/trx/core/completion.h
@@ -21,7 +21,7 @@ typedef struct {
 } COMPLETION;
 
 // A completion source: `fn` fills `out` for the token under the caret in
-// `line`, with an absolute [start, end) span; `ctx` carries whatever the source
+// `line`, with an absolute [start, end) span; `ctx` carries what the source
 // needs to resolve it, or nullptr. A zeroed COMPLETER (fn == nullptr) completes
 // nothing.
 typedef struct {

--- a/src/trx/core/handle.h
+++ b/src/trx/core/handle.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 // A weak reference to a game entity, of the kind a script holds across time. It
-// pairs the entity's id - a pool slot, a room number, whatever the owning
+// pairs the entity's id - a pool slot, a room number, the number the owning
 // module keys on - with a generation that says which occupant of that id is
 // meant. The value is self-contained: copied, compared and dropped freely, with
 // nothing to free. Resolving it back to a live pointer stays with the module

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -29,7 +29,7 @@ void Input_Shutdown(void);
 void Input_Update(void);
 
 // Reconciles the connected devices with the current configuration: enabled
-// backends acquire whatever hardware is present, disabled ones release it.
+// backends acquire the hardware that is present, disabled ones release it.
 void Input_Discover(void);
 void Input_Reset(void);
 

--- a/src/trx/game/inventory.c
+++ b/src/trx/game/inventory.c
@@ -241,7 +241,7 @@ void Inv_SetState(const INVENTORY_STATE *const state)
         }
     }
     // The compass and the stopwatch are not carried so much as always to hand,
-    // so they are put back whatever the state says.
+    // so they are put back regardless of what the state says.
     Inv_EnsureItem(O_STOPWATCH_OPTION);
     Inv_EnsureItem(O_COMPASS_OPTION);
     Inv_EnsureItem(O_GLOBE_SELECT_OPTION);

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -165,7 +165,7 @@ void Item_InitialiseItems(const int32_t num_items)
         m_Items[i].properties = (ITEM_PROPERTY_SET) {};
     }
 
-    // A handle retained across a level change must not rebind to whatever now
+    // A handle retained across a level change must not rebind to what now
     // occupies the same slot index, so the whole pool is retired at once.
     if (m_ItemHandles.gens == nullptr) {
         Handle_RegistryInit(&m_ItemHandles, m_ItemGens, MAX_ITEMS);

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -92,7 +92,7 @@ void Item_DetachFromRoom(int16_t item_num);
 // live play when it goes on.
 void Item_AddSimulated(int16_t item_num);
 
-// Take the item off the simulation list, whatever put it there. Fires
+// Take the item off the simulation list, however it got there. Fires
 // on_leave_sim during live play if it was simulated.
 void Item_RemoveSimulated(int16_t item_num);
 

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -75,8 +75,8 @@ bool Item_IsInactive(const ITEM *const item)
 
 bool Item_IsAlive(const ITEM *const item)
 {
-    // A removed item is gone whatever its hit points say. An object's own test
-    // reads those, and a destroyed item keeps whatever it had.
+    // A removed item is gone regardless of its hit points. An object's own test
+    // reads those, and a destroyed item keeps the ones it had.
     if (item->is_destroyed) {
         return false;
     }
@@ -167,9 +167,9 @@ void Item_TakeDamage(
         Stats_AddKill();
     }
 
-    // A kill deals an item whatever it has left, which is nothing once it is
-    // already down, and Lara's death paths leave her below zero. Neither is a
-    // hit worth reporting.
+    // A kill deals an item the hit points it has left, which is nothing once it
+    // is already down, and Lara's death paths leave her below zero. Neither is
+    // a hit worth reporting.
     if (damage > 0) {
         const LUA_EVENT_ARG args[] = {
             { .type = LUA_EVENT_ARG_INT32,

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -207,9 +207,9 @@ void Lara_InitialiseInventory(const GF_LEVEL *const level)
     if (resume != nullptr) {
         Inv_SetState(&resume->inv);
         if (Gun_HasInfiniteAmmo(LGT_PISTOLS)) {
-            // The pistols never run out, whatever the level she is arriving
-            // from left in the resume info, and what she has none of she
-            // carries no rounds for.
+            // The pistols never run out, regardless of what the level she is
+            // arriving from left in the resume info, and what she has none of
+            // she carries no rounds for.
             Inv_SetAmmo(
                 LGT_PISTOLS,
                 Inv_HasItem(O_PISTOL_ITEM) ? Gun_GetInitialRounds(LGT_PISTOLS)

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -348,8 +348,8 @@ void Lara_Skin_Initialise(void)
     }
 
     // A level need not carry the swap objects: a title that never shows her
-    // has no use for them. No outfit is applied then, and she keeps whatever
-    // meshes the level loaded for her. A level that does hold her and not them
+    // has no use for them. No outfit is applied then, and she keeps the meshes
+    // the level loaded for her. A level that does hold her and not them
     // used to fail an assertion here, and is still an incomplete install.
     if (!M_CanDress()) {
         if (GF_GetCurrentLevel() != nullptr && Object_Get(O_LARA)->loaded) {

--- a/src/trx/game/lara/skin/seam.c
+++ b/src/trx/game/lara/skin/seam.c
@@ -13,7 +13,7 @@ static bool M_VertexMatches(const XYZ_32 a, const XYZ_32 b)
 // Applies the exact inverse of "to"'s rotation to a world-space vector. The
 // entries are quantized to 1/(1<<W2V_SHIFT), so the transpose is only an
 // approximate inverse, and the leftover error reads as a hairline crack
-// between welded meshes; the adjugate stays exact for whatever rotation the
+// between welded meshes; the adjugate stays exact for any rotation the
 // matrix holds.
 static XYZ_F M_UndoRotation(
     const MATRIX *const to, const double dx, const double dy, const double dz)

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -284,7 +284,7 @@ static const FIELD_DESC m_Fields[] = {
 TYPE_DEFINE(ITEM, m_Fields)
 
 // The generation carried by the handle is what keeps an index from silently
-// rebinding to whatever item recycled the slot; Item_FromHandle checks it.
+// rebinding to the item that recycled the slot; Item_FromHandle checks it.
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
     return Item_FromHandle(ref->handle);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -737,7 +737,7 @@ MUSIC_TRACK_STATE *Music_GetTrackState(const MUSIC_ID track_id)
 
 void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
 {
-    // An antitrigger aimed at track 0 silences whatever plays.
+    // An antitrigger aimed at track 0 silences the track that is playing.
     if (track_id == (MUSIC_ID)0 && trigger->kind == MUSIC_TRIGGER_ANTI) {
         Music_Stop();
         return;

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -72,7 +72,7 @@ static const OBJECT_PROPERTY_ENTRY *M_GetObjectEntry(
 
 // Whether the property will take the value at all, asked without an item to
 // take it to: the member's width first, as in Field_Set, since the fit is a
-// property of the storage rather than of what the value means, then whatever
+// property of the storage rather than of what the value means, then what
 // the property itself says. A property with no member has no width to be held
 // to.
 //

--- a/src/trx/game/objects/property.h
+++ b/src/trx/game/objects/property.h
@@ -94,8 +94,8 @@ typedef OBJECT_PROPERTY_SET ITEM_PROPERTY_SET;
     }
 
 // A property an item carries in a member of its own rather than in what its
-// object keeps privately: one the engine reads for every object, whatever it
-// is. `set_` may be nullptr.
+// object keeps privately: one the engine reads for every object, of any kind.
+// `set_` may be nullptr.
 #define OBJECT_PROPERTY_ITEM(member_, value_, check_, set_, description_)      \
     {                                                                          \
         .name = #member_,                                                      \

--- a/src/trx/game/output/lights/tr4.c
+++ b/src/trx/game/output/lights/tr4.c
@@ -909,7 +909,7 @@ static void M_CreateFogPos(M_FOG_BULB *const bulb)
 }
 
 // Port of the OG ControlFXBulb (polyinsert.cpp:379), sans the smoke spawns
-// (those are the responsibility of whatever triggered the bulb).
+// (those are the responsibility of what triggered the bulb).
 static void M_ControlFXBulb(M_FOG_BULB *const bulb)
 {
     if (bulb->timer > 0) {

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -636,7 +636,7 @@ static void M_DrawBakedGroupRanges(
 // see-through faces. Sorting its faces cannot order a part against another it
 // is buried in, so the depth buffer does it instead: the solid part lays down
 // its depth, and then only the surface that depth kept is blended, once. It
-// happens where the object sorts, so whatever is in front of it still comes
+// happens where the object sorts, so what is in front of it still comes
 // after.
 static void M_DrawBakedGroup(
     MESH_BATCHER *const batcher, const int32_t group_idx)

--- a/src/trx/game/phase/phase_cutscene.c
+++ b/src/trx/game/phase/phase_cutscene.c
@@ -42,7 +42,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     }
     Game_SetIsPlaying(true);
     Lara_SetControllable(false);
-    // The same event a played level fires: whatever the level is, this is the
+    // The same event a played level fires: for any level, this is the
     // moment it starts running.
     // A cutscene level is never resumed from a save.
     LUA_FireEventBool(LUA_EVENT_GAME_START, false);

--- a/src/trx/game/phase/phase_demo.c
+++ b/src/trx/game/phase/phase_demo.c
@@ -43,7 +43,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     p->state = STATE_RUN;
     Game_SetIsPlaying(true);
 
-    // The same event a played level fires: whatever the level is, this is the
+    // The same event a played level fires: for any level, this is the
     // moment it starts running.
     // A demo is never resumed from a save.
     LUA_FireEventBool(LUA_EVENT_GAME_START, false);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -329,7 +329,7 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
 
     M_SetupWaterStatus(Room_Get(item->room_num));
 
-    // A fading body scales down whatever tint is already in force rather than
+    // A fading body scales down the tint already in force rather than
     // replacing it, so it keeps the water color it is lying in.
     const bool is_fading = item->fade > 0;
     if (is_fading) {

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -57,7 +57,8 @@ typedef struct M_SAMPLE_ENTRY {
 
 static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 // One generation per slot, bumped when a slot is handed to a new voice, so a
-// script handle to a finished voice does not address whatever replaced it.
+// script handle to a finished voice does not address the voice that replaced
+// it.
 static uint32_t m_SlotGens[M_MAX_ACTIVE_SOUNDS];
 static HANDLE_REGISTRY m_SlotHandles;
 static bool m_Initialised = false;
@@ -617,7 +618,7 @@ int32_t Sound_Effect_Direct(
         sound->pos_ptr = nullptr;
     }
     M_ClearActiveSoundHandles(sound);
-    // The slot now holds a new voice, so a handle to whatever was here before
+    // The slot now holds a new voice, so a handle to the one here before
     // must stop resolving. The WAIT and LOOPED early returns above keep an
     // existing voice, and its handle, alive.
     const int32_t slot = (int32_t)(sound - m_ActiveSounds);

--- a/src/trx/game/sound/common.h
+++ b/src/trx/game/sound/common.h
@@ -74,7 +74,7 @@ bool Sound_GetActiveSlot(int32_t slot, SAMPLE_ID *out_sample_id);
 
 // A handle to the voice currently in the slot, and the sample a handle still
 // names or false. Each play hands the slot to a new voice; the generation is
-// what keeps a handle from addressing whatever later took its slot.
+// what keeps a handle from addressing the voice that later took its slot.
 TRX_HANDLE Sound_GetActiveSlotHandle(int32_t slot);
 bool Sound_ResolveActiveSlot(TRX_HANDLE handle, SAMPLE_ID *out_sample_id);
 

--- a/src/trx/game/ui/scaler.h
+++ b/src/trx/game/ui/scaler.h
@@ -14,7 +14,7 @@ float UI_Scaler_Calc(float unit, UI_SCALER_TARGET target);
 float UI_Scaler_CalcInverse(float unit, UI_SCALER_TARGET target);
 
 // The size everything text-shaped is drawn at: the player's text scale, times
-// whatever fit factor is currently pushed. Widgets size themselves from this
+// the fit factor currently pushed. Widgets size themselves from this
 // rather than from the config, so a subtree can be scaled as a whole.
 float UI_Scaler_GetTextScale(void);
 

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -410,7 +410,7 @@ static size_t M_WordWrap(
             }
 
             // Compute width (sum widths + spacing). The spacing after the last
-            // glyph counts too: whatever follows the word is a space, which
+            // glyph counts too: what follows the word is a space, which
             // M_Process draws after that spacing.
             float word_width = 0.0f;
             for (size_t j = i; j < i + word_len; j++) {

--- a/tools/lint/checks/lua_module_order
+++ b/tools/lint/checks/lua_module_order
@@ -9,7 +9,7 @@ from harness import LintWarning, repo_check
 from shared.paths import SRC_DIR
 
 # api.module("name", { order = N, ... }) - the order the module takes in the
-# generated reference. Two modules sharing one leave their pages in whatever
+# generated reference. Two modules sharing one leave their pages in the
 # order the sort happens to settle on.
 MODULE_RE = re.compile(
     r"""api\.module\(\s*"([^"]+)"\s*,\s*\{[^}]*?\border\s*=\s*(\d+)""",

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -244,7 +244,7 @@ def anchored(path: str) -> str:
 
 
 def where() -> str:
-    """The declaration whatever is being read sits in.
+    """The declaration the text being read sits in.
 
     Most of what the writer needs: the same name can be written in a dozen
     places, and only one of them has to move.

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -290,12 +290,14 @@ def linked_prose(text: str) -> str:
 
 
 def typed(spec: dict) -> str:
-    """The type a declaration reads as.
+    """The type a declaration reads as, and whether it holds one or many.
 
     A number that names an enum is that enum: `trx.assault.Track` says what
-    `integer` does not, and the constants are a link away.
+    `integer` does not, and the constants are a link away. `list` says the
+    declaration holds several of them, which a description used to.
     """
-    return type_names(spec["type"])
+    named = type_names(spec["type"])
+    return f"a list of {named}" if spec.get("list") else named
 
 
 def type_names(name) -> str:
@@ -486,8 +488,7 @@ def one_return(spec: dict) -> str:
     A row that has a type of its own says `list` and names it; one declared
     where it is returned spells its keys out below instead.
     """
-    named = typed(spec)
-    bits = [f"a list of {named}" if spec.get("list") else named]
+    bits = [typed(spec)]
     if spec.get("nullable"):
         bits.append("or `nil`")
     return f"{' '.join(bits)}. {describe(spec)}".rstrip()
@@ -973,6 +974,10 @@ def blank_args(spec: dict, path: str) -> list[str]:
     A parameter renders as its name and its type, and a result as its type
     alone, so one with no words leaves the reader to guess what it is for from
     the name. A `ref` counts as words: it says what the number is.
+
+    A result holding several of something is named by the call that hands it
+    back, and the words left to write above get_property_names would be "the
+    names".
     """
     out = []
     for param in spec.get("params") or []:
@@ -983,7 +988,7 @@ def blank_args(spec: dict, path: str) -> list[str]:
                 out.append(f"{path}({param['name']}) -> {arg['name']}")
     returns = spec.get("returns")
     for one in returns if isinstance(returns, list) else [returns] if returns else []:
-        if not documented(one):
+        if not documented(one) and not one.get("list"):
             out.append(f"{path} returns {one['type']}")
     return out
 

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -168,6 +168,17 @@ def keys_of(spec: dict, path: str) -> set[str]:
     return out
 
 
+def container_path(container: dict) -> str:
+    """What a container is written as.
+
+    A module is indexed on itself; a collection a module hands out has a name
+    of its own, and `trx.sound.samples` is what a script writes.
+    """
+    if container.get("member"):
+        return f"{container['module']}.{container['member']}"
+    return container["module"]
+
+
 def anchors_of(api: dict) -> set[str]:
     """Every path a declaration can be pointed at by.
 
@@ -177,6 +188,7 @@ def anchors_of(api: dict) -> set[str]:
     too, since a script writes `trx.lara.air` and not the type's own path.
     """
     out = {module["name"] for module in api["modules"]}
+    out.update(container_path(c) for c in api.get("containers", []))
     for group in ("numbers", "units", "enums", "functions", "properties", "namespaces", "constants"):
         out.update(entry["path"] for entry in api.get(group, []))
     for group in ("functions", "namespaces"):
@@ -720,7 +732,7 @@ def render_container(name: str, spec: dict) -> list[str]:
     at(name)
     key, value = spec["key"], spec["value"]
     nullable = " or `nil`" if value.get("nullable") else ""
-    out = ["### Indexing", ""]
+    out = []
     if spec.get("description"):
         out.extend(render_prose(spec["description"], ""))
         out.append("")
@@ -801,11 +813,12 @@ def render_page(module: dict, api: dict) -> str:
     ]
     units = [u for u in api.get("units", []) if u["path"].startswith(f"{name}.")]
 
-    container = next(
-        (c for c in api.get("containers", []) if c["module"] == name), None
-    )
-    if container:
-        out.extend(render_container(name, container))
+    mine = [c for c in api.get("containers", []) if c["module"] == name]
+    if mine:
+        out.append("### Indexing")
+        out.append("")
+        for container in mine:
+            out.extend(render_container(container_path(container), container))
 
     # A group raised by a property declaration has nothing to say that its
     # members do not: the properties carry the full dotted path already.
@@ -904,7 +917,7 @@ def read(api: dict) -> None:
         if isinstance(accepted, list):
             accepted = next((one for one in accepted if one in ENUM_PATHS), None)
         if accepted:
-            KEYED_BY[container["module"]] = accepted
+            KEYED_BY[container_path(container)] = accepted
     for enum in api.get("enums", []):
         ENUM_PATHS.add(enum["path"])
         CONSTANTS[enum["path"]] = {
@@ -946,7 +959,7 @@ def undocumented(api: dict) -> list[str]:
             out.append(space["path"])
     for container in api.get("containers", []):
         if not container.get("description"):
-            out.append(f"{container['module']}[]")
+            out.append(f"{container_path(container)}[]")
     for enum in api.get("enums", []):
         for value in enum.get("values") or []:
             if not value.get("description"):
@@ -1081,10 +1094,10 @@ def descriptions(api: dict) -> list[tuple[str, str]]:
     for spec in api.get("types", []):
         walk(spec, spec["path"])
     for container in api.get("containers", []):
-        walk(container, container["module"])
+        walk(container, container_path(container))
         for side in ("key", "value"):
             if container.get(side):
-                walk(container[side], container["module"])
+                walk(container[side], container_path(container))
     return out
 
 
@@ -1214,7 +1227,7 @@ def walk(api: dict) -> list[tuple[str, dict]]:
     for container in api.get("containers", []):
         for side in ("key", "value"):
             if container.get(side):
-                rec(container[side], f"{container['module']}[{side}]")
+                rec(container[side], f"{container_path(container)}[{side}]")
     return out
 
 

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -481,7 +481,13 @@ def render_params(params: list[dict] | None, indent: str) -> list[str]:
 
 
 def one_return(spec: dict) -> str:
-    bits = [typed(spec)]
+    """What a call hands back, and whether it hands back one or many of them.
+
+    A row that has a type of its own says `list` and names it; one declared
+    where it is returned spells its keys out below instead.
+    """
+    named = typed(spec)
+    bits = [f"a list of {named}" if spec.get("list") else named]
     if spec.get("nullable"):
         bits.append("or `nil`")
     return f"{' '.join(bits)}. {describe(spec)}".rstrip()

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -231,9 +231,19 @@ def anchored(path: str) -> str:
     return at
 
 
+def where() -> str:
+    """The declaration whatever is being read sits in.
+
+    Most of what the writer needs: the same name can be written in a dozen
+    places, and only one of them has to move.
+    """
+    return f" in `trx.{CONTEXT}`" if CONTEXT else ""
+
+
 def unknown(path: str) -> str:
+    """A name that lands nowhere, and the declaration it was read from."""
     return (
-        f"error: `trx.{path}` names nothing the API declares.\n"
+        f"error: `trx.{path}`{where()} names nothing the API declares.\n"
         f"  fix the reference in src/lua/api/, or declare what it names"
     )
 
@@ -305,7 +315,7 @@ def type_name(name: str) -> str:
     if name in TYPE_PATHS or name in ENUM_PATHS or name in NUMBERS or name in UNITS:
         return link(name, f"trx.{name}")
     if "." in name:
-        raise SystemExit(f"error: type `{name}` names no declared type")
+        raise SystemExit(f"error: type `{name}`{where()} names no declared type")
     return name
 
 

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -674,7 +674,7 @@ def render_type(spec: dict) -> list[str]:
             out.extend(
                 render_lead(
                     f"{INDENT}- {anchor(spec['path'] + '.' + field['name'])}"
-                    f"**`{field['name']}`**: {typed(field)}. ",
+                    f"**`{field['name']}`**: {render_bits(field)}. ",
                     f"{describe(field)}{suffix}".lstrip(),
                     f"{INDENT}  ",
                 )

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -729,6 +729,11 @@ def render_type(spec: dict) -> list[str]:
 
 
 def render_container(name: str, spec: dict) -> list[str]:
+    """A collection, and what a script may index it with.
+
+    The key is named as well as the value: strict mode holds a script to it, so
+    a reader who is handed an error about it has somewhere to have read it.
+    """
     at(name)
     key, value = spec["key"], spec["value"]
     nullable = " or `nil`" if value.get("nullable") else ""
@@ -739,7 +744,7 @@ def render_container(name: str, spec: dict) -> list[str]:
     out.extend(
         render_lead(
             f"- {anchor(name + '[]')}**`trx.{name}[key]`** "
-            f"({typed(value)}{nullable}). ",
+            f"(key: {typed(key)}, value: {typed(value)}{nullable}). ",
             describe(key),
             "  ",
         )

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -930,15 +930,22 @@ def read(api: dict) -> None:
 def documented(spec: dict) -> bool:
     """Whether the reader is told anything: its own words, or the type it holds.
 
-    A declaration typed by an enum, a number or a unit needs no words of its
-    own: what it is, and what it may be, is what the type says.
+    A declaration typed by something this surface declares needs no words of
+    its own: what it is, and what it may be, is what the type says, on the page
+    the reader is a link away from. Words that only name the type again read as
+    an afterthought hanging off it.
     """
     if spec.get("description"):
         return True
     named = spec.get("type")
     if isinstance(named, list):
         return True
-    return named in ENUM_PATHS or named in NUMBERS or named in UNITS
+    return (
+        named in TYPE_PATHS
+        or named in ENUM_PATHS
+        or named in NUMBERS
+        or named in UNITS
+    )
 
 
 def undocumented(api: dict) -> list[str]:

--- a/tools/lint/gen/lua_docs
+++ b/tools/lint/gen/lua_docs
@@ -648,7 +648,10 @@ def render_type(spec: dict) -> list[str]:
         out.append(f"{INDENT}Properties:")
         for field in spec["fields"]:
             at(f"{spec['path']}.{field['name']}")
-            suffix = "" if field.get("writable") else " *(read-only)*"
+            # A handle's field addresses a struct member and a Lua class's is a
+            # pair of accessors, so either may be read-only. A record a call
+            # hands back says nothing either way, and carries no key.
+            suffix = "" if field.get("writable") is not False else " *(read-only)*"
             out.extend(
                 render_lead(
                     f"{INDENT}- {anchor(spec['path'] + '.' + field['name'])}"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reworks the registry behind `trx.*` so that a declaration carries what the reference used to spell out in prose, and so that strict mode can hold a script to more of it. The registry is now one table of entries keyed by path, and each kind of declaration says in one place how it is made, how it reads in the docs, and how it is ordered there.

- A table a call takes or hands back is declared as a type of its own, and named where it is used. `trx.math.Vec3`, `trx.math.Rot`, `trx.lua.Error`, `trx.strings.Match`, `trx.console.Command`, `trx.config.Shape` and `trx.assault.Record` replace seven results that were typed `table` with their keys written out again at each place that passed them.
- A declaration that holds several of something says `list`, so the reference reads "a list of `trx.game.Level`" rather than leaving it to a sentence that could go stale.
- A module that hands out a collection declares it. `trx.sound.samples`, `trx.sound.streams`, `trx.music.tracks` and `trx.music.streams` were hand-rolled tables behind a property, invisible to the reference; each now has an Indexing entry saying what it is keyed by, what it holds, and where it counts from.
- Where a collection counts from belongs to the number its key names, so a container keyed by an item number counts as items do without saying so twice.
- Strict mode checks the keys of a table a script writes out, the entries of a list one at a time, and what a collection is indexed with. A typo in an options table used to read as nothing at all.

Before this, the registry kept what a declaration built across a table per question, and the parts of a declaration that were not checkable were carried in the description instead: a result's keys, whether it held one or many, what a module's collection was keyed by. That prose is not linked, not checked, and is written again at every place that passes the same table, so it drifted. A collection reached through a property was worse than undocumented — the reference had nowhere to put it at all.

For mod authors, two utility modules come along:

```lua
trx.json.encode(value)      -- a value as JSON, on one line, keys sorted
trx.strings.dedent(text)    -- the shared indent off a [[ ]] block
```

Both were already written inside the registry, which had no business knowing how a string is escaped or how a block of prose is laid out. They move out and are declared like anything else.

Everything a script already wrote goes on working with checking off; with `trx.api.strict(true)` on, a table with a key nothing declares, a list holding the wrong type, or a fractional collection index now raises where it used to reach C.
