### PR TITLE
lara/state/land: fix stop to roll state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,7 @@
 - fixed Lara moving too quickly towards targets when animated interactions are enabled, which could result in sliding in some cases during long transitions, or not being able to interact with the target at all (regression from Tomb1Main 2.7)
 - fixed Lara being unable to collect some pickups that are very close to edges with a drop when animated interactions are enabled (regression from Tomb1Main 2.7)
 - fixed changing the number of save or quick save slots mid-game discarding the progress of the levels played so far (#6054)
+- fixed Lara repeating a pickup animation if jump and roll are held during the pickup (regression from TR1X 4.14 / TR2X 1.4)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -353,14 +353,13 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
             && Item_TestAnimEqual(item, LA(LA_STAND_IDLE))
             && Lara_State_IsResponsive(LA_STAND_TO_JUMP)) {
             item->current_anim_state = LS(LS_NEUTRAL_ROLL);
-            item->goal_anim_state = LS(LS_STOP);
             Item_SwitchToAnim(item, LA(LA_JUMP_NEUTRAL_ROLL), 0);
         } else if (!g_Input.jump || !g_Config.gameplay.enable_neutral_twists) {
             Lara_Col_WadeSplash(item);
             item->current_anim_state = LS(LS_ROLL);
-            item->goal_anim_state = LS(LS_STOP);
             Item_SwitchToAnim(item, LA(LA_ROLL_START), M_LF_ROLL);
         }
+        item->goal_anim_state = LS(LS_STOP);
         return;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes neutral twists allowing stale goal animation states to carry through the stop routine, allowing such things as continuous pickups. Regression in 03fda2d.

Resolves TRX923.
