### PR TITLE
Give effects their own control hook

### DIFF
--- a/src/trx/game/effects/manager.c
+++ b/src/trx/game/effects/manager.c
@@ -66,8 +66,8 @@ void Effect_Control(void)
         const EFFECT *const effect = Effect_Get(effect_num);
         const OBJECT *const obj = Object_Get(effect->object_id);
         const int16_t next = effect->next_active;
-        if (obj->control_func != nullptr) {
-            obj->control_func(effect_num);
+        if (obj->effect_control_func != nullptr) {
+            obj->effect_control_func(effect_num);
         }
         effect_num = next;
     }

--- a/src/trx/game/objects/creatures/claw_mutant_plasma_ball.c
+++ b/src/trx/game/objects/creatures/claw_mutant_plasma_ball.c
@@ -191,7 +191,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->draw_func = nullptr;
 }
 

--- a/src/trx/game/objects/creatures/natla_gun.c
+++ b/src/trx/game/objects/creatures/natla_gun.c
@@ -41,7 +41,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
 }
 
 REGISTER_OBJECT(O_NATLA_GUN, M_Setup)

--- a/src/trx/game/objects/creatures/sophia_plasma_ball.c
+++ b/src/trx/game/objects/creatures/sophia_plasma_ball.c
@@ -147,7 +147,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->draw_func = nullptr;
 }
 

--- a/src/trx/game/objects/creatures/tony_fire_ball.c
+++ b/src/trx/game/objects/creatures/tony_fire_ball.c
@@ -242,7 +242,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->draw_func = nullptr;
 }
 

--- a/src/trx/game/objects/creatures/willard_plasma_ball.c
+++ b/src/trx/game/objects/creatures/willard_plasma_ball.c
@@ -206,7 +206,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->draw_func = nullptr;
 }
 

--- a/src/trx/game/objects/effects/blood.c
+++ b/src/trx/game/objects/effects/blood.c
@@ -22,7 +22,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->semi_transparent = g_TRVersion >= 2;
 }
 

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -257,13 +257,13 @@ static void M_Setup(OBJECT *const obj)
 {
     switch (g_TRVersion) {
     case 4:
-        obj->control_func = M_Control_TR4;
+        obj->effect_control_func = M_Control_TR4;
         break;
     case 3:
-        obj->control_func = M_Control_TR3;
+        obj->effect_control_func = M_Control_TR3;
         break;
     default:
-        obj->control_func = M_Control_TR12;
+        obj->effect_control_func = M_Control_TR12;
         break;
     }
     obj->loaded = true;

--- a/src/trx/game/objects/effects/bubble.c
+++ b/src/trx/game/objects/effects/bubble.c
@@ -87,7 +87,8 @@ static void M_Control_TR3(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = g_TRVersion == 3 ? M_Control_TR3 : M_Control_TR1TR2;
+    obj->effect_control_func =
+        g_TRVersion == 3 ? M_Control_TR3 : M_Control_TR1TR2;
     if (obj->loaded) {
         for (int32_t i = 0; i < -obj->mesh_count; i++) {
             Output_GetSpriteTexture(obj->mesh_idx + i)->flags = VERT_ABS_SPRITE;

--- a/src/trx/game/objects/effects/dart_effect.c
+++ b/src/trx/game/objects/effects/dart_effect.c
@@ -19,7 +19,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->draw_func = Object_DrawSpriteItem;
     obj->semi_transparent = g_TRVersion >= 2;
 }

--- a/src/trx/game/objects/effects/ember.c
+++ b/src/trx/game/objects/effects/ember.c
@@ -31,7 +31,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->semi_transparent = g_TRVersion >= 2;
 }
 

--- a/src/trx/game/objects/effects/explosion.c
+++ b/src/trx/game/objects/effects/explosion.c
@@ -25,7 +25,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->semi_transparent = g_TRVersion >= 2;
 }
 

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -523,10 +523,11 @@ static bool M_TR4_Draw(const EFFECT *const effect)
 static void M_Setup(OBJECT *const obj)
 {
     if (g_TRVersion == 4) {
-        obj->control_func = M_TR4_Control;
+        obj->effect_control_func = M_TR4_Control;
         obj->effect_draw_func = M_TR4_Draw;
     } else {
-        obj->control_func = g_TRVersion == 3 ? M_TR3_Control : M_TR12_Control;
+        obj->effect_control_func =
+            g_TRVersion == 3 ? M_TR3_Control : M_TR12_Control;
     }
     obj->semi_transparent = true;
 }

--- a/src/trx/game/objects/effects/glow.c
+++ b/src/trx/game/objects/effects/glow.c
@@ -19,7 +19,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     if (obj->loaded) {
         // The glow is a halo around a light source, so it must always face the
         // camera - the sprite lock modes would let it tilt away from it.

--- a/src/trx/game/objects/effects/gun_flash.c
+++ b/src/trx/game/objects/effects/gun_flash.c
@@ -30,7 +30,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     Gun_ApplyFlashSemiTransparency();
 }
 

--- a/src/trx/game/objects/effects/gun_shell.c
+++ b/src/trx/game/objects/effects/gun_shell.c
@@ -85,7 +85,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->mesh_count = 0;
 }
 

