### PR TITLE
Let a game say which weapons never run out

### DIFF
--- a/data/trx/ship/games/tr1/weapons.json5
+++ b/data/trx/ship/games/tr1/weapons.json5
@@ -39,6 +39,7 @@
             "initial_shots": 32,
             "box_shots": 32,
             "box_label_qty": 2,
+            "infinite": true,
         },
         "target_dist": 8.0,
         "recoil_frame": 9,

--- a/data/trx/ship/games/tr2/weapons.json5
+++ b/data/trx/ship/games/tr2/weapons.json5
@@ -38,6 +38,7 @@
             "initial_shots": 32,
             "box_shots": 32,
             "box_label_qty": 2,
+            "infinite": true,
         },
         "target_dist": 8.0,
         "recoil_frame": 9,
@@ -346,6 +347,9 @@
         "shot_accuracy": 8,
         "gun_height": 400,
         "damage": 3,
+        "ammo": {
+            "infinite": true,
+        },
         "target_dist": 8.0,
         "recoil_frame": 0,
         "flash_time": 2,

--- a/data/trx/ship/games/tr3/weapons.json5
+++ b/data/trx/ship/games/tr3/weapons.json5
@@ -29,6 +29,7 @@
             "initial_shots": 32,
             "box_shots": 32,
             "box_label_qty": 2,
+            "infinite": true,
         },
         "target_dist": 8.0,
         "recoil_frame": 9,
@@ -344,6 +345,9 @@
         "shot_accuracy": 8,
         "gun_height": 400,
         "damage": 3,
+        "ammo": {
+            "infinite": true,
+        },
         "target_dist": 8.0,
         "recoil_frame": 0,
         "flash_time": 2,

--- a/data/trx/ship/games/tr4/weapons.json5
+++ b/data/trx/ship/games/tr4/weapons.json5
@@ -29,6 +29,7 @@
             "initial_shots": 32,
             "box_shots": 32,
             "box_label_qty": 2,
+            "infinite": true,
         },
         "target_dist": 8.0,
         "recoil_frame": 9,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - changed the `/give` console command to autocomplete what it can hand over and to reach the savegame crystal by name; `/give keys` now covers the plot items alone, and `/keys`, `/guns` and `/moreguns` are commands of their own
 - changed the `/spawn`, `/kill` and `/tp` console commands to accept a family such as `pickup`, `door` or `enemy` in place of a name, and to offer the families each of them can act on in autocompletion
 - changed the `/tp` console command to place Lara better at whatever she is sent to
