### PR TITLE
objects/generic_switch: retain collision when one shot

### DIFF
--- a/src/trx/game/objects/general/generic_switch.c
+++ b/src/trx/game/objects/general/generic_switch.c
@@ -80,6 +80,7 @@ static void M_Collision(
 {
     ITEM *const item = Item_Get(item_num);
     if (item->trigger.spent) {
+        Object_Collision(item_num, lara_item, coll);
         return;
     }
 

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -159,6 +159,7 @@ static const M_DYNAMIC_PATH_POLICY m_PathPolicies[TRX_DYNAMIC_PATH_NUMBER_OF] = 
     [TRX_DYNAMIC_PATH_LEVEL_SCRIPT_FILE] = {
         .patterns = {
             "%mod_dir%/scripts/%rel%",
+            "%trx_dir%/data/scripts/%rel%", // TODO: remove in 1.13
             nullptr,
         },
         .check_exists = true,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This retains collision on TR4's generic switches even when one shot, per OG.

Resolves TRX939.
