### PR TITLE
inventory_ring/control: restore item duplication glitch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,6 +101,7 @@
 - fixed Lara being unable to collect some pickups that are very close to edges with a drop when animated interactions are enabled (regression from Tomb1Main 2.7)
 - fixed changing the number of save or quick save slots mid-game discarding the progress of the levels played so far (#6054)
 - fixed Lara repeating a pickup animation if jump and roll are held during the pickup (regression from TR1X 4.14 / TR2X 1.4)
+- fixed not being able to perform the item duplication glitch (regression from 1.2)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -928,7 +928,9 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
         }
     }
 
-    g_InvRing_Source[RT_KEYS].current = 0;
+    if (g_Config.gameplay.fix_item_duplication_glitch) {
+        g_InvRing_Source[RT_KEYS].current = 0;
+    }
     for (int32_t i = 0; i < g_InvRing_Source[RT_KEYS].count; i++) {
         InvRing_InitInvItem(g_InvRing_Source[RT_KEYS].items[i]);
     }

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -141,7 +141,7 @@ static void M_FixStaticsVisibility(void)
     // A room lends out the statics it holds, not the ones it was lent. Reading
     // the vector as it grows would pass a mesh on from room to room, into ones
     // it never reaches.
-    int32_t *const own_counts = Memory_Alloc(sizeof(int32_t) * total_rooms);
+    int32_t *own_counts = Memory_Alloc(sizeof(int32_t) * total_rooms);
     for (int32_t i = 0; i < total_rooms; i++) {
         own_counts[i] = room_stat_vecs[i]->count;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes being unable to perform the item duplication glitch. Regression in 943412f.
(Fixed a minor compiler warning too).

Resolves TRX937.