+- changed the developer console to accept the numpad Enter key for issuing commands (#6056)
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
 - changed the save crystals option to a mode: crystals can save on the spot, be collected to save from the inventory as on PS1 TR3, heal, or be collectibles (Gameplay → General → Crystal mode) (#5939)
 - changed the Target change option to allow selecting TR4 behavior, where tapping Look switches target and holding it looks around (Gameplay → Controls → Target change)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - changed object properties to take effect as soon as they change, rather than only when the item is first set up
 - changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed New Game+ in TR1 so that flares Lara has collected are kept between levels rather than taken away at the start of each one
+- added an `ammo.infinite` key to `weapons.json5`, saying which weapons and flares never run out; a game that takes it away from the pistols makes their clips worth collecting
 - changed the ammunition keys in `weapons.json5` to say what they count; refer to migration notes
 - changed boxes of ammunition in the inventory to always show what Lara is really carrying, where finishing a level could round them down
 - fixed the alternative ammunition pickups, such as the second kind of shotgun ammunition, going into the inventory without loading the weapon
@@ -163,7 +164,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `p`, a global shorthand for `trx.console.log`, and made the console log functions take any value, pretty-printing a table
 - added a new Lua module, `trx.math`, with the engine's own fixed-point trigonometry and the `DEG_1`, `DEG_45`, `DEG_90` and `WALL_L` constants
 - added a new Lua module, `trx.strings`, with `fuzzy_match()` and `regex_match()`
-- added a new Lua module, `trx.rules`, holding the numbers the game plays by; the first of them are the cold exposure ceiling, rates and damage, and how fast a dead enemy fades away
+- added a new Lua module, `trx.rules`, holding the numbers the game plays by
 - added a new Lua module, `trx.argparse`, a declarative argument parser inspired by Python's argparse
 - added a new Lua module, `trx.locale`, for the text the player reads, looked up by key
 - added a new Lua module, `trx.weather`, to read and set the runtime weather

--- a/docs/trx/WEAPONS.md
+++ b/docs/trx/WEAPONS.md
@@ -142,6 +142,11 @@ described in the table below.
     <td>Multiplier used in the inventory ring for each loose ammo pickup.</td>
   </tr>
   <tr valign="top">
+    <td><code>ammo.infinite</code></td>
+    <td>Boolean</td>
+    <td>Whether firing spends nothing, so that the weapon never runs out and shows no count in the inventory ring or the overlay. The pistols and the skidoo's guns have it; taking it away from the pistols makes pistol clips worth collecting. The flare answers to it as well, and a bonus game overrides it for everything.</td>
+  </tr>
+  <tr valign="top">
     <td><code>recoil_frame</code></td>
     <td>Integer</td>
     <td>For pistol type weapons, this value determines when Lara should snap back to the aiming frame after the weapon is fired i.e. Uzis have a lower value than Pistols for faster fire rate.</td>

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -187,6 +187,11 @@ OBJECT_ID Gun_GetAmmoObject(const LARA_GUN_TYPE gun_type)
     return NO_OBJECT;
 }
 
+bool Gun_HasInfiniteAmmo(const LARA_GUN_TYPE gun_type)
+{
+    return gun_type == LGT_PISTOLS;
+}
+
 int32_t Inv_GetAmmo(const LARA_GUN_TYPE gun_type)
 {
     return 0;

--- a/src/trx/game/game_flow/inventory.c
+++ b/src/trx/game/game_flow/inventory.c
@@ -251,8 +251,9 @@ void GF_InventoryModifier_ApplyToResumeInfo(const GF_LEVEL *const level)
         resume->gun_status = LGS_ARMLESS;
     }
 
-    if (!Inv_State_Has(&resume->inv, O_PISTOL_ITEM)
-        && m_Add2InvItems[O_PISTOL_ITEM]) {
+    const bool pistols_given = !Inv_State_Has(&resume->inv, O_PISTOL_ITEM)
+        && m_Add2InvItems[O_PISTOL_ITEM] != 0;
+    if (pistols_given) {
         Inv_State_SetCount(&resume->inv, O_PISTOL_ITEM, 1);
         if (resume->equipped_gun_type == LGT_UNARMED) {
             resume->equipped_gun_type = LGT_PISTOLS;
@@ -261,6 +262,14 @@ void GF_InventoryModifier_ApplyToResumeInfo(const GF_LEVEL *const level)
 
     if (m_RemoveAmmo) {
         memset(resume->inv.ammo, 0, sizeof(resume->inv.ammo));
+    }
+
+    // Pistols the game flow hands over come loaded, whatever else the level
+    // took away. An endless supply needs no such rounds: the count follows the
+    // gun, and Inv_State_SetCount has already written it.
+    if (pistols_given && !Gun_HasInfiniteAmmo(LGT_PISTOLS)) {
+        Inv_State_AddAmmo(
+            &resume->inv, LGT_PISTOLS, Gun_GetInitialRounds(LGT_PISTOLS));
     }
 
     if (m_RemoveScions) {

--- a/src/trx/game/gun/common.c
+++ b/src/trx/game/gun/common.c
@@ -2,6 +2,7 @@
 #include <trx/core/colors.h>
 #include <trx/debug.h>
 #include <trx/game/const.h>
+#include <trx/game/game.h>
 #include <trx/game/gun.h>
 #include <trx/game/lara.h>
 #include <trx/game/output.h>
@@ -176,6 +177,26 @@ LARA_GUN_TYPE Gun_GetHolsterChoice(const INVENTORY_STATE *const inv)
 LARA_GUN_TYPE Gun_GetBackChoice(const INVENTORY_STATE *const inv)
 {
     return M_GetFirstCarried(inv, m_BackGuns);
+}
+
+bool Gun_HasInfiniteAmmo(const LARA_GUN_TYPE gun_type)
+{
+    if (Game_IsBonusFlagSet(GBF_NGPLUS)) {
+        return true;
+    }
+    return M_IsWeapon(gun_type) && g_Weapons[gun_type].ammo.infinite;
+}
+
+bool Gun_HasRoundsLeft(const LARA_GUN_TYPE gun_type)
+{
+    return Gun_HasInfiniteAmmo(gun_type) || Inv_GetAmmo(gun_type) > 0;
+}
+
+void Gun_SpendRound(const LARA_GUN_TYPE gun_type)
+{
+    if (!Gun_HasInfiniteAmmo(gun_type)) {
+        Inv_AddAmmo(gun_type, -1);
+    }
 }
 
 bool Gun_IsRifleType(const LARA_GUN_TYPE gun_type)

--- a/src/trx/game/gun/common.h
+++ b/src/trx/game/gun/common.h
@@ -28,6 +28,15 @@ int32_t Gun_GetAmmoInventoryQuantity(LARA_GUN_TYPE gun_type);
 LARA_GUN_TYPE Gun_GetHolsterChoice(const INVENTORY_STATE *inv);
 LARA_GUN_TYPE Gun_GetBackChoice(const INVENTORY_STATE *inv);
 
+// Whether the weapon spends nothing when it fires, so that its rounds are
+// neither counted down nor shown to the player.
+bool Gun_HasInfiniteAmmo(LARA_GUN_TYPE gun_type);
+// Whether the weapon has anything left to fire. One that never runs out
+// always has.
+bool Gun_HasRoundsLeft(LARA_GUN_TYPE gun_type);
+// Takes the round a shot costs, from a weapon that spends any.
+void Gun_SpendRound(LARA_GUN_TYPE gun_type);
+
 bool Gun_IsRifleType(LARA_GUN_TYPE gun_type);
 bool Gun_IsSinglePistolType(LARA_GUN_TYPE gun_type);
 

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -44,6 +44,15 @@ static struct {
     { .gun_type = LGT_UNKNOWN, .input_role = (INPUT_ROLE)-1 },
 };
 
+// What Lara reaches for when the weapon in her hands has run dry: the pistols,
+// so long as she carries them and they have anything left to spend.
+static LARA_GUN_TYPE M_GetFallbackGunType(void)
+{
+    return Inv_HasItem(O_PISTOL_ITEM) && Gun_HasRoundsLeft(LGT_PISTOLS)
+        ? LGT_PISTOLS
+        : LGT_UNARMED;
+}
+
 static void M_CheckSmashablesBehindTarget(
     const ITEM *const target, const GAME_VECTOR start,
     const GAME_VECTOR hit_pos, const int32_t max_dist)
@@ -436,18 +445,17 @@ void Gun_Control(void)
         break;
 
     case LGS_READY:
-        const bool is_firing = Inv_GetAmmo(LGT_PISTOLS) != 0 && g_Input.action;
-        Lara_Skin_SetCombatFace(is_firing);
+        const bool has_rounds = Gun_HasRoundsLeft(lara->gun_type);
+        Lara_Skin_SetCombatFace(has_rounds && g_Input.action);
         M_RequestCombatCamera();
 
         if (g_Input.action) {
-            if (Inv_GetAmmo(lara->gun_type) <= 0) {
+            if (!has_rounds) {
                 Inv_SetAmmo(lara->gun_type, 0);
                 if (g_TRVersion >= 2) {
                     Sound_Effect(SFX_CLICK, &lara_item->pos, SPM_NORMAL);
                 }
-                lara->request_gun_type =
-                    Inv_HasItem(O_PISTOL_ITEM) ? LGT_PISTOLS : LGT_UNARMED;
+                lara->request_gun_type = M_GetFallbackGunType();
                 break;
             }
         }
@@ -503,25 +511,20 @@ int32_t Gun_FireWeapon(
 
     ASSERT(Inv_HasAmmoSlot(weapon_type));
 
-    // The pistols and what shoots from their supply never run down, and
-    // neither does anything in a bonus game.
-    if (weapon_type == LGT_PISTOLS || weapon_type == LGT_SKIDOO
-        || Game_IsBonusFlagSet(GBF_NGPLUS)) {
-        Inv_SetAmmo(weapon_type, 1000);
-    }
-    if (Inv_GetAmmo(weapon_type) <= 0) {
+    if (!Gun_HasRoundsLeft(weapon_type)) {
         Inv_SetAmmo(weapon_type, 0);
         if (g_TRVersion == 1) {
             Sound_Effect(SFX_LARA_EMPTY, &src->pos, SPM_NORMAL);
-            if (Inv_HasItem(O_PISTOL_ITEM)) {
-                lara->request_gun_type = LGT_PISTOLS;
-            } else {
+            const LARA_GUN_TYPE fallback = M_GetFallbackGunType();
+            if (fallback == LGT_UNARMED) {
                 lara->gun_status = LGS_UNDRAW;
+            } else {
+                lara->request_gun_type = fallback;
             }
         }
         return 0;
     }
-    Inv_AddAmmo(weapon_type, -1);
+    Gun_SpendRound(weapon_type);
     Stats_AddAmmoUsed();
     lara->has_fired = true;
 

--- a/src/trx/game/gun/rifle.c
+++ b/src/trx/game/gun/rifle.c
@@ -3,7 +3,6 @@
 #include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/game/camera.h>
-#include <trx/game/game.h>
 #include <trx/game/gun/common.h>
 #include <trx/game/gun/control.h>
 #include <trx/game/gun/misc.h>
@@ -41,6 +40,7 @@ typedef enum {
 
 static bool m_M16Firing = false;
 static bool m_ReloadHarpoon = false;
+static int32_t m_HarpoonShots = 0;
 
 static void M_SetTR3ProjectileShade(ITEM *const item)
 {
@@ -176,7 +176,7 @@ static void M_FireHarpoon(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (Inv_GetAmmo(LGT_HARPOON) <= 0) {
+    if (!Gun_HasRoundsLeft(LGT_HARPOON)) {
         goto finish;
     }
 
@@ -253,21 +253,23 @@ static void M_FireHarpoon(void)
         },
         nullptr, projectile_item->object_id);
 
-    Inv_AddAmmo(LGT_HARPOON, -1);
+    Gun_SpendRound(LGT_HARPOON);
     Stats_AddAmmoUsed();
 
 finish:
     const int32_t recoil = g_Config.gameplay.harpoon_recoil;
-    const bool is_ngplus = Game_IsBonusFlagSet(GBF_NGPLUS);
     if (recoil <= 0) {
-        if (is_ngplus) {
-            Inv_AddAmmo(LGT_HARPOON, 1);
-        }
-    } else if ((Inv_GetAmmo(LGT_HARPOON) % recoil) == 0) {
-        if (is_ngplus) {
-            Inv_AddAmmo(LGT_HARPOON, recoil);
-        }
-        m_ReloadHarpoon = Inv_GetAmmo(LGT_HARPOON) > 0;
+        return;
+    }
+    // The reload comes every few shots. A gun that spends its rounds reaches
+    // that point when the count divides by the interval; one that spends none
+    // counts the shots instead.
+    m_HarpoonShots = (m_HarpoonShots + 1) % recoil;
+    const int32_t count = Gun_HasInfiniteAmmo(LGT_HARPOON)
+        ? m_HarpoonShots
+        : Inv_GetAmmo(LGT_HARPOON);
+    if ((count % recoil) == 0) {
+        m_ReloadHarpoon = Gun_HasRoundsLeft(LGT_HARPOON);
     }
 }
 
@@ -275,7 +277,7 @@ static void M_FireGrenade(void)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
     const ITEM *const lara_item = Lara_GetItem();
-    if (Inv_GetAmmo(LGT_GRENADE) <= 0) {
+    if (!Gun_HasRoundsLeft(LGT_GRENADE)) {
         return;
     }
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_GRENADE];
@@ -352,9 +354,7 @@ static void M_FireGrenade(void)
         },
         nullptr, projectile_item->object_id);
 
-    if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
-        Inv_AddAmmo(LGT_GRENADE, -1);
-    }
+    Gun_SpendRound(LGT_GRENADE);
     Stats_AddAmmoUsed();
 
     Gun_Smoke_OnFire(LGT_GRENADE, true);
@@ -364,7 +364,7 @@ static void M_FireRocket(void)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
     const ITEM *const lara_item = Lara_GetItem();
-    if (Inv_GetAmmo(LGT_ROCKET) <= 0) {
+    if (!Gun_HasRoundsLeft(LGT_ROCKET)) {
         return;
     }
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_ROCKET];
@@ -415,9 +415,7 @@ static void M_FireRocket(void)
         },
         nullptr, projectile_item->object_id);
 
-    if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
-        Inv_AddAmmo(LGT_ROCKET, -1);
-    }
+    Gun_SpendRound(LGT_ROCKET);
     Stats_AddAmmoUsed();
 
     if (g_TRVersion >= 3) {

--- a/src/trx/game/gun/types.h
+++ b/src/trx/game/gun/types.h
@@ -21,6 +21,9 @@ typedef struct {
     int32_t box_shots;
     // What a box shows on its inventory icon, which follows nothing else.
     int32_t box_label_qty;
+    // Whether firing spends nothing, so that the weapon never runs out and
+    // carries no counter.
+    bool infinite;
 } WEAPON_AMMO_INFO;
 
 typedef struct {

--- a/src/trx/game/gun/vars.c
+++ b/src/trx/game/gun/vars.c
@@ -83,6 +83,7 @@ static void M_ReadAmmoInfo(JSON_OBJECT *const obj, const int32_t type)
         M_ReadAmmoValue(ammo_obj, "box_shots", "pickup_qty", ammo->box_shots);
     ammo->box_label_qty = M_ReadAmmoValue(
         ammo_obj, "box_label_qty", "inventory_qty", ammo->box_label_qty);
+    ammo->infinite = JSON_ObjectGetBool(ammo_obj, "infinite", ammo->infinite);
 }
 
 void Gun_LoadVars(const char *const path)

--- a/src/trx/game/gun/vars.c
+++ b/src/trx/game/gun/vars.c
@@ -7,6 +7,8 @@
 #include <trx/game/const.h>
 #include <trx/game/shell/common.h>
 
+#include <string.h>
+
 WEAPON_INFO g_Weapons[NUM_WEAPONS] = {};
 
 static void M_ReadAngles(
@@ -100,6 +102,9 @@ void Gun_LoadVars(const char *const path)
         Shell_ExitSystemFmt("invalid weapons vars file: %s", path);
     }
 
+    // Every weapon starts from nothing, so that what the file leaves out is
+    // absent rather than left over from the mod played before this one.
+    memset(g_Weapons, 0, sizeof(g_Weapons));
     for (int32_t i = 0; i < NUM_WEAPONS; i++) {
         g_Weapons[i].glow_scale = 1.0f;
     }

--- a/src/trx/game/inventory.c
+++ b/src/trx/game/inventory.c
@@ -41,11 +41,13 @@ static const INVENTORY_ENTRY *M_FindEntry(
 static void M_SetCount(
     INVENTORY_STATE *const state, const OBJECT_ID object_id, const int32_t qty)
 {
-    // The pistols' rounds are the supply that never runs out, so they follow
-    // the gun rather than anything she picked up. Left behind, they would draw
-    // boxes of clips she never found.
-    if (object_id == O_PISTOL_OPTION) {
-        Inv_State_SetAmmo(state, LGT_PISTOLS, qty > 0 ? 1000 : 0);
+    // While the pistols' supply never runs out, the number behind it stands
+    // for the gun rather than for anything she picked up. Left behind, it
+    // would draw boxes of clips she never found.
+    if (object_id == O_PISTOL_OPTION && Gun_HasInfiniteAmmo(LGT_PISTOLS)) {
+        Inv_State_SetAmmo(
+            state, LGT_PISTOLS,
+            qty > 0 ? Gun_GetInitialRounds(LGT_PISTOLS) : 0);
     }
 
     const int32_t idx = M_FindEntryIndex(state, object_id);
@@ -413,11 +415,12 @@ bool Inv_AddItem(const OBJECT_ID object_id)
         return true;
     }
 
-    // The pistols come with the supply that never runs out, as every other
-    // weapon arrives with the rounds it is picked up with.
+    // The pistols arrive loaded, as every other weapon arrives with the rounds
+    // it is picked up with. They are kept out of Item_GlobalReplace: a level
+    // that is not meant to hold them says so through the game flow.
     if (inv_object_id == O_PISTOL_OPTION) {
+        Inv_AddAmmo(LGT_PISTOLS, Gun_GetInitialRounds(LGT_PISTOLS));
         M_SetCount(&m_State, O_PISTOL_OPTION, 1);
-        Inv_SetAmmo(LGT_PISTOLS, 1000);
         if (lara->last_gun_type == LGT_UNARMED) {
             lara->last_gun_type = LGT_PISTOLS;
         }

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -111,11 +111,23 @@ static INV_RING_VISIBLE M_GetVisibleRing(const RING_TYPE type)
     return (INV_RING_VISIBLE) { .items = dst, .count = count };
 }
 
-static void M_ShowAmmoQuantity(const char *const fmt, const int32_t qty)
+// What Lara has for one weapon, and nothing at all where the number cannot run
+// down: a weapon that never runs out has none to show.
+static void M_ShowAmmoQuantity(
+    const LARA_GUN_TYPE gun_type, const char *const fmt, const int32_t qty)
 {
-    if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
+    if (!Gun_HasInfiniteAmmo(gun_type)) {
         InvRing_ShowItemQuantity(fmt, qty);
     }
+}
+
+// What a weapon has left, counted in shots rather than in the rounds behind
+// them: the shotgun spends six of those on one shot.
+static void M_ShowGunAmmoQuantity(
+    const LARA_GUN_TYPE gun_type, const char *const fmt)
+{
+    M_ShowAmmoQuantity(
+        gun_type, fmt, Inv_GetAmmo(gun_type) / Gun_GetRoundsPerShot(gun_type));
 }
 
 static void M_RingIsOpen(INV_RING *const ring)
@@ -138,43 +150,44 @@ static void M_RingNotActive(
     const int32_t qty = Inv_GetItemCount(inv_item->object_id);
 
     switch (inv_item->object_id) {
+    case O_PISTOL_OPTION:
+        M_ShowGunAmmoQuantity(LGT_PISTOLS, "%5d");
+        break;
     case O_SHOTGUN_OPTION:
-        M_ShowAmmoQuantity(
-            g_TRVersion == 1 ? "%5d \\{ammo shotgun}" : "%5d",
-            Inv_GetAmmo(LGT_SHOTGUN) / Gun_GetRoundsPerShot(LGT_SHOTGUN));
+        M_ShowGunAmmoQuantity(
+            LGT_SHOTGUN, g_TRVersion == 1 ? "%5d \\{ammo shotgun}" : "%5d");
         break;
     case O_MAGNUM_OPTION:
-        M_ShowAmmoQuantity(
-            g_TRVersion == 1 ? "%5d \\{ammo magnums}" : "%5d",
-            Inv_GetAmmo(LGT_MAGNUMS));
+        M_ShowGunAmmoQuantity(
+            LGT_MAGNUMS, g_TRVersion == 1 ? "%5d \\{ammo magnums}" : "%5d");
         break;
     case O_AUTOS_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_AUTOS));
+        M_ShowGunAmmoQuantity(LGT_AUTOS, "%5d");
         break;
     case O_DESERT_EAGLE_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_DESERT_EAGLE));
+        M_ShowGunAmmoQuantity(LGT_DESERT_EAGLE, "%5d");
         break;
     case O_UZI_OPTION:
-        M_ShowAmmoQuantity(
-            g_TRVersion == 1 ? "%5d \\{ammo uzis}" : "%5d",
-            Inv_GetAmmo(LGT_UZIS));
+        M_ShowGunAmmoQuantity(
+            LGT_UZIS, g_TRVersion == 1 ? "%5d \\{ammo uzis}" : "%5d");
         break;
     case O_HARPOON_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_HARPOON));
+        M_ShowGunAmmoQuantity(LGT_HARPOON, "%5d");
         break;
     case O_M16_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_M16));
+        M_ShowGunAmmoQuantity(LGT_M16, "%5d");
         break;
     case O_MP5_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_MP5));
