### PR TITLE
Add a key to name each level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -185,6 +185,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.config.describe()`, to read a setting's shape and accepted values
 - added `trx.config.format_value()`, the current value spelled the way the console prints it
 - added `trx.config.accepted_values()`, what a setting takes, as text for an error message
+- added `trx.game.Level.key`, what a level is called after the file it loads
 - added new Lua game state, `trx.game.is_loaded` and `trx.game.is_playable`
 - added `trx.game.is_ngplus`, which tells whether the run started from the passport's bonus entry
 - added `trx.console.register()`, for a script to add its own console command

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6561,6 +6561,12 @@
       ],
       "fields": [
         {
+          "description": "What the level is called, taken from the name of the file it loads: `wall.tr2` reads\nback as `wall`. Lower case, regardless of the case on disk, and `nil` for a level that loads no file\nof its own. <!--noref: wall.tr2, wall-->\n\nThis is the name to write into a table of per-level data. `trx.game.Level.num` is a position and\nmoves as soon as a game flow gains a level, and `trx.game.Level.path` is wherever the file sits on\nthis install.",
+          "name": "key",
+          "type": "string",
+          "writable": false
+        },
+        {
           "description": "The outfit Lara starts the level in.",
           "name": "lara_outfit",
           "type": "string",

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -91,6 +91,13 @@ Module for the game flow: which levels there are, and which one is being played.
     unrelated one.
 
     Properties:
+    - <a id="game.Level.key" name="game.Level.key"></a>**`key`**: string. What the level is called, taken from the name of the file it loads: `wall.tr2` reads
+      back as `wall`. Lower case, regardless of the case on disk, and `nil` for a level that loads no file
+      of its own.
+
+      This is the name to write into a table of per-level data. [`num`](#game.Level.num) is a position and
+      moves as soon as a game flow gains a level, and [`path`](#game.Level.path) is wherever the file sits on
+      this install. *(read-only)*
     - <a id="game.Level.lara_outfit" name="game.Level.lara_outfit"></a>**`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
     - <a id="game.Level.music_track" name="game.Level.music_track"></a>**`music_track`**: [trx.catalog.music](CATALOG.md#catalog.music). The track that plays when the level starts. *(read-only)*
     - <a id="game.Level.num" name="game.Level.num"></a>**`num`**: [trx.game.LevelNum](#game.LevelNum). *(read-only)*

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -64,6 +64,18 @@ api.type("game.Level", {
       type = "game.LevelNum",
       writable = false,
     },
+    key = {
+      from = "key",
+      type = "string",
+      writable = false,
+      description = [[What the level is called, taken from the name of the file it loads: `wall.tr2` reads
+back as `wall`. Lower case, regardless of the case on disk, and `nil` for a level that loads no file
+of its own. <!--noref: wall.tr2, wall-->
+
+This is the name to write into a table of per-level data. `trx.game.Level.num` is a position and
+moves as soon as a game flow gains a level, and `trx.game.Level.path` is wherever the file sits on
+this install.]],
+    },
     type = {
       from = "type",
       type = "game.LevelType",

--- a/src/tests/fakes/game.c
+++ b/src/tests/fakes/game.c
@@ -234,6 +234,7 @@ static void M_Reset(void)
         .type = GFL_GYM,
         .title = "Lara's Home",
         .path = "gym.phd",
+        .key = "gym",
         .lara_outfit = "casual",
         .water_particles = false,
     };
@@ -242,6 +243,7 @@ static void M_Reset(void)
         .type = GFL_NORMAL,
         .title = "Caves",
         .path = "level1.phd",
+        .key = "level1",
         .script_path = "caves.lua",
         .lara_outfit = "default",
         .water_particles = true,
@@ -252,6 +254,7 @@ static void M_Reset(void)
         .type = GFL_NORMAL,
         .title = "Vilcabamba",
         .path = "level2.phd",
+        .key = "level2",
     };
     m_Cutscenes[0] = (GF_LEVEL) {
         .num = 0,

--- a/src/tests/lua/api/game.lua
+++ b/src/tests/lua/api/game.lua
@@ -37,6 +37,12 @@ test("a level carries what the game flow said about it", function()
   assert(caves.unobtainable_secrets == 2)
 end)
 
+test("a level's key reads through", function()
+  assert(trx.game.levels[1].key == "level1")
+  assert(trx.game.levels[2].key == "level2")
+  assert(trx.game.cutscenes[1].key == nil, "a level with no file has no key")
+end)
+
 test("a level is read-only", function()
   raises(function()
     trx.game.levels[1].title = "Nope"

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -204,6 +204,20 @@ unit_tests += {
   'engine': ['core/handle.c'],
 }
 
+# core/filesystem formats paths with core/strings, so PCRE2 comes along, and it
+# stats open files through POSIX, which -std=c2x alone hides.
+unit_tests += {
+  'name': 'trx/core/filesystem',
+  'engine': [
+    'core/filesystem.c',
+    'core/memory.c',
+    'core/strings/common.c',
+    'core/vector.c',
+  ],
+  'deps': [dep_pcre2],
+  'args': ['-DPCRE2_CODE_UNIT_WIDTH=8', '-D_DEFAULT_SOURCE'],
+}
+
 unit_tests += {
   'name': 'trx/game/items/actions',
   'engine': ['game/items/actions/common.c'],

--- a/src/tests/trx/core/filesystem.c
+++ b/src/tests/trx/core/filesystem.c
@@ -10,6 +10,15 @@ static void M_CheckStem(const char *const path, const char *const expected)
     Memory_FreePointer(&stem);
 }
 
+TEST(a_base_name_is_what_follows_the_last_separator)
+{
+    CHECK_EQ_STR(File_GetBaseName("wall.tr2"), "wall.tr2");
+    CHECK_EQ_STR(File_GetBaseName("data/wall.tr2"), "wall.tr2");
+    CHECK_EQ_STR(File_GetBaseName("data\\wall.tr2"), "wall.tr2");
+    CHECK_EQ_STR(File_GetBaseName("data\\levels/wall.tr2"), "wall.tr2");
+    CHECK_NULL(File_GetBaseName(nullptr));
+}
+
 TEST(a_stem_is_the_file_name_without_its_extension)
 {
     M_CheckStem("wall.tr2", "wall");

--- a/src/tests/trx/core/filesystem.c
+++ b/src/tests/trx/core/filesystem.c
@@ -1,0 +1,37 @@
+#include <harness/harness.h>
+
+#include <trx/core/filesystem.h>
+#include <trx/core/memory.h>
+
+static void M_CheckStem(const char *const path, const char *const expected)
+{
+    char *stem = File_GetStem(path);
+    CHECK_EQ_STR(stem, expected);
+    Memory_FreePointer(&stem);
+}
+
+TEST(a_stem_is_the_file_name_without_its_extension)
+{
+    M_CheckStem("wall.tr2", "wall");
+    M_CheckStem("wall", "wall");
+}
+
+TEST(a_stem_keeps_neither_directory_nor_separator_flavour)
+{
+    M_CheckStem("data/wall.tr2", "wall");
+    M_CheckStem("data\\wall.tr2", "wall");
+    M_CheckStem("data\\levels/wall.tr2", "wall");
+}
+
+// A name is cut at the last dot, so a version or a date in it stays part of
+// the stem rather than ending it.
+TEST(a_stem_ends_at_the_last_dot)
+{
+    M_CheckStem("wall.v2.tr2", "wall.v2");
+    M_CheckStem(".hidden", "");
+}
+
+TEST(a_path_that_is_not_there_has_no_stem)
+{
+    CHECK_NULL(File_GetStem(nullptr));
+}

--- a/src/trx/core/filesystem.c
+++ b/src/trx/core/filesystem.c
@@ -127,14 +127,23 @@ char *File_GetParentDirectory(const char *path)
     return nullptr;
 }
 
-char *File_GetStem(const char *const path)
+const char *File_GetBaseName(const char *const path)
 {
     if (path == nullptr) {
         return nullptr;
     }
 
     const char *const last_delim = MAX(strrchr(path, '/'), strrchr(path, '\\'));
-    const char *const name = last_delim != nullptr ? last_delim + 1 : path;
+    return last_delim != nullptr ? last_delim + 1 : path;
+}
+
+char *File_GetStem(const char *const path)
+{
+    if (path == nullptr) {
+        return nullptr;
+    }
+
+    const char *const name = File_GetBaseName(path);
     const char *const dot = strrchr(name, '.');
     const size_t len = dot != nullptr ? (size_t)(dot - name) : strlen(name);
     return String_Format("%.*s", (int)len, name);

--- a/src/trx/core/filesystem.c
+++ b/src/trx/core/filesystem.c
@@ -119,12 +119,25 @@ char *File_GetParentDirectory(const char *path)
         return nullptr;
     }
 
-    char *last_delim = MAX(strrchr(path, '/'), strrchr(path, '\\'));
+    const char *const last_delim = MAX(strrchr(path, '/'), strrchr(path, '\\'));
     if (last_delim != nullptr) {
-        return String_Format("%.*s", last_delim - path, path);
+        return String_Format("%.*s", (int32_t)(last_delim - path), path);
     }
 
     return nullptr;
+}
+
+char *File_GetStem(const char *const path)
+{
+    if (path == nullptr) {
+        return nullptr;
+    }
+
+    const char *const last_delim = MAX(strrchr(path, '/'), strrchr(path, '\\'));
+    const char *const name = last_delim != nullptr ? last_delim + 1 : path;
+    const char *const dot = strrchr(name, '.');
+    const size_t len = dot != nullptr ? (size_t)(dot - name) : strlen(name);
+    return String_Format("%.*s", (int)len, name);
 }
 
 MYFILE *File_Open(const char *path, FILE_OPEN_MODE mode)

--- a/src/trx/core/filesystem.h
+++ b/src/trx/core/filesystem.h
@@ -39,6 +39,10 @@ bool File_Exists(const char *path);
 // Return parent directory component of path (owning string), or nullptr.
 char *File_GetParentDirectory(const char *path);
 
+// Return the name of the file path points at, pointing into path itself, or
+// nullptr when path is nullptr. Path with no directory in it is its own name.
+const char *File_GetBaseName(const char *path);
+
 // Return the name of the file path points at, without its directory and
 // without its extension (owning string), or nullptr when path is nullptr.
 char *File_GetStem(const char *path);

--- a/src/trx/core/filesystem.h
+++ b/src/trx/core/filesystem.h
@@ -39,6 +39,10 @@ bool File_Exists(const char *path);
 // Return parent directory component of path (owning string), or nullptr.
 char *File_GetParentDirectory(const char *path);
 
+// Return the name of the file path points at, without its directory and
+// without its extension (owning string), or nullptr when path is nullptr.
+char *File_GetStem(const char *path);
+
 // ============================================================================
 // File handle functions
 

--- a/src/trx/game/game_flow/common.c
+++ b/src/trx/game/game_flow/common.c
@@ -33,6 +33,7 @@ static void M_FreeInjections(INJECTION_DATA *const injections)
 static void M_FreeLevel(GF_LEVEL *const level)
 {
     Memory_FreePointer(&level->path);
+    Memory_FreePointer(&level->key);
     Memory_FreePointer(&level->title);
     Memory_FreePointer(&level->script_path);
     Memory_FreePointer(&level->lara_outfit);

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -123,6 +123,17 @@ static M_SEQUENCE_EVENT_HANDLER *M_GetSequenceEventHandlers(void)
     return m_SequenceEventHandlers;
 }
 
+// What a script keys its own data by. The case is lowered here rather than in
+// File_GetStem, which is a path split and holds no case policy.
+static char *M_MakeLevelKey(const char *const path)
+{
+    char *const key = File_GetStem(path);
+    for (char *c = key; c != nullptr && *c != '\0'; c++) {
+        *c = (*c >= 'A' && *c <= 'Z') ? *c + ('a' - 'A') : *c;
+    }
+    return key;
+}
+
 // Read a "path" value that may be either a plain string or an array of
 // candidate strings tried in order.
 // Pass optional=true to allow the key to be absent (out_path is set to nullptr
@@ -837,6 +848,7 @@ static bool M_LoadLevel(
             : TRX_DYNAMIC_PATH_LEVEL_FILE;
         JSON_MUST(
             M_ReadPath(io, "path", false, path_type, &level->path, false));
+        level->key = M_MakeLevelKey(level->path);
     }
     {
         const char *tmp_script = nullptr;

--- a/src/trx/game/game_flow/types.h
+++ b/src/trx/game/game_flow/types.h
@@ -125,6 +125,8 @@ typedef struct {
     int32_t num;
     GF_LEVEL_TYPE type;
     char *path;
+    // The stem of path, lower-cased; nullptr for a level that loads no file.
+    char *key;
     char *title;
     // Path to a Lua script executed when this level loads
     char *script_path;

--- a/src/trx/game/game_strings/manager.c
+++ b/src/trx/game/game_strings/manager.c
@@ -257,9 +257,7 @@ void GameStringManager_DiscoverLanguages(void)
     for (int32_t i = 0; i < m_SourceFiles->count; ++i) {
         const M_FILE_ENTRY *src = Vector_Get(m_SourceFiles, i);
         char *dir = File_GetParentDirectory(src->path);
-        const char *base =
-            MAX(strrchr(src->path, '\\'), strrchr(src->path, '/'));
-        base = (base != nullptr) ? base + 1 : src->path;
+        const char *const base = File_GetBaseName(src->path);
         const char *ext = strrchr(base, '.');
         if (dir == nullptr || ext == nullptr) {
             Memory_Free(dir);

--- a/src/trx/game/level/cache.c
+++ b/src/trx/game/level/cache.c
@@ -9,7 +9,6 @@
 
 #include <inttypes.h>
 #include <stdlib.h>
-#include <string.h>
 #include <uthash.h>
 
 #define M_CACHE_MAGIC UINT32_C(0x4C434831)
@@ -176,20 +175,8 @@ const char *LevelCache_GetLevelKey(const GF_LEVEL *const level)
         break;
     }
 
-    const char *name = level->path != nullptr ? level->path : "unknown";
-    const char *const slash = strrchr(name, '/');
-    const char *const backslash = strrchr(name, '\\');
-    if (slash != nullptr && backslash != nullptr) {
-        name = slash > backslash ? slash + 1 : backslash + 1;
-    } else if (slash != nullptr) {
-        name = slash + 1;
-    } else if (backslash != nullptr) {
-        name = backslash + 1;
-    }
-
-    const size_t stem_len = strcspn(name, ".");
-    return String_FormatStatic(
-        "%c%d_%.*s", type_key, level->num, (int)stem_len, name);
+    const char *const name = level->key != nullptr ? level->key : "unknown";
+    return String_FormatStatic("%c%d_%s", type_key, level->num, name);
 }
 
 MYFILE *LevelCache_OpenBinaryRead(

--- a/src/trx/game/lua/capi/game.c
+++ b/src/trx/game/lua/capi/game.c
@@ -36,6 +36,7 @@ static bool M_GetOrdinal(const void *const self, TRX_VALUE *const out)
 // clang-format off
 static const FIELD_DESC m_Fields[] = {
     FIELD_FN("num", TVT_S32, M_GetOrdinal, nullptr),
+    FIELD_RO(GF_LEVEL, key),
     FIELD_RO(GF_LEVEL, type),
     FIELD_RO(GF_LEVEL, path),
     FIELD_RO(GF_LEVEL, title),

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -291,22 +291,11 @@ static void M_ImageCandidates_Scan(
     LOG_INFO("Searching for overlay images");
     VECTOR *candidates = nullptr;
 
-    const char *last_slash = strrchr(base_image_path, '/');
-    const char *last_backslash = strrchr(base_image_path, '\\');
-    const char *last_sep =
-        last_slash > last_backslash ? last_slash : last_backslash;
-
-    size_t dir_len = 0;
-    char *dir_path = nullptr;
-    if (last_sep != nullptr) {
-        dir_len = (size_t)(last_sep - base_image_path);
-        dir_path = String_Format("%.*s", (int)dir_len, base_image_path);
-    } else {
+    char *dir_path = File_GetParentDirectory(base_image_path);
+    if (dir_path == nullptr) {
         dir_path = Memory_DupStr(".");
     }
-
-    const char *const file_name =
-        last_sep != nullptr ? last_sep + 1 : base_image_path;
+    const char *const file_name = File_GetBaseName(base_image_path);
 
     void *const dir_handle = File_OpenDirectory(dir_path);
     if (dir_handle == nullptr) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Every level now carries a key: the name of the file it loads, without the directory and without the extension, in lower case. `data/WALL.TR2` reads back as `wall`, and a level that loads no file of its own reads `nil`.

```lua
local level = trx.game.current_level
level.key -- "wall"
```

Before this, a script keying its own data by level had `trx.game.Level.num`, a position that moves as soon as a game flow gains a level, or `trx.game.Level.path`, which is where the file sits on this install.

The second commit shares the path split the key needed: `File_GetBaseName` in core/filesystem, which the game string language scan, the overlay image scan and the level cache now call.
