### PR TITLE
Check the declaration order in C files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,6 @@ repos:
     entry: tools/lint/checks/static_order
     language: python
     files: \.c$
-    exclude: ^src/tests/
 
   - id: lint-module-static
     name: Module functions are static

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     files: \.c$
 
   - id: lint-static-order
-    name: Static functions come before public ones
+    name: Declarations come in the order the guidelines give
     entry: tools/lint/checks/static_order
     language: python
     files: \.c$

--- a/src/tests/fakes/assault.c
+++ b/src/tests/fakes/assault.c
@@ -14,6 +14,18 @@ static bool m_Running[GYM_TRACK_NUMBER_OF];
 static bool m_Visible[GYM_TRACK_NUMBER_OF];
 static GYM_TRACK_TYPE m_ActiveTrack;
 
+static void M_Reset(void)
+{
+    g_Config = (CONFIG) {};
+    m_InGym = true;
+    m_ActiveTrack = GYM_TRACK_NONE;
+    for (int32_t i = 0; i < GYM_TRACK_NUMBER_OF; i++) {
+        m_HasStats[i] = true;
+        m_Running[i] = false;
+        m_Visible[i] = false;
+    }
+}
+
 bool Game_IsInGym(void)
 {
     return m_InGym;
@@ -77,18 +89,6 @@ void Gym_TrackManager_Reset(const GYM_TRACK_TYPE track)
 void Gym_TrackManager_Finish(const GYM_TRACK_TYPE track)
 {
     FAKE_RECORD("finish", FV(track));
-}
-
-static void M_Reset(void)
-{
-    g_Config = (CONFIG) {};
-    m_InGym = true;
-    m_ActiveTrack = GYM_TRACK_NONE;
-    for (int32_t i = 0; i < GYM_TRACK_NUMBER_OF; i++) {
-        m_HasStats[i] = true;
-        m_Running[i] = false;
-        m_Visible[i] = false;
-    }
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/camera.c
+++ b/src/tests/fakes/camera.c
@@ -13,6 +13,21 @@
 CAMERA_INFO g_Camera;
 static bool m_FlybyActive;
 
+static void M_Reset(void)
+{
+    g_Camera = (CAMERA_INFO) {};
+    g_Camera.pos.x = 1024;
+    g_Camera.pos.y = 2048;
+    g_Camera.pos.z = 3072;
+    // The engine and Lua both count rooms from 0.
+    g_Camera.pos.room_num = FAKE_CAMERA_ROOM;
+    g_Camera.target.x = 4096;
+    g_Camera.target.y = 5120;
+    g_Camera.target.z = 6144;
+    g_Camera.target.room_num = FAKE_CAMERA_TARGET_ROOM;
+    m_FlybyActive = false;
+}
+
 void Camera_ResetPosition(void)
 {
     FAKE_RECORD("reset");
@@ -43,21 +58,6 @@ bool FlybyMode_Cancel(void)
 void FakeCamera_SetFlybyActive(const bool active)
 {
     m_FlybyActive = active;
-}
-
-static void M_Reset(void)
-{
-    g_Camera = (CAMERA_INFO) {};
-    g_Camera.pos.x = 1024;
-    g_Camera.pos.y = 2048;
-    g_Camera.pos.z = 3072;
-    // The engine and Lua both count rooms from 0.
-    g_Camera.pos.room_num = FAKE_CAMERA_ROOM;
-    g_Camera.target.x = 4096;
-    g_Camera.target.y = 5120;
-    g_Camera.target.z = 6144;
-    g_Camera.target.room_num = FAKE_CAMERA_TARGET_ROOM;
-    m_FlybyActive = false;
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/config.c
+++ b/src/tests/fakes/config.c
@@ -64,6 +64,20 @@ static void M_DefineEnums(void)
         "extra_dark");
 }
 
+static void M_Reset(void)
+{
+    M_DefineEnums();
+    ConfigOverride_Clear();
+    m_Enforced = false;
+    m_EnableMusic = true;
+    m_Fov = 65;
+    m_Brightness = 1.5;
+    m_MasterVolume = 1.0;
+    free(m_WaterColor);
+    m_WaterColor = strdup("ff0000");
+    m_ShadowType = 0;
+}
+
 const CONFIG_OPTION *Config_GetOptionMap(void)
 {
     return m_Options;
@@ -217,20 +231,6 @@ bool Config_RestoreOptionDefault(const void *const target)
         return false;
     }
     return Config_RestoreOptionDefaultForce(target);
-}
-
-static void M_Reset(void)
-{
-    M_DefineEnums();
-    ConfigOverride_Clear();
-    m_Enforced = false;
-    m_EnableMusic = true;
-    m_Fov = 65;
-    m_Brightness = 1.5;
-    m_MasterVolume = 1.0;
-    free(m_WaterColor);
-    m_WaterColor = strdup("ff0000");
-    m_ShadowType = 0;
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/console.c
+++ b/src/tests/fakes/console.c
@@ -20,75 +20,13 @@
 #include <string.h>
 #include <strings.h>
 
-static bool m_Verbose;
-static COMMAND_RESULT m_EvalResult;
-static LUA_CONTEXT m_Context = LUA_CONTEXT_GLOBAL;
-
-LUA_CONTEXT LUA_GetScriptContext(void)
-{
-    return m_Context;
-}
-
-void LUA_SetScriptContext(const LUA_CONTEXT context)
-{
-    m_Context = context;
-}
-
-void Console_LogEx(
-    const LOG_LEVEL level, const char *const file, const int line,
-    const char *const func, const char *const fmt, ...)
-{
-    char message[256];
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(message, sizeof(message), fmt, args);
-    va_end(args);
-    FAKE_RECORD("log", FV(level), FV_STR(message));
-}
-
-void Console_Clear(void)
-{
-    FAKE_RECORD("clear");
-}
-
-COMMAND_RESULT Console_Eval(const char *const cmdline)
-{
-    // The bridge sets verbose around the call and restores it afterwards, so
-    // the value that matters is the one visible from in here.
-    const bool verbose = m_Verbose;
-    FAKE_RECORD("eval", FV_STR(cmdline), FV(verbose));
-    return m_EvalResult;
-}
-
-void Console_SetVerbose(const bool verbose)
-{
-    m_Verbose = verbose;
-}
-
-bool Console_IsVerbose(void)
-{
-    return m_Verbose;
-}
-
 #define FAKE_MAX_COMMANDS 32
 static CONSOLE_COMMAND m_Commands[FAKE_MAX_COMMANDS];
 static int32_t m_CommandCount;
 
-void Console_Registry_Add(const CONSOLE_COMMAND command)
-{
-    // Dropping one would leave the test that registered it looking at a command
-    // that is not there, and passing.
-    assert(m_CommandCount < FAKE_MAX_COMMANDS);
-    CONSOLE_COMMAND *const slot = &m_Commands[m_CommandCount++];
-    *slot = command;
-    // Copied, as the real registry copies them: a Lua registration's strings
-    // belong to the Lua state.
-    slot->prefix = command.prefix != nullptr ? strdup(command.prefix) : nullptr;
-    slot->help_id =
-        command.help_id != nullptr ? strdup(command.help_id) : nullptr;
-    slot->aliases =
-        command.aliases != nullptr ? strdup(command.aliases) : nullptr;
-}
+static bool m_Verbose;
+static COMMAND_RESULT m_EvalResult;
+static LUA_CONTEXT m_Context = LUA_CONTEXT_GLOBAL;
 
 // The aliases arrive comma-joined ("secondary, third"); each spelling
 // dispatches.
@@ -119,77 +57,12 @@ static bool M_FakeAliasMatch(const char *const aliases, const char *const word)
     return false;
 }
 
-// The real registry matches a command name case-insensitively, so a test that
-// matched exactly would not see what the player typing /HEAL sees.
-const CONSOLE_COMMAND *Console_Registry_Get(const char *const prefix)
-{
-    for (int32_t i = 0; i < m_CommandCount; i++) {
-        if (strcasecmp(m_Commands[i].prefix, prefix) == 0
-            || M_FakeAliasMatch(m_Commands[i].aliases, prefix)) {
-            return &m_Commands[i];
-        }
-    }
-    return nullptr;
-}
-
-VECTOR *Console_Registry_GetAll(void)
-{
-    VECTOR *const vec = Vector_Create(sizeof(const CONSOLE_COMMAND *));
-    for (int32_t i = 0; i < m_CommandCount; i++) {
-        const CONSOLE_COMMAND *const cmd = &m_Commands[i];
-        Vector_Add(vec, &cmd);
-    }
-    return vec;
-}
-
-void Console_Registry_Clear(void)
-{
-    for (int32_t i = 0; i < m_CommandCount; i++) {
-        free((char *)m_Commands[i].prefix);
-        free((char *)m_Commands[i].help_id);
-        free((char *)m_Commands[i].aliases);
-    }
-    m_CommandCount = 0;
-}
-
-COMMAND_RESULT FakeConsole_Run(const char *const prefix, const char *const args)
-{
-    const CONSOLE_COMMAND *const command = Console_Registry_Get(prefix);
-    if (command == nullptr) {
-        return CR_BAD_INVOCATION;
-    }
-    const COMMAND_CONTEXT ctx = {
-        .cmd = command,
-        .prefix = prefix,
-        .args = args,
-    };
-    return command->proc(&ctx);
-}
-
-int32_t FakeConsole_CommandCount(void)
-{
-    return m_CommandCount;
-}
-
-const char *FakeConsole_HelpId(const char *const prefix)
-{
-    const CONSOLE_COMMAND *const command = Console_Registry_Get(prefix);
-    return command != nullptr ? command->help_id : nullptr;
-}
-
 static void M_Reset(void)
 {
     m_Verbose = false;
     m_EvalResult = CR_SUCCESS;
     m_Context = LUA_CONTEXT_GLOBAL;
     // The commands stay: a command is registered once, at load time.
-}
-
-FAKE_ON_RESET(M_Reset)
-
-void FakeConsole_SetEvalResult(const COMMAND_RESULT result)
-{
-    m_EvalResult = result;
 }
 
 // fake.set_eval_result(result) - what the next Console_Eval hands back.
@@ -281,6 +154,133 @@ static int M_L_IsVerbose(lua_State *const L)
 {
     lua_pushboolean(L, Console_IsVerbose());
     return 1;
+}
+
+LUA_CONTEXT LUA_GetScriptContext(void)
+{
+    return m_Context;
+}
+
+void LUA_SetScriptContext(const LUA_CONTEXT context)
+{
+    m_Context = context;
+}
+
+void Console_LogEx(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+    char message[256];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+    FAKE_RECORD("log", FV(level), FV_STR(message));
+}
+
+void Console_Clear(void)
+{
+    FAKE_RECORD("clear");
+}
+
+COMMAND_RESULT Console_Eval(const char *const cmdline)
+{
+    // The bridge sets verbose around the call and restores it afterwards, so
+    // the value that matters is the one visible from in here.
+    const bool verbose = m_Verbose;
+    FAKE_RECORD("eval", FV_STR(cmdline), FV(verbose));
+    return m_EvalResult;
+}
+
+void Console_SetVerbose(const bool verbose)
+{
+    m_Verbose = verbose;
+}
+
+bool Console_IsVerbose(void)
+{
+    return m_Verbose;
+}
+
+void Console_Registry_Add(const CONSOLE_COMMAND command)
+{
+    // Dropping one would leave the test that registered it looking at a command
+    // that is not there, and passing.
+    assert(m_CommandCount < FAKE_MAX_COMMANDS);
+    CONSOLE_COMMAND *const slot = &m_Commands[m_CommandCount++];
+    *slot = command;
+    // Copied, as the real registry copies them: a Lua registration's strings
+    // belong to the Lua state.
+    slot->prefix = command.prefix != nullptr ? strdup(command.prefix) : nullptr;
+    slot->help_id =
+        command.help_id != nullptr ? strdup(command.help_id) : nullptr;
+    slot->aliases =
+        command.aliases != nullptr ? strdup(command.aliases) : nullptr;
+}
+
+// The real registry matches a command name case-insensitively, so a test that
+// matched exactly would not see what the player typing /HEAL sees.
+const CONSOLE_COMMAND *Console_Registry_Get(const char *const prefix)
+{
+    for (int32_t i = 0; i < m_CommandCount; i++) {
+        if (strcasecmp(m_Commands[i].prefix, prefix) == 0
+            || M_FakeAliasMatch(m_Commands[i].aliases, prefix)) {
+            return &m_Commands[i];
+        }
+    }
+    return nullptr;
+}
+
+VECTOR *Console_Registry_GetAll(void)
+{
+    VECTOR *const vec = Vector_Create(sizeof(const CONSOLE_COMMAND *));
+    for (int32_t i = 0; i < m_CommandCount; i++) {
+        const CONSOLE_COMMAND *const cmd = &m_Commands[i];
+        Vector_Add(vec, &cmd);
+    }
+    return vec;
+}
+
+void Console_Registry_Clear(void)
+{
+    for (int32_t i = 0; i < m_CommandCount; i++) {
+        free((char *)m_Commands[i].prefix);
+        free((char *)m_Commands[i].help_id);
+        free((char *)m_Commands[i].aliases);
+    }
+    m_CommandCount = 0;
+}
+
+COMMAND_RESULT FakeConsole_Run(const char *const prefix, const char *const args)
+{
+    const CONSOLE_COMMAND *const command = Console_Registry_Get(prefix);
+    if (command == nullptr) {
+        return CR_BAD_INVOCATION;
+    }
+    const COMMAND_CONTEXT ctx = {
+        .cmd = command,
+        .prefix = prefix,
+        .args = args,
+    };
+    return command->proc(&ctx);
+}
+
+int32_t FakeConsole_CommandCount(void)
+{
+    return m_CommandCount;
+}
+
+const char *FakeConsole_HelpId(const char *const prefix)
+{
+    const CONSOLE_COMMAND *const command = Console_Registry_Get(prefix);
+    return command != nullptr ? command->help_id : nullptr;
+}
+
+FAKE_ON_RESET(M_Reset)
+
+void FakeConsole_SetEvalResult(const COMMAND_RESULT result)
+{
+    m_EvalResult = result;
 }
 
 void FakeConsole_PushLua(lua_State *const L)

--- a/src/tests/fakes/creatures.c
+++ b/src/tests/fakes/creatures.c
@@ -10,6 +10,11 @@
 
 static bool m_AlliesHostile;
 
+static void M_Reset(void)
+{
+    m_AlliesHostile = false;
+}
+
 bool Creature_AreAlliesHostile(void)
 {
     return m_AlliesHostile;
@@ -28,11 +33,6 @@ void Creature_AddAlly(const OBJECT_ID obj_id)
 void Creature_AddAllyTargetingEnemy(const OBJECT_ID obj_id)
 {
     FAKE_RECORD("add_ally_target", FV(obj_id));
-}
-
-static void M_Reset(void)
-{
-    m_AlliesHostile = false;
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/game.c
+++ b/src/tests/fakes/game.c
@@ -12,7 +12,120 @@
 #include <trx/game/savegame.h>
 #include <trx/game/screenshot.h>
 
+#include <string.h>
+
 #include <lauxlib.h>
+
+static GF_LEVEL m_Levels[FAKE_LEVEL_COUNT];
+static GF_LEVEL m_Cutscenes[FAKE_CUTSCENE_COUNT];
+static GF_LEVEL m_Demos[FAKE_DEMO_COUNT];
+static GF_LEVEL m_TitleLevel;
+static GF_LEVEL_TABLE m_Tables[GFLT_NUMBER_OF];
+static const GF_LEVEL *m_CurrentLevel;
+static bool m_HasGym;
+static bool m_InCutscene;
+
+// The bonus start is a passport choice, so a test says whether this run is one.
+static bool m_IsNGPlus;
+
+static void M_Reset(void)
+{
+    memset(m_Levels, 0, sizeof(m_Levels));
+    memset(m_Cutscenes, 0, sizeof(m_Cutscenes));
+    memset(m_Demos, 0, sizeof(m_Demos));
+
+    m_Levels[0] = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_GYM,
+        .title = "Lara's Home",
+        .path = "gym.phd",
+        .key = "gym",
+        .lara_outfit = "casual",
+        .water_particles = false,
+    };
+    m_Levels[1] = (GF_LEVEL) {
+        .num = 1,
+        .type = GFL_NORMAL,
+        .title = "Caves",
+        .path = "level1.phd",
+        .key = "level1",
+        .script_path = "caves.lua",
+        .lara_outfit = "default",
+        .water_particles = true,
+        .unobtainable = { .pickups = 1, .secrets = 2 },
+    };
+    m_Levels[2] = (GF_LEVEL) {
+        .num = 2,
+        .type = GFL_NORMAL,
+        .title = "Vilcabamba",
+        .path = "level2.phd",
+        .key = "level2",
+    };
+    m_Cutscenes[0] = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_CUTSCENE,
+        .title = "Cutscene 1",
+    };
+    m_Demos[0] = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_DEMO,
+        .title = "Demo 1",
+    };
+    m_TitleLevel = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_TITLE,
+        .title = "Title",
+    };
+
+    m_Tables[GFLT_MAIN] =
+        (GF_LEVEL_TABLE) { .count = FAKE_LEVEL_COUNT, .levels = m_Levels };
+    m_Tables[GFLT_CUTSCENES] = (GF_LEVEL_TABLE) { .count = FAKE_CUTSCENE_COUNT,
+                                                  .levels = m_Cutscenes };
+    m_Tables[GFLT_DEMOS] =
+        (GF_LEVEL_TABLE) { .count = FAKE_DEMO_COUNT, .levels = m_Demos };
+    m_Tables[GFLT_TITLE] = (GF_LEVEL_TABLE) { .count = 0, .levels = nullptr };
+
+    m_CurrentLevel = nullptr;
+    m_IsNGPlus = false;
+    m_HasGym = true;
+    m_InCutscene = false;
+}
+
+// fake.set_current_level(n) - nil for a game that is not in a level at all.
+static int M_L_SetCurrentLevel(lua_State *const L)
+{
+    FakeGame_SetCurrentLevel(
+        lua_isnil(L, 1) ? -1 : (int32_t)luaL_checkinteger(L, 1) - 1);
+    return 0;
+}
+
+// fake.set_current_title() - the title level, which is not in any table.
+static int M_L_SetCurrentTitle(lua_State *const L)
+{
+    m_CurrentLevel = &m_TitleLevel;
+    return 0;
+}
+
+// fake.set_in_cutscene(bool) - a level is loaded, but the game takes no input.
+static int M_L_SetInCutscene(lua_State *const L)
+{
+    FakeGame_SetInCutscene(lua_toboolean(L, 1));
+    return 0;
+}
+
+// fake.set_gym_present(bool) - whether the flow has a gym to play.
+static int M_L_SetGymPresent(lua_State *const L)
+{
+    FakeGame_SetGymPresent(lua_toboolean(L, 1));
+    return 0;
+}
+
+// fake.set_ngplus(bool) - whether this run started from the bonus entry.
+static int M_L_SetNGPlus(lua_State *const L)
+{
+    FakeGame_SetNGPlus(lua_toboolean(L, 1));
+    return 0;
+}
 
 void Screenshot_Make(const SCREENSHOT_FORMAT format)
 {
@@ -26,16 +139,6 @@ void Lara_Cheat_EndLevel(void)
 {
     FAKE_RECORD("end_level");
 }
-#include <string.h>
-
-static GF_LEVEL m_Levels[FAKE_LEVEL_COUNT];
-static GF_LEVEL m_Cutscenes[FAKE_CUTSCENE_COUNT];
-static GF_LEVEL m_Demos[FAKE_DEMO_COUNT];
-static GF_LEVEL m_TitleLevel;
-static GF_LEVEL_TABLE m_Tables[GFLT_NUMBER_OF];
-static const GF_LEVEL *m_CurrentLevel;
-static bool m_HasGym;
-static bool m_InCutscene;
 
 const GF_LEVEL_TABLE *GF_GetLevelTable(const GF_LEVEL_TABLE_TYPE table_type)
 {
@@ -200,9 +303,6 @@ bool Game_IsLoaded(void)
     return m_CurrentLevel != nullptr;
 }
 
-// The bonus start is a passport choice, so a test says whether this run is one.
-static bool m_IsNGPlus;
-
 bool Game_IsBonusFlagSet(const GAME_BONUS_FLAG flag)
 {
     return flag == GBF_NGPLUS && m_IsNGPlus;
@@ -223,69 +323,6 @@ void FakeGame_SetInCutscene(const bool in_cutscene)
     m_InCutscene = in_cutscene;
 }
 
-static void M_Reset(void)
-{
-    memset(m_Levels, 0, sizeof(m_Levels));
-    memset(m_Cutscenes, 0, sizeof(m_Cutscenes));
-    memset(m_Demos, 0, sizeof(m_Demos));
-
-    m_Levels[0] = (GF_LEVEL) {
-        .num = 0,
-        .type = GFL_GYM,
-        .title = "Lara's Home",
-        .path = "gym.phd",
-        .key = "gym",
-        .lara_outfit = "casual",
-        .water_particles = false,
-    };
-    m_Levels[1] = (GF_LEVEL) {
-        .num = 1,
-        .type = GFL_NORMAL,
-        .title = "Caves",
-        .path = "level1.phd",
-        .key = "level1",
-        .script_path = "caves.lua",
-        .lara_outfit = "default",
-        .water_particles = true,
-        .unobtainable = { .pickups = 1, .secrets = 2 },
-    };
-    m_Levels[2] = (GF_LEVEL) {
-        .num = 2,
-        .type = GFL_NORMAL,
-        .title = "Vilcabamba",
-        .path = "level2.phd",
-        .key = "level2",
-    };
-    m_Cutscenes[0] = (GF_LEVEL) {
-        .num = 0,
-        .type = GFL_CUTSCENE,
-        .title = "Cutscene 1",
-    };
-    m_Demos[0] = (GF_LEVEL) {
-        .num = 0,
-        .type = GFL_DEMO,
-        .title = "Demo 1",
-    };
-    m_TitleLevel = (GF_LEVEL) {
-        .num = 0,
-        .type = GFL_TITLE,
-        .title = "Title",
-    };
-
-    m_Tables[GFLT_MAIN] =
-        (GF_LEVEL_TABLE) { .count = FAKE_LEVEL_COUNT, .levels = m_Levels };
-    m_Tables[GFLT_CUTSCENES] = (GF_LEVEL_TABLE) { .count = FAKE_CUTSCENE_COUNT,
-                                                  .levels = m_Cutscenes };
-    m_Tables[GFLT_DEMOS] =
-        (GF_LEVEL_TABLE) { .count = FAKE_DEMO_COUNT, .levels = m_Demos };
-    m_Tables[GFLT_TITLE] = (GF_LEVEL_TABLE) { .count = 0, .levels = nullptr };
-
-    m_CurrentLevel = nullptr;
-    m_IsNGPlus = false;
-    m_HasGym = true;
-    m_InCutscene = false;
-}
-
 FAKE_ON_RESET(M_Reset)
 
 void FakeGame_SetGymPresent(const bool present)
@@ -296,42 +333,6 @@ void FakeGame_SetGymPresent(const bool present)
 void FakeGame_SetCurrentLevel(const int32_t idx)
 {
     m_CurrentLevel = idx < 0 ? nullptr : &m_Levels[idx];
-}
-
-// fake.set_current_level(n) - nil for a game that is not in a level at all.
-static int M_L_SetCurrentLevel(lua_State *const L)
-{
-    FakeGame_SetCurrentLevel(
-        lua_isnil(L, 1) ? -1 : (int32_t)luaL_checkinteger(L, 1) - 1);
-    return 0;
-}
-
-// fake.set_current_title() - the title level, which is not in any table.
-static int M_L_SetCurrentTitle(lua_State *const L)
-{
-    m_CurrentLevel = &m_TitleLevel;
-    return 0;
-}
-
-// fake.set_in_cutscene(bool) - a level is loaded, but the game takes no input.
-static int M_L_SetInCutscene(lua_State *const L)
-{
-    FakeGame_SetInCutscene(lua_toboolean(L, 1));
-    return 0;
-}
-
-// fake.set_gym_present(bool) - whether the flow has a gym to play.
-static int M_L_SetGymPresent(lua_State *const L)
-{
-    FakeGame_SetGymPresent(lua_toboolean(L, 1));
-    return 0;
-}
-
-// fake.set_ngplus(bool) - whether this run started from the bonus entry.
-static int M_L_SetNGPlus(lua_State *const L)
-{
-    FakeGame_SetNGPlus(lua_toboolean(L, 1));
-    return 0;
 }
 
 void FakeGame_PushLua(lua_State *const L)

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -52,6 +52,27 @@ static struct {
 // is exactly what item.properties overlays, so the default lives here.
 static int32_t m_ObjectHP[FAKE_OBJ_COUNT];
 
+// The names an object answers to. The lookup that fuzzy-matches them is Lua
+// now, so all the engine has to do is say what they are.
+static const char *const m_WolfNames[] = { "wolf", nullptr };
+static const char *const m_VaseNames[] = { "vase", "large vase",
+                                           // A name with none of its own
+                                           // words in it, the way a large
+                                           // medipack answers to "big
+                                           // medipack".
+                                           "big urn", nullptr };
+static const char *const m_KeyNames[] = { "key", nullptr };
+
+// The real pickups answer to names of their own. None shares a word with
+// another, so a name reaches exactly one of them.
+static const char *const m_LatchNames[] = { "latch", nullptr };
+static const char *const m_CogNames[] = { "cog", nullptr };
+static const char *const m_CrowbarNames[] = { "crowbar", nullptr };
+static const char *const m_LeadbarNames[] = { "ingot", nullptr };
+static const char *const m_TrinketNames[] = { "trinket", nullptr };
+static const char *const m_ScionNames[] = { "scion", nullptr };
+static const char *const m_CrystalNames[] = { "crystal", nullptr };
+
 const OBJECT_ID g_CreatureObjects[] = { FAKE_OBJ_WOLF, NO_OBJECT };
 const OBJECT_ID g_LoyalObjects[] = { NO_OBJECT };
 // The fake's own two, and then the real ones a pickup family names, so a
@@ -511,26 +532,6 @@ OBJECT *Object_Get(const OBJECT_ID object_id)
     }
     return &m_Objects[object_id];
 }
