### PR TITLE
objects/pickup: expose effect properties 

### DIFF
--- a/data/te/tr1/Properties/default.xml
+++ b/data/te/tr1/Properties/default.xml
@@ -158,6 +158,8 @@
     </moveable>
     <moveable id="84-94,110-113,126,129-132,141,142,144,187,241-246,248,249,251-256">
         <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal, Hidden Reach-in, Crowbar" internalName="pickup_mode" type="Enum" />
+        <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
+        <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
     <moveable id="145">
         <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />

--- a/data/te/tr1/Properties/extra.xml
+++ b/data/te/tr1/Properties/extra.xml
@@ -49,6 +49,8 @@
     <!--placeholder for O_BINOCULARS_ITEM..O_WATERSKIN_2_EMPTY-->
     <moveable id="-1">
         <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal, Hidden Reach-in, Crowbar" internalName="pickup_mode" type="Enum" />
+        <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
+        <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
     <!--placeholder for O_BIRD_GUARDIAN-->
     <moveable id="-1">

--- a/data/te/tr2/Properties/default.xml
+++ b/data/te/tr2/Properties/default.xml
@@ -210,6 +210,8 @@
     </moveable>
     <moveable id="135-151,174-177,190-196,205,206,282,283,288,289,293,294,299,300">
         <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal, Hidden Reach-in, Crowbar" internalName="pickup_mode" type="Enum" />
+        <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
+        <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
     <moveable id="152">
         <property category="TRX" defaultValue="60" description="How long the flare burns for, in seconds." displayName="Burn Time" internalName="burn_time" minValue="0" type="Float" />

--- a/data/te/tr2/Properties/extra.xml
+++ b/data/te/tr2/Properties/extra.xml
@@ -52,6 +52,8 @@
     <!--placeholder for O_BINOCULARS_ITEM..O_WATERSKIN_2_EMPTY-->
     <moveable id="-1">
         <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal, Hidden Reach-in, Crowbar" internalName="pickup_mode" type="Enum" />
+        <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
+        <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
     <!--placeholder for O_CEILING_TRAPDOOR_1..O_FLOOR_TRAPDOOR_2-->
     <moveable id="-1">

--- a/data/te/tr3/Properties/default.xml
+++ b/data/te/tr3/Properties/default.xml
@@ -266,6 +266,8 @@
     </moveable>
     <moveable id="160-178,205-208,221-227,236,237,240-243,381,382,386,387,391,392">
         <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal, Hidden Reach-in, Crowbar" internalName="pickup_mode" type="Enum" />
+        <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
+        <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
     <moveable id="179">
         <property category="TRX" defaultValue="30" description="How long the flare burns for, in seconds." displayName="Burn Time" internalName="burn_time" minValue="0" type="Float" />

--- a/data/te/tr3/Properties/extra.xml
+++ b/data/te/tr3/Properties/extra.xml
@@ -77,6 +77,8 @@
     <!--placeholder for O_BINOCULARS_ITEM..O_WATERSKIN_2_EMPTY-->
     <moveable id="-1">
         <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal, Hidden Reach-in, Crowbar" internalName="pickup_mode" type="Enum" />
+        <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
+        <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
     <!--placeholder for O_BIRD_GUARDIAN-->
     <moveable id="-1">

