### PR TITLE
music: default non-ambient floor data music as one shot

### DIFF
--- a/data/trx/ship/games/tr3-la/scripts/_game.lua
+++ b/data/trx/ship/games/tr3-la/scripts/_game.lua
@@ -1,0 +1,5 @@
+trx.events.on_game_start(function()
+  local level = trx.game.current_level
+  local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
+  trx.rules.set("music.is_one_shot_default", use_one_shot)
+end)

--- a/data/trx/ship/games/tr3/scripts/_game.lua
+++ b/data/trx/ship/games/tr3/scripts/_game.lua
@@ -1,0 +1,5 @@
+trx.events.on_game_start(function()
+  local level = trx.game.current_level
+  local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
+  trx.rules.set("music.is_one_shot_default", use_one_shot)
+end)

--- a/data/trx/ship/games/tr4/scripts/_game.lua
+++ b/data/trx/ship/games/tr4/scripts/_game.lua
@@ -1,0 +1,5 @@
+trx.events.on_game_start(function()
+  local level = trx.game.current_level
+  local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
+  trx.rules.set("music.is_one_shot_default", use_one_shot)
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -126,6 +126,7 @@
 - fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
 - fixed a crash when a level holds fewer raptors than its raptor emitters can send out
 - fixed jittery train interpolation (regression from 1.4)
+- fixed one-shot music playing more than once (#5312)
 
 **TR4**
 - added dead enemies fading away a few seconds after they fall, as in the original TR4

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1109,6 +1109,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── tower.tr2
 │   │   │   └── triboss.tr2
 │   │   ├── scripts
+│   │   │   ├── _game.lua
 │   │   │   ├── antarc.lua
 │   │   │   ├── area51.lua
 │   │   │   ├── chamber.lua
@@ -1224,6 +1225,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── willsden.tr2
 │   │   │   └── zoo.tr2
 │   │   ├── scripts
+│   │   │   ├── _game.lua
 │   │   │   ├── chunnel.lua
 │   │   │   ├── slinc.lua
 │   │   │   ├── undersea.lua
@@ -1250,6 +1252,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── lara_outfits.bin
 │   │   │   └── sparks_gfx.bin
 │   │   ├── scripts
+│   │   │   ├── _game.lua
 │   │   │   ├── alexhub2.lua
 │   │   │   ├── alexhub.lua
 │   │   │   ├── ang_race.lua
@@ -2441,6 +2444,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── tower.tr2
     │   │   │   │   └── triboss.tr2
     │   │   │   ├── scripts
+    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── antarc.lua
     │   │   │   │   ├── area51.lua
     │   │   │   │   ├── chamber.lua
@@ -2556,6 +2560,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── willsden.tr2
     │   │   │   │   └── zoo.tr2
     │   │   │   ├── scripts
+    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── chunnel.lua
     │   │   │   │   ├── slinc.lua
     │   │   │   │   ├── undersea.lua
@@ -2582,6 +2587,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── lara_outfits.bin
     │   │   │   │   └── sparks_gfx.bin
     │   │   │   ├── scripts
+    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── alexhub2.lua
     │   │   │   │   ├── alexhub.lua
     │   │   │   │   ├── ang_race.lua

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5712,6 +5712,11 @@
       "callable": false,
       "implicit": true,
       "path": "rules.corpse"
+    },
+    {
+      "callable": false,
+      "implicit": true,
+      "path": "rules.music"
     }
   ],
   "numbers": [
@@ -6090,6 +6095,12 @@
       "description": "How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.",
       "path": "rules.corpse.fade_speed",
       "type": "integer",
+      "writable": true
+    },
+    {
+      "description": "Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.",
+      "path": "rules.music.is_one_shot_default",
+      "type": "boolean",
       "writable": true
     },
     {

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -32,6 +32,7 @@ that wants the defaults back asks for them.
 - <a id="rules.exposure.recovery" name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
 - <a id="rules.exposure.damage" name="rules.exposure.damage"></a>**`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
 - <a id="rules.corpse.fade_speed" name="rules.corpse.fade_speed"></a>**`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
+- <a id="rules.music.is_one_shot_default" name="rules.music.is_one_shot_default"></a>**`trx.rules.music.is_one_shot_default`** (boolean). Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.
 
 ### Functions
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -67,6 +67,12 @@ rule("corpse.fade_speed", {
     .. "away once nothing is left. `0` leaves it where it lies.",
 })
 
+rule("music.is_one_shot_default", {
+  type = "boolean",
+  description = "Whether non-ambient tracks triggered from floor data default "
+    .. "to being flagged as one-shot.",
+})
+
 api.define("rules.list", {
   description = "Every rule there is, as dotted `group.field` keys, in no particular order. "
     .. "<!--noref: group.field-->",

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -14,6 +14,7 @@
 #include <trx/game/music/backend_cdaudio.h>
 #include <trx/game/music/backend_cdaudio_wad.h>
 #include <trx/game/music/backend_files.h>
+#include <trx/game/rules.h>
 #include <trx/game/shell/paths.h>
 #include <trx/version.h>
 
@@ -781,13 +782,20 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
         return;
     }
 
-    if (trigger->kind != MUSIC_TRIGGER_SWITCH) {
-        if ((track->mask & trigger->mask) != 0) {
+    const bool is_ambient = M_IsAmbientTrack(track_id);
+    if (g_TRVersion != 2 || trigger->kind != MUSIC_TRIGGER_SWITCH) {
+        if ((track->mask & trigger->mask) != 0 || track->is_one_shot) {
             return;
         }
-        if (trigger->one_shot) {
+        if (trigger->one_shot && !is_ambient) {
             track->mask |= trigger->mask;
+            track->is_one_shot = true;
         }
+    }
+
+    if (g_Rules.music.is_one_shot_default && !is_ambient) {
+        track->mask |= trigger->mask;
+        track->is_one_shot = true;
     }
 
     if (trigger->timer == 0 || g_TRVersion != 2) {

--- a/src/trx/game/rules.def
+++ b/src/trx/game/rules.def
@@ -25,3 +25,9 @@ X_GROUP_END(exposure)
 X_GROUP_BEGIN(corpse)
 X_RULE(int16_t, corpse, fade_speed, 0)
 X_GROUP_END(corpse)
+
+// Determines how music triggered from floor data is played and the
+// interpretation of their state flags.
+X_GROUP_BEGIN(music)
+X_RULE(bool, music, is_one_shot_default, false)
+X_GROUP_END(music)

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -168,6 +168,7 @@ static const M_DYNAMIC_PATH_POLICY m_PathPolicies[TRX_DYNAMIC_PATH_NUMBER_OF] = 
         .patterns = {
             "%mod_dir%/scripts/%rel%",
             "%base_mod_dir%/scripts/%rel%",
+            "%trx_dir%/data/scripts/%rel%", // TODO: remove in 1.13
             nullptr,
         },
         .check_exists = true,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This defaults all non-ambient floor data triggered music tracks as being one shot in TR3 and TR4, aside from in TR3's gym level. If the config option to fix one-shot triggers is switched off, then these tracks can be replayed.

Marking FD triggers in the original levels as one-shot isn't feasible, as ones with additional commands would be impacted, e.g. making a door one shot, or timed switches usable only once.

I'd like to streamline the `Music_Trigger` function as a separate task - if we like the idea of rules, I can look at extending that to cover all the engine version quirks.

Resolves #5312 / TRX161.