### PR TITLE
objects/keyhole: retain simulation on trigger check

### DIFF
--- a/src/trx/game/objects/general/keyhole.c
+++ b/src/trx/game/objects/general/keyhole.c
@@ -195,7 +195,6 @@ bool Keyhole_Trigger(const int16_t item_num)
         return false;
     }
     Item_SetFinished(item, true);
-    Item_RemoveSimulated(item_num);
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids keyhole triggers stopping animated slots after a few frames. They continue to be marked as finished though, such that the trigger itself only runs once. 9bcb4fa.

Resolves TRX940.