### PR TITLE
installer: explain a failed download

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
 - changed skidoo and quad bike crashes to not kill Lara when she is immune
 - changed Lara to say "No" when attempting to use the binoculars when it is not possible to do so
+- changed the installer to explain when it cannot download the files it needs, and to offer to try again (#6052)
 - fixed the sun's glare staying on screen in cutscenes once the camera has looked away from it
 - fixed exploding deaths in TR4 showing no flames or explosions
 - fixed Lara's shadow in TR4 being darker than in the original game

--- a/tools/installer/TRX_Installer/DownloadFailedException.cs
+++ b/tools/installer/TRX_Installer/DownloadFailedException.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Net.Http;
+
+namespace TRX_Installer;
+
+// A download that did not finish, described in terms of what the person running
+// the installer can act on. The framework exception it wraps stays available for
+// the log.
+internal class DownloadFailedException : Exception
+{
+    public DownloadFailedException(string url, Exception innerException)
+        : base(BuildMessage(url, innerException), innerException)
+    {
+    }
+
+    private static string BuildMessage(string url, Exception innerException)
+    {
+        string reason = innerException switch
+        {
+            HttpRequestException { StatusCode: not null } ex
+                => $"the server answered with {(int)ex.StatusCode} ({ex.StatusCode}).",
+            TaskCanceledException => "the connection timed out.",
+            _ => "the installer could not reach the server.",
+        };
+
+        return $"Could not download {Path.GetFileName(url)}: {reason}"
+            + Environment.NewLine
+            + Environment.NewLine
+            + "The installer downloads part of what it installs, so it needs "
+            + "internet access. Check that you are online and that no firewall "
+            + "or antivirus is stopping the installer from connecting, then "
+            + "press Retry."
+            + Environment.NewLine
+            + Environment.NewLine
+            + $"The file it was fetching is {url}";
+    }
+}

--- a/tools/installer/TRX_Installer/InstallerService.cs
+++ b/tools/installer/TRX_Installer/InstallerService.cs
@@ -107,14 +107,23 @@ internal class InstallerService
         progress.SetDescription($"Downloading {fileName}...");
         progress.SetSubDescription("Starting download...");
         progress.AppendLog($"Downloading {url}");
-        using HttpResponseMessage response = await HttpClient.GetAsync(
-            url, HttpCompletionOption.ResponseHeadersRead);
-        response.EnsureSuccessStatusCode();
 
-        long? totalBytes = response.Content.Headers.ContentLength;
-        using Stream responseStream = await response.Content.ReadAsStreamAsync();
         using MemoryStream stream = new();
-        await CopyToMemoryStreamAsync(responseStream, stream, totalBytes, progress);
+        try
+        {
+            using HttpResponseMessage response = await HttpClient.GetAsync(
+                url, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+
+            long? totalBytes = response.Content.Headers.ContentLength;
+            using Stream responseStream = await response.Content.ReadAsStreamAsync();
+            await CopyToMemoryStreamAsync(responseStream, stream, totalBytes, progress);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or TaskCanceledException)
+        {
+            throw new DownloadFailedException(url, ex);
+        }
+
         stream.Position = 0;
         await ExtractZipAsync(stream, targetDirectory, progress);
     }

--- a/tools/installer/TRX_Installer/MainWindow.xaml
+++ b/tools/installer/TRX_Installer/MainWindow.xaml
@@ -159,6 +159,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
@@ -175,7 +176,13 @@
                              Minimum="0"
                              Maximum="{Binding InnerMaximumProgress}"
                              Value="{Binding InnerCurrentProgress}" />
-                <TextBox x:Name="_logTextBox" Grid.Row="5" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
+                <Border Grid.Row="5" Margin="0,0,0,12" Padding="10"
+                        Background="#FFF4F4" BorderThickness="1" BorderBrush="#E0A0A0"
+                        Visibility="{Binding InstallFailed, Mode=OneWay, Converter={StaticResource BoolToVisible}}">
+                    <TextBlock TextWrapping="Wrap" Foreground="#A00000"
+                               Text="{Binding InstallErrorMessage, Mode=OneWay}" />
+                </Border>
+                <TextBox x:Name="_logTextBox" Grid.Row="6" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
                          VerticalScrollBarVisibility="Auto"
                          Text="{Binding LogText, Mode=OneWay}" />
             </Grid>

--- a/tools/installer/TRX_Installer/MainWindow.xaml.cs
+++ b/tools/installer/TRX_Installer/MainWindow.xaml.cs
@@ -104,6 +104,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged, IInstallerProg
     public string NextButtonText => CurrentStep switch
     {
         InstallerStep.Setup => "_Install",
+        InstallerStep.Installing when InstallFailed => "_Retry",
         _ => "_Next >",
     };
 
@@ -166,6 +167,37 @@ public partial class MainWindow : Window, INotifyPropertyChanged, IInstallerProg
             }
             _installSubDescription = value;
             OnPropertyChanged();
+        }
+    }
+
+    // What went wrong, in the words of the person who has to fix it. The log
+    // below it keeps the framework's own account.
+    public string InstallErrorMessage
+    {
+        get => _installErrorMessage;
+        set
+        {
+            if (value == _installErrorMessage)
+            {
+                return;
+            }
+            _installErrorMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool InstallFailed
+    {
+        get => _installFailed;
+        set
+        {
+            if (value == _installFailed)
+            {
+                return;
+            }
+            _installFailed = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(NextButtonText));
         }
     }
 
@@ -295,6 +327,8 @@ public partial class MainWindow : Window, INotifyPropertyChanged, IInstallerProg
     private bool _createShortcut;
     private string _installDescription = string.Empty;
     private string _installSubDescription = string.Empty;
+    private string _installErrorMessage = string.Empty;
+    private bool _installFailed;
     private int _outerCurrentProgress;
     private int _outerMaximumProgress = 1;
     private int _innerCurrentProgress;
@@ -307,7 +341,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged, IInstallerProg
 
     private async void Next_Click(object sender, RoutedEventArgs e)
     {
-        if (CurrentStep == InstallerStep.Setup)
+        if (CurrentStep == InstallerStep.Setup || InstallFailed)
         {
             await RunInstallAsync();
         }
@@ -433,6 +467,8 @@ public partial class MainWindow : Window, INotifyPropertyChanged, IInstallerProg
 
         CurrentStep = InstallerStep.Installing;
         _installFinished = false;
+        InstallFailed = false;
+        InstallErrorMessage = string.Empty;
         LogText = string.Empty;
         InstallSubDescription = string.Empty;
         OuterCurrentProgress = 0;
@@ -446,8 +482,13 @@ public partial class MainWindow : Window, INotifyPropertyChanged, IInstallerProg
         }
         catch (Exception ex)
         {
+            InstallFailed = true;
             InstallDescription = "Installation failed.";
-            InstallSubDescription = "See the log for details.";
+            InstallSubDescription = string.Empty;
+            InstallErrorMessage = ex is DownloadFailedException
+                ? ex.Message
+                : $"{ex.Message}{Environment.NewLine}{Environment.NewLine}"
+                    + "The log below has the details.";
             ((IInstallerProgress)this).AppendLog(ex.ToString());
         }
         finally


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A download the installer cannot make now stops the run with a message naming the file, the reason, and what to check - being online, and whether a firewall or antivirus is in the way. The Next button becomes Retry, so the run no longer carries on to the page announcing success. The framework's own account of the error stays in the log.

Resolves #6052 / TRX903

