### PR TITLE
music: extract version behavior into rules

### DIFF
--- a/data/trx/ship/games/tr1-ub/scripts/_game.lua
+++ b/data/trx/ship/games/tr1-ub/scripts/_game.lua
@@ -1,0 +1,3 @@
+trx.events.on_game_start(function()
+  trx.rules.set("music.accumulate_trigger_masks", true)
+end)

--- a/data/trx/ship/games/tr1/scripts/_game.lua
+++ b/data/trx/ship/games/tr1/scripts/_game.lua
@@ -1,0 +1,3 @@
+trx.events.on_game_start(function()
+  trx.rules.set("music.accumulate_trigger_masks", true)
+end)

--- a/data/trx/ship/games/tr2-gm/scripts/_game.lua
+++ b/data/trx/ship/games/tr2-gm/scripts/_game.lua
@@ -1,0 +1,3 @@
+trx.events.on_game_start(function()
+  trx.rules.set("music.supports_delay", true)
+end)

--- a/data/trx/ship/games/tr2/scripts/_game.lua
+++ b/data/trx/ship/games/tr2/scripts/_game.lua
@@ -1,0 +1,3 @@
+trx.events.on_game_start(function()
+  trx.rules.set("music.supports_delay", true)
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -114,6 +114,7 @@
 - fixed Lara being able to use a detonator box or a gong a second time by selecting its key in the inventory
 - fixed Lara's braid floating or being aligned to the water height when vaulting out of wading depth water (#5900)
 - fixed the Silver and Jade Dragon secrets being listed in the wrong order in the Floating Islands statistics (OG bug); saves made before this version have the two swapped
+- fixed music triggered from one-shot switches playing more than once (OG bug)
 
 **TR3**
 - changed the Hand of Rathmore in Reunion to not show pickup aids, in line with the other artefacts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - changed object properties to take effect as soon as they change, rather than only when the item is first set up
 - changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed New Game+ in TR1 so that flares Lara has collected are kept between levels rather than taken away at the start of each one
+- changed engine-specific music trigger behavior by defining rules settable in Lua; refer to documentation
 - added an `ammo.infinite` key to `weapons.json5`, saying which weapons and flares never run out; a game that takes it away from the pistols makes their clips worth collecting
 - changed the ammunition keys in `weapons.json5` to say what they count; refer to migration notes
 - changed boxes of ammunition in the inventory to always show what Lara is really carrying, where finishing a level could round them down

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -348,6 +348,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── track59.flac
 │   │   │   └── track60.flac
 │   │   ├── scripts
+│   │   │   ├── _game.lua
 │   │   │   ├── gym.lua
 │   │   │   └── level10b.lua
 │   │   ├── catalog_item_actions.csv
@@ -396,6 +397,8 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── egypt.phd
 │   │   │   ├── end2.phd
 │   │   │   └── end.phd
+│   │   ├── scripts
+│   │   │   └── _game.lua
 │   │   ├── gameflow.json5
 │   │   ├── strings-de.json5
 │   │   ├── strings-fr.json5
@@ -770,6 +773,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── 60.mp3
 │   │   │   └── 61.mp3
 │   │   ├── scripts
+│   │   │   ├── _game.lua
 │   │   │   ├── assault.lua
 │   │   │   ├── cut3.lua
 │   │   │   ├── floating.lua
@@ -842,6 +846,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── level5.tr2
 │   │   │   └── title.tr2
 │   │   ├── scripts
+│   │   │   ├── _game.lua
 │   │   │   ├── level1.lua
 │   │   │   ├── level3.lua
 │   │   │   └── level4.lua
@@ -1683,6 +1688,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── track59.flac
     │   │   │   │   └── track60.flac
     │   │   │   ├── scripts
+    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── gym.lua
     │   │   │   │   └── level10b.lua
     │   │   │   ├── catalog_item_actions.csv
@@ -1731,6 +1737,8 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── egypt.phd
     │   │   │   │   ├── end2.phd
     │   │   │   │   └── end.phd
+    │   │   │   ├── scripts
+    │   │   │   │   └── _game.lua
     │   │   │   ├── gameflow.json5
     │   │   │   ├── strings-de.json5
     │   │   │   ├── strings-fr.json5
@@ -2105,6 +2113,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── 60.mp3
     │   │   │   │   └── 61.mp3
     │   │   │   ├── scripts
+    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── assault.lua
     │   │   │   │   ├── cut3.lua
     │   │   │   │   ├── floating.lua
@@ -2177,6 +2186,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── level5.tr2
     │   │   │   │   └── title.tr2
     │   │   │   ├── scripts
+    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── level1.lua
     │   │   │   │   ├── level3.lua
     │   │   │   │   └── level4.lua

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6217,8 +6217,20 @@
       "writable": true
     },
     {
+      "description": "Whether non-ambient tracks triggered from floor data should react to trigger masks, requiring all bits to be set for the music to play. Current playing music whose mask becomes unset will stop.",
+      "path": "rules.music.accumulate_trigger_masks",
+      "type": "boolean",
+      "writable": true
+    },
+    {
       "description": "Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.",
       "path": "rules.music.is_one_shot_default",
+      "type": "boolean",
+      "writable": true
+    },
+    {
+      "description": "Whether timers used for non-ambient tracks triggered from floor data should be interpreted as a delay before playing the track.",
+      "path": "rules.music.supports_delay",
       "type": "boolean",
       "writable": true
     },

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -32,7 +32,9 @@ that wants the defaults back asks for them.
 - <a id="rules.exposure.recovery" name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
 - <a id="rules.exposure.damage" name="rules.exposure.damage"></a>**`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
 - <a id="rules.corpse.fade_speed" name="rules.corpse.fade_speed"></a>**`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