--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -124,6 +124,7 @@
         // 4. Sleeping with the Fishes
         {
             "path": "undersea.tr2",
+            "script": "undersea.lua",
             "music_track": 27,
             "lara_outfit": "tr3_catsuit",
             "sequence": [

--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -175,6 +175,7 @@
         // 6. Reunion
         {
             "path": "slinc.tr2",
+            "script": "slinc.lua",
             "music_track": 26,
             "lara_outfit": "tr3_catsuit",
             "sequence": [

--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -554,6 +554,7 @@
         // 19. Meteorite Cavern
         {
             "path": "chamber.tr2",
+            "script": "chamber.lua",
             "music_track": 26,
             "lara_outfit": "tr3_antarctica",
             "weather_type": "snow",

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -2,6 +2,11 @@ trx.events.on_game_start(function()
   local props = trx.objects.strobe_light.properties
   props.requires_alarm_active = true
   trx.creatures.add_ally(trx.catalog.objects.prisoner)
+
+  props = trx.objects.quest_item_2.properties
+  props.glow_color = "#00F87C"
+  props.rotation = trx.math.DEG_90 // 16
+  props.show_pickup_aid = false
 end)
 
 trx.events.on_pickup(function(pickup_item)

--- a/data/trx/ship/games/tr3/scripts/chamber.lua
+++ b/data/trx/ship/games/tr3/scripts/chamber.lua
@@ -1,0 +1,13 @@
+trx.events.on_game_start(function()
+  local quest_objects = {
+    trx.objects.quest_item_1,
+    trx.objects.quest_item_2,
+    trx.objects.quest_item_3,
+    trx.objects.quest_item_4,
+  }
+  for _, obj in pairs(quest_objects) do
+    obj.properties.glow_color = "#00F87C"
+    obj.properties.rotation = trx.math.DEG_90 // 16
+    obj.properties.show_pickup_aid = false
+  end
+end)

--- a/data/trx/ship/games/tr3/scripts/office.lua
+++ b/data/trx/ship/games/tr3/scripts/office.lua
@@ -4,3 +4,10 @@ trx.events.on_pickup(function(pickup_item)
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end
 end)
+
+trx.events.on_game_start(function()
+  local props = trx.objects.quest_item_3.properties
+  props.glow_color = "#00F87C"
+  props.rotation = trx.math.DEG_90 // 16
+  props.show_pickup_aid = false
+end)

--- a/data/trx/ship/games/tr3/scripts/slinc.lua
+++ b/data/trx/ship/games/tr3/scripts/slinc.lua
@@ -1,0 +1,3 @@
+trx.events.on_game_start(function()
+  trx.items[58].properties.show_pickup_aid = false
+end)

--- a/data/trx/ship/games/tr3/scripts/tonyboss.lua
+++ b/data/trx/ship/games/tr3/scripts/tonyboss.lua
@@ -4,3 +4,10 @@ trx.events.on_pickup(function(pickup_item)
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end
 end)
+
+trx.events.on_game_start(function()
+  local props = trx.objects.quest_item_1.properties
+  props.glow_color = "#00F87C"
+  props.rotation = trx.math.DEG_90 // 16
+  props.show_pickup_aid = false
+end)

--- a/data/trx/ship/games/tr3/scripts/triboss.lua
+++ b/data/trx/ship/games/tr3/scripts/triboss.lua
@@ -4,3 +4,10 @@ trx.events.on_pickup(function(pickup_item)
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end
 end)
+
+trx.events.on_game_start(function()
+  local props = trx.objects.quest_item_4.properties
+  props.glow_color = "#00F87C"
+  props.rotation = trx.math.DEG_90 // 16
+  props.show_pickup_aid = false
+end)

--- a/data/trx/ship/games/tr3/scripts/undersea.lua
+++ b/data/trx/ship/games/tr3/scripts/undersea.lua
@@ -1,0 +1,6 @@
+trx.events.on_game_start(function()
+  local props = trx.objects.quest_item_1.properties
+  props.glow_color = "#00F87C"
+  props.rotation = trx.math.DEG_90 // 16
+  props.show_pickup_aid = false
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,7 @@
 - fixed the Silver and Jade Dragon secrets being listed in the wrong order in the Floating Islands statistics (OG bug); saves made before this version have the two swapped
 
 **TR3**
+- changed the Hand of Rathmore in Reunion to not show pickup aids, in line with the other artefacts
 - removed the PS1 SFX replacements option from the Sound menu, which has no relevance in TR3/TR3LA
 - removed the hardcoded glow color and rotation speed of artefact pickups, and moved to Lua properties instead; refer to migration guide
 - fixed Willard being visible outside the hut at the beginning of the cutscene following Antarctica (resolves #5929)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added support for Lara to use animated interactions when picking up thrown flares
 - added a `damage` property to the `O_POWER_SAW` object
 - added a bindable hotkey for using the binoculars
+- added `show_pickup_aid`, `rotation` and `glow_color` properties for all pickup types
 - improved error messages related to bad command invocations
 - changed the game mode selection option so that Never starts every new game as a regular one (Gameplay → General → Game mode selection)
 - changed reflections UV mapping to be more correct
@@ -112,13 +113,14 @@
 - fixed the Silver and Jade Dragon secrets being listed in the wrong order in the Floating Islands statistics (OG bug); saves made before this version have the two swapped
 
 **TR3**
+- removed the PS1 SFX replacements option from the Sound menu, which has no relevance in TR3/TR3LA
+- removed the hardcoded glow color and rotation speed of artefact pickups, and moved to Lua properties instead; refer to migration guide
 - fixed Willard being visible outside the hut at the beginning of the cutscene following Antarctica (resolves #5929)
 - fixed scenery that leans out of its room, such as the streetlight glow in It's a Madhouse!, flickering as the camera turns (OG bug)
 - fixed enemies and objects that reach out of their room, such as the Loch Ness monster in Highland Fling, flickering as the camera turns (OG bug)
 - fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)
 - fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
 - fixed a crash when a level holds fewer raptors than its raptor emitters can send out
-- removed the PS1 SFX replacements option from the Sound menu, which has no relevance in TR3/TR3LA
 
 **TR4**
 - added dead enemies fading away a few seconds after they fall, as in the original TR4

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1124,6 +1124,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── office.lua
 │   │   │   ├── rapids.lua
 │   │   │   ├── shore.lua
+│   │   │   ├── slinc.lua
 │   │   │   ├── temple.lua
 │   │   │   ├── thames.lua
 │   │   │   ├── tinnos.lua
@@ -2453,6 +2454,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── office.lua
     │   │   │   │   ├── rapids.lua
     │   │   │   │   ├── shore.lua
+    │   │   │   │   ├── slinc.lua
     │   │   │   │   ├── temple.lua
     │   │   │   │   ├── thames.lua
     │   │   │   │   ├── tinnos.lua

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1111,6 +1111,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── aldwych.lua
 │   │   │   ├── antarc.lua
 │   │   │   ├── area51.lua
+│   │   │   ├── chamber.lua
 │   │   │   ├── chunnel.lua
 │   │   │   ├── compound.lua
 │   │   │   ├── crash.lua
@@ -1129,6 +1130,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── tonyboss.lua
 │   │   │   ├── tower.lua
 │   │   │   ├── triboss.lua
+│   │   │   ├── undersea.lua
 │   │   │   └── zoo.lua
 │   │   ├── catalog_item_actions.csv
 │   │   ├── catalog_lara_anims.csv
@@ -2438,6 +2440,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── aldwych.lua
     │   │   │   │   ├── antarc.lua
     │   │   │   │   ├── area51.lua
+    │   │   │   │   ├── chamber.lua
     │   │   │   │   ├── chunnel.lua
     │   │   │   │   ├── compound.lua
     │   │   │   │   ├── crash.lua
@@ -2456,6 +2459,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── tonyboss.lua
     │   │   │   │   ├── tower.lua
     │   │   │   │   ├── triboss.lua
+    │   │   │   │   ├── undersea.lua
     │   │   │   │   └── zoo.lua
     │   │   │   ├── catalog_item_actions.csv
     │   │   │   ├── catalog_lara_anims.csv

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -296,6 +296,11 @@ order: 3
    - `pickup_qty` is now `box_shots`
    - `inventory_qty` is now `box_label_qty`
 
+29. **Update TR3 artefact pickups**
+   The glow color and rotation speed of artefact pickups is no longer hardcoded,
+   instead configurable via Lua properties. Refer to the default Lua scripts for
+   OG TR3 levels.
+
 ### Version 1.8 to 1.9
 
 1. **Update Lara pushblock animations**

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -1651,6 +1651,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (249)</th><th align="center">TR2 (144)</th><th align="center">TR3 (387)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1659,6 +1662,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (248)</th><th align="center">TR2 (137)</th><th align="center">TR3 (386)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1676,6 +1682,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1708,6 +1717,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1716,6 +1728,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1724,6 +1739,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1732,6 +1750,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1740,6 +1761,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1748,6 +1772,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (252)</th><th align="center">TR2 (289)</th><th align="center">TR3 (170)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1756,6 +1783,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (251)</th><th align="center">TR2 (288)</th><th align="center">TR3 (162)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1836,6 +1866,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1844,6 +1877,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1852,6 +1888,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1860,6 +1899,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (92)</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1868,6 +1910,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (187)</th><th align="center">TR2 (151)</th><th align="center">TR3 (178)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1900,6 +1945,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1908,6 +1956,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1916,6 +1967,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (245)</th><th align="center">TR2 (148)</th><th align="center">TR3 (175)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1924,6 +1978,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (242)</th><th align="center">TR2 (141)</th><th align="center">TR3 (167)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1932,6 +1989,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (246)</th><th align="center">TR2 (146)</th><th align="center">TR3 (172)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1940,6 +2000,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (243)</th><th align="center">TR2 (139)</th><th align="center">TR3 (164)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1956,6 +2019,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (129)</th><th align="center">TR2 (193)</th><th align="center">TR3 (224)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1964,6 +2030,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1972,6 +2041,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1980,6 +2052,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (130)</th><th align="center">TR2 (194)</th><th align="center">TR3 (225)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1988,6 +2063,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -1996,6 +2074,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2004,6 +2085,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (131)</th><th align="center">TR2 (195)</th><th align="center">TR3 (226)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2012,6 +2096,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2020,6 +2107,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2028,6 +2118,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (132)</th><th align="center">TR2 (196)</th><th align="center">TR3 (227)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2036,6 +2129,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2044,6 +2140,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2052,6 +2151,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2060,6 +2162,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2068,6 +2173,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2076,6 +2184,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2084,6 +2195,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2092,6 +2206,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2100,6 +2217,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2108,6 +2228,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2116,6 +2239,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2124,6 +2250,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2132,6 +2261,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2140,6 +2272,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2148,6 +2283,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2156,6 +2294,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2164,6 +2305,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2172,6 +2316,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2188,6 +2335,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (94)</th><th align="center">TR2 (150)</th><th align="center">TR3 (177)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2196,6 +2346,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2204,6 +2357,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (126)</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2222,6 +2378,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (244)</th><th align="center">TR2 (147)</th><th align="center">TR3 (392)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2230,6 +2389,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (241)</th><th align="center">TR2 (140)</th><th align="center">TR3 (391)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2238,6 +2400,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (90)</th><th align="center">TR2 (283)</th><th align="center">TR3 (382)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2246,6 +2411,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (86)</th><th align="center">TR2 (282)</th><th align="center">TR3 (381)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2265,6 +2433,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (254)</th><th align="center">TR2 (294)</th><th align="center">TR3 (173)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2273,6 +2444,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (253)</th><th align="center">TR2 (293)</th><th align="center">TR3 (165)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2281,6 +2455,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (141)</th><th align="center">TR2 (205)</th><th align="center">TR3 (236)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2289,6 +2466,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2297,6 +2477,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2305,6 +2488,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (142)</th><th align="center">TR2 (206)</th><th align="center">TR3 (237)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2313,6 +2499,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2321,6 +2510,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2329,6 +2521,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2337,6 +2532,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2345,6 +2543,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2353,6 +2554,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2361,6 +2565,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2369,6 +2576,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2386,6 +2596,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (88)</th><th align="center">TR2 (142)</th><th align="center">TR3 (168)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2394,6 +2607,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (84)</th><th align="center">TR2 (135)</th><th align="center">TR3 (160)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2490,6 +2706,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (110)</th><th align="center">TR2 (174)</th><th align="center">TR3 (205)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2498,6 +2717,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2506,6 +2728,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2514,6 +2739,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (111)</th><th align="center">TR2 (175)</th><th align="center">TR3 (206)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2522,6 +2750,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2530,6 +2761,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2538,6 +2772,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (112)</th><th align="center">TR2 (176)</th><th align="center">TR3 (207)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2546,6 +2783,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2554,6 +2794,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2562,6 +2805,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (113)</th><th align="center">TR2 (177)</th><th align="center">TR3 (208)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2570,6 +2816,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2578,6 +2827,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2586,6 +2838,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2594,6 +2849,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2602,6 +2860,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2610,6 +2871,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2618,6 +2882,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2626,6 +2893,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2634,6 +2904,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2642,6 +2915,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2650,6 +2926,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2658,6 +2937,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2666,6 +2948,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2674,6 +2959,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2682,6 +2970,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2690,6 +2981,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2698,6 +2992,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2706,6 +3003,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2727,6 +3027,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3 (240)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2735,6 +3038,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3 (241)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2743,6 +3049,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3 (242)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2751,6 +3060,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3 (243)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2759,6 +3071,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2767,6 +3082,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2775,6 +3093,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2783,6 +3104,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2803,6 +3127,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (256)</th><th align="center">TR2 (300)</th><th align="center">TR3 (174)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2811,6 +3138,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (255)</th><th align="center">TR2 (299)</th><th align="center">TR3 (166)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2830,6 +3160,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (144)</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2846,6 +3179,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2 (190)</th><th align="center">TR3 (221)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2854,6 +3190,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2 (191)</th><th align="center">TR3 (222)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2862,6 +3201,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2 (192)</th><th align="center">TR3 (223)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2870,6 +3212,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2878,6 +3223,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (89)</th><th align="center">TR2 (143)</th><th align="center">TR3 (169)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2886,6 +3234,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (85)</th><th align="center">TR2 (136)</th><th align="center">TR3 (161)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -2919,6 +3270,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (93)</th><th align="center">TR2 (149)</th><th align="center">TR3 (176)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3034,6 +3388,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (91)</th><th align="center">TR2 (145)</th><th align="center">TR3 (171)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3042,6 +3399,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1 (87)</th><th align="center">TR2 (138)</th><th align="center">TR3 (163)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3050,6 +3410,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3058,6 +3421,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3066,6 +3432,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3074,6 +3443,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3082,6 +3454,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3090,6 +3465,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3098,6 +3476,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3106,6 +3487,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3114,6 +3498,9 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>
 
@@ -3122,5 +3509,8 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pickup_mode</code></td><td colspan="3" align="center">0</td><td>Pickup animation mode - 0: normal; 1: low pedestal; 2: high pedestal; 3: hidden reach-in; 4: crowbar.</td></tr>
+<tr><td><code>show_pickup_aid</code></td><td colspan="3" align="center">true</td><td>Show a twinkle effect above the item.</td></tr>
+<tr><td><code>rotation</code></td><td colspan="3" align="center">0</td><td>How much to rotate the item by each frame while it's active, in engine angle units. Value range: minimum -16384; maximum 16384.</td></tr>
+<tr><td><code>glow_color</code></td><td colspan="3" align="center">(0, 0, 0)</td><td>The color of the item's glow while it's active. Black infers no glow.</td></tr>
 </tbody>
 </table>

--- a/src/trx/game/inject/editors/properties.c
+++ b/src/trx/game/inject/editors/properties.c
@@ -45,6 +45,7 @@ typedef enum {
     M_DISK_DOUBLE = 2,
     M_DISK_BOOL = 3,
     M_DISK_XYZ = 4,
+    M_DISK_RGB = 5,
 } M_DISK_PROPERTY_TYPE;
 
 static TRX_VALUE M_ReadValue(const INJECTION *const injection)
@@ -75,6 +76,14 @@ static TRX_VALUE M_ReadValue(const INJECTION *const injection)
             .x = VFile_ReadS32(injection->fp),
             .y = VFile_ReadS32(injection->fp),
             .z = VFile_ReadS32(injection->fp),
+        };
+        break;
+    case M_DISK_RGB:
+        value.type = TVT_RGB_888;
+        value.as_rgb = (RGB_888) {
+            .r = VFile_ReadU8(injection->fp),
+            .g = VFile_ReadU8(injection->fp),
+            .b = VFile_ReadU8(injection->fp),
         };
         break;
     default:

--- a/src/trx/game/lua/capi/struct.c
+++ b/src/trx/game/lua/capi/struct.c
@@ -172,41 +172,6 @@ static int M_IsValid(lua_State *const L)
     return 1;
 }
 
-static TRX_VALUE M_CheckPropertyValue(lua_State *const L, const int arg)
-{
-    switch (lua_type(L, arg)) {
-    case LUA_TBOOLEAN:
-        return (TRX_VALUE) {
-            .type = TVT_BOOL,
-            .as_bool = lua_toboolean(L, arg),
-        };
-
-    case LUA_TNUMBER:
-        if (lua_isinteger(L, arg)) {
-            return (TRX_VALUE) {
-                .type = TVT_S32,
-                .as_int = lua_tointeger(L, arg),
-            };
-        }
-        return (TRX_VALUE) {
-            .type = TVT_DOUBLE,
-            .as_num = lua_tonumber(L, arg),
-        };
-
-    case LUA_TTABLE:
-        return (TRX_VALUE) {
-            .type = TVT_XYZ_32,
-            .as_xyz = LUA_CheckXYZ(L, arg),
-        };
-
-    default:
-        break;
-    }
-
-    luaL_error(L, "property value must be a number, boolean or table");
-    return (TRX_VALUE) {};
-}
-
 // Each bridge closes over its LUA_PROPERTY_DESC in upvalue 1.
 static int M_PropertyGet(lua_State *const L)
 {
@@ -230,13 +195,13 @@ static int M_PropertySet(lua_State *const L)
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, desc->type);
     void *const self = LUA_Struct_Deref(L, ref);
     const char *const name = luaL_checkstring(L, 2);
-    const TRX_VALUE value = M_CheckPropertyValue(L, 3);
     // As in M_NewIndex, a name nobody declared is reported as such rather than
     // as a value the property would not take.
     TRX_VALUE existing = {};
     if (!desc->get(self, name, &existing)) {
         return luaL_error(L, "unknown %s property '%s'", desc->what, name);
     }
+    const TRX_VALUE value = LUA_CheckValue(L, 3, existing.type);
     const char *const err = desc->set(self, name, value);
     if (err != nullptr) {
         return luaL_error(

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -123,6 +123,9 @@ typedef struct {
     uint32_t secret_mask;
     PICKUP_MODE pickup_mode;
     bool animate;
+    bool show_pickup_aid;
+    int16_t rotation;
+    RGB_888 glow_color;
 } M_PRIV;
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
@@ -135,6 +138,12 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
 {
     const M_PRIV *const p = item->priv;
     JSONW_WRITE(io, "animate", p->animate);
+}
+
+static const char *M_CheckRotation(const TRX_VALUE *const in)
+{
+    return ABS(in->as_int) > DEG_90 ? "rotation is beyond a quarter turn"
+                                    : nullptr;
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -274,12 +283,28 @@ static void M_ControlPickupAids(ITEM *const item)
 
 static void M_ControlPickupLights(ITEM *const item)
 {
+    const M_PRIV *const p = item->priv;
+    if (p->glow_color.r == 0 && p->glow_color.g == 0 && p->glow_color.b == 0) {
+        return;
+    }
+
     const int16_t timer = Output_GetTimeInGame();
     const int16_t angle = Math_Cos((timer & 0x3F) << 10);
     int32_t c = ABS(angle >> 9);
     CLAMPG(c, 31);
     c <<= 3;
-    Output_AddDynamicLightRGB(item->pos, 8, (RGB_888) { 0, c, c >> 1 });
+
+    // Using 0xF8 rather than 0xFF allows for achieving the exact curve present
+    // with OG TR3's quest items.
+#define L_GLOW(channel, intensity) (((channel) * (intensity)) / 0xF8)
+    const RGB_888 color = {
+        .r = L_GLOW(p->glow_color.r, c),
+        .g = L_GLOW(p->glow_color.g, c),
+        .b = L_GLOW(p->glow_color.b, c),
+    };
+    Output_AddDynamicLightRGB(item->pos, 8, color);
+
+#undef L_GLOW
 }
 
 static void M_Control(const int16_t item_num)
@@ -304,12 +329,12 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    if (Object_IsType(item->object_id, g_QuestObjects)) {
-        if (!Item_IsInactive(item)) {
-            item->rot.y += 1024;
-            M_ControlPickupLights(item);
-        }
-    } else if (g_Config.gameplay.enable_pickup_aids) {
+    if (!Item_IsInactive(item)) {
+        item->rot.y += p->rotation;
+        M_ControlPickupLights(item);
+    }
+
+    if (p->show_pickup_aid && g_Config.gameplay.enable_pickup_aids) {
         M_ControlPickupAids(item);
     }
 }
@@ -919,7 +944,19 @@ static void M_Setup(OBJECT *const obj)
         OBJECT_PROPERTY_CHECKED(
             M_PRIV, pickup_mode, PICKUP_MODE_NORMAL, M_CheckPickupMode,
             "Pickup animation mode - 0: normal; 1: low pedestal; 2: high "
-            "pedestal; 3: hidden reach-in; 4: crowbar."));
+            "pedestal; 3: hidden reach-in; 4: crowbar."),
+        OBJECT_PROPERTY(
+            M_PRIV, show_pickup_aid, true,
+            "Show a twinkle effect above the item."),
+        OBJECT_PROPERTY_CHECKED(
+            M_PRIV, rotation, 0, M_CheckRotation,
+            "How much to rotate the item by each frame while it's active, in "
+            "engine angle units. Value range: "
+            "minimum -16384; maximum 16384."),
+        OBJECT_PROPERTY(
+            M_PRIV, glow_color, ((RGB_888) { 0, 0, 0 }),
+            "The color of the item's glow while it's active. Black infers no "
+            "glow."));
 }
 
 const OBJECT_BOUNDS *Pickup_Bounds(void)

--- a/tools/lint/gen/object_docs
+++ b/tools/lint/gen/object_docs
@@ -1104,7 +1104,8 @@ class XmlExporter:
                 continue
 
             props = self.property_catalog.properties_for(object_id)
-            # Tomb Editor has no color property type to map RGB onto.
+            # TODO: Tomb Editor supports color properties but its TRX injector
+            # does not. Once TE is updated, write out RGB values as well.
             properties = [
                 self._build_property_dict(name, props[name])
                 for name in props


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This exposes properties on pickup items to configure whether or not they glow and rotate like TR3 artefacts, and whether or not pickup aids are shown. The ability to set glow colour in Lua using hex strings is now in place as a result. I've added injection support as well, but will raise a TE injector PR after our next stable, hence these colour properties remain hidden from the XML files for the time being.

The glow in TR3's artefacts matches the OG curve exactly when using the hex value in the scripts provided here. Using `0xFF` gives a slightly different curve (not noticeable to my eye, only in the logs 😄) so I just opted to keep it at `0xF8` for the benefit of the doubt. LMK what you think.

We'll just need to confirm the artefacts behave correctly in each TR3 level they appear. And of course, TR4's quest items should now behave normally.

Resolves TRX914.

Ref: https://github.com/LostArtefacts/TRXInjectionTool/pull/329
