### PR TITLE
objects/pickup: fix pickup triggers

### DIFF
--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -982,7 +982,9 @@ uint32_t Pickup_GetSecretMask(const ITEM *const item)
 bool Pickup_Trigger(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    if (item->is_visible) {
+    // is_visible prevents the trigger activating before the item has been
+    // collected, while is_finished prevents it running more than once.
+    if (item->is_visible || item->is_finished) {
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes pickup triggers activating repeatedly. Unreleased regression in 9bcb4fa.
Other than Mastabas, this can also be checked in Obelisk when collecting the artefacts.

Resolves TRX871.