+        M_ShowGunAmmoQuantity(LGT_MP5, "%5d");
         break;
     case O_GRENADE_GUN_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_GRENADE));
+        M_ShowGunAmmoQuantity(LGT_GRENADE, "%5d");
         break;
     case O_ROCKET_GUN_OPTION:
-        M_ShowAmmoQuantity("%5d", Inv_GetAmmo(LGT_ROCKET));
+        M_ShowGunAmmoQuantity(LGT_ROCKET, "%5d");
         break;
 
+    case O_PISTOL_AMMO_OPTION:
     case O_SHOTGUN_AMMO_OPTION:
     case O_MAGNUM_AMMO_OPTION:
     case O_AUTOS_AMMO_OPTION:
@@ -188,12 +201,13 @@ static void M_RingNotActive(
         const OBJECT_ID ammo_object_id = Inv_GetItemPickup(inv_item->object_id);
         const LARA_GUN_TYPE gun_type = Gun_GetType(
             Object_GetCognateInverse(ammo_object_id, g_GunAmmoObjectMap));
-        M_ShowAmmoQuantity("%d", qty * Gun_GetAmmoInventoryQuantity(gun_type));
+        M_ShowAmmoQuantity(
+            gun_type, "%d", qty * Gun_GetAmmoInventoryQuantity(gun_type));
         break;
     }
 
     case O_FLAREBOX_OPTION:
-        M_ShowAmmoQuantity("%d", qty);
+        M_ShowAmmoQuantity(LGT_FLARE, "%d", qty);
         break;
 
     case O_SMALL_MEDIPACK_OPTION:

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -206,10 +206,15 @@ void Lara_InitialiseInventory(const GF_LEVEL *const level)
 
     if (resume != nullptr) {
         Inv_SetState(&resume->inv);
-        // The pistols never run out, whatever the level she is arriving from
-        // left in the resume info, and what she has none of she carries no
-        // rounds for.
-        Inv_SetAmmo(LGT_PISTOLS, Inv_HasItem(O_PISTOL_ITEM) ? 1000 : 0);
+        if (Gun_HasInfiniteAmmo(LGT_PISTOLS)) {
+            // The pistols never run out, whatever the level she is arriving
+            // from left in the resume info, and what she has none of she
+            // carries no rounds for.
+            Inv_SetAmmo(
+                LGT_PISTOLS,
+                Inv_HasItem(O_PISTOL_ITEM) ? Gun_GetInitialRounds(LGT_PISTOLS)
+                                           : 0);
+        }
 
         // A weapon she already carries turns the ones lying in the level into
         // boxes of ammunition for it. The pistols are left alone: a level that

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -313,7 +313,7 @@ void Lara_Flare_Draw(void)
         frame_num = LF_FL_DRAW;
     } else if (frame_num == LF_FL_DRAW_GOT_IT) {
         Lara_Flare_DrawMeshes();
-        if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
+        if (!Gun_HasInfiniteAmmo(LGT_FLARE)) {
             Inv_RemoveItem(O_FLAREBOX_ITEM);
         }
     } else if (frame_num >= LF_FL_IGNITE && frame_num <= LF_FL_2_HOLD - 2) {

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -3,7 +3,6 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/game/camera.h>
-#include <trx/game/game.h>
 #include <trx/game/gun.h>
 #include <trx/game/input.h>
 #include <trx/game/inventory.h>
@@ -629,7 +628,7 @@ static void M_DoCurrent(ITEM *const item)
 static void M_FireHarpoon(ITEM *const item)
 {
     M_PRIV *const p = item->priv;
-    if (Inv_GetAmmo(LGT_HARPOON) <= 0) {
+    if (!Gun_HasRoundsLeft(LGT_HARPOON)) {
         return;
     }
 
@@ -660,10 +659,7 @@ static void M_FireHarpoon(ITEM *const item)
     Item_AddSimulated(item_num);
     Sound_Effect(SFX_UPV_HARPOON, &Lara_GetItem()->pos, SPM_ALWAYS);
 
-    if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
-        Inv_AddAmmo(LGT_HARPOON, -1);
-    }
-
+    Gun_SpendRound(LGT_HARPOON);
     Stats_AddAmmoUsed();
     p->current_weapon ^= 1;
 }

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -195,7 +195,6 @@ static void M_PersistInventory(RESUME_INFO *const resume)
     const INVENTORY_STATE *const live = Inv_GetState();
     resume->inv = (INVENTORY_STATE) {};
     memcpy(resume->inv.ammo, live->ammo, sizeof(resume->inv.ammo));
-    resume->inv.ammo[LGT_PISTOLS] = Inv_HasItem(O_PISTOL_ITEM) ? 1000 : 0;
 
     for (const SAVEGAME_RESUME_WEAPON *entry = g_Savegame_ResumeWeapons;
          entry->has_key != nullptr; entry++) {
@@ -526,7 +525,7 @@ void Savegame_Init(void)
         resume_info->lara_hitpoints = LARA_MAX_HITPOINTS;
         resume_info->flags.available = true;
         Inv_State_SetCount(&resume_info->inv, O_PISTOL_ITEM, 1);
-        resume_info->inv.ammo[LGT_PISTOLS] = 1000;
+        resume_info->inv.ammo[LGT_PISTOLS] = Gun_GetInitialRounds(LGT_PISTOLS);
         resume_info->gun_status = LGS_ARMLESS;
         resume_info->equipped_gun_type = LGT_PISTOLS;
         resume_info->holsters_gun_type = LGT_PISTOLS;
@@ -794,7 +793,7 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         // She starts the game with her pistols and nothing else.
         resume->inv = (INVENTORY_STATE) {};
         Inv_State_SetCount(&resume->inv, O_PISTOL_ITEM, 1);
-        resume->inv.ammo[LGT_PISTOLS] = 1000;
+        resume->inv.ammo[LGT_PISTOLS] = Gun_GetInitialRounds(LGT_PISTOLS);
 
         resume->equipped_gun_type = LGT_PISTOLS;
         resume->holsters_gun_type = LGT_PISTOLS;
@@ -811,7 +810,9 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
                 continue;
             }
             Inv_State_SetCount(&resume->inv, gun_object, 1);
-            resume->inv.ammo[gun_type] = gun_type == LGT_PISTOLS ? 1000 : 10000;
+            resume->inv.ammo[gun_type] = gun_type == LGT_PISTOLS
+                ? Gun_GetInitialRounds(LGT_PISTOLS)
+                : 10000;
         }
         if (g_TRVersion > 1) {
             Inv_State_SetCount(&resume->inv, O_FLARE_ITEM, MAX_QTY);

--- a/src/trx/game/ui/elements/ammo_label.c
+++ b/src/trx/game/ui/elements/ammo_label.c
@@ -2,7 +2,6 @@
 
 #include <trx/config.h>
 #include <trx/core/strings.h>
-#include <trx/game/game.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/gun.h>
 #include <trx/game/inventory.h>
@@ -23,15 +22,18 @@ bool UI_AmmoLabel(void)
 
     const ITEM *const vehicle_item = Lara_Vehicle_GetItem();
     if (vehicle_item != nullptr && vehicle_item->object_id == O_UPV) {
+        if (Gun_HasInfiniteAmmo(LGT_HARPOON)) {
+            return false;
+        }
         ammo = Inv_GetAmmo(LGT_HARPOON);
     } else {
-        if (lara->gun_status != LGS_READY || Game_IsBonusFlagSet(GBF_NGPLUS)) {
+        if (lara->gun_status != LGS_READY) {
             return false;
         }
 
-        // The pistols never run out, so they carry no label, and neither does
-        // anything with no box of ammunition to draw on.
-        if (lara->gun_type == LGT_PISTOLS
+        // A weapon that spends nothing carries no label, and neither does one
+        // with no box of ammunition to draw on.
+        if (Gun_HasInfiniteAmmo(lara->gun_type)
             || Gun_GetAmmoObject(lara->gun_type) == NO_OBJECT) {
             return false;
         }

--- a/src/trx/game/ui/keys.c
+++ b/src/trx/game/ui/keys.c
@@ -20,6 +20,7 @@ static UI_INPUT M_TranslateInput(const uint32_t system_keycode)
     case SDLK_END:       return UI_KEY_END;
     case SDLK_BACKSPACE: return UI_KEY_BACK;
     case SDLK_RETURN:    return UI_KEY_RETURN;
+    case SDLK_KP_ENTER:  return UI_KEY_RETURN;
     case SDLK_ESCAPE:    return UI_KEY_ESCAPE;
     case SDLK_TAB:
         return (SDL_GetModState() & KMOD_SHIFT) != 0 ? UI_KEY_SHIFT_TAB


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A game can now say which of its weapons never run out, one weapon at a time, through a new `ammo.infinite` key in `weapons.json5`:

```json5
"LGT_PISTOLS": {
    "ammo": {
        "initial_shots": 32,
        "box_shots": 32,
        "infinite": true,  // firing spends nothing
    },
},
```

The pistols and the skidoo's guns carry the key, so the shipped games play as they always did. Taking it away from the pistols is what the change is for: they then hold rounds like every other weapon.

- They arrive with `initial_shots`, and pistol clips are worth collecting for the first time.
- The count shows on the pistols and on their clips in the inventory ring, and on the overlay while they are drawn.
- Firing spends a round, an empty pair clicks, and running dry leaves Lara unarmed rather than reaching for the empty pistols she is already holding.

Flares answer to the same key, where lighting one has always spent one, meaning the builders can now choose to offer infinite flares.

The NG+ flag overrides all of it, as before.
There is no runtime control — `trx.weapons` has no setter for it, and a fuller Lua surface for the weapon numbers is separate work.

Resolves #176 / TRX887

#### Testing

##### Pistols
- [x] with the key taken away, the pistols run down, click when empty, and leave Lara unarmed
- [x] pistol clips add shots (`/give pistol clips`), and show their own count in the ring when she has no pistols
- [x] the count shows in the inventory ring and on the overlay, and matches what she has left
- [x] with the key in place, no count shows anywhere and the pistols never run down

##### Other weapons
- [x] a weapon given the key, such as the magnums, never runs down and shows no count in the ring or the overlay
- [x] the weapons without it are unchanged
- [x] when running out of ammo in a finite gun, the game cycles back to pistols, even if they're empty, then if they are, back to unarmed

##### Vehicles
- [x] the skidoo's guns stay endless while the pistols are finite, and leave her pistol count where it was
- [ ] UPV never runs out of harpoons when the harpoon gun is marked as infinite, and do not display overlay

##### Flares
- [x] flares given the key are never spent, and the flare box shows no count

##### Carrying over
- [x] pistol rounds survive a save and a load, and carry into the next level
- [x] New Game+ is unchanged