+- <a id="rules.music.accumulate_trigger_masks" name="rules.music.accumulate_trigger_masks"></a>**`trx.rules.music.accumulate_trigger_masks`** (boolean). Whether non-ambient tracks triggered from floor data should react to trigger masks, requiring all bits to be set for the music to play. Current playing music whose mask becomes unset will stop.
 - <a id="rules.music.is_one_shot_default" name="rules.music.is_one_shot_default"></a>**`trx.rules.music.is_one_shot_default`** (boolean). Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.
+- <a id="rules.music.supports_delay" name="rules.music.supports_delay"></a>**`trx.rules.music.supports_delay`** (boolean). Whether timers used for non-ambient tracks triggered from floor data should be interpreted as a delay before playing the track.
 
 ### Functions
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -67,10 +67,23 @@ rule("corpse.fade_speed", {
     .. "away once nothing is left. `0` leaves it where it lies.",
 })
 
+rule("music.accumulate_trigger_masks", {
+  type = "boolean",
+  description = "Whether non-ambient tracks triggered from floor data should "
+    .. "react to trigger masks, requiring all bits to be set for the music to "
+    .. "play. Current playing music whose mask becomes unset will stop.",
+})
+
 rule("music.is_one_shot_default", {
   type = "boolean",
   description = "Whether non-ambient tracks triggered from floor data default "
     .. "to being flagged as one-shot.",
+})
+
+rule("music.supports_delay", {
+  type = "boolean",
+  description = "Whether timers used for non-ambient tracks triggered from "
+    .. "floor data should be interpreted as a delay before playing the track.",
 })
 
 api.define("rules.list", {

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -783,17 +783,12 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
     }
 
     const bool is_ambient = M_IsAmbientTrack(track_id);
-    if (g_TRVersion != 2 || trigger->kind != MUSIC_TRIGGER_SWITCH) {
-        if ((track->mask & trigger->mask) != 0 || track->is_one_shot) {
-            return;
-        }
-        if (trigger->one_shot && !is_ambient) {
-            track->mask |= trigger->mask;
-            track->is_one_shot = true;
-        }
+    if ((track->mask & trigger->mask) != 0 || track->is_one_shot) {
+        return;
     }
 
-    if (g_Rules.music.is_one_shot_default && !is_ambient) {
+    if ((trigger->one_shot || g_Rules.music.is_one_shot_default)
+        && !is_ambient) {
         track->mask |= trigger->mask;
         track->is_one_shot = true;
     }

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -750,6 +750,14 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
     }
 
     MUSIC_TRACK_STATE *const track = &m_TrackStates[track_id];
+    if (track->is_one_shot) {
+        return;
+    }
+
+    if (M_IsAmbientTrack(track_id)) {
+        Music_Play_Direct(track_id, MPM_LOOP);
+        return;
+    }
 
     MUSIC_PLAY_MODE play_mode = MPM_NO_REPEAT;
     if (g_Config.audio.fix_speeches_killing_music
@@ -757,43 +765,29 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
         play_mode = MPM_OVERLAY;
     }
 
-    // TODO: consolidate
-    if (g_TRVersion == 1) {
-        if (track->is_one_shot) {
-            return;
-        }
-
+    if (g_Rules.music.accumulate_trigger_masks) {
         if (trigger->kind == MUSIC_TRIGGER_SWITCH) {
             track->mask ^= trigger->mask;
         } else if (trigger->kind == MUSIC_TRIGGER_ANTI) {
             track->mask &= ~trigger->mask;
-        } else if (trigger->mask != 0) {
+        } else {
             track->mask |= trigger->mask;
         }
 
-        if (track->mask == TRIGGER_MASK_ALL) {
-            if (trigger->one_shot) {
-                track->is_one_shot = true;
-            }
-            Music_Play_Direct(track_id, play_mode);
-        } else {
+        if (track->mask != TRIGGER_MASK_ALL) {
             Music_StopTrack_Direct(track_id);
+            return;
         }
+    } else if ((track->mask & trigger->mask) != 0) {
         return;
     }
 
-    const bool is_ambient = M_IsAmbientTrack(track_id);
-    if ((track->mask & trigger->mask) != 0 || track->is_one_shot) {
-        return;
-    }
-
-    if ((trigger->one_shot || g_Rules.music.is_one_shot_default)
-        && !is_ambient) {
+    if (trigger->one_shot || g_Rules.music.is_one_shot_default) {
         track->mask |= trigger->mask;
         track->is_one_shot = true;
     }
 
-    if (trigger->timer == 0 || g_TRVersion != 2) {
+    if (trigger->timer == 0 || !g_Rules.music.supports_delay) {
         Music_Play_Direct(track_id, play_mode);
         return;
     }

--- a/src/trx/game/rules.def
+++ b/src/trx/game/rules.def
@@ -29,5 +29,7 @@ X_GROUP_END(corpse)
 // Determines how music triggered from floor data is played and the
 // interpretation of their state flags.
 X_GROUP_BEGIN(music)
+X_RULE(bool, music, accumulate_trigger_masks, false)
 X_RULE(bool, music, is_one_shot_default, false)
+X_RULE(bool, music, supports_delay, false)
 X_GROUP_END(music)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This extracts engine-specific music trigger behavior into explicit rules and fixes music triggered from one-shot switches in TR2 being able to play more than once. Triggered ambient tracks bypass the rules as that's a backported TR3 feature.

Resolves TRX944.

Tests:
- [x] non-timed switches in TR1 (e.g. Caves room 9) - turning the switch off before the music finishes should stop the track
- [x] delayed music tracks in TR2 should continue to work as normal e.g. Gym, "this is another climbing wall..."
- [x] repeating the one-shot lever pull in Temple of Xian room 80 should not repeat the music
- [x] repeating a non one-shot button press in TR2 should repeat the music e.g. Gym, push the Venice Violins button, interrupt it with a different music track, then push the button again
- [x] triggers with masks set to 0 continue to work as normal e.g. Area 51 room 63
- [x] one shot behaves as expected with save/load
