### PR TITLE
Keep unrecognized JSON keys in the config

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - added an `ammo.infinite` key to `weapons.json5`, saying which weapons and flares never run out; a game that takes it away from the pistols makes their clips worth collecting
 - changed the ammunition keys in `weapons.json5` to say what they count; refer to migration notes
 - changed boxes of ammunition in the inventory to always show what Lara is really carrying, where finishing a level could round them down
+- fixed settings belonging to another game being dropped from the settings file
 - fixed the alternative ammunition pickups, such as the second kind of shotgun ammunition, going into the inventory without loading the weapon
 - changed the gameflow's `main_menu_picture` to be optional: a game that names no picture shows its title level behind the menu, and its title script says what plays there
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -190,6 +190,16 @@ unit_tests += {
 }
 
 unit_tests += {
+  'name': 'trx/core/json',
+  'engine': [
+    'core/json/base.c',
+    'core/json/parse.c',
+    'core/json/write.c',
+    'core/memory.c',
+  ],
+}
+
+unit_tests += {
   'name': 'trx/core/handle',
   'engine': ['core/handle.c'],
 }

--- a/src/tests/trx/config/legacy.c
+++ b/src/tests/trx/config/legacy.c
@@ -78,3 +78,23 @@ TEST(the_version_the_file_was_last_written_by_is_brought_up_to_date)
     M_Load("{}");
     CHECK_EQ_INT(g_Config.config_version, -1);
 }
+
+TEST(a_key_a_migration_reads_is_one_the_writer_drops)
+{
+    // The answer stands on the migrations this build has, not on what any file
+    // held or on a load having happened first.
+    CHECK(ConfigLegacy_IsKey("enable_target_change"));
+    CHECK(ConfigLegacy_IsKey("enable_breeze"));
+    CHECK(ConfigLegacy_IsKey("enable_save_crystals"));
+    CHECK(ConfigLegacy_IsKey("enable_game_modes"));
+}
+
+TEST(an_option_a_game_still_writes_is_not_a_legacy_key)
+{
+    // config/file.c asks this about every key it did not write, and a mod's
+    // declared option is the case it must answer no for.
+    CHECK(!ConfigLegacy_IsKey("water_color_mode"));
+    CHECK(!ConfigLegacy_IsKey("target_change_mode"));
+    CHECK(!ConfigLegacy_IsKey("bar_look"));
+    CHECK(!ConfigLegacy_IsKey(nullptr));
+}

--- a/src/tests/trx/core/json.c
+++ b/src/tests/trx/core/json.c
@@ -1,0 +1,75 @@
+// Copying a parsed JSON value.
+//
+// The settings file keeps what it read so it can put back the keys the writer
+// did not produce - another game's declared options. That only works if the
+// copy owns everything it points at: the file is re-read on every launch, and
+// the value it hands over outlives the tree it came from.
+
+#include <harness/harness.h>
+
+#include <trx/core/json.h>
+#include <trx/core/memory.h>
+
+#include <string.h>
+
+static JSON_VALUE *M_Parse(const char *const text)
+{
+    return JSON_Parse(text, strlen(text));
+}
+
+// Copies, frees the original, and only then reads - so anything the copy still
+// shared with it would be read after the free.
+static char *M_CopyAndWrite(const char *const text)
+{
+    JSON_VALUE *const parsed = M_Parse(text);
+    CHECK_NOT_NULL(parsed);
+    JSON_VALUE *const copy = JSON_ValueCopy(parsed);
+    JSON_ValueFree(parsed);
+
+    size_t size = 0;
+    char *const written = JSON_WriteMinified(copy, &size);
+    JSON_ValueFree(copy);
+    return written;
+}
+
+TEST(a_copy_holds_what_the_original_held)
+{
+    char *const written = M_CopyAndWrite(
+        "{\"a\":1,\"b\":\"text\",\"c\":true,\"d\":false,\"e\":null,"
+        "\"f\":[1,2,3],\"g\":{\"h\":\"nested\"}}");
+    CHECK_NOT_NULL(written);
+    CHECK_EQ_STR(
+        written,
+        "{\"a\":1,\"b\":\"text\",\"c\":true,\"d\":false,\"e\":null,"
+        "\"f\":[1,2,3],\"g\":{\"h\":\"nested\"}}");
+    Memory_Free(written);
+}
+
+TEST(a_number_is_copied_as_it_was_written)
+{
+    // A number is stored as its text. Copying it through a double would round
+    // a setting the player never touched.
+    char *const written = M_CopyAndWrite("{\"a\":1.500,\"b\":100000000000}");
+    CHECK_NOT_NULL(written);
+    CHECK_EQ_STR(written, "{\"a\":1.500,\"b\":100000000000}");
+    Memory_Free(written);
+}
+
+TEST(freeing_a_copy_leaves_the_original_whole)
+{
+    JSON_VALUE *const parsed = M_Parse("{\"a\":[1,{\"b\":\"text\"}]}");
+    CHECK_NOT_NULL(parsed);
+    JSON_ValueFree(JSON_ValueCopy(parsed));
+
+    size_t size = 0;
+    char *const written = JSON_WriteMinified(parsed, &size);
+    JSON_ValueFree(parsed);
+    CHECK_NOT_NULL(written);
+    CHECK_EQ_STR(written, "{\"a\":[1,{\"b\":\"text\"}]}");
+    Memory_Free(written);
+}
+
+TEST(copying_nothing_gives_nothing)
+{
+    CHECK(JSON_ValueCopy(nullptr) == nullptr);
+}

