### PR TITLE
tr3/data: fix artefact effects

### DIFF
--- a/data/trx/ship/games/tr3-la/scripts/undersea.lua
+++ b/data/trx/ship/games/tr3-la/scripts/undersea.lua
@@ -1,6 +1,3 @@
 trx.events.on_game_start(function()
-  local props = trx.objects.quest_item_1.properties
-  props.glow_color = "#00F87C"
-  props.rotation = trx.math.DEG_90 // 16
-  props.show_pickup_aid = false
+  trx.objects.quest_item_1.properties.show_pickup_aid = false
 end)

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -7,6 +7,11 @@ trx.events.on_game_start(function()
   props.glow_color = "#00F87C"
   props.rotation = trx.math.DEG_90 // 16
   props.show_pickup_aid = false
+
+  local element115 = trx.items[44]
+  if element115.trigger_mask == 0 then
+    element115:deactivate()
+  end
 end)
 
 trx.events.on_pickup(function(pickup_item)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Element 115 Area 51 from being active before triggering it, and removes all effects from the Hand of Rathmore in Sleeping with the Fishes.

Resolves TRX930.