-
-// The names an object answers to. The lookup that fuzzy-matches them is Lua
-// now, so all the engine has to do is say what they are.
-static const char *const m_WolfNames[] = { "wolf", nullptr };
-static const char *const m_VaseNames[] = { "vase", "large vase",
-                                           // A name with none of its own
-                                           // words in it, the way a large
-                                           // medipack answers to "big
-                                           // medipack".
-                                           "big urn", nullptr };
-static const char *const m_KeyNames[] = { "key", nullptr };
-// The real pickups answer to names of their own. None shares a word with
-// another, so a name reaches exactly one of them.
-static const char *const m_LatchNames[] = { "latch", nullptr };
-static const char *const m_CogNames[] = { "cog", nullptr };
-static const char *const m_CrowbarNames[] = { "crowbar", nullptr };
-static const char *const m_LeadbarNames[] = { "ingot", nullptr };
-static const char *const m_TrinketNames[] = { "trinket", nullptr };
-static const char *const m_ScionNames[] = { "scion", nullptr };
-static const char *const m_CrystalNames[] = { "crystal", nullptr };
 
 const VECTOR *Object_GetNames(const OBJECT_ID obj_id)
 {

--- a/src/tests/fakes/lara.c
+++ b/src/tests/fakes/lara.c
@@ -30,6 +30,48 @@ static struct {
     OBJECT_ID base;
 } m_InvShared[FAKE_INV_SHARED];
 
+// The inventory Lara is carrying, which is a state like any other - the same
+// one trx.inventory reaches. The engine maps a pickup to the icon it goes into
+// before it counts; the fake keeps that mapping and nothing else.
+static INVENTORY_STATE m_LiveState;
+static bool m_CanAdd = true;
+
+// A stored inventory is a plain struct, so the fake works it as the engine
+// does rather than standing in for it.
+static INVENTORY_ENTRY *M_StateEntry(
+    INVENTORY_STATE *const state, const OBJECT_ID object_id)
+{
+    for (int32_t i = 0; i < state->count; i++) {
+        if (state->entries[i].object_id == object_id) {
+            return &state->entries[i];
+        }
+    }
+    return nullptr;
+}
+
+static void M_Reset(void)
+{
+    memset(&m_Lara, 0, sizeof(m_Lara));
+
+    m_Lara.air = 1800;
+    m_Lara.exposure_timer = 600;
+    m_Lara.water_status = LWS_ABOVE_WATER;
+    m_Lara.gun_status = LGS_ARMLESS;
+    m_Lara.gun_type = LGT_UNARMED;
+    m_Lara.request_gun_type = LGT_UNARMED;
+    m_Lara.hit_direction = -1;
+    // One damp mesh, so a test can watch is_wet flip when Lara is dried.
+    m_Lara.wet[LM_HEAD] = 1;
+    m_HolstersVisible = true;
+    m_HasPistols = true;
+    m_Skin = 0;
+    m_CanAdd = true;
+    for (int32_t i = 0; i < FAKE_INV_SHARED; i++) {
+        m_InvShared[i] = (typeof(m_InvShared[0])) { NO_OBJECT, NO_OBJECT };
+    }
+    m_LiveState = (INVENTORY_STATE) {};
+}
+
 // The weapon table the bridge walks to decide whether Lara has a pistol at all.
 WEAPON_INFO g_Weapons[NUM_WEAPONS] = {
     [LGT_PISTOLS] = { .type = WEAPON_TYPE_DUAL_PISTOLS },
@@ -52,12 +94,6 @@ int16_t Item_GetRelativeObjAnim(const ITEM *const item, const OBJECT_ID obj_id)
 {
     return -1;
 }
-
-// The inventory Lara is carrying, which is a state like any other - the same
-// one trx.inventory reaches. The engine maps a pickup to the icon it goes into
-// before it counts; the fake keeps that mapping and nothing else.
-static INVENTORY_STATE m_LiveState;
-static bool m_CanAdd = true;
 
 // The engine holds one backpack entry per inventory icon, and several pickups
 // can share one - the scion in each of its states, a waterskin at each fill
@@ -199,19 +235,6 @@ int32_t Inv_GetDrawnEntries(
     INVENTORY_ENTRY *const entries, const int32_t max_count)
 {
     return Inv_State_GetDrawnEntries(&m_LiveState, entries, max_count);
-}
-
-// A stored inventory is a plain struct, so the fake works it as the engine
-// does rather than standing in for it.
-static INVENTORY_ENTRY *M_StateEntry(
-    INVENTORY_STATE *const state, const OBJECT_ID object_id)
-{
-    for (int32_t i = 0; i < state->count; i++) {
-        if (state->entries[i].object_id == object_id) {
-            return &state->entries[i];
-        }
-    }
-    return nullptr;
 }
 
 INVENTORY_STATE *Inv_GetState(void)
@@ -371,29 +394,6 @@ LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
         return 1;
     }
     return -1;
-}
-
-static void M_Reset(void)
-{
-    memset(&m_Lara, 0, sizeof(m_Lara));
-
-    m_Lara.air = 1800;
-    m_Lara.exposure_timer = 600;
-    m_Lara.water_status = LWS_ABOVE_WATER;
-    m_Lara.gun_status = LGS_ARMLESS;
-    m_Lara.gun_type = LGT_UNARMED;
-    m_Lara.request_gun_type = LGT_UNARMED;
-    m_Lara.hit_direction = -1;
-    // One damp mesh, so a test can watch is_wet flip when Lara is dried.
-    m_Lara.wet[LM_HEAD] = 1;
-    m_HolstersVisible = true;
-    m_HasPistols = true;
-    m_Skin = 0;
-    m_CanAdd = true;
-    for (int32_t i = 0; i < FAKE_INV_SHARED; i++) {
-        m_InvShared[i] = (typeof(m_InvShared[0])) { NO_OBJECT, NO_OBJECT };
-    }
-    m_LiveState = (INVENTORY_STATE) {};
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/lua.c
+++ b/src/tests/fakes/lua.c
@@ -10,11 +10,6 @@
 
 static lua_State *m_State = nullptr;
 
-void FakeLua_SetState(lua_State *const L)
-{
-    m_State = L;
-}
-
 static LUA_RESULT M_Finish(lua_State *const L, int32_t status)
 {
     if (status == LUA_OK) {
@@ -26,6 +21,11 @@ static LUA_RESULT M_Finish(lua_State *const L, int32_t status)
         lua_pop(L, 1);
     }
     return result;
+}
+
+void FakeLua_SetState(lua_State *const L)
+{
+    m_State = L;
 }
 
 LUA_RESULT LUA_Eval(const char *const code)

--- a/src/tests/fakes/music.c
+++ b/src/tests/fakes/music.c
@@ -9,9 +9,6 @@
 #include <trx/game/music/common.h>
 #include <trx/game/music/ids.h>
 
-static MUSIC_ID m_Playing = MX_INACTIVE;
-static MUSIC_ID m_Looped = MX_INACTIVE;
-
 typedef struct {
     bool active;
     int32_t track_id;
@@ -19,7 +16,19 @@ typedef struct {
     double timestamp;
 } FAKE_SLOT;
 
+static MUSIC_ID m_Playing = MX_INACTIVE;
+static MUSIC_ID m_Looped = MX_INACTIVE;
+
 static FAKE_SLOT m_Slots[FAKE_MUSIC_SLOT_COUNT];
+
+static void M_Reset(void)
+{
+    m_Playing = MX_INACTIVE;
+    m_Looped = MX_INACTIVE;
+    for (int32_t i = 0; i < FAKE_MUSIC_SLOT_COUNT; i++) {
+        m_Slots[i] = (FAKE_SLOT) {};
+    }
+}
 
 int32_t Music_Play_Direct(const MUSIC_ID track, const MUSIC_PLAY_MODE mode)
 {
@@ -126,15 +135,6 @@ void Music_Stop(void)
 {
     FAKE_RECORD("stop");
     m_Playing = MX_INACTIVE;
-}
-
-static void M_Reset(void)
-{
-    m_Playing = MX_INACTIVE;
-    m_Looped = MX_INACTIVE;
-    for (int32_t i = 0; i < FAKE_MUSIC_SLOT_COUNT; i++) {
-        m_Slots[i] = (FAKE_SLOT) {};
-    }
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/rooms.c
+++ b/src/tests/fakes/rooms.c
@@ -14,13 +14,6 @@ static HANDLE_EPOCH m_RoomEpoch;
 static bool m_FlipStatus;
 static ITEM_ACTION_INTERCEPTOR m_Interceptor;
 
-// What loading the next level does to the room table: the rooms are replaced,
-// so every handle to one of the old ones is stale.
-void FakeRooms_LoadNextLevel(void)
-{
-    Handle_EpochBump(&m_RoomEpoch);
-}
-
 static void M_Reset(void)
 {
     Handle_EpochBump(&m_RoomEpoch);
@@ -41,6 +34,13 @@ static void M_Reset(void)
     m_Rooms[0].flipped_room = 1;
     m_Rooms[0].flip_status = RFS_UNFLIPPED;
     m_Rooms[1].flip_status = RFS_FLIPPED;
+}
+
+// What loading the next level does to the room table: the rooms are replaced,
+// so every handle to one of the old ones is stale.
+void FakeRooms_LoadNextLevel(void)
+{
+    Handle_EpochBump(&m_RoomEpoch);
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/sound.c
+++ b/src/tests/fakes/sound.c
@@ -19,6 +19,18 @@ static FAKE_SLOT m_Slots[FAKE_SOUND_SLOT_COUNT];
 static uint32_t m_SlotGens[FAKE_SOUND_SLOT_COUNT];
 static HANDLE_REGISTRY m_Handles;
 
+static void M_Reset(void)
+{
+    for (int32_t i = 0; i < FAKE_SOUND_SLOT_COUNT; i++) {
+        m_Slots[i] = (FAKE_SLOT) {};
+    }
+    // The generations persist across the reset, as the engine's do, so a handle
+    // from before it cannot match a slot that a later play reuses.
+    if (m_Handles.gens == nullptr) {
+        Handle_RegistryInit(&m_Handles, m_SlotGens, FAKE_SOUND_SLOT_COUNT);
+    }
+}
+
 bool Sound_IsAvailable_Direct(const SAMPLE_ID sample_id)
 {
     return sample_id == FAKE_SAMPLE;
@@ -123,18 +135,6 @@ void Sound_StopEffect_Direct(const SAMPLE_ID sfx_num)
 void Sound_StopAll(void)
 {
     FAKE_RECORD("stop_all");
-}
-
-static void M_Reset(void)
-{
-    for (int32_t i = 0; i < FAKE_SOUND_SLOT_COUNT; i++) {
-        m_Slots[i] = (FAKE_SLOT) {};
-    }
-    // The generations persist across the reset, as the engine's do, so a handle
-    // from before it cannot match a slot that a later play reuses.
-    if (m_Handles.gens == nullptr) {
-        Handle_RegistryInit(&m_Handles, m_SlotGens, FAKE_SOUND_SLOT_COUNT);
-    }
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/stats.c
+++ b/src/tests/fakes/stats.c
@@ -55,6 +55,15 @@ static uint32_t M_GetUnobtainable(
     }
 }
 
+static void M_Reset(void)
+{
+    for (int32_t i = 0; i < M_LEVEL_SLOTS; i++) {
+        m_Stats[i] = (LEVEL_STATS) {};
+        m_MaxStats[i] = (LEVEL_MAX_STATS) {};
+        m_AlliesHurt[i] = false;
+    }
+}
+
 LEVEL_STATS *Stats_GetLevelStats(const GF_LEVEL *const level)
 {
     const int32_t slot = M_GetSlot(level);
@@ -151,15 +160,6 @@ bool Stats_HaveAlliesBeenHurt(const GF_LEVEL *const level)
 {
     const int32_t slot = M_GetSlot(level);
     return slot >= 0 && m_AlliesHurt[slot];
-}
-
-static void M_Reset(void)
-{
-    for (int32_t i = 0; i < M_LEVEL_SLOTS; i++) {
-        m_Stats[i] = (LEVEL_STATS) {};
-        m_MaxStats[i] = (LEVEL_MAX_STATS) {};
-        m_AlliesHurt[i] = false;
-    }
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/harness/fake_calls.c
+++ b/src/tests/harness/fake_calls.c
@@ -87,6 +87,27 @@ static void M_PushValue(
     luaL_error(L, "cannot record %s as %s", name, Value_TypeName(value->type));
 }
 
+// The arguments of one call, as a table, with its name under `name`.
+static void M_PushArgs(lua_State *const L, const FAKE_CALL *const call)
+{
+    lua_pushstring(L, call->name);
+    lua_setfield(L, -2, "name");
+    for (int32_t i = 0; i < call->arg_count; i++) {
+        M_PushValue(L, call->args[i].name, &call->args[i].value);
+        lua_setfield(L, -2, call->args[i].name);
+    }
+}
+
+// Answers a count of zero for a call that never happened, so a test can say so
+// without the group having to exist.
+static int M_GroupIndex(lua_State *const L)
+{
+    lua_newtable(L);
+    lua_pushinteger(L, 0);
+    lua_setfield(L, -2, "count");
+    return 1;
+}
+
 void FakeCalls_Record(const char *const name, const FAKE_ARG *args)
 {
     if (m_CallCount >= FAKE_MAX_CALLS) {
@@ -129,27 +150,6 @@ void FakeCalls_OnReset(void (*const func)(void))
         M_Fail("reset hooks", FAKE_MAX_RESETS);
     }
     m_Resets[m_ResetCount++] = func;
-}
-
-// The arguments of one call, as a table, with its name under `name`.
-static void M_PushArgs(lua_State *const L, const FAKE_CALL *const call)
-{
-    lua_pushstring(L, call->name);
-    lua_setfield(L, -2, "name");
-    for (int32_t i = 0; i < call->arg_count; i++) {
-        M_PushValue(L, call->args[i].name, &call->args[i].value);
-        lua_setfield(L, -2, call->args[i].name);
-    }
-}
-
-// Answers a count of zero for a call that never happened, so a test can say so
-// without the group having to exist.
-static int M_GroupIndex(lua_State *const L)
-{
-    lua_newtable(L);
-    lua_pushinteger(L, 0);
-    lua_setfield(L, -2, "count");
-    return 1;
 }
 
 int FakeCalls_Push(lua_State *const L)

--- a/src/tests/harness/lua_surface.c
+++ b/src/tests/harness/lua_surface.c
@@ -10,6 +10,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+// The modules this run loads, in the order their bodies are run: what a module
+// requires comes before it. The engine registers every module's preload before
+// running any body, so a require during a body hands back a table rather than
+// running a second module mid-flight; the harness does the same.
+#define M_MAX_MODULES 64
+static char *m_Order[M_MAX_MODULES];
+static int32_t m_Count;
+
+// Names the walk has been down, which is not the order they run in: a module is
+// recorded here on the way in and lands in m_Order on the way out, after what
+// it requires.
+static char *m_Visited[M_MAX_MODULES];
+static int32_t m_VisitedCount;
+
 // The shared fake.reset(), for a fake that records through FAKE_RECORD and
 // registers what else it holds with FAKE_ON_RESET.
 static int M_Reset(lua_State *const L)
@@ -63,20 +77,6 @@ static void M_RunFileAs(
     }
     free(source);
 }
-
-// The modules this run loads, in the order their bodies are run: what a module
-// requires comes before it. The engine registers every module's preload before
-// running any body, so a require during a body hands back a table rather than
-// running a second module mid-flight; the harness does the same.
-#define M_MAX_MODULES 64
-static char *m_Order[M_MAX_MODULES];
-static int32_t m_Count;
-
-// Names the walk has been down, which is not the order they run in: a module is
-// recorded here on the way in and lands in m_Order on the way out, after what
-// it requires.
-static char *m_Visited[M_MAX_MODULES];
-static int32_t m_VisitedCount;
 
 static bool M_Visit(const char *const name)
 {

--- a/src/tests/lua/api/events.c
+++ b/src/tests/lua/api/events.c
@@ -19,16 +19,6 @@
 
 static LUA_CONTEXT m_Context = LUA_CONTEXT_GLOBAL;
 
-LUA_CONTEXT LUA_GetScriptContext(void)
-{
-    return m_Context;
-}
-
-void LUA_SetScriptContext(const LUA_CONTEXT context)
-{
-    m_Context = context;
-}
-
 // fake.fire(name, ...) - mirrors the engine's own fire sites, argument for
 // argument.
 // Drops every listener, then stands the module back up: the shutdown clears
@@ -101,6 +91,16 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "as_level_script");
     lua_pushcfunction(L, M_FakeEndLevel);
     lua_setfield(L, -2, "end_level");
+}
+
+LUA_CONTEXT LUA_GetScriptContext(void)
+{
+    return m_Context;
+}
+
+void LUA_SetScriptContext(const LUA_CONTEXT context)
+{
+    m_Context = context;
 }
 
 int main(void)

--- a/src/tests/lua/api/items.c
+++ b/src/tests/lua/api/items.c
@@ -8,21 +8,6 @@
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/events.h>
 
-// Event listeners attach against a script context; a global one lives for the
-// whole session, which is all these tests need.
-LUA_CONTEXT LUA_GetScriptContext(void)
-{
-    return LUA_CONTEXT_GLOBAL;
-}
-
-void LUA_SetScriptContext(const LUA_CONTEXT context)
-{
-}
-
-void ItemAction_SetInterceptor(const ITEM_ACTION_INTERCEPTOR interceptor)
-{
-}
-
 static void M_SetUpExtra(lua_State *const L)
 {
     // items.lua's `room` extension hands off to trx.rooms, which is not under
@@ -157,6 +142,21 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "fire_hit");
     lua_pushcfunction(L, M_L_FireKill);
     lua_setfield(L, -2, "fire_kill");
+}
+
+// Event listeners attach against a script context; a global one lives for the
+// whole session, which is all these tests need.
+LUA_CONTEXT LUA_GetScriptContext(void)
+{
+    return LUA_CONTEXT_GLOBAL;
+}
+
+void LUA_SetScriptContext(const LUA_CONTEXT context)
+{
+}
+
+void ItemAction_SetInterceptor(const ITEM_ACTION_INTERCEPTOR interceptor)
+{
 }
 
 int main(void)

--- a/src/tests/lua/api/mod.c
+++ b/src/tests/lua/api/mod.c
@@ -35,6 +35,15 @@ static SHELL_MOD m_Mods[] = {
 
 static SHELL_ARGS m_Args = { .startup = { .mod = &m_Mods[0] } };
 
+static const char *m_RequestedMod;
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeCalls_Reset();
+    m_RequestedMod = nullptr;
+    return 0;
+}
+
 int32_t Shell_GetModCount(void)
 {
     return 2;
@@ -69,8 +78,6 @@ bool Shell_CanSwitchToMod(const SHELL_MOD *const mod)
     return mod != nullptr && mod->is_valid;
 }
 
-static const char *m_RequestedMod;
-
 void Shell_RequestModSwitch(const char *const mod_name)
 {
     m_RequestedMod = mod_name;
@@ -78,13 +85,6 @@ void Shell_RequestModSwitch(const char *const mod_name)
 
 void GF_OverrideCommand(const GF_COMMAND command)
 {
-}
-
-static int M_FakeReset(lua_State *const L)
-{
-    FakeCalls_Reset();
-    m_RequestedMod = nullptr;
-    return 0;
 }
 
 int main(void)

--- a/src/tests/lua/api/rooms.c
+++ b/src/tests/lua/api/rooms.c
@@ -10,17 +10,6 @@
 
 #include <lauxlib.h>
 
-// The room hooks go through the real listener registry, which asks for the
-// script context to scope a listener.
-LUA_CONTEXT LUA_GetScriptContext(void)
-{
-    return LUA_CONTEXT_GLOBAL;
-}
-
-void LUA_SetScriptContext(const LUA_CONTEXT context)
-{
-}
-
 // fake.fire_room_change(item_num, old_room, new_room) - mirrors the
 // Item_UpdateRoom fire site, argument for argument.
 static int M_L_FireRoomChange(lua_State *const L)
@@ -53,6 +42,17 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "load_next_level");
     lua_pushcfunction(L, M_L_FireRoomChange);
     lua_setfield(L, -2, "fire_room_change");
+}
+
+// The room hooks go through the real listener registry, which asks for the
+// script context to scope a listener.
+LUA_CONTEXT LUA_GetScriptContext(void)
+{
+    return LUA_CONTEXT_GLOBAL;
+}
+
+void LUA_SetScriptContext(const LUA_CONTEXT context)
+{
 }
 
 int main(void)

--- a/src/tests/lua/api/savegame.c
+++ b/src/tests/lua/api/savegame.c
@@ -10,6 +10,31 @@
 #include <trx/game/game_flow.h>
 #include <trx/game/savegame.h>
 
+static SAVEGAME_SLOT_REF m_SavedSlot = { .index = -1 };
+
+static int32_t m_LoadedParam = -1;
+
+// The slot the fake ended up holding is state, not a call, so it is read here.
+static int M_FakeReset(lua_State *const L)
+{
+    FakeCalls_Reset();
+    m_LoadedParam = -1;
+    m_SavedSlot = (SAVEGAME_SLOT_REF) { .index = -1 };
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    FakeCalls_Push(L);
+    lua_pushinteger(L, m_LoadedParam);
+    lua_setfield(L, -2, "loaded_param");
+    lua_pushinteger(L, m_SavedSlot.index);
+    lua_setfield(L, -2, "saved_index");
+    lua_pushinteger(L, m_SavedSlot.pool);
+    lua_setfield(L, -2, "saved_pool");
+    return 1;
+}
+
 int32_t SG_Manager_GetSlotCount(const SAVEGAME_SLOT_POOL pool)
 {
     return pool == SAVEGAME_SLOT_POOL_QUICK ? 4 : 3;
@@ -53,40 +78,15 @@ bool SG_Manager_IsValidSlotRef(const SAVEGAME_SLOT_REF slot)
     return slot.index >= 0;
 }
 
-static SAVEGAME_SLOT_REF m_SavedSlot = { .index = -1 };
-
 bool Savegame_Save(const SAVEGAME_SLOT_REF slot)
 {
     m_SavedSlot = slot;
     return true;
 }
 
-static int32_t m_LoadedParam = -1;
-
 void GF_OverrideCommand(const GF_COMMAND command)
 {
     m_LoadedParam = command.param;
-}
-
-// The slot the fake ended up holding is state, not a call, so it is read here.
-static int M_FakeReset(lua_State *const L)
-{
-    FakeCalls_Reset();
-    m_LoadedParam = -1;
-    m_SavedSlot = (SAVEGAME_SLOT_REF) { .index = -1 };
-    return 0;
-}
-
-static int M_FakeCalls(lua_State *const L)
-{
-    FakeCalls_Push(L);
-    lua_pushinteger(L, m_LoadedParam);
-    lua_setfield(L, -2, "loaded_param");
-    lua_pushinteger(L, m_SavedSlot.index);
-    lua_setfield(L, -2, "saved_index");
-    lua_pushinteger(L, m_SavedSlot.pool);
-    lua_setfield(L, -2, "saved_pool");
-    return 1;
 }
 
 int main(void)

--- a/src/tests/lua/api/weather.c
+++ b/src/tests/lua/api/weather.c
@@ -10,6 +10,13 @@
 
 static WEATHER_TYPE m_Weather = WEATHER_NONE;
 
+static int M_FakeReset(lua_State *const L)
+{
+    FakeCalls_Reset();
+    m_Weather = WEATHER_NONE;
+    return 0;
+}
+
 void FX_Weather_SetWeather(const WEATHER_TYPE weather_type)
 {
     m_Weather = weather_type;
@@ -18,13 +25,6 @@ void FX_Weather_SetWeather(const WEATHER_TYPE weather_type)
 WEATHER_TYPE FX_Weather_GetWeather(void)
 {
     return m_Weather;
-}
-
-static int M_FakeReset(lua_State *const L)
-{
-    FakeCalls_Reset();
-    m_Weather = WEATHER_NONE;
-    return 0;
 }
 
 int main(void)

--- a/src/tests/lua/api/zones.c
+++ b/src/tests/lua/api/zones.c
@@ -22,16 +22,6 @@
 
 static LUA_CONTEXT m_Context = LUA_CONTEXT_GLOBAL;
 
-LUA_CONTEXT LUA_GetScriptContext(void)
-{
-    return m_Context;
-}
-
-void LUA_SetScriptContext(const LUA_CONTEXT context)
-{
-    m_Context = context;
-}
-
 static int M_L_Control(lua_State *const L)
 {
     LUA_FireEvent(LUA_EVENT_AFTER_CONTROL);
@@ -129,6 +119,16 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "destroy");
     lua_pushcfunction(L, M_L_Flyby);
     lua_setfield(L, -2, "flyby");
+}
+
+LUA_CONTEXT LUA_GetScriptContext(void)
+{
+    return m_Context;
+}
+
+void LUA_SetScriptContext(const LUA_CONTEXT context)
+{
+    m_Context = context;
 }
 
 int main(void)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -903,7 +903,7 @@ endif
 # engine code, so they mirror nothing under trx/.
 python_exe = find_program('python3', required: false)
 if python_exe.found()
-  foreach name : ['lua_sources', 'update_lua_docs', 'game_strings']
+  foreach name : ['lua_sources', 'update_lua_docs', 'game_strings', 'cfuncs']
     test(
       'tools.' + name,
       python_exe,

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -903,7 +903,7 @@ endif
 # engine code, so they mirror nothing under trx/.
 python_exe = find_program('python3', required: false)
 if python_exe.found()
-  foreach name : ['lua_sources', 'update_lua_docs', 'game_strings', 'cfuncs']
+  foreach name : ['lua_sources', 'update_lua_docs', 'game_strings', 'cfuncs', 'cdecls']
     test(
       'tools.' + name,
       python_exe,

--- a/src/tests/tools/cdecls.py
+++ b/src/tests/tools/cdecls.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+"""The declaration-order check against the shapes it has to tell apart.
+
+docs/CODING_GUIDELINES.md orders a file defines, types, static variables,
+static functions, public functions. What the check has to get right is which
+of the five a line is: a define continued with a backslash, a brace inside a
+string, and anything written inside a function body are all places a naive
+read finds a declaration that is not there.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from shared.cdecls import declarations, out_of_order  # noqa: E402
+
+ORDERED = """\
+#define M_LIMIT 4
+
+typedef struct {
+    int x;
+} M_THING;
+
+static M_THING m_Thing = { .x = 1 };
+
+static void M_Helper(void)
+{
+}
+
+void Module_Public(void)
+{
+}
+"""
+
+CASES = [
+    (
+        "a file in order",
+        ORDERED,
+        ["define", "type", "static variable", "static function", "public function"],
+    ),
+    (
+        "a define continued across lines",
+        "#define M_WIDE(a, b) \\\n    ((a) + (b))\nstatic int m_N = 0;\n",
+        ["define", "static variable"],
+    ),
+    (
+        "declarations written inside a function body",
+        "void Module_Public(void)\n{\n#define M_INNER 1\n    static int m_Cache;\n}\n",
+        ["public function"],
+    ),
+    (
+        "a brace inside a string literal",
+        'static const char *m_Fmt = "{";\nstatic void M_Helper(void)\n{\n}\n',
+        ["static variable", "static function"],
+    ),
+    (
+        "an array initialiser spanning lines",
+        "static const int m_Table[] = {\n    1,\n    2,\n};\nvoid Module_Public(void)\n{\n}\n",
+        ["static variable", "public function"],
+    ),
+]
+
+
+def kinds(source):
+    return [decl.kind for decl in declarations(source)]
+
+
+def bad_lines(source):
+    return [decl.line for decl, _ in out_of_order(source)]
+
+
+def main() -> int:
+    failures = []
+
+    for label, source, expected in CASES:
+        found = kinds(source)
+        if found != expected:
+            failures.append(f"{label}: expected {expected}, got {found}")
+
+    if bad_lines(ORDERED) != []:
+        failures.append("a file in order was reported out of order")
+
+    # Each of the four ways to sit below something that outranks you.
+    for label, source, expected_lines in [
+        ("a define under a static function", "static void M_A(void)\n{\n}\n#define M_L 1\n", [4]),
+        ("a type under a static variable", "static int m_N;\ntypedef struct {\n    int x;\n} M_T;\n", [2]),
+        ("a static variable under a static function", "static void M_A(void)\n{\n}\nstatic int m_N;\n", [4]),
+        ("a static function under a public one", "void Module_P(void)\n{\n}\nstatic void M_A(void)\n{\n}\n", [4]),
+    ]:
+        found = bad_lines(source)
+        if found != expected_lines:
+            failures.append(f"{label}: expected {expected_lines}, got {found}")
+
+    # A table naming the static functions above it has to sit below them, or
+    # every one of them needs a forward declaration first.
+    reaching_back = (
+        "static void M_Step(void)\n{\n}\n\n"
+        "static const MODULE m_Module = {\n    .step = M_Step,\n};\n"
+    )
+    if bad_lines(reaching_back) != []:
+        failures.append("a table reaching back to a static function was reported")
+
+    # The same shape naming nothing above it has nothing forcing it down.
+    reaching_nothing = (
+        "static void M_Step(void)\n{\n}\n\nstatic const int m_Limit = 4;\n"
+    )
+    if bad_lines(reaching_nothing) != [5]:
+        failures.append(
+            f"a plain static below a function: expected [5], "
+            f"got {bad_lines(reaching_nothing)}"
+        )
+
+    # A define the file takes back with #undef reaches only the lines between
+    # the two, and what sits there is written expecting it.
+    scoped = (
+        "static void M_A(void)\n{\n}\n\n"
+        "#define X_ENTRY(name) name,\n"
+        "#include <trx/thing.def>\n"
+        "#undef X_ENTRY\n"
+    )
+    if bad_lines(scoped) != []:
+        failures.append("an #undef'd define was told to move out of its stretch")
+
+    # A forward declaration names no storage, and the guidelines give one as a
+    # reason to deviate. A pointer to a function does name storage.
+    forwards = "static void M_A(void)\n{\n}\n\nstatic bool M_B(const char *s);\n"
+    if [d.kind for d in declarations(forwards)] != ["static function"]:
+        failures.append("a forward declaration was read as a declaration")
+    pointer = "static void M_A(void)\n{\n}\n\nstatic void (*m_Handlers[4])(int);\n"
+    if bad_lines(pointer) != [5]:
+        failures.append(
+            f"a function-pointer variable: expected [5], got {bad_lines(pointer)}"
+        )
+
+    for failure in failures:
+        print(f"  FAIL  {failure}", file=sys.stderr)
+    if failures:
+        return 1
+
+    print(f"  PASS  {len(CASES) + 10} cases")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tests/tools/cfuncs.py
+++ b/src/tests/tools/cfuncs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+"""The C parser the declaration-order checks read a source through.
+
+It finds a definition by its opening brace and walks back over the signature.
+What tells it where the signature starts is the shape of the line above, so a
+definition written straight under the closing brace of the one before it is
+the case to hold: read as a continuation, it reports the earlier definition a
+second time and the check never sees the later one at all.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from shared.cfuncs import definitions, is_static, name_of  # noqa: E402
+
+CASES = [
+    (
+        "a definition under the closing brace of the one before it",
+        "void Public_One(void)\n{\n}\nstatic void M_After(void)\n{\n}\n",
+        [(1, "Public_One"), (4, "M_After")],
+    ),
+    (
+        "a blank line between them",
+        "void Public_One(void)\n{\n}\n\nstatic void M_After(void)\n{\n}\n",
+        [(1, "Public_One"), (5, "M_After")],
+    ),
+    (
+        "a signature spanning several lines",
+        "void A(void)\n{\n}\nstatic void M_B(\n    const int x,\n    const int y)\n{\n}\n",
+        [(1, "A"), (4, "M_B")],
+    ),
+    (
+        "a comment sitting on the definition",
+        "void A(void)\n{\n}\n// why\nstatic void M_B(void)\n{\n}\n",
+        [(1, "A"), (5, "M_B")],
+    ),
+    (
+        "a preprocessor line above",
+        "#ifdef _WIN32\nstatic void M_B(void)\n{\n}\n#endif\n",
+        [(2, "M_B")],
+    ),
+    (
+        "an initialiser, which keeps its brace on the line that opens it",
+        "static const int m_Table[] = {\n    1,\n};\nstatic void M_B(void)\n{\n}\n",
+        [(4, "M_B")],
+    ),
+]
+
+
+def main() -> int:
+    failures = []
+
+    for label, source, expected in CASES:
+        found = [(line, name_of(sig)) for line, sig in definitions(source)]
+        if found != expected:
+            failures.append(f"{label}: expected {expected}, got {found}")
+
+    static_source = "void A(void)\n{\n}\nstatic void M_B(void)\n{\n}\n"
+    staticness = [is_static(sig) for _, sig in definitions(static_source)]
+    if staticness != [False, True]:
+        failures.append(f"is_static: expected [False, True], got {staticness}")
+
+    for failure in failures:
+        print(f"  FAIL  {failure}", file=sys.stderr)
+    if failures:
+        return 1
+
+    print(f"  PASS  {len(CASES) + 1} cases")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tests/trx/config/override.c
+++ b/src/tests/trx/config/override.c
@@ -44,6 +44,16 @@ static const CONFIG_OPTION *M_Option(const char *const name)
     return nullptr;
 }
 
+static void M_SetUp(void)
+{
+    ConfigOverride_Clear();
+    m_Enforced = false;
+    m_MusicOn = true;
+    m_Fov = 65;
+    free(m_WaterColor);
+    m_WaterColor = strdup("ff0000");
+}
+
 // The two things the stack asks the config layer for. The real parser lives in
 // config/common.c, which drags in the game; this one reads the same spellings.
 const CONFIG_OPTION *Config_GetOption(const void *const target)
@@ -99,16 +109,6 @@ bool Config_SetOptionValueFromString(
     default:
         return false;
     }
-}
-
-static void M_SetUp(void)
-{
-    ConfigOverride_Clear();
-    m_Enforced = false;
-    m_MusicOn = true;
-    m_Fov = 65;
-    free(m_WaterColor);
-    m_WaterColor = strdup("ff0000");
 }
 
 TEST(an_override_holds_the_option_and_a_restore_gives_it_back)

--- a/src/tests/trx/game/console/completion.c
+++ b/src/tests/trx/game/console/completion.c
@@ -8,15 +8,15 @@
 
 #include <string.h>
 
-static COMMAND_RESULT M_Dummy(const COMMAND_CONTEXT *const ctx)
-{
-    return CR_SUCCESS;
-}
-
 // A stub argument completer reports a fixed region-relative span, so a case can
 // watch where the selector shifts it onto the line.
 static size_t m_StubStart;
 static size_t m_StubEnd;
+
+static COMMAND_RESULT M_Dummy(const COMMAND_CONTEXT *const ctx)
+{
+    return CR_SUCCESS;
+}
 
 static void M_StubComplete(
     const struct CONSOLE_COMMAND *const cmd, const char *const text,

--- a/src/tests/trx/game/cutseq/decoder.c
+++ b/src/tests/trx/game/cutseq/decoder.c
@@ -14,6 +14,13 @@
 #define M_MAX_NODES 2
 #define M_BUF_SIZE 512
 
+// A track that never moves, for the two axes a test is not looking at.
+#define M_IDLE_AXIS                                                            \
+    (M_AXIS)                                                                   \
+    {                                                                          \
+        .key = 0, .pack_method = 8, .length = 0, .word_count = 0,              \
+    }
+
 typedef struct {
     int16_t key;
     uint8_t pack_method;
@@ -71,13 +78,6 @@ static uint32_t M_Build(
     }
     return offset;
 }
-
-// A track that never moves, for the two axes a test is not looking at.
-#define M_IDLE_AXIS                                                            \
-    (M_AXIS)                                                                   \
-    {                                                                          \
-        .key = 0, .pack_method = 8, .length = 0, .word_count = 0,              \
-    }
 
 TEST(init_nodes_reports_the_size_it_consumed)
 {

--- a/src/tests/trx/game/cutseq/pak.c
+++ b/src/tests/trx/game/cutseq/pak.c
@@ -1,6 +1,9 @@
 #include <harness/harness.h>
 
 #include <trx/game/cutseq/pak.h>
+#include <trx/core/memory.h>
+#include <trx/game/objects.h>
+#include <trx/game/shell/paths.h>
 
 #include <zlib.h>
 
@@ -297,10 +300,6 @@ TEST(a_missing_file_is_not_a_loaded_pak)
 
 // The loader's view of the outside world: a file that holds what the test
 // last published, and object ids it does not act on here.
-
-#include <trx/core/memory.h>
-#include <trx/game/objects.h>
-#include <trx/game/shell/paths.h>
 
 const char *TRXPath_TryResolve(
     const TRX_DYNAMIC_PATH path, const char *const rel)

--- a/src/tests/trx/game/items/actions.c
+++ b/src/tests/trx/game/items/actions.c
@@ -17,21 +17,6 @@ static int32_t m_ClaimedEffect;
 
 static bool m_RoutineRan;
 
-int16_t Item_GetIndex(const ITEM *const item)
-{
-    return m_FakeItemIndex;
-}
-
-ITEM_TRX_ACTION ItemAction_FromGameID(const ITEM_ACTION action)
-{
-    return (ITEM_TRX_ACTION)action;
-}
-
-int32_t Room_GetFlipEffect(void)
-{
-    return -1;
-}
-
 static bool M_Interceptor(
     const int32_t effect_num, const int32_t timer, const int16_t item_num)
 {
@@ -58,6 +43,21 @@ static void M_Reset(const int32_t claimed_effect)
     m_ClaimedEffect = claimed_effect;
     ItemAction_SetInterceptor(M_Interceptor);
     ItemAction_Register(ITEM_ACTION_LARA_NORMAL, M_Routine);
+}
+
+int16_t Item_GetIndex(const ITEM *const item)
+{
+    return m_FakeItemIndex;
+}
+
+ITEM_TRX_ACTION ItemAction_FromGameID(const ITEM_ACTION action)
+{
+    return (ITEM_TRX_ACTION)action;
+}
+
+int32_t Room_GetFlipEffect(void)
+{
+    return -1;
 }
 
 TEST(run_direct_hands_a_claimed_number_to_the_interceptor)

--- a/src/tests/trx/game/items/trigger.c
+++ b/src/tests/trx/game/items/trigger.c
@@ -29,22 +29,6 @@ static bool m_FuncCalled;
 static ITEM_TRIGGER_KIND m_FuncSawKind;
 static bool m_FuncReturn;
 
-ITEM *Item_Get(const int16_t num)
-{
-    return &m_Items[num];
-}
-
-const OBJECT *Object_Get(const OBJECT_ID id)
-{
-    return &m_Objects[id];
-}
-
-void Item_Activate(const int16_t item_num, const bool force)
-{
-    m_Activated = item_num;
-    m_ActivateCount++;
-}
-
 // Item_Trigger fires on_trigger through LUA_FireEventEx. Record that fire so
 // the matrix can check the notification, argument for argument, against the
 // real LUA_EVENT_ARG layout.
@@ -52,25 +36,6 @@ static int32_t m_NotifyCount;
 static ITEM_TRIGGER_KIND m_NotifyKind;
 static int32_t m_NotifyMask;
 static bool m_NotifyOneShot;
-
-bool Game_IsSettingUpItems(void)
-{
-    return false;
-}
-
-bool LUA_FireEventEx(
-    const LUA_EVENT_TYPE ev, const LUA_EVENT_ARG *const args,
-    const int32_t arg_count)
-{
-    if (ev != LUA_EVENT_TRIGGER) {
-        return false;
-    }
-    m_NotifyCount++;
-    m_NotifyKind = args[1].value.i32;
-    m_NotifyMask = args[2].value.i32;
-    m_NotifyOneShot = args[4].value.b;
-    return false;
-}
 
 // Mirrors the objects that read the trigger (falling_block reads the kind):
 // with the old convention this would dereference a null trigger. It must not
@@ -104,6 +69,41 @@ static ITEM *M_Reset(const int32_t version)
 static void M_Fire(const ITEM_TRIGGER trigger)
 {
     Item_Trigger(M_ITEM, &trigger);
+}
+
+ITEM *Item_Get(const int16_t num)
+{
+    return &m_Items[num];
+}
+
+const OBJECT *Object_Get(const OBJECT_ID id)
+{
+    return &m_Objects[id];
+}
+
+void Item_Activate(const int16_t item_num, const bool force)
+{
+    m_Activated = item_num;
+    m_ActivateCount++;
+}
+
+bool Game_IsSettingUpItems(void)
+{
+    return false;
+}
+
+bool LUA_FireEventEx(
+    const LUA_EVENT_TYPE ev, const LUA_EVENT_ARG *const args,
+    const int32_t arg_count)
+{
+    if (ev != LUA_EVENT_TRIGGER) {
+        return false;
+    }
+    m_NotifyCount++;
+    m_NotifyKind = args[1].value.i32;
+    m_NotifyMask = args[2].value.i32;
+    m_NotifyOneShot = args[4].value.b;
+    return false;
 }
 
 TEST(notify_carries_the_trigger_fundamentals)

--- a/src/tests/trx/game/lua/capi/struct.c
+++ b/src/tests/trx/game/lua/capi/struct.c
@@ -12,6 +12,10 @@
 // rather than merely tidy: if any of them regress, a member the declarations
 // deliberately withheld becomes reachable again.
 
+// A tiny pool so handles can be made stale on demand, the way Item_Destroy
+// does.
+#define M_POOL_SIZE 4
+
 typedef struct {
     int32_t visible;
     int32_t secret; // reachable by C, never declared to Lua
@@ -30,12 +34,24 @@ static const FIELD_DESC m_WidgetFields[] = {
 
 TYPE_DEFINE(WIDGET, m_WidgetFields)
 
-// A tiny pool so handles can be made stale on demand, the way Item_Destroy
-// does.
-#define M_POOL_SIZE 4
 static WIDGET m_Pool[M_POOL_SIZE];
 static uint16_t m_Gen[M_POOL_SIZE];
 static bool m_Dead[M_POOL_SIZE];
+
+// The declaration every test starts from: `visible` and `flag` are public,
+// `locked` is public but read-only, `reveal` is a method. `secret` and
+// `backdoor` are deliberately withheld.
+static const char DECL[] =
+    "trxc.struct.expose_field('WIDGET', 'visible', 'visible', true)\n"
+    "trxc.struct.expose_field('WIDGET', 'flag', 'flag', true)\n"
+    "trxc.struct.expose_field('WIDGET', 'locked', 'locked', false)\n"
+    // The same plain C member under two public names, one writable and one not.
+    // Read-only is the declaration's to decide, not the struct's.
+    "trxc.struct.expose_field('WIDGET', 'guarded', 'visible', false)\n"
+    "trxc.struct.expose_method('WIDGET', 'reveal', 'reveal')\n"
+    "trxc.struct.expose_computed('WIDGET', 'doubled', function(w)\n"
+    "  return w.visible * 2\n"
+    "end)\n";
 
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
@@ -107,21 +123,6 @@ static lua_State *M_NewState(const char *const declaration)
     }
     return L;
 }
-
-// The declaration every test starts from: `visible` and `flag` are public,
-// `locked` is public but read-only, `reveal` is a method. `secret` and
-// `backdoor` are deliberately withheld.
-static const char DECL[] =
-    "trxc.struct.expose_field('WIDGET', 'visible', 'visible', true)\n"
-    "trxc.struct.expose_field('WIDGET', 'flag', 'flag', true)\n"
-    "trxc.struct.expose_field('WIDGET', 'locked', 'locked', false)\n"
-    // The same plain C member under two public names, one writable and one not.
-    // Read-only is the declaration's to decide, not the struct's.
-    "trxc.struct.expose_field('WIDGET', 'guarded', 'visible', false)\n"
-    "trxc.struct.expose_method('WIDGET', 'reveal', 'reveal')\n"
-    "trxc.struct.expose_computed('WIDGET', 'doubled', function(w)\n"
-    "  return w.visible * 2\n"
-    "end)\n";
 
 // Runs a chunk; returns true if it completed without error.
 static bool M_Run(lua_State *const L, const char *const code)

--- a/src/tests/trx/game/lua/guard.c
+++ b/src/tests/trx/game/lua/guard.c
@@ -11,12 +11,6 @@
 
 static double m_Now = 0.0;
 
-double Clock_GetRealTime(void)
-{
-    m_Now += 1.0;
-    return m_Now;
-}
-
 static lua_State *M_Guarded(void)
 {
     lua_State *const L = luaL_newstate();
@@ -36,6 +30,12 @@ static bool M_Dies(lua_State *const L, const char *const src)
         && strstr(message, "without returning control") != nullptr;
     lua_pop(L, 1);
     return blamed;
+}
+
+double Clock_GetRealTime(void)
+{
+    m_Now += 1.0;
+    return m_Now;
 }
 
 TEST(guard_aborts_a_runaway_script)

--- a/src/tests/trx/game/savegame/resume.c
+++ b/src/tests/trx/game/savegame/resume.c
@@ -52,6 +52,20 @@ static LARA_INFO m_Lara;
 static ITEM m_LaraItem;
 static bool m_BonusFlag;
 
+static void M_SetUp(void)
+{
+    g_Config = (CONFIG) {};
+    g_Config.gameplay.start_lara_hitpoints = 1000;
+    g_TRVersion = 1;
+    m_BonusFlag = false;
+    m_LiveInv = (INVENTORY_STATE) {};
+    m_Lara = (LARA_INFO) {};
+    m_LaraItem = (ITEM) {};
+
+    SG_Resume_Shutdown();
+    SG_Resume_Init();
+}
+
 int32_t g_TRVersion = 1;
 WEAPON_INFO g_Weapons[NUM_WEAPONS] = {};
 
@@ -185,20 +199,6 @@ void CutSeq_SetPlayedMask(const uint64_t mask)
 const char *EnumMap_ToString(const char *const enum_name, const int32_t value)
 {
     return "?";
-}
-
-static void M_SetUp(void)
-{
-    g_Config = (CONFIG) {};
-    g_Config.gameplay.start_lara_hitpoints = 1000;
-    g_TRVersion = 1;
-    m_BonusFlag = false;
-    m_LiveInv = (INVENTORY_STATE) {};
-    m_Lara = (LARA_INFO) {};
-    m_LaraItem = (ITEM) {};
-
-    SG_Resume_Shutdown();
-    SG_Resume_Init();
 }
 
 TEST(an_entry_belongs_to_its_level_and_the_demos_share_one)

--- a/src/tests/trx/game/ui.c
+++ b/src/tests/trx/game/ui.c
@@ -44,6 +44,12 @@ typedef struct {
     void (*free)(UI_SETTINGS_DIALOG_STATE *);
 } M_DIALOG;
 
+// How far the worst node reaches outside the screen, and outside its own box.
+typedef struct {
+    float screen;
+    float box;
+} M_OVERFLOW;
+
 static const M_DIALOG m_Dialogs[] = {
     { "gameplay", UI_GameplaySettings_Init, UI_GameplaySettings,
       UI_GameplaySettings_Free },
@@ -146,12 +152,6 @@ static void M_CheckNode(
         M_CheckNode(child, canvas_w, worst, worst_box);
     }
 }
-
-// How far the worst node reaches outside the screen, and outside its own box.
-typedef struct {
-    float screen;
-    float box;
-} M_OVERFLOW;
 
 static M_OVERFLOW M_MeasureScene(void)
 {

--- a/src/trx/core/bson/write.c
+++ b/src/trx/core/bson/write.c
@@ -15,6 +15,12 @@ static bool M_GetValueWrappedSize(
 static char *M_WriteValueWrapped(
     char *data, const char *key, const JSON_VALUE *value);
 
+typedef enum {
+    M_NUMBER_INT32,
+    M_NUMBER_INT64,
+    M_NUMBER_DOUBLE,
+} M_NUMBER_KIND;
+
 static bool M_GetMarkerSize(size_t *size, const char *key)
 {
     ASSERT(size != nullptr);
@@ -102,12 +108,6 @@ static bool M_GetDoubleWrappedSize(size_t *size, const char *key)
     }
     return true;
 }
-
-typedef enum {
-    M_NUMBER_INT32,
-    M_NUMBER_INT64,
-    M_NUMBER_DOUBLE,
-} M_NUMBER_KIND;
 
 // A JSON number is a literal, and BSON has three forms to put one in. The
 // sizing pass and the writing pass have to land on the same one, so both ask

--- a/src/trx/core/virtual_file.c
+++ b/src/trx/core/virtual_file.c
@@ -7,6 +7,12 @@
 
 #include <string.h>
 
+#define DEFINE_TRY_READ(name, type)                                            \
+    bool name(VFILE *const file, type *const dst)                              \
+    {                                                                          \
+        return VFile_TryRead(file, dst, sizeof(type));                         \
+    }
+
 VFILE *VFile_CreateFromPath(const char *const path)
 {
     MYFILE *fp = File_Open(path, FILE_OPEN_READ);
@@ -152,12 +158,6 @@ double VFile_ReadDouble(VFILE *const file)
     VFile_Read(file, &result, sizeof(result));
     return result;
 }
-
-#define DEFINE_TRY_READ(name, type)                                            \
-    bool name(VFILE *const file, type *const dst)                              \
-    {                                                                          \
-        return VFile_TryRead(file, dst, sizeof(type));                         \
-    }
 
 DEFINE_TRY_READ(VFile_TryReadS8, int8_t)
 DEFINE_TRY_READ(VFile_TryReadS16, int16_t)

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -22,6 +22,20 @@ typedef struct {
     const char *name_str;
 } M_ENTRY;
 
+// Internal map from name to CATALOG_ID
+typedef struct {
+    const char *name_str;
+    int32_t enum_value;
+    UT_hash_handle hh;
+} M_NAME_ENTRY;
+
+// Internal map from game ID to CATALOG_ID
+typedef struct {
+    int32_t game_id;
+    int32_t enum_value;
+    UT_hash_handle hh;
+} M_GAME_ID_ENTRY;
+
 static const M_ENTRY m_CatalogEntryDefs[] = {
 #define X_CATALOG_ID(enum_value) { CATALOG_MUSIC, enum_value, #enum_value },
 #include <trx/game/catalog/music.def>
@@ -49,20 +63,8 @@ static const M_ENTRY m_CatalogEntryDefs[] = {
 // Number of catalog entries
 static const size_t m_CatalogEntryCount = ARRAY_SIZE(m_CatalogEntryDefs);
 
-// Internal map from name to CATALOG_ID
-typedef struct {
-    const char *name_str;
-    int32_t enum_value;
-    UT_hash_handle hh;
-} M_NAME_ENTRY;
 static M_NAME_ENTRY *m_Name2EnumMap[CATALOG_CONTEXT_MAX] = { nullptr };
 
-// Internal map from game ID to CATALOG_ID
-typedef struct {
-    int32_t game_id;
-    int32_t enum_value;
-    UT_hash_handle hh;
-} M_GAME_ID_ENTRY;
 static M_GAME_ID_ENTRY *m_GameID2EnumMap[CATALOG_CONTEXT_MAX] = { nullptr };
 
 // Parsed game IDs arrays (dynamically sized)

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -23,13 +23,6 @@
 #include <trx/game/sparks.h>
 #include <trx/version.h>
 
-static CAMERA_INFO m_LocalCamera = {};
-static OBJECT_MESH **m_CapturedObjectMeshes = nullptr;
-static OBJECT_ID *m_CapturedObjectMeshOwners = nullptr;
-static int32_t m_CapturedObjectMeshCount = 0;
-static bool m_DrawLeftGunFlash = false;
-static bool m_DrawRightGunFlash = false;
-
 typedef struct {
     bool is_valid;
     LARA_SKIN_TYPE skin_type;
@@ -39,6 +32,13 @@ typedef struct {
     LARA_GUN_TYPE thigh_r_type;
     bool holsters_visible;
 } M_LARA_CUTSCENE_STATE;
+
+static CAMERA_INFO m_LocalCamera = {};
+static OBJECT_MESH **m_CapturedObjectMeshes = nullptr;
+static OBJECT_ID *m_CapturedObjectMeshOwners = nullptr;
+static int32_t m_CapturedObjectMeshCount = 0;
+static bool m_DrawLeftGunFlash = false;
+static bool m_DrawRightGunFlash = false;
 
 static M_LARA_CUTSCENE_STATE m_LaraCutsceneState = {};
 

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -26,12 +26,6 @@
 
 #include <string.h>
 
-static bool m_IsPlaying = false;
-
-static const char *const m_FallbackExts[] = {
-    ".mp4", ".mpeg", ".webm", ".avi", ".fmv", ".rpl", nullptr,
-};
-
 #define M_FADE_TIME 0.4f
 #define M_PAUSE_OVERLAY_OPACITY 0.8f
 
@@ -45,6 +39,12 @@ typedef struct {
     bool show_pause_overlay;
     FADER pause_fader;
 } M_RENDER_CONTEXT;
+
+static bool m_IsPlaying = false;
+
+static const char *const m_FallbackExts[] = {
+    ".mp4", ".mpeg", ".webm", ".avi", ".fmv", ".rpl", nullptr,
+};
 
 static OUTPUT_QUAD_SURFACE_DESC M_MakeSurfaceDesc(
     const int32_t width, const int32_t height)

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -20,17 +20,17 @@
 
 #include <string.h>
 
+#define M_DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(name)                            \
+    int32_t name(                                                              \
+        const M_CONTEXT *ctx, GF_SEQUENCE_EVENT *event, void *extra_data,      \
+        void *user_arg)
+
 typedef struct {
     GAME_FLOW *gf;
     const char *script_path;
     JSON_READ_IO *io;
     bool validation_mode;
 } M_CONTEXT;
-
-#define M_DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(name)                            \
-    int32_t name(                                                              \
-        const M_CONTEXT *ctx, GF_SEQUENCE_EVENT *event, void *extra_data,      \
-        void *user_arg)
 
 typedef int32_t (*M_SEQUENCE_EVENT_HANDLER_FUNC)(
     const M_CONTEXT *ctx, GF_SEQUENCE_EVENT *event, void *extra_data,

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -22,21 +22,6 @@
 
 #define M_NEAR_ANGLE (DEG_1 * 15) // = 2730
 
-static ITEM *m_TargetList[LOT_SLOT_COUNT] = {};
-static ITEM *m_LastTargetList[LOT_SLOT_COUNT] = {};
-static ITEM *m_BestTarget = nullptr;
-static int16_t m_TargetCount = 0;
-
-static bool M_TargetListContains(const ITEM *const item, const int16_t count)
-{
-    for (int16_t i = 0; i < count; i++) {
-        if (m_TargetList[i] == item) {
-            return true;
-        }
-    }
-    return false;
-}
-
 typedef struct {
     const WEAPON_INFO *weapon;
     const GAME_VECTOR *start;
@@ -52,6 +37,21 @@ typedef struct {
     int16_t old_target_y_rot;
     bool old_target_in_list;
 } M_TARGET_CONTEXT;
+
+static ITEM *m_TargetList[LOT_SLOT_COUNT] = {};
+static ITEM *m_LastTargetList[LOT_SLOT_COUNT] = {};
+static ITEM *m_BestTarget = nullptr;
+static int16_t m_TargetCount = 0;
+
+static bool M_TargetListContains(const ITEM *const item, const int16_t count)
+{
+    for (int16_t i = 0; i < count; i++) {
+        if (m_TargetList[i] == item) {
+            return true;
+        }
+    }
+    return false;
+}
 
 static void M_ConsiderTarget(M_TARGET_CONTEXT *const ctx, ITEM *const item)
 {

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -18,6 +18,11 @@
 #define M_NO_TIME (-1)
 #define M_MAX_ASSAULT_TIME_FRAMES (60 * 60 * LOGIC_FPS - 3) // 59:59
 
+#define M_PRIV_INITIAL                                                         \
+    {                                                                          \
+        .is_inventory_open_enabled = -1,                                       \
+    }
+
 typedef struct {
     int32_t is_inventory_open_enabled;
     int16_t completion_timer;
@@ -41,11 +46,6 @@ typedef struct {
         int32_t lap_time_display_timer;
     } quad_course;
 } M_PRIV;
-
-#define M_PRIV_INITIAL                                                         \
-    {                                                                          \
-        .is_inventory_open_enabled = -1,                                       \
-    }
 
 static M_PRIV m_Priv = M_PRIV_INITIAL;
 

--- a/src/trx/game/inject/editors/properties.c
+++ b/src/trx/game/inject/editors/properties.c
@@ -20,6 +20,18 @@ typedef struct {
     VECTOR *properties;
 } M_PROPERTY_BATCH;
 
+// On-disk property type tags, fixed by the injection file format.
+// TRX_VALUE_TYPE orders its own constants independently, so the tag read from
+// the file is mapped to a TRX_VALUE_TYPE explicitly rather than cast.
+typedef enum {
+    M_DISK_INT = 0,
+    M_DISK_FLOAT = 1,
+    M_DISK_DOUBLE = 2,
+    M_DISK_BOOL = 3,
+    M_DISK_XYZ = 4,
+    M_DISK_RGB = 5,
+} M_DISK_PROPERTY_TYPE;
+
 static VECTOR *m_Batches = nullptr;
 
 static const char *M_ReadName(const INJECTION *const injection)
@@ -35,18 +47,6 @@ static const char *M_ReadName(const INJECTION *const injection)
 
     return name;
 }
-
-// On-disk property type tags, fixed by the injection file format.
-// TRX_VALUE_TYPE orders its own constants independently, so the tag read from
-// the file is mapped to a TRX_VALUE_TYPE explicitly rather than cast.
-typedef enum {
-    M_DISK_INT = 0,
-    M_DISK_FLOAT = 1,
-    M_DISK_DOUBLE = 2,
-    M_DISK_BOOL = 3,
-    M_DISK_XYZ = 4,
-    M_DISK_RGB = 5,
-} M_DISK_PROPERTY_TYPE;
 
 static TRX_VALUE M_ReadValue(const INJECTION *const injection)
 {

--- a/src/trx/game/input/backends/controller.c
+++ b/src/trx/game/input/backends/controller.c
@@ -8,35 +8,6 @@
 #include <SDL2/SDL_gamecontroller.h>
 #include <string.h>
 
-typedef enum {
-    BT_BUTTON = 0,
-    BT_AXIS = 1,
-} BUTTON_TYPE;
-
-typedef struct {
-    BUTTON_TYPE type;
-    union {
-        SDL_GameControllerButton button;
-        SDL_GameControllerAxis axis;
-    } bind;
-    int16_t axis_dir;
-} CONTROLLER_MAP;
-
-typedef struct {
-    INPUT_ROLE role;
-    CONTROLLER_MAP map;
-} BUILTIN_CONTROLLER_LAYOUT;
-
-static BUILTIN_CONTROLLER_LAYOUT m_BuiltinLayout[] = {
-#define INPUT_CONTROLLER_ASSIGN_BUTTON(role, bind)                             \
-    { role, { BT_BUTTON, { .button = bind }, 0 } },
-#define INPUT_CONTROLLER_ASSIGN_AXIS(role, bind, axis_dir)                     \
-    { role, { BT_AXIS, { .axis = bind }, axis_dir } },
-#include <trx/game/input/backends/controller.def>
-    // guard
-    { -1, { 0, { 0 }, 0 } },
-};
-
 // clang-format off
 #define M_ICON_X              "\\{controller button cross}"
 #define M_ICON_CIRCLE         "\\{controller button circle}"
@@ -93,6 +64,30 @@ static BUILTIN_CONTROLLER_LAYOUT m_BuiltinLayout[] = {
 #define M_NAME_Y              "\\{controller button y}"
 // clang-format on
 
+// Per-button/axis tracking for combo prefix deferral.
+// Index: buttons use their enum directly, axes use
+// SDL_CONTROLLER_BUTTON_MAX + axis*2 + (axis_dir == 1 ? 1 : 0).
+#define M_PREFIX_SLOTS (SDL_CONTROLLER_BUTTON_MAX + SDL_CONTROLLER_AXIS_MAX * 2)
+
+typedef enum {
+    BT_BUTTON = 0,
+    BT_AXIS = 1,
+} BUTTON_TYPE;
+
+typedef struct {
+    BUTTON_TYPE type;
+    union {
+        SDL_GameControllerButton button;
+        SDL_GameControllerAxis axis;
+    } bind;
+    int16_t axis_dir;
+} CONTROLLER_MAP;
+
+typedef struct {
+    INPUT_ROLE role;
+    CONTROLLER_MAP map;
+} BUILTIN_CONTROLLER_LAYOUT;
+
 typedef struct {
     int32_t key_count;
     CONTROLLER_MAP keys[INPUT_COMBO_MAX_KEYS];
@@ -101,6 +96,16 @@ typedef struct {
 typedef struct {
     CONTROLLER_BINDING slots[INPUT_BINDING_SLOTS];
 } CONTROLLER_ROLE_BINDING;
+
+static BUILTIN_CONTROLLER_LAYOUT m_BuiltinLayout[] = {
+#define INPUT_CONTROLLER_ASSIGN_BUTTON(role, bind)                             \
+    { role, { BT_BUTTON, { .button = bind }, 0 } },
+#define INPUT_CONTROLLER_ASSIGN_AXIS(role, bind, axis_dir)                     \
+    { role, { BT_AXIS, { .axis = bind }, axis_dir } },
+#include <trx/game/input/backends/controller.def>
+    // guard
+    { -1, { 0, { 0 }, 0 } },
+};
 
 static CONTROLLER_ROLE_BINDING m_Layout[INPUT_LAYOUT_NUMBER_OF]
                                        [INPUT_ROLE_NUMBER_OF];
@@ -114,6 +119,23 @@ static bool m_Conflicts[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF] = {};
 // Internal controller state tables updated via SDL events
 static bool m_ButtonState[SDL_CONTROLLER_BUTTON_MAX] = {};
 static int16_t m_AxisState[SDL_CONTROLLER_AXIS_MAX] = {};
+
+static bool m_PrefixWasHeld[M_PREFIX_SLOTS];
+static bool m_PrefixComboFired[M_PREFIX_SLOTS];
+
+// Per-input press-tick table, indexed the same way as the prefix arrays.
+static uint32_t m_InputDownTick[M_PREFIX_SLOTS];
+static uint32_t m_Tick;
+
+// Per-role deferral tracking for combo disambiguation.
+static bool m_RoleWasActive[INPUT_ROLE_NUMBER_OF];
+
+static bool m_RoleLongerFired[INPUT_ROLE_NUMBER_OF];
+
+// Combo capture state for listen mode.
+static CONTROLLER_BINDING m_CaptureBuffer = { .key_count = 0 };
+
+static bool m_CaptureActive = false;
 
 static const char *M_GetButtonName(const SDL_GameControllerButton button)
 {
@@ -270,10 +292,39 @@ static bool M_CheckBinding(const CONTROLLER_BINDING *const bind)
     return true;
 }
 
-// Combo adapter forward declarations.
+static const CONTROLLER_BINDING *M_GetBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    return &m_Layout[layout][role].slots[slot];
+}
+
 static INPUT_COMBO_BINDING M_GetComboBinding(
-    INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
-static bool M_ComboKeysEqual(const void *a, const void *b);
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    const CONTROLLER_BINDING *b = M_GetBinding(layout, role, slot);
+    return (INPUT_COMBO_BINDING) {
+        .key_count = b->key_count,
+        .keys = b->keys,
+        .key_stride = sizeof(CONTROLLER_MAP),
+    };
+}
+
+static bool M_MapsEqual(
+    const CONTROLLER_MAP *const a, const CONTROLLER_MAP *const b)
+{
+    if (a->type != b->type) {
+        return false;
+    }
+    if (a->type == BT_BUTTON) {
+        return a->bind.button == b->bind.button;
+    }
+    return a->bind.axis == b->bind.axis && a->axis_dir == b->axis_dir;
+}
+
+static bool M_ComboKeysEqual(const void *const a, const void *const b)
+{
+    return M_MapsEqual((const CONTROLLER_MAP *)a, (const CONTROLLER_MAP *)b);
+}
 
 static bool M_GetBindState(const INPUT_LAYOUT layout, const INPUT_ROLE role)
 {
@@ -289,24 +340,6 @@ static bool M_GetBindState(const INPUT_LAYOUT layout, const INPUT_ROLE role)
         }
     }
     return false;
-}
-
-static const CONTROLLER_BINDING *M_GetBinding(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
-{
-    return &m_Layout[layout][role].slots[slot];
-}
-
-static bool M_MapsEqual(
-    const CONTROLLER_MAP *const a, const CONTROLLER_MAP *const b)
-{
-    if (a->type != b->type) {
-        return false;
-    }
-    if (a->type == BT_BUTTON) {
-        return a->bind.button == b->bind.button;
-    }
-    return a->bind.axis == b->bind.axis && a->axis_dir == b->axis_dir;
 }
 
 static bool M_BindingsEqual(
@@ -703,17 +736,6 @@ static bool M_AssignToJSONObject(
     return true;
 }
 
-// Per-button/axis tracking for combo prefix deferral.
-// Index: buttons use their enum directly, axes use
-// SDL_CONTROLLER_BUTTON_MAX + axis*2 + (axis_dir == 1 ? 1 : 0).
-#define M_PREFIX_SLOTS (SDL_CONTROLLER_BUTTON_MAX + SDL_CONTROLLER_AXIS_MAX * 2)
-static bool m_PrefixWasHeld[M_PREFIX_SLOTS];
-static bool m_PrefixComboFired[M_PREFIX_SLOTS];
-
-// Per-input press-tick table, indexed the same way as the prefix arrays.
-static uint32_t m_InputDownTick[M_PREFIX_SLOTS];
-static uint32_t m_Tick;
-
 static int32_t M_MapToPrefixIdx(const CONTROLLER_MAP *const map)
 {
     if (map->type == BT_BUTTON) {
@@ -731,23 +753,6 @@ static uint32_t M_GetPressTick(const void *const key)
 static bool M_IsInputHeld(const CONTROLLER_MAP *const map)
 {
     return M_CheckMap(map);
-}
-
-// Combo adapter functions for the shared combo layer.
-static INPUT_COMBO_BINDING M_GetComboBinding(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
-{
-    const CONTROLLER_BINDING *b = M_GetBinding(layout, role, slot);
-    return (INPUT_COMBO_BINDING) {
-        .key_count = b->key_count,
-        .keys = b->keys,
-        .key_stride = sizeof(CONTROLLER_MAP),
-    };
-}
-
-static bool M_ComboKeysEqual(const void *const a, const void *const b)
-{
-    return M_MapsEqual((const CONTROLLER_MAP *)a, (const CONTROLLER_MAP *)b);
 }
 
 static INPUT_COMBO_BINDING M_ToCombo(const CONTROLLER_BINDING *const b)
@@ -798,10 +803,6 @@ static void M_ResolvePrefixDeferral(
 
     m_PrefixWasHeld[idx] = held;
 }
-
-// Per-role deferral tracking for combo disambiguation.
-static bool m_RoleWasActive[INPUT_ROLE_NUMBER_OF];
-static bool m_RoleLongerFired[INPUT_ROLE_NUMBER_OF];
 
 static void M_ResolveCombos(
     const INPUT_LAYOUT layout, INPUT_STATE *const result)
@@ -972,10 +973,6 @@ static void M_ResolveCombos(
         }
     }
 }
-
-// Combo capture state for listen mode.
-static CONTROLLER_BINDING m_CaptureBuffer = { .key_count = 0 };
-static bool m_CaptureActive = false;
 
 static bool M_CaptureHasMap(const CONTROLLER_MAP *const map)
 {

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -42,6 +42,26 @@ static BUILTIN_KEYBOARD_LAYOUT m_BuiltinLayout[ARRAY_SIZE(m_BuiltinLayoutBase)];
 static KEYBOARD_ROLE_BINDING m_Layout[INPUT_LAYOUT_NUMBER_OF]
                                      [INPUT_ROLE_NUMBER_OF];
 
+// Per-scancode tracking for combo prefix deferral.
+static bool m_PrefixWasHeld[SDL_NUM_SCANCODES];
+static bool m_PrefixComboFired[SDL_NUM_SCANCODES];
+
+// Per-scancode press-tick table. Records the tick each key most recently
+// transitioned from released to held, so combos that start on keys the
+// user was already holding can be rejected.
+static uint32_t m_KeyDownTick[SDL_NUM_SCANCODES];
+static uint32_t m_Tick;
+
+// Per-role deferral tracking for combo disambiguation.
+static bool m_RoleWasActive[INPUT_ROLE_NUMBER_OF];
+
+static bool m_RoleLongerFired[INPUT_ROLE_NUMBER_OF];
+
+// Combo capture state for listen mode.
+static KEYBOARD_BINDING m_CaptureBuffer = { .key_count = 0 };
+
+static bool m_CaptureActive = false;
+
 // Update internal controller button/axis state from SDL events.
 // @param event     Event to process.
 static void M_ProcessEvent(const SDL_Event *const event)
@@ -355,10 +375,28 @@ static bool M_CheckBinding(const KEYBOARD_BINDING *const bind)
     return true;
 }
 
-// Combo adapter forward declarations.
+static const KEYBOARD_BINDING *M_GetBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    return &m_Layout[layout][role].slots[slot];
+}
+
+// Combo adapter functions for the shared combo layer.
 static INPUT_COMBO_BINDING M_GetComboBinding(
-    INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
-static bool M_ComboKeysEqual(const void *a, const void *b);
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    const KEYBOARD_BINDING *b = M_GetBinding(layout, role, slot);
+    return (INPUT_COMBO_BINDING) {
+        .key_count = b->key_count,
+        .keys = b->keys,
+        .key_stride = sizeof(SDL_Scancode),
+    };
+}
+
+static bool M_ComboKeysEqual(const void *const a, const void *const b)
+{
+    return *(const SDL_Scancode *)a == *(const SDL_Scancode *)b;
+}
 
 static bool M_Key(const INPUT_LAYOUT layout, const INPUT_ROLE role)
 {
@@ -374,12 +412,6 @@ static bool M_Key(const INPUT_LAYOUT layout, const INPUT_ROLE role)
         }
     }
     return false;
-}
-
-static const KEYBOARD_BINDING *M_GetBinding(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
-{
-    return &m_Layout[layout][role].slots[slot];
 }
 
 static bool M_BindingsEqual(
@@ -643,36 +675,9 @@ static bool M_AssignToJSONObject(
     return true;
 }
 
-// Per-scancode tracking for combo prefix deferral.
-static bool m_PrefixWasHeld[SDL_NUM_SCANCODES];
-static bool m_PrefixComboFired[SDL_NUM_SCANCODES];
-
-// Per-scancode press-tick table. Records the tick each key most recently
-// transitioned from released to held, so combos that start on keys the
-// user was already holding can be rejected.
-static uint32_t m_KeyDownTick[SDL_NUM_SCANCODES];
-static uint32_t m_Tick;
-
 static uint32_t M_GetPressTick(const void *const key)
 {
     return m_KeyDownTick[*(const SDL_Scancode *)key];
-}
-
-// Combo adapter functions for the shared combo layer.
-static INPUT_COMBO_BINDING M_GetComboBinding(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
-{
-    const KEYBOARD_BINDING *b = M_GetBinding(layout, role, slot);
-    return (INPUT_COMBO_BINDING) {
-        .key_count = b->key_count,
-        .keys = b->keys,
-        .key_stride = sizeof(SDL_Scancode),
-    };
-}
-
-static bool M_ComboKeysEqual(const void *const a, const void *const b)
-{
-    return *(const SDL_Scancode *)a == *(const SDL_Scancode *)b;
 }
 
 static INPUT_COMBO_BINDING M_ToCombo(const KEYBOARD_BINDING *const b)
@@ -695,10 +700,6 @@ static const KEYBOARD_BINDING *M_GetPressedBinding(
     }
     return nullptr;
 }
-
-// Per-role deferral tracking for combo disambiguation.
-static bool m_RoleWasActive[INPUT_ROLE_NUMBER_OF];
-static bool m_RoleLongerFired[INPUT_ROLE_NUMBER_OF];
 
 static void M_ResolveCombos(
     const INPUT_LAYOUT layout, INPUT_STATE *const result)
@@ -860,10 +861,6 @@ static void M_ResolveCombos(
         m_PrefixWasHeld[sc] = held;
     }
 }
-
-// Combo capture state for listen mode.
-static KEYBOARD_BINDING m_CaptureBuffer = { .key_count = 0 };
-static bool m_CaptureActive = false;
 
 static bool M_CaptureHasKey(const SDL_Scancode scancode)
 {

--- a/src/trx/game/lara/electric.c
+++ b/src/trx/game/lara/electric.c
@@ -7,6 +7,11 @@
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/random.h>
 
+typedef struct {
+    XYZ_16 pos;
+    XYZ_16 vel;
+} M_ELECTRIC_POINT;
+
 static const uint8_t m_LaraMeshes[28] = {
     0, 1, 1, 2, 2, 3,  0, 4,  4,  5,  5,  6,  0, 7,
     7, 8, 8, 9, 9, 10, 7, 11, 11, 12, 12, 13, 7, 14,
@@ -15,11 +20,6 @@ static const uint8_t m_LaraLastPoints[14] = {
     0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 1,
 };
 static const uint8_t m_LaraLineCounts[6] = { 12, 12, 4, 12, 12, 4 };
-
-typedef struct {
-    XYZ_16 pos;
-    XYZ_16 vel;
-} M_ELECTRIC_POINT;
 
 static M_ELECTRIC_POINT m_ElectricityPoints[32] = {};
 

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -26,11 +26,6 @@
 #define M_BONE_IDX(segment)                                                    \
     (segment == M_HAIR_SEGMENTS ? (segment - 2) : (segment - 1))
 
-static bool m_IsFirstHair[M_MAX_BRAIDS];
-static SPHERE m_HairSpheres[M_HAIR_SPHERES];
-static XYZ_32 m_HairVelocity[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
-static HAIR_SEGMENT m_HairSegments[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
-
 // A ring of vertices two braid meshes share, found once at outfit apply and
 // pinned by the weld each frame. Empty when the meshes share no ring, which
 // leaves that seam drawn exactly as authored.
@@ -38,6 +33,11 @@ typedef struct {
     int32_t count;
     SEAM_VERTEX_PAIR pairs[SEAM_MAX_VERTEX_PAIRS];
 } M_SEGMENT_SEAM;
+
+static bool m_IsFirstHair[M_MAX_BRAIDS];
+static SPHERE m_HairSpheres[M_HAIR_SPHERES];
+static XYZ_32 m_HairVelocity[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
+static HAIR_SEGMENT m_HairSegments[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
 
 // The braid weld state, kept between outfit applies.
 //

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -13,6 +13,16 @@
 #include <trx/game/pathing/lot.h>
 #include <trx/game/rooms.h>
 
+typedef struct {
+    XYZ_32 min;
+    XYZ_32 max;
+} M_BOX;
+
+typedef struct {
+    XYZ_32 centre;
+    int64_t radius_sq;
+} M_SPHERE;
+
 static bool M_GetAnim(const void *const self, TRX_VALUE *const out)
 {
     *out = (TRX_VALUE) {
@@ -446,16 +456,6 @@ static int M_PushItemsWhere(
     }
     return 1;
 }
-
-typedef struct {
-    XYZ_32 min;
-    XYZ_32 max;
-} M_BOX;
-
-typedef struct {
-    XYZ_32 centre;
-    int64_t radius_sq;
-} M_SPHERE;
 
 static bool M_InBox(const XYZ_32 pos, const void *const arg)
 {

--- a/src/trx/game/lua/capi/music.c
+++ b/src/trx/game/lua/capi/music.c
@@ -17,15 +17,24 @@ typedef struct {
     double timestamp;
 } MUSIC_STREAM_VIEW;
 
+// A track handle addresses a track by id, and exists only while the track is
+// available: a handle to a track the loaded level does not carry goes stale.
+typedef struct {
+    int32_t id;
+} MUSIC_TRACK_VIEW;
+
 static MUSIC_STREAM_VIEW m_StreamViews[1 + MUSIC_MAX_OVERLAY_TRACKS];
 
-// clang-format off
 static const FIELD_DESC m_StreamFields[] = {
     FIELD_RO(MUSIC_STREAM_VIEW, track_id),
     FIELD_RO(MUSIC_STREAM_VIEW, mode),
     FIELD_RO(MUSIC_STREAM_VIEW, timestamp),
 };
-// clang-format on
+static MUSIC_TRACK_VIEW m_TrackView;
+
+static const FIELD_DESC m_TrackFields[] = {
+    FIELD_RO(MUSIC_TRACK_VIEW, id),
+};
 
 TYPE_DEFINE(MUSIC_STREAM_VIEW, m_StreamFields)
 
@@ -154,20 +163,6 @@ static int M_L_MusicGetLoopedTrack(lua_State *const L)
     }
     return 1;
 }
-
-// A track handle addresses a track by id, and exists only while the track is
-// available: a handle to a track the loaded level does not carry goes stale.
-typedef struct {
-    int32_t id;
-} MUSIC_TRACK_VIEW;
-
-static MUSIC_TRACK_VIEW m_TrackView;
-
-// clang-format off
-static const FIELD_DESC m_TrackFields[] = {
-    FIELD_RO(MUSIC_TRACK_VIEW, id),
-};
-// clang-format on
 
 TYPE_DEFINE(MUSIC_TRACK_VIEW, m_TrackFields)
 

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -34,105 +34,6 @@ static const FIELD_DESC m_Fields[] = {
 
 TYPE_DEFINE(OBJECT, m_Fields)
 
-// An object is addressed by its id, and an id is valid for the whole session -
-// there is no pool to recycle and nothing to go stale. An object the level did
-// not load still exists as a definition; `loaded` is how a script tells.
-static void *M_Resolve(const LUA_STRUCT_REF *const ref)
-{
-    return Object_TryGet((OBJECT_ID)ref->handle.id);
-}
-
-// The object property overlay stays a separate namespace: fields address the
-// OBJECT struct, properties are what the object declares about itself. The
-// bridges themselves are in lua/utils.
-static bool M_GetPropertyValue(
-    const void *const self, const char *const name, TRX_VALUE *const out)
-{
-    return ObjectProperty_GetObjectValue(self, name, out);
-}
-
-static const char *M_SetPropertyValue(
-    void *const self, const char *const name, const TRX_VALUE value)
-{
-    return ObjectProperty_SetObjectValueRaw(self, name, value);
-}
-
-static int32_t M_GetPropertyCount(const void *const self)
-{
-    return ObjectProperty_GetObjectNameCount(self);
-}
-
-static const char *M_GetPropertyName(const void *const self, const int32_t idx)
-{
-    return ObjectProperty_GetObjectName(self, idx);
-}
-
-// trxc.objects.get(object_id) -> OBJECT handle or nil
-static int M_L_ObjectsGet(lua_State *const L)
-{
-    int32_t object_id;
-    if (!LUA_CheckBoundedInt(L, 1, O_FIRST, O_NUMBER_OF - 1, &object_id)) {
-        lua_pushnil(L);
-        return 1;
-    }
-    LUA_Struct_Push(
-        L, &TYPE_OBJECT, M_Resolve,
-        (TRX_HANDLE) { .id = (OBJECT_ID)object_id });
-    return 1;
-}
-
-// trxc.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)
-static int M_L_ObjectsSwapMesh(lua_State *const L)
-{
-    const int32_t arg_count = lua_gettop(L);
-    const OBJECT_ID obj1_id = LUA_CheckObjectID(L, 1);
-    const OBJECT_ID obj2_id = LUA_CheckObjectID(L, 2);
-    if (arg_count == 2) {
-        Object_SwapAllMeshes(obj1_id, obj2_id);
-        return 0;
-    }
-    if (arg_count != 4) {
-        return luaL_error(L, "swap_mesh takes both mesh numbers, or neither");
-    }
-
-    // An object that did not load has no meshes, and no count to measure a mesh
-    // number against.
-    const OBJECT *const obj1 = Object_Get(obj1_id);
-    const OBJECT *const obj2 = Object_Get(obj2_id);
-    if (!obj1->loaded || !obj2->loaded) {
-        return 0;
-    }
-
-    // Object_SwapMeshEx swaps the two pointers at an offset it does not check.
-    const int32_t mesh1_num =
-        LUA_CheckRange(L, 3, obj1->mesh_count, "no such mesh on this object");
-    const int32_t mesh2_num =
-        LUA_CheckRange(L, 4, obj2->mesh_count, "no such mesh on this object");
-    Object_SwapMeshEx(obj1_id, obj2_id, mesh1_num, mesh2_num);
-    return 0;
-}
-
-// trxc.objects.swap_sprite(obj1_id, obj2_id)
-static int M_L_ObjectsSwapSprite(lua_State *const L)
-{
-    const OBJECT_ID obj1_id = LUA_CheckObjectID(L, 1);
-    const OBJECT_ID obj2_id = LUA_CheckObjectID(L, 2);
-    const OBJECT *const obj1 = Object_Get(obj1_id);
-    const OBJECT *const obj2 = Object_Get(obj2_id);
-    if (!obj1->loaded || !obj2->loaded) {
-        return 0;
-    }
-
-    // A modelled object holds meshes in the slots this writes, so moving a
-    // sprite into one would draw it from mesh data.
-    if (obj1->mesh_count >= 0 || obj2->mesh_count >= 0) {
-        return luaL_error(L, "both objects must be drawn as sprites");
-    }
-
-    Object_SwapSprite(obj1_id, obj2_id);
-    return 0;
-}
-
 // What a pickup is, as pickups.def already divides them. These are a scripting
 // concept and nothing in the engine asks for them, so they stay here rather
 // than joining the global object arrays.
@@ -232,6 +133,105 @@ static const struct {
     { "inventory", g_InvObjects },
     { nullptr, nullptr },
 };
+
+// An object is addressed by its id, and an id is valid for the whole session -
+// there is no pool to recycle and nothing to go stale. An object the level did
+// not load still exists as a definition; `loaded` is how a script tells.
+static void *M_Resolve(const LUA_STRUCT_REF *const ref)
+{
+    return Object_TryGet((OBJECT_ID)ref->handle.id);
+}
+
+// The object property overlay stays a separate namespace: fields address the
+// OBJECT struct, properties are what the object declares about itself. The
+// bridges themselves are in lua/utils.
+static bool M_GetPropertyValue(
+    const void *const self, const char *const name, TRX_VALUE *const out)
+{
+    return ObjectProperty_GetObjectValue(self, name, out);
+}
+
+static const char *M_SetPropertyValue(
+    void *const self, const char *const name, const TRX_VALUE value)
+{
+    return ObjectProperty_SetObjectValueRaw(self, name, value);
+}
+
+static int32_t M_GetPropertyCount(const void *const self)
+{
+    return ObjectProperty_GetObjectNameCount(self);
+}
+
+static const char *M_GetPropertyName(const void *const self, const int32_t idx)
+{
+    return ObjectProperty_GetObjectName(self, idx);
+}
+
+// trxc.objects.get(object_id) -> OBJECT handle or nil
+static int M_L_ObjectsGet(lua_State *const L)
+{
+    int32_t object_id;
+    if (!LUA_CheckBoundedInt(L, 1, O_FIRST, O_NUMBER_OF - 1, &object_id)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    LUA_Struct_Push(
+        L, &TYPE_OBJECT, M_Resolve,
+        (TRX_HANDLE) { .id = (OBJECT_ID)object_id });
+    return 1;
+}
+
+// trxc.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)
+static int M_L_ObjectsSwapMesh(lua_State *const L)
+{
+    const int32_t arg_count = lua_gettop(L);
+    const OBJECT_ID obj1_id = LUA_CheckObjectID(L, 1);
+    const OBJECT_ID obj2_id = LUA_CheckObjectID(L, 2);
+    if (arg_count == 2) {
+        Object_SwapAllMeshes(obj1_id, obj2_id);
+        return 0;
+    }
+    if (arg_count != 4) {
+        return luaL_error(L, "swap_mesh takes both mesh numbers, or neither");
+    }
+
+    // An object that did not load has no meshes, and no count to measure a mesh
+    // number against.
+    const OBJECT *const obj1 = Object_Get(obj1_id);
+    const OBJECT *const obj2 = Object_Get(obj2_id);
+    if (!obj1->loaded || !obj2->loaded) {
+        return 0;
+    }
+
+    // Object_SwapMeshEx swaps the two pointers at an offset it does not check.
+    const int32_t mesh1_num =
+        LUA_CheckRange(L, 3, obj1->mesh_count, "no such mesh on this object");
+    const int32_t mesh2_num =
+        LUA_CheckRange(L, 4, obj2->mesh_count, "no such mesh on this object");
+    Object_SwapMeshEx(obj1_id, obj2_id, mesh1_num, mesh2_num);
+    return 0;
+}
+
+// trxc.objects.swap_sprite(obj1_id, obj2_id)
+static int M_L_ObjectsSwapSprite(lua_State *const L)
+{
+    const OBJECT_ID obj1_id = LUA_CheckObjectID(L, 1);
+    const OBJECT_ID obj2_id = LUA_CheckObjectID(L, 2);
+    const OBJECT *const obj1 = Object_Get(obj1_id);
+    const OBJECT *const obj2 = Object_Get(obj2_id);
+    if (!obj1->loaded || !obj2->loaded) {
+        return 0;
+    }
+
+    // A modelled object holds meshes in the slots this writes, so moving a
+    // sprite into one would draw it from mesh data.
+    if (obj1->mesh_count >= 0 || obj2->mesh_count >= 0) {
+        return luaL_error(L, "both objects must be drawn as sprites");
+    }
+
+    Object_SwapSprite(obj1_id, obj2_id);
+    return 0;
+}
 
 // trxc.objects.is_type(object_id, kind) -> bool
 static int M_L_ObjectsIsType(lua_State *const L)

--- a/src/trx/game/lua/capi/sound.c
+++ b/src/trx/game/lua/capi/sound.c
@@ -19,13 +19,13 @@ typedef struct {
     int32_t pitch;
 } SOUND_SAMPLE_VIEW;
 
-static SOUND_SAMPLE_VIEW m_SampleView;
-
 // A stream handle addresses an active-sound slot; when the slot falls silent,
 // the handle goes stale.
 typedef struct {
     int32_t sample_id;
 } SOUND_STREAM_VIEW;
+
+static SOUND_SAMPLE_VIEW m_SampleView;
 
 static SOUND_STREAM_VIEW m_StreamView;
 

--- a/src/trx/game/lua/capi/stats.c
+++ b/src/trx/game/lua/capi/stats.c
@@ -23,18 +23,6 @@
 #define M_CAT_LEVEL(packed) ((packed) >> 8)
 #define M_CAT_ID(packed) ((packed) & 0xff)
 
-// The count is the level's, and the view is a copy of it, so a write goes back
-// to where it came from rather than into the copy.
-static const char *M_SetCategoryCount(
-    void *const self, const TRX_VALUE *const in)
-{
-    const STATS_CATEGORY *const category = self;
-    if (!Stats_SetCategoryCount(category->level, category->id, in->as_int)) {
-        return "this count is not the level's to set";
-    }
-    return nullptr;
-}
-
 // clang-format off
 static const FIELD_DESC m_StatsFields[] = {
     FIELD(LEVEL_STATS, timer),
@@ -48,6 +36,18 @@ static const FIELD_DESC m_StatsFields[] = {
     // counts behind it are not members here. The secret mask is not one
     // either: which secrets Lara holds is what the secret verbs answer.
 };
+
+// The count is the level's, and the view is a copy of it, so a write goes back
+// to where it came from rather than into the copy.
+static const char *M_SetCategoryCount(
+    void *const self, const TRX_VALUE *const in)
+{
+    const STATS_CATEGORY *const category = self;
+    if (!Stats_SetCategoryCount(category->level, category->id, in->as_int)) {
+        return "this count is not the level's to set";
+    }
+    return nullptr;
+}
 
 static const FIELD_DESC m_CategoryFields[] = {
     FIELD_SET(STATS_CATEGORY, count, M_SetCategoryCount),

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -17,6 +17,13 @@
 #include <trx/game/shell/paths.h>
 #include <trx/version.h>
 
+typedef struct {
+    int32_t audio_stream_id;
+    MUSIC_ID track_id;
+    MUSIC_PLAY_MODE mode;
+    bool active;
+} M_MUSIC_STREAM;
+
 static bool m_Initialised = false;
 static MUSIC_TRACK_STATE m_TrackStates[MAX_MUSIC_TRACKS] = {};
 static MUSIC_ID m_TrackCurrent = MX_INACTIVE;
@@ -26,13 +33,6 @@ static MUSIC_ID m_TrackLooped = MX_INACTIVE;
 // immediately restarting it if Lara remains on the same trigger.
 static MUSIC_ID m_TrackLastPlayed = MX_INACTIVE;
 static MUSIC_ID m_TrackLastLooped = MX_INACTIVE;
-
-typedef struct {
-    int32_t audio_stream_id;
-    MUSIC_ID track_id;
-    MUSIC_PLAY_MODE mode;
-    bool active;
-} M_MUSIC_STREAM;
 
 static float m_MusicVolume = 0.0f;
 static MUSIC_BACKEND *m_Backend = nullptr;

--- a/src/trx/game/objects/creatures/crocodile.c
+++ b/src/trx/game/objects/creatures/crocodile.c
@@ -60,6 +60,10 @@ typedef enum {
     M_ALLIGATOR_STATE_DEATH = 3,
 } M_ALLIGATOR_STATE;
 
+typedef struct {
+    int32_t damage;
+} M_PRIV;
+
 static BITE m_CrocodileBite = {
     .pos = { 5, -21, 467 },
     .mesh_num = 9,
@@ -75,10 +79,6 @@ static const HYBRID_INFO m_CrocodileInfo = {
     .water.death_anim = M_ALLIGATOR_DIE_ANIM,
     .water.death_state = M_ALLIGATOR_STATE_DEATH,
 };
-
-typedef struct {
-    int32_t damage;
-} M_PRIV;
 
 static void M_UpdateCreatureLOT(const ITEM *const item)
 {

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -32,11 +32,6 @@ typedef struct {
     int32_t jump_damage;
 } M_PRIV;
 
-static BITE m_MonkeyBite = {
-    .pos = { 10, 10, 11 },
-    .mesh_num = 13,
-};
-
 typedef enum {
     M_STATE_EMPTY,
     M_STATE_STOP,
@@ -71,6 +66,11 @@ typedef enum {
     M_ANIM_DOWN_3 = 21,
     M_ANIM_DOWN_4 = 20,
 } M_ANIM;
+
+static BITE m_MonkeyBite = {
+    .pos = { 10, 10, 11 },
+    .mesh_num = 13,
+};
 
 static void M_Bite(ITEM *const item, ITEM *const enemy, const int32_t dmg)
 {

--- a/src/trx/game/objects/creatures/patrol_dog.c
+++ b/src/trx/game/objects/creatures/patrol_dog.c
@@ -32,11 +32,6 @@ typedef struct {
     int32_t bite_damage;
 } M_PRIV;
 
-static BITE m_DogBite = {
-    .pos = { .x = 0, .y = 0, .z = 100 },
-    .mesh_num = 3,
-};
-
 typedef enum {
     M_STATE_NULL,
     M_STATE_STOP,
@@ -59,6 +54,11 @@ typedef enum {
     M_ANIM_DEATH_2 = 21,
     M_ANIM_DEATH_3 = 22,
 } M_ANIM;
+
+static BITE m_DogBite = {
+    .pos = { .x = 0, .y = 0, .z = 100 },
+    .mesh_num = 3,
+};
 
 static M_ANIM m_DeathAnimCount = 4;
 static M_ANIM m_DeathAnims[4] = {

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -45,6 +45,13 @@ typedef struct {
     bool speech_started;
 } M_PRIV;
 
+static const CREATURE_GUN m_KidGun1 = {
+    .muzzle = { .pos = { 0, 150, 34 }, .mesh_num = 7 },
+};
+static const CREATURE_GUN m_KidGun2 = {
+    .muzzle = { .pos = { 0, 150, 37 }, .mesh_num = 4 },
+};
+
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
@@ -56,13 +63,6 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     const M_PRIV *const p = item->priv;
     JSONW_WRITE(io, "speech_started", p->speech_started);
 }
-
-static const CREATURE_GUN m_KidGun1 = {
-    .muzzle = { .pos = { 0, 150, 34 }, .mesh_num = 7 },
-};
-static const CREATURE_GUN m_KidGun2 = {
-    .muzzle = { .pos = { 0, 150, 37 }, .mesh_num = 4 },
-};
 
 static void M_Initialise(const int16_t item_num)
 {

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -38,6 +38,18 @@ static const OBJECT_BOUNDS m_CrowbarDoorBounds = {
     },
 };
 
+static const SECTOR m_BlockedSector = {
+    .idx = 0,
+    .box = NO_BOX,
+    .ceiling.height = NO_HEIGHT,
+    .floor.height = NO_HEIGHT,
+    .ceiling.tilt = {},
+    .floor.tilt = {},
+    .portal_room.sky = NO_ROOM,
+    .portal_room.pit = NO_ROOM,
+    .portal_room.wall = NO_ROOM,
+};
+
 static const XYZ_32 m_CrowbarDoorPosition = { .x = -412, .y = 0, .z = 140 };
 
 static bool M_ShowCrowbarInventory(void)
@@ -53,18 +65,6 @@ static bool M_ShowCrowbarInventory(void)
     }
     return true;
 }
-
-static const SECTOR m_BlockedSector = {
-    .idx = 0,
-    .box = NO_BOX,
-    .ceiling.height = NO_HEIGHT,
-    .floor.height = NO_HEIGHT,
-    .ceiling.tilt = {},
-    .floor.tilt = {},
-    .portal_room.sky = NO_ROOM,
-    .portal_room.pit = NO_ROOM,
-    .portal_room.wall = NO_ROOM,
-};
 
 static SECTOR *M_GetRoomRelSector(
     const ROOM *const room, const ITEM *item, const int32_t sector_dx,

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -13,15 +13,15 @@
 #include <trx/game/stats.h>
 #include <trx/version.h>
 
-typedef struct {
-    int16_t base_x_rot;
-    bool base_x_rot_valid;
-} M_PRIV;
-
 #define M_TR3_HIT_POINTS 256
 #define M_TR3_WOBBLE_START 192
 #define M_TR3_SPEED_UW 128
 #define M_TR3_SPEED_AIR 256
+
+typedef struct {
+    int16_t base_x_rot;
+    bool base_x_rot_valid;
+} M_PRIV;
 
 static void M_SetTR3ProjectileShade(ITEM *const item)
 {

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -44,6 +44,17 @@
 #define M_AID_WAIT_MIN           (LOGIC_FPS * 2.5) // 75
 #define M_AID_WAIT_MAX           (LOGIC_FPS * 5)   // 150
 #define M_AID_WAIT_BREAK_CHANCE  0x1200
+
+typedef struct {
+    int32_t aid_timer;
+    uint32_t secret_mask;
+    PICKUP_MODE pickup_mode;
+    bool animate;
+    bool show_pickup_aid;
+    int16_t rotation;
+    RGB_888 glow_color;
+} M_PRIV;
+
 // clang-format on
 
 static const OBJECT_BOUNDS m_PickUpBounds = {
@@ -117,16 +128,6 @@ static const XYZ_32 m_PickupPositionUW = { .x = 0, .y = -200, .z = -350 };
 static const XYZ_32 m_PickupPositionPlinth = { .x = 0, .y = 0, .z = -380 };
 static const XYZ_32 m_PickupPositionHidden = { .x = 0, .y = 0, .z = -690 };
 static const XYZ_32 m_PickupPositionCrowbar = { .x = 0, .y = 0, .z = 225 };
-
-typedef struct {
-    int32_t aid_timer;
-    uint32_t secret_mask;
-    PICKUP_MODE pickup_mode;
-    bool animate;
-    bool show_pickup_aid;
-    int16_t rotation;
-    RGB_888 glow_color;
-} M_PRIV;
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -29,24 +29,6 @@ typedef struct {
     bool has_fired;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
-{
-    M_PRIV *const p = item->priv;
-    JSON_OPTIONAL(JSON_READ(io, "active_muzzle", &p->active_muzzle));
-    JSON_OPTIONAL(JSON_READ(io, "muzzle_flash_timer", &p->muzzle_flash_timer));
-    JSON_OPTIONAL(JSON_READ(io, "is_alerted", &p->is_alerted));
-    JSON_OPTIONAL(JSON_READ(io, "has_fired", &p->has_fired));
-}
-
-static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
-{
-    const M_PRIV *const p = item->priv;
-    JSONW_WRITE(io, "active_muzzle", p->active_muzzle);
-    JSONW_WRITE(io, "muzzle_flash_timer", p->muzzle_flash_timer);
-    JSONW_WRITE(io, "is_alerted", p->is_alerted);
-    JSONW_WRITE(io, "has_fired", p->has_fired);
-}
-
 static const CREATURE_GUN m_FireLeft = {
     .muzzle = {
         .pos = { .x = 110, .y = -30, .z = -530 },
@@ -76,6 +58,24 @@ static const CREATURE_GUN m_FireRight = {
     .tr3_flash_shade = 600,
     .tr3_flash_rot_x = -DEG_180,
 };
+
+static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+{
+    M_PRIV *const p = item->priv;
+    JSON_OPTIONAL(JSON_READ(io, "active_muzzle", &p->active_muzzle));
+    JSON_OPTIONAL(JSON_READ(io, "muzzle_flash_timer", &p->muzzle_flash_timer));
+    JSON_OPTIONAL(JSON_READ(io, "is_alerted", &p->is_alerted));
+    JSON_OPTIONAL(JSON_READ(io, "has_fired", &p->has_fired));
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
+{
+    const M_PRIV *const p = item->priv;
+    JSONW_WRITE(io, "active_muzzle", p->active_muzzle);
+    JSONW_WRITE(io, "muzzle_flash_timer", p->muzzle_flash_timer);
+    JSONW_WRITE(io, "is_alerted", p->is_alerted);
+    JSONW_WRITE(io, "has_fired", p->has_fired);
+}
 
 static void M_Initialise(const int16_t item_num)
 {

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -23,15 +23,6 @@
 
 #define M_STATIC_RADIUS 100
 
-static const BITE m_QuadBites[6] = {
-    { .pos = { .x = -56, .y = -32, .z = -380 }, .mesh_num = 0 },
-    { .pos = { .x = 56, .y = -32, .z = -380 }, .mesh_num = 0 },
-    { .pos = { .x = -8, .y = 180, .z = -48 }, .mesh_num = 3 },
-    { .pos = { .x = 8, .y = 180, .z = -48 }, .mesh_num = 4 },
-    { .pos = { .x = 90, .y = 180, .z = -32 }, .mesh_num = 6 },
-    { .pos = { .x = -90, .y = 180, .z = -32 }, .mesh_num = 7 },
-};
-
 typedef enum {
     M_STATE_EMPTY,
     M_STATE_DRIVE,
@@ -75,11 +66,6 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
-static bool m_DontExitQuad;
-static bool m_HandbrakeStarting;
-static bool m_CanHandbrakeStart;
-static uint8_t m_ExhaustSmokeVel;
-
 typedef struct {
     int32_t velocity;
     int16_t front_rot;
@@ -104,6 +90,20 @@ typedef struct {
     int32_t front_rot_x_idx[2];
     bool test_static_collision;
 } M_PRIV;
+
+static const BITE m_QuadBites[6] = {
+    { .pos = { .x = -56, .y = -32, .z = -380 }, .mesh_num = 0 },
+    { .pos = { .x = 56, .y = -32, .z = -380 }, .mesh_num = 0 },
+    { .pos = { .x = -8, .y = 180, .z = -48 }, .mesh_num = 3 },
+    { .pos = { .x = 8, .y = 180, .z = -48 }, .mesh_num = 4 },
+    { .pos = { .x = 90, .y = 180, .z = -32 }, .mesh_num = 6 },
+    { .pos = { .x = -90, .y = 180, .z = -32 }, .mesh_num = 7 },
+};
+
+static bool m_DontExitQuad;
+static bool m_HandbrakeStarting;
+static bool m_CanHandbrakeStart;
+static uint8_t m_ExhaustSmokeVel;
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -29,16 +29,6 @@
 #define M_MAX_UPDOWN       0x16C0000
 #define M_CAM_ELEVATION    (DEG_1 * -60) // = -10920
 // clang-format on
-
-static const BITE m_UPVBites[6] = {
-    { .pos = { .x = 0, .y = 0, .z = 0 }, .mesh_num = 3 },
-    { .pos = { .x = 0, .y = 96, .z = 256 }, .mesh_num = 0 },
-    { .pos = { .x = -128, .y = 0, .z = -64 }, .mesh_num = 1 },
-    { .pos = { .x = 0, .y = 0, .z = -64 }, .mesh_num = 1 },
-    { .pos = { .x = 128, .y = 0, .z = -64 }, .mesh_num = 2 },
-    { .pos = { .x = 0, .y = 0, .z = -64 }, .mesh_num = 2 },
-};
-
 typedef struct {
     int32_t vel;
     int32_t rot;
@@ -76,6 +66,15 @@ typedef enum {
     M_ANIM_GET_ON           = 13,
     // clang-format on
 } M_ANIM;
+
+static const BITE m_UPVBites[6] = {
+    { .pos = { .x = 0, .y = 0, .z = 0 }, .mesh_num = 3 },
+    { .pos = { .x = 0, .y = 96, .z = 256 }, .mesh_num = 0 },
+    { .pos = { .x = -128, .y = 0, .z = -64 }, .mesh_num = 1 },
+    { .pos = { .x = 0, .y = 0, .z = -64 }, .mesh_num = 1 },
+    { .pos = { .x = 128, .y = 0, .z = -64 }, .mesh_num = 2 },
+    { .pos = { .x = 0, .y = 0, .z = -64 }, .mesh_num = 2 },
+};
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {

--- a/src/trx/game/output/lights/tr4.c
+++ b/src/trx/game/output/lights/tr4.c
@@ -30,6 +30,9 @@
 #define M_MAX_ITEM_LIGHTS 21 // the OG ITEM_LIGHT current/prev list capacity
 #define M_FADE_FRAMES 8
 #define M_MAX_FOG_BULBS 20
+#define M_MAX_FX_FOG_BULBS 5
+#define M_MAX_ACTIVE_FOG_BULBS 5
+#define M_FOG_BULB_MAX_SQ_DIST 0x19000000 // = 20480^2, the OG CreateFogPos
 
 // Room light baked at level load (the OG PCLIGHT_INFO, drawroom.cpp
 // ProcessRoomData).
@@ -108,10 +111,6 @@ typedef struct {
     float view_dist;
     float sq_cam_dist;
 } M_FOG_BULB;
-
-#define M_MAX_FX_FOG_BULBS 5
-#define M_MAX_ACTIVE_FOG_BULBS 5
-#define M_FOG_BULB_MAX_SQ_DIST 0x19000000 // = 20480^2, the OG CreateFogPos
 
 static M_ROOM_BAKE *m_RoomBake = nullptr;
 static int32_t m_RoomBakeCount = 0;

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -12,6 +12,11 @@
 
 #include <uthash.h>
 
+// Order two values as a sign. The differences here are wider than the int the
+// comparator returns, and a truncated difference orders qsort's input
+// inconsistently rather than merely imprecisely.
+#define M_COMPARE(a_, b_) (((a_) > (b_)) - ((a_) < (b_)))
+
 typedef float M_MESH_SHADE;
 
 typedef struct {
@@ -239,11 +244,6 @@ static bool M_IsGroupEntry(const M_FACE_SORT *const sort_ptr)
 {
     return sort_ptr->face == nullptr;
 }
-
-// Order two values as a sign. The differences here are wider than the int the
-// comparator returns, and a truncated difference orders qsort's input
-// inconsistently rather than merely imprecisely.
-#define M_COMPARE(a_, b_) (((a_) > (b_)) - ((a_) < (b_)))
 
 // Compare two faces by camera-space depth.
 static int M_CompareFaceDepth(const void *const a, const void *const b)

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -13,12 +13,6 @@
 
 #define M_VARIANT_COUNT 3
 
-static const char *const m_VariantPaths[M_VARIANT_COUNT] = {
-    "meshes_tr12.glsl",
-    "meshes_tr3.glsl",
-    "meshes_tr4.glsl",
-};
-
 struct OUTPUT_MESH_SHADER {
     OUTPUT_SHADER *base[M_VARIANT_COUNT];
 
@@ -30,6 +24,12 @@ struct OUTPUT_MESH_SHADER {
     bool is_alpha_discard_enabled[M_VARIANT_COUNT];
     RGBA_F tint[M_VARIANT_COUNT];
     OUTPUT_ATLAS_RECT env_map_rect[M_VARIANT_COUNT];
+};
+
+static const char *const m_VariantPaths[M_VARIANT_COUNT] = {
+    "meshes_tr12.glsl",
+    "meshes_tr3.glsl",
+    "meshes_tr4.glsl",
 };
 
 static int32_t M_GetVariantIndex(void)

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -28,6 +28,15 @@ typedef struct {
     const OUTPUT_OBJECT_MESH_POLICY *policy;
 } M_POLICY_ENTRY;
 
+typedef void (*M_FACE_VERTEX_FUNC)(
+    OUTPUT_MESH_VERTEX *vertex, const FACE *face, int32_t vertex_idx,
+    const void *user);
+
+typedef struct {
+    const XYZ_F *positions;
+    const XYZ_F *normals;
+} M_GEOMETRY_UPDATE;
+
 static M_PRIV m_Priv = {};
 static VECTOR *m_MeshPolicies = nullptr;
 
@@ -255,10 +264,6 @@ static void M_FreeMeshes(M_PRIV *const p)
     Memory_ArenaReset(&p->alloc);
 }
 
-typedef void (*M_FACE_VERTEX_FUNC)(
-    OUTPUT_MESH_VERTEX *vertex, const FACE *face, int32_t vertex_idx,
-    const void *user);
-
 // The GPU buffer stores one vertex per face corner, in the same order the
 // faces were flattened in M_PrepareMeshes (tex faces, then flat faces), so
 // this walk mirrors that layout.
@@ -298,11 +303,6 @@ static void M_UpdateVertexFlags(
         vertex->flags |= VERT_REFLECTIVE;
     }
 }
-
-typedef struct {
-    const XYZ_F *positions;
-    const XYZ_F *normals;
-} M_GEOMETRY_UPDATE;
 
 static void M_ResyncVertexGeometry(
     OUTPUT_MESH_VERTEX *const vertex, const FACE *const face,

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -20,6 +20,8 @@
 #include <SDL2/SDL_mutex.h>
 #include <string.h>
 
+#define M_TRANSPARENCY_CACHE_VERSION 1
+
 typedef struct {
     OUTPUT_UVW corners[4];
 } M_UVW_PACK;
@@ -86,7 +88,6 @@ static bool M_IsUVRotateEnabled(void)
     return m_UVRotateRangeCount > 0 && Output_GetUVRotateSpeed() != 0;
 }
 
-#define M_TRANSPARENCY_CACHE_VERSION 1
 static uint64_t M_ComputeTransparencyChecksum(void)
 {
     const GF_LEVEL *const level = GF_GetCurrentLevel();

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -36,16 +36,6 @@ typedef struct {
     bool used_deprecated_args;
 } M_PARSE_CTX;
 
-static inline M_PARSE_CTX M_ParseCtxInit(void)
-{
-    return (M_PARSE_CTX) {
-        .startup.settings = {
-            .level_request = { .num = -1 },
-            .save_to_load = -1,
-        },
-    };
-}
-
 typedef struct {
     bool collecting;
     int32_t brace_depth;
@@ -86,10 +76,11 @@ typedef struct {
     } test_mode;
 } M_PRIV;
 
-static M_PRIV m_Priv = {};
-
 typedef bool (*M_EVENT_HANDLER)(const char *token);
+
 typedef bool (*M_HEADER_HANDLER)(const char *line, M_PARSE_CTX *ctx);
+
+static M_PRIV m_Priv = {};
 
 // Event parsers
 static bool M_ParseQuitEvent(const char *event_str);
@@ -125,6 +116,16 @@ static const M_EVENT_HANDLER m_EventHandlers[] = {
     M_ParseNoopEvent,   M_ParseCommandEvent,
     M_ParseLuaEvent,    nullptr,
 };
+
+static inline M_PARSE_CTX M_ParseCtxInit(void)
+{
+    return (M_PARSE_CTX) {
+        .startup.settings = {
+            .level_request = { .num = -1 },
+            .save_to_load = -1,
+        },
+    };
+}
 
 static void M_TestPrint(const char *const fmt, ...)
 {

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -16,6 +16,13 @@
 
 #include <string.h>
 
+#define M_OUTSIDE_TABLE_STEP_SHIFT 2
+#define M_OUTSIDE_TABLE_STEP (1 << M_OUTSIDE_TABLE_STEP_SHIFT)
+#define M_OUTSIDE_TABLE_BLOCK_SHIFT (WALL_SHIFT + M_OUTSIDE_TABLE_STEP_SHIFT)
+#define M_OUTSIDE_TABLE_MAX_ROOMS_PER_CELL 64
+#define M_OUTSIDE_TABLE_SENTINEL NO_ROOM
+#define M_OUTSIDE_OFFSET_EMPTY 0xFFFF
+
 static int32_t m_RoomCount = 0;
 static ROOM *m_Rooms = nullptr;
 static HANDLE_EPOCH m_RoomEpoch;
@@ -23,13 +30,6 @@ static bool m_FlipStatus = false;
 static int32_t m_FlipEffect = -1;
 static int32_t m_FlipTimer = 0;
 static FLIP_SLOT m_FlipSlots[MAX_FLIP_MAPS] = {};
-
-#define M_OUTSIDE_TABLE_STEP_SHIFT 2
-#define M_OUTSIDE_TABLE_STEP (1 << M_OUTSIDE_TABLE_STEP_SHIFT)
-#define M_OUTSIDE_TABLE_BLOCK_SHIFT (WALL_SHIFT + M_OUTSIDE_TABLE_STEP_SHIFT)
-#define M_OUTSIDE_TABLE_MAX_ROOMS_PER_CELL 64
-#define M_OUTSIDE_TABLE_SENTINEL NO_ROOM
-#define M_OUTSIDE_OFFSET_EMPTY 0xFFFF
 
 static int16_t *m_OutsideRoomTable = nullptr;
 static uint16_t *m_OutsideRoomOffsets = nullptr;

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -23,6 +23,19 @@ typedef struct {
     int32_t zv;
 } M_PORTAL_VBUF;
 
+static VECTOR *m_RoomsToDraw = nullptr;
+static ROOM_DRAWSET m_DrawnStatics = {};
+
+static int32_t m_Outside;
+static int32_t m_OutsideRight;
+static int32_t m_OutsideLeft;
+static int32_t m_OutsideTop;
+static int32_t m_OutsideBottom;
+
+static int32_t m_BoundStart;
+static int32_t m_BoundEnd;
+static int32_t m_BoundRooms[M_MAX_BOUND_ROOMS] = {};
+
 static inline void M_DrawSet_Init(ROOM_DRAWSET *const s)
 {
     s->count = 0;
@@ -77,19 +90,6 @@ static inline void M_DrawSet_ForEach(
         }
     }
 }
-
-static VECTOR *m_RoomsToDraw = nullptr;
-static ROOM_DRAWSET m_DrawnStatics = {};
-
-static int32_t m_Outside;
-static int32_t m_OutsideRight;
-static int32_t m_OutsideLeft;
-static int32_t m_OutsideTop;
-static int32_t m_OutsideBottom;
-
-static int32_t m_BoundStart;
-static int32_t m_BoundEnd;
-static int32_t m_BoundRooms[M_MAX_BOUND_ROOMS] = {};
 
 static void M_EnsureRoomsToDraw(void)
 {

--- a/src/trx/game/shell/state.c
+++ b/src/trx/game/shell/state.c
@@ -9,9 +9,9 @@
 
 #include <string.h>
 
-static char *m_LastPlayedMod = nullptr;
-
 #define M_LAST_PLAYED_MOD_KEY "last_played_mod"
+
+static char *m_LastPlayedMod = nullptr;
 
 __attribute__((destructor)) static void M_Shutdown(void)
 {

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -17,11 +17,6 @@
 #include <math.h>
 #include <uthash.h>
 
-typedef enum {
-    SF_FLIP = 0x40,
-    SF_UNFLIP = 0x80,
-} SOUND_SOURCE_FLAG;
-
 #define M_DECIBEL_LUT_SIZE 512
 #define M_SOUND_CLOSE_RANGE (1 * WALL_L)
 
@@ -30,6 +25,11 @@ typedef enum {
 #define M_SOUND_MAX_VOLUME 0x8000
 #define M_SOUND_MAX_PITCH_CHANGE 6000
 #define M_SOUND_MAX_VOLUME_CHANGE (g_TRVersion >= 3 ? 0x1000 : 0x2000)
+
+typedef enum {
+    SF_FLIP = 0x40,
+    SF_UNFLIP = 0x80,
+} SOUND_SOURCE_FLAG;
 
 typedef struct {
     SAMPLE_ID sample_id;

--- a/src/trx/game/ui/dialogs/controls_editor.c
+++ b/src/trx/game/ui/dialogs/controls_editor.c
@@ -36,11 +36,6 @@ typedef enum {
     M_PHASE_EXIT,
 } M_PHASE;
 
-static bool M_IsTouch(const UI_CONTROLS_EDITOR_STATE *const s)
-{
-    return s->backend == INPUT_BACKEND_TOUCH;
-}
-
 static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     {
         .header_gs = GS_ID("general/settings/controls/tabs/basics"),
@@ -140,6 +135,11 @@ static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
         .rows = nullptr,
     },
 };
+
+static bool M_IsTouch(const UI_CONTROLS_EDITOR_STATE *const s)
+{
+    return s->backend == INPUT_BACKEND_TOUCH;
+}
 
 static int32_t M_GetVisibleRows(void)
 {

--- a/src/trx/game/ui/touch_overlay.c
+++ b/src/trx/game/ui/touch_overlay.c
@@ -58,6 +58,12 @@
 #define M_SPRITE_BULLET 792
 #define M_SPRITE_SWIM 793
 
+#define M_NUM_BUTTON_DEFS ((int32_t)ARRAY_SIZE(m_ButtonDefs))
+#define M_MAX_BUTTONS M_NUM_BUTTON_DEFS
+
+// D-pad expands its single def into four positions; all other defs map 1:1.
+#define M_NUM_POSITIONS (M_POS_BUTTON_BASE + M_NUM_BUTTON_DEFS - 1)
+
 typedef enum {
     M_ANCHOR_BOTTOM_LEFT,
     M_ANCHOR_BOTTOM_RIGHT,
@@ -124,12 +130,6 @@ static const M_TOUCH_BUTTON_DEF m_ButtonDefs[] = {
     { .role = INPUT_ROLE_PAUSE,       .anchor = M_ANCHOR_TOP_CENTER,   .offset_x = 0.05f, .offset_y = 0.04f, .radius = 0.03f },
 };
 // clang-format on
-
-#define M_NUM_BUTTON_DEFS ((int32_t)ARRAY_SIZE(m_ButtonDefs))
-#define M_MAX_BUTTONS M_NUM_BUTTON_DEFS
-
-// D-pad expands its single def into four positions; all other defs map 1:1.
-#define M_NUM_POSITIONS (M_POS_BUTTON_BASE + M_NUM_BUTTON_DEFS - 1)
 
 static bool m_Visible = false;
 static M_TOUCH_BUTTON m_Buttons[M_MAX_BUTTONS];

--- a/tools/lint/checks/static_order
+++ b/tools/lint/checks/static_order
@@ -5,23 +5,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from harness import LintWarning, file_check
-from shared.cfuncs import definitions, is_static, name_of
+from shared.cdecls import out_of_order
 
 
 def check(path, text):
-    first_public = None
-    for line_num, signature in definitions(text):
-        if not is_static(signature):
-            if first_public is None:
-                first_public = line_num
-            continue
-        if first_public is None:
-            continue
+    for decl, above in out_of_order(text):
         yield LintWarning(
             path,
-            f"{name_of(signature) or 'static function'} belongs above the "
-            f"public function on line {first_public}",
-            line=line_num,
+            f"{decl.label} belongs above the {above.kind} on line {above.line}",
+            line=decl.line,
         )
 
 

--- a/tools/shared/cdecls.py
+++ b/tools/shared/cdecls.py
@@ -1,0 +1,145 @@
+"""Read the top-level declarations of a clang-formatted C file in order.
+
+docs/CODING_GUIDELINES.md gives them one: defines, local module types, static
+module variables, static module functions, public functions. It also allows a
+deviation the code shape forces, and one such shape is common enough to name:
+a table of function pointers, or any other initialiser naming static functions,
+has to sit below the functions it names or every one of them needs a forward
+declaration first. A declaration reaching back like that is left alone.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from .cfuncs import definitions, is_static, name_of
+
+RANK = {
+    "define": 0,
+    "type": 1,
+    "static variable": 2,
+    "static function": 3,
+    "public function": 4,
+}
+
+DEFINE_RE = re.compile(r"^#\s*define\s")
+TYPE_RE = re.compile(r"^(typedef|struct|enum|union)\b")
+STATIC_RE = re.compile(r"^static\b")
+VAR_NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*(\[|=|;)")
+WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# `static bool M_Parse(const char *line);` names no storage. The guidelines
+# give a forward declaration as a reason to deviate from the order, so it is
+# not read as a declaration at all. A pointer to a function is storage, and
+# writes its name in parentheses - `static void (*m_Handlers[N])(...)` - which
+# is what tells the two apart.
+FORWARD_RE = re.compile(r"^static\b(?![^(]*\(\s*\*)[^=]*\([^;]*\)\s*;\s*$", re.S)
+
+
+@dataclass
+class Declaration:
+    line: int
+    kind: str
+    label: str
+    text: str
+
+
+def _without_literals(line: str) -> str:
+    # A brace inside a string, a character or a line comment opens nothing.
+    line = re.sub(r"\\.", "", line)
+    line = re.sub(r'"[^"]*"', '""', line)
+    line = re.sub(r"'[^']*'", "''", line)
+    return line.split("//")[0]
+
+
+def _label(kind: str, line: str) -> str:
+    if kind == "define":
+        return f"the define of {line.split()[1].split('(')[0]}"
+    if kind == "static variable":
+        match = VAR_NAME_RE.search(line)
+        return match[1] if match else "a static variable"
+    return "a type"
+
+
+def _span(lines: list[str], idx: int) -> tuple[str, int]:
+    """The declaration's own text, and the index of the line after it."""
+    if DEFINE_RE.match(lines[idx]):
+        end = idx
+        while end < len(lines) - 1 and lines[end].endswith("\\"):
+            end += 1
+        return "\n".join(lines[idx : end + 1]), end + 1
+
+    depth, end = 0, idx
+    while end < len(lines):
+        stripped = _without_literals(lines[end])
+        depth += stripped.count("{") - stripped.count("}")
+        if depth <= 0 and stripped.rstrip().endswith(";"):
+            break
+        end += 1
+    return "\n".join(lines[idx : end + 1]), end + 1
+
+
+def declarations(text: str) -> Iterator[Declaration]:
+    """Yield each top-level declaration in the order it is written."""
+    lines = text.split("\n")
+    functions = {
+        line_num: ("static function" if is_static(sig) else "public function", sig)
+        for line_num, sig in definitions(text)
+    }
+
+    depth = 0
+    continued = False
+    for idx, raw in enumerate(lines):
+        line_num = idx + 1
+        if depth == 0 and not continued:
+            if line_num in functions:
+                kind, sig = functions[line_num]
+                yield Declaration(line_num, kind, name_of(sig) or kind, sig)
+            elif DEFINE_RE.match(raw) or TYPE_RE.match(raw) or STATIC_RE.match(raw):
+                kind = (
+                    "define"
+                    if DEFINE_RE.match(raw)
+                    else "type" if TYPE_RE.match(raw) else "static variable"
+                )
+                body, _ = _span(lines, idx)
+                if kind == "static variable" and FORWARD_RE.match(body):
+                    continue
+                yield Declaration(line_num, kind, _label(kind, raw), body)
+        continued = raw.endswith("\\")
+        stripped = _without_literals(raw)
+        depth += stripped.count("{") - stripped.count("}")
+
+
+def _is_scoped(decl: Declaration, undefined: set[str]) -> bool:
+    # A define the file takes back with #undef reaches only as far as the lines
+    # between the two, and what sits there is written expecting it. An X-macro
+    # feeding the #include below it is the usual shape. Moving the define out
+    # of that stretch changes what those lines mean, so it stays where it is.
+    if decl.kind != "define":
+        return False
+    return decl.text.split()[1].split("(")[0] in undefined
+
+
+def out_of_order(text: str) -> Iterator[tuple[Declaration, Declaration]]:
+    """Yield (declaration, the higher-ranked one above it) for each violation."""
+    static_funcs = {
+        name_of(sig): line_num
+        for line_num, sig in definitions(text)
+        if is_static(sig)
+    }
+    undefined = set(re.findall(r"^#\s*undef\s+([A-Za-z_][A-Za-z0-9_]*)", text, re.M))
+
+    highest = None
+    for decl in declarations(text):
+        if highest is not None and RANK[decl.kind] < RANK[highest.kind]:
+            reached = {
+                word
+                for word in WORD_RE.findall(decl.text)
+                if static_funcs.get(word, decl.line) < decl.line
+            }
+            if not reached and not _is_scoped(decl, undefined):
+                yield decl, highest
+            continue
+        if highest is None or RANK[decl.kind] > RANK[highest.kind]:
+            highest = decl

--- a/tools/shared/cfuncs.py
+++ b/tools/shared/cfuncs.py
@@ -15,10 +15,19 @@ NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
 def _head(lines: list[str], brace_idx: int) -> int | None:
-    # Walk back to the start of the paragraph holding the brace, then forward
-    # past any comment lines, which leaves the first line of the signature.
+    # Walk back to the start of the signature holding the brace, then forward
+    # past any comment lines, which leaves its first line. A signature is
+    # continued across lines by an open parenthesis or a comma, so a line that
+    # closes something is where the one above ends: without that stop, a
+    # definition written straight under the closing brace of the one before it
+    # reads as a continuation of that one.
     start = brace_idx
-    while start > 0 and lines[start - 1].strip():
+    while start > 0:
+        above = lines[start - 1]
+        if not above.strip() or above.startswith("#"):
+            break
+        if above.rstrip().endswith(("}", ";")):
+            break
         start -= 1
     while start < brace_idx and lines[start].lstrip().startswith("//"):
         start += 1


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The lint check that kept static functions above public ones now reads every kind of top-level declaration, and the 74 files it reports are put in order. docs/CODING_GUIDELINES.md already gave the order; only the boundary between the last two kinds could be checked.

The check leaves alone the deviations the guidelines allow:

- a define the file takes back with `#undef`, which reaches only the lines between the two
- a forward declaration, which names no storage
- a declaration naming a static function above it, such as a table of function pointers

The parser underneath is fixed as well: a definition written straight under the closing brace of the one before it was read as part of that one, so neither was reported.

`src/tests` is no longer excluded. This change is internal only.