--- a/src/trx/game/objects/effects/hot_liquid.c
+++ b/src/trx/game/objects/effects/hot_liquid.c
@@ -40,7 +40,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->semi_transparent = true;
 }
 

--- a/src/trx/game/objects/effects/missile.c
+++ b/src/trx/game/objects/effects/missile.c
@@ -245,37 +245,37 @@ static void M_ControlKnife(const int16_t effect_num)
 
 static void M_SetupAtlanteanBomb(OBJECT *const obj)
 {
-    obj->control_func = M_ControlAtlanteanBomb;
+    obj->effect_control_func = M_ControlAtlanteanBomb;
     obj->save_position = true;
 }
 
 static void M_SetupAtlanteanShard(OBJECT *const obj)
 {
-    obj->control_func = M_ControlAtlanteanShard;
+    obj->effect_control_func = M_ControlAtlanteanShard;
     obj->save_position = true;
 }
 
 static void M_SetupFlame(OBJECT *const obj)
 {
-    obj->control_func = M_ControlFlame;
+    obj->effect_control_func = M_ControlFlame;
     obj->save_position = true;
 }
 
 static void M_SetupPoison(OBJECT *const obj)
 {
-    obj->control_func = M_ControlPoison;
+    obj->effect_control_func = M_ControlPoison;
     obj->save_position = true;
 }
 
 static void M_SetupHarpoon(OBJECT *const obj)
 {
-    obj->control_func = M_ControlHarpoon;
+    obj->effect_control_func = M_ControlHarpoon;
     obj->save_position = true;
 }
 
 static void M_SetupKnife(OBJECT *const obj)
 {
-    obj->control_func = M_ControlKnife;
+    obj->effect_control_func = M_ControlKnife;
     obj->save_position = true;
 }
 

--- a/src/trx/game/objects/effects/pickup_aid.c
+++ b/src/trx/game/objects/effects/pickup_aid.c
@@ -16,7 +16,7 @@ static void M_Control(int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
 }
 
 REGISTER_OBJECT(O_PICKUP_AID, M_Setup)

--- a/src/trx/game/objects/effects/ricochet.c
+++ b/src/trx/game/objects/effects/ricochet.c
@@ -12,7 +12,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
 }
 
 REGISTER_OBJECT(O_RICOCHET, M_Setup)

--- a/src/trx/game/objects/effects/snow_sprite.c
+++ b/src/trx/game/objects/effects/snow_sprite.c
@@ -24,7 +24,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
 }
 
 REGISTER_OBJECT(O_SNOW_SPRITE, M_Setup)

--- a/src/trx/game/objects/effects/splash.c
+++ b/src/trx/game/objects/effects/splash.c
@@ -20,7 +20,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->semi_transparent = g_TRVersion >= 2;
 }
 

--- a/src/trx/game/objects/effects/twinkle.c
+++ b/src/trx/game/objects/effects/twinkle.c
@@ -81,7 +81,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
 }
 
 void Twinkle_SparkleItem(const ITEM *const item, const uint32_t mesh_mask)

--- a/src/trx/game/objects/effects/water_sprite.c
+++ b/src/trx/game/objects/effects/water_sprite.c
@@ -31,7 +31,7 @@ static void M_Control(const int16_t effect_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->effect_control_func = M_Control;
     obj->semi_transparent = true;
 }
 

--- a/src/trx/game/objects/general/kill_all_triggered.c
+++ b/src/trx/game/objects/general/kill_all_triggered.c
@@ -46,7 +46,7 @@ static void M_DestroyAllActiveEffects(void)
         const int16_t next_effect_num = effect->next_active;
         const OBJECT *const obj = Object_Get(effect->object_id);
 
-        if (obj->control_func != nullptr
+        if (obj->effect_control_func != nullptr
             && (effect->object_id != O_FLAME || effect->counter >= 0)) {
             Effect_Destroy(effect_num);
         }

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -69,9 +69,13 @@ typedef struct OBJECT {
 
     void (*control_func)(int16_t item_num);
     bool (*draw_func)(const ITEM *item);
-    // NOTE: not to be union'd with draw_func, due to default draw_func impl
-    // being Object_DrawAnimatingItem which takes an ITEM*
-    bool (*effect_draw_func)(const EFFECT *item);
+
+    // Effects are counted in their own pool and drawn from their own struct,
+    // so neither of these can be the item's: the number a control takes would
+    // name another item, and the default draw is Object_DrawAnimatingItem,
+    // which takes an ITEM.
+    void (*effect_control_func)(int16_t effect_num);
+    bool (*effect_draw_func)(const EFFECT *effect);
 
     void (*collision_func)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
     int32_t (*floor_height_func)(const ITEM *item, XYZ_32 pos, int32_t height);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR gives effects their own `effect_control_func`, so that the `int16_t` an effect's control takes is no longer the same field as the one an item's control takes, mirroring the `effect_draw_func` beside it.

This change is internal only.