--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -1,6 +1,7 @@
 #include <trx/config/file.h>
 
 #include <trx/config/common.h>
+#include <trx/config/legacy.h>
 #include <trx/config/value.h>
 #include <trx/core/colors.h>
 #include <trx/core/filesystem.h>
@@ -128,9 +129,7 @@ static bool M_ReadFromJSON(
         }
     }
 
-    if (cfg_root) {
-        JSON_ValueFree(cfg_root);
-    }
+    JSON_ValueFree(cfg_root);
     if (enf_root) {
         JSON_ValueFree(enf_root);
     }
@@ -195,6 +194,40 @@ static bool M_ProcessOptionValue(
     return action(option, &raw);
 }
 
+// Everything the file already held that this build had nothing to say about.
+//
+// An option is in the map only while the game that declared it is loaded, so a
+// key that belongs to no option this build has is another game's setting rather
+// than one to drop. The gym stat blocks go the same way, and the input section
+// is written on every save, so nothing has to name them here.
+//
+// An option the map does have is left to the writer, whether or not it produced
+// a key for it: a null string is left out so that a reload falls back to its
+// default, and putting the old value back would take that away - the "Default"
+// outfit would never stick. See ConfigFile_DumpOptions.
+//
+// A key a migration replaced goes too: it belongs to no game any more, and
+// carrying it along would let the migration read it again on every launch,
+// putting back the value the player changed away from - see config/legacy.h.
+static void M_CarryOverUnwrittenKeys(
+    JSON_OBJECT *const root_obj, const char *const path)
+{
+    JSON_VALUE *const old_root = JSONFile_Read(path);
+    const JSON_OBJECT *const old_obj = JSON_ValueAsObject(old_root);
+    if (old_obj != nullptr) {
+        for (const JSON_OBJECT_ELEMENT *elem = old_obj->start; elem != nullptr;
+             elem = elem->next) {
+            const char *const name = elem->name->string;
+            if (JSON_ObjectGetValue(root_obj, name) == nullptr
+                && Config_GetOptionByPath(name) == nullptr
+                && !ConfigLegacy_IsKey(name)) {
+                JSON_ObjectAppend(root_obj, name, JSON_ValueCopy(elem->value));
+            }
+        }
+    }
+    JSON_ValueFree(old_root);
+}
+
 bool ConfigFile_Read(const CONFIG_IO_ARGS *const args)
 {
     ASSERT(args->default_path != nullptr);
@@ -208,6 +241,7 @@ bool ConfigFile_Write(const CONFIG_IO_ARGS *const args)
     ASSERT(args->default_path != nullptr);
     JSON_OBJECT *const root_obj = JSON_ObjectNew();
     args->action(root_obj);
+    M_CarryOverUnwrittenKeys(root_obj, args->default_path);
 
     JSON_VALUE *const new_root = JSON_ValueFromObject(root_obj);
     const bool updated = JSONFile_Write(args->default_path, new_root);

--- a/src/trx/config/legacy.c
+++ b/src/trx/config/legacy.c
@@ -3,49 +3,90 @@
 #include <trx/config/vars.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 // What last wrote the file, for a migration that has to tell one build from
 // another rather than one key from another. Nothing keys on it today.
 #define M_CONFIG_VERSION_CURRENT 1
 
-void ConfigLegacy_Load(JSON_OBJECT *const parent_obj)
+// Reads one key an older release wrote. The value is what the file holds for
+// it, or nullptr where the file does not have it at all.
+typedef void (*M_APPLY)(const JSON_VALUE *value);
+
+typedef struct {
+    // The key that release wrote.
+    const char *old_key;
+    // The option that replaced it. While the file has this one, that is where
+    // the player's answer went, and reading the old key over it would put back
+    // what they changed away from.
+    const char *new_key;
+    M_APPLY apply;
+} M_MIGRATION;
+
+static void M_ApplyGameModes(const JSON_VALUE *const value)
 {
+    g_Config.gameplay.game_modes_policy = JSON_ValueIsTrue(value)
+        ? GAME_MODES_POLICY_ALWAYS
+        : GAME_MODES_POLICY_NEVER;
+}
+
+static void M_ApplyTargetChange(const JSON_VALUE *const value)
+{
+    g_Config.gameplay.target_change_mode = JSON_ValueIsTrue(value)
+        ? TARGET_CHANGE_MODE_ENHANCED
+        : TARGET_CHANGE_MODE_OFF;
+}
+
+static void M_ApplyBreeze(const JSON_VALUE *const value)
+{
+    if (JSON_ValueIsTrue(value)) {
+        g_Config.visuals.breeze_mode =
+            g_TRVersion <= 2 ? BREEZE_MODE_TR2 : BREEZE_MODE_TR3;
+    } else {
+        g_Config.visuals.breeze_mode = BREEZE_MODE_OFF;
+    }
+}
+
+static void M_ApplySaveCrystals(const JSON_VALUE *const value)
+{
+    // Only an explicit opt-in carries over; the per-game default covers the
+    // rest, so TR3 keeps healing.
+    if (JSON_ValueIsTrue(value)) {
+        g_Config.gameplay.save_crystal_mode = SAVE_CRYSTAL_SAVE;
+    }
+}
+
+// Every key no build writes any more, and what became of it.
+static const M_MIGRATION m_Migrations[] = {
     // TRX ..1.9: game modes changed to policy.
-    if (JSON_ObjectGetValue(parent_obj, "game_modes_policy") == nullptr) {
-        const JSON_VALUE *const value =
-            JSON_ObjectGetValue(parent_obj, "enable_game_modes");
-        g_Config.gameplay.game_modes_policy = JSON_ValueIsTrue(value)
-            ? GAME_MODES_POLICY_ALWAYS
-            : GAME_MODES_POLICY_NEVER;
-    }
+    { "enable_game_modes", "game_modes_policy", M_ApplyGameModes },
+    // TRX ..1.10: target change on/off changed to mode.
+    { "enable_target_change", "target_change_mode", M_ApplyTargetChange },
+    // TRX ..1.10: breeze on/off changed to mode.
+    { "enable_breeze", "breeze_mode", M_ApplyBreeze },
+    // TRX ..1.10: save crystals on/off changed to mode.
+    { "enable_save_crystals", "save_crystal_mode", M_ApplySaveCrystals },
+    {}, // sentinel
+};
 
-    // TRX ..1.10: target change on/off changed to mode
-    if (JSON_ObjectGetValue(parent_obj, "target_change_mode") == nullptr) {
-        const JSON_VALUE *const value =
-            JSON_ObjectGetValue(parent_obj, "enable_target_change");
-        g_Config.gameplay.target_change_mode = JSON_ValueIsTrue(value)
-            ? TARGET_CHANGE_MODE_ENHANCED
-            : TARGET_CHANGE_MODE_OFF;
+bool ConfigLegacy_IsKey(const char *const name)
+{
+    if (name == nullptr) {
+        return false;
     }
-
-    // TRX ..1.10: breeze on/off changed to mode
-    if (JSON_ObjectGetValue(parent_obj, "breeze_mode") == nullptr) {
-        const JSON_VALUE *const value =
-            JSON_ObjectGetValue(parent_obj, "enable_breeze");
-        if (JSON_ValueIsTrue(value)) {
-            g_Config.visuals.breeze_mode =
-                g_TRVersion <= 2 ? BREEZE_MODE_TR2 : BREEZE_MODE_TR3;
-        } else {
-            g_Config.visuals.breeze_mode = BREEZE_MODE_OFF;
+    for (const M_MIGRATION *m = m_Migrations; m->old_key != nullptr; m++) {
+        if (strcmp(m->old_key, name) == 0) {
+            return true;
         }
     }
+    return false;
+}
 
-    // TRX ..1.10: save crystals on/off changed to mode. Only an explicit opt-in
-    // carries over; the per-game default covers the rest, so TR3 keeps healing.
-    if (JSON_ObjectGetValue(parent_obj, "save_crystal_mode") == nullptr) {
-        const JSON_VALUE *const value =
-            JSON_ObjectGetValue(parent_obj, "enable_save_crystals");
-        if (JSON_ValueIsTrue(value)) {
-            g_Config.gameplay.save_crystal_mode = SAVE_CRYSTAL_SAVE;
+void ConfigLegacy_Load(JSON_OBJECT *const parent_obj)
+{
+    for (const M_MIGRATION *m = m_Migrations; m->old_key != nullptr; m++) {
+        if (JSON_ObjectGetValue(parent_obj, m->new_key) == nullptr) {
+            m->apply(JSON_ObjectGetValue(parent_obj, m->old_key));
         }
     }
 

--- a/src/trx/config/legacy.h
+++ b/src/trx/config/legacy.h
@@ -13,3 +13,9 @@
 // Applies every migration to a config file that has already been read for the
 // options this build has. What it finds it writes straight to g_Config.
 void ConfigLegacy_Load(JSON_OBJECT *root_obj);
+
+// Whether a key is one a migration reads, and so one no build writes any more.
+// config/file.c carries a key it cannot place over to the new file, and this is
+// what it asks to tell a setting belonging to another mod from one a migration
+// has already had.
+bool ConfigLegacy_IsKey(const char *name);

--- a/src/trx/core/json/base.c
+++ b/src/trx/core/json/base.c
@@ -60,6 +60,17 @@ static JSON_NUMBER *M_NumberNewDouble(const double number)
     return elem;
 }
 
+// A number is held as the text it was written with, so a copy takes that text
+// rather than the value it stands for: one read from a file goes back out
+// spelled the way it came in.
+static JSON_NUMBER *M_NumberNewRaw(const char *const text)
+{
+    JSON_NUMBER *const elem = Memory_Alloc(sizeof(JSON_NUMBER));
+    elem->number = Memory_DupStr(text);
+    elem->number_size = strlen(text);
+    return elem;
+}
+
 static void M_NumberFree(JSON_NUMBER *const num)
 {
     if (num->ref_count == 0) {
@@ -181,6 +192,54 @@ void JSON_ValueFree(JSON_VALUE *const value)
     if (value->ref_count == 0) {
         Memory_Free(value);
     }
+}
+
+JSON_VALUE *JSON_ValueCopy(const JSON_VALUE *const value)
+{
+    if (value == nullptr) {
+        return nullptr;
+    }
+
+    switch (value->type) {
+    case JSON_TYPE_STRING:
+        return JSON_ValueFromString(
+            ((const JSON_STRING *)value->payload)->string);
+
+    case JSON_TYPE_NUMBER:
+        return M_ValueFromNumber(
+            M_NumberNewRaw(((const JSON_NUMBER *)value->payload)->number));
+
+    case JSON_TYPE_ARRAY: {
+        const JSON_ARRAY *const src = value->payload;
+        JSON_ARRAY *const dst = JSON_ArrayNew();
+        for (const JSON_ARRAY_ELEMENT *elem = src->start; elem != nullptr;
+             elem = elem->next) {
+            JSON_ArrayAppend(dst, JSON_ValueCopy(elem->value));
+        }
+        return JSON_ValueFromArray(dst);
+    }
+
+    case JSON_TYPE_OBJECT: {
+        const JSON_OBJECT *const src = value->payload;
+        JSON_OBJECT *const dst = JSON_ObjectNew();
+        for (const JSON_OBJECT_ELEMENT *elem = src->start; elem != nullptr;
+             elem = elem->next) {
+            JSON_ObjectAppend(
+                dst, elem->name->string, JSON_ValueCopy(elem->value));
+        }
+        return JSON_ValueFromObject(dst);
+    }
+
+    case JSON_TYPE_TRUE:
+    case JSON_TYPE_FALSE:
+    case JSON_TYPE_NULL:
+        break;
+    }
+
+    JSON_VALUE *const copy = Memory_Alloc(sizeof(JSON_VALUE));
+    copy->type = value->type;
+    copy->payload = nullptr;
+    return copy;
 }
 
 bool JSON_ValueIsNull(const JSON_VALUE *const value)

--- a/src/trx/core/json/base.h
+++ b/src/trx/core/json/base.h
@@ -13,6 +13,10 @@ JSON_VALUE *JSON_ValueFromArray(JSON_ARRAY *arr);
 JSON_VALUE *JSON_ValueFromObject(JSON_OBJECT *obj);
 void JSON_ValueFree(JSON_VALUE *value);
 
+// A deep copy, owning everything it points at, so freeing either one leaves
+// the other whole.
+JSON_VALUE *JSON_ValueCopy(const JSON_VALUE *value);
+
 bool JSON_ValueIsNull(const JSON_VALUE *value);
 bool JSON_ValueIsTrue(const JSON_VALUE *value);
 bool JSON_ValueIsFalse(const JSON_VALUE *value);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The write now reads what is on disk and puts back every key it did not produce itself.

This should help with switching between versions. Legacy keys are evicted upon migration.