### PR TITLE
Let a game declare settings of its own, and add water color presets

### DIFF
--- a/data/trx/ship/cfg/base_strings-de.json5
+++ b/data/trx/ship/cfg/base_strings-de.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Wasser-Farbe",
             "description": "Farbe des Wassers.",
+        },
+        "visuals.water_color_mode": {
+            "description": "\\{review}Welcher Unterwasser-Farbton verwendet wird. Solange eine Vorgabe gewählt ist, hält sie die Wasserfarbe unten fest; Benutzerdefiniert überlässt diese Farbe Ihnen.",
+            "title": "\\{review}Wasserfarbvorgabe",
+            "values": {
+                "custom": "\\{review}Benutzerdefiniert",
+                "dos": "\\{review}DOS",
+                "pc": "\\{review}PC",
+                "pc_hardware": "\\{review}PC (Hardware)",
+                "pc_software": "\\{review}PC (Software)",
+                "ps1": "\\{review}PS1",
+                "tombati": "\\{review}TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/base_strings-en-gb.json5
+++ b/data/trx/ship/cfg/base_strings-en-gb.json5
@@ -124,6 +124,10 @@
         "visuals.water_color": {
             "title": "Water colour",
             "description": "Colour of the water.",
+        },
+        "visuals.water_color_mode": {
+            "title": "Water colour preset",
+            "description": "Which release's underwater tint to use. While a preset is picked it holds the water colour below; Custom leaves that colour to you.",
         }
     }
 }

--- a/data/trx/ship/cfg/base_strings-fr.json5
+++ b/data/trx/ship/cfg/base_strings-fr.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Couleur de l'eau",
             "description": "\\{review}Couleur de l'eau.",
+        },
+        "visuals.water_color_mode": {
+            "description": "\\{review}Quelle teinte sous-marine utiliser. Tant qu'un préréglage est sélectionné, il maintient la couleur de l'eau ci-dessous ; Personnalisé vous laisse cette couleur.",
+            "title": "\\{review}Préréglage de la couleur de l'eau",
+            "values": {
+                "custom": "\\{review}Personnalisé",
+                "dos": "\\{review}DOS",
+                "pc": "\\{review}PC",
+                "pc_hardware": "\\{review}PC (matériel)",
+                "pc_software": "\\{review}PC (logiciel)",
+                "ps1": "\\{review}PS1",
+                "tombati": "\\{review}TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/base_strings-gd.json5
+++ b/data/trx/ship/cfg/base_strings-gd.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Dath an uisge",
             "description": "Dath an uisge.",
+        },
+        "visuals.water_color_mode": {
+            "description": "\\{review}Dè an tuar fo-uisge a thèid a chleachdadh. Fhad 's a tha ro-shuidheachadh air a thaghadh, cumaidh e dath an uisge gu h-ìosal; fàgaidh Gnàthaichte an dath sin agad fhèin.",
+            "title": "\\{review}Ro-shuidheachadh dath an uisge",
+            "values": {
+                "custom": "\\{review}Gnàthaichte",
+                "dos": "\\{review}DOS",
+                "pc": "\\{review}PC",
+                "pc_hardware": "\\{review}PC (bathar-cruaidh)",
+                "pc_software": "\\{review}PC (bathar-bog)",
+                "ps1": "\\{review}PS1",
+                "tombati": "\\{review}TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/base_strings-it.json5
+++ b/data/trx/ship/cfg/base_strings-it.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Colore acqua",
             "description": "Colore dell'acqua.",
+        },
+        "visuals.water_color_mode": {
+            "description": "\\{review}Quale tonalità subacquea usare. Finché una preimpostazione è selezionata, mantiene il colore dell'acqua qui sotto; Personalizzato lascia quel colore a te.",
+            "title": "\\{review}Preimpostazione del colore dell'acqua",
+            "values": {
+                "custom": "\\{review}Personalizzato",
+                "dos": "\\{review}DOS",
+                "pc": "\\{review}PC",
+                "pc_hardware": "\\{review}PC (hardware)",
+                "pc_software": "\\{review}PC (software)",
+                "ps1": "\\{review}PS1",
+                "tombati": "\\{review}TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/base_strings-pl.json5
+++ b/data/trx/ship/cfg/base_strings-pl.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Kolor wody",
             "description": "Kolor wody.",
+        },
+        "visuals.water_color_mode": {
+            "description": "\\{review}Który podwodny odcień ma zostać użyty. Dopóki ustawienie jest wybrane, utrzymuje kolor wody poniżej; Własny pozostawia ten kolor tobie.",
+            "title": "\\{review}Ustawienie koloru wody",
+            "values": {
+                "custom": "\\{review}Własny",
+                "dos": "\\{review}DOS",
+                "pc": "\\{review}PC",
+                "pc_hardware": "\\{review}PC (sprzętowy)",
+                "pc_software": "\\{review}PC (programowy)",
+                "ps1": "\\{review}PS1",
+                "tombati": "\\{review}TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/base_strings-ru.json5
+++ b/data/trx/ship/cfg/base_strings-ru.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Цвет воды",
             "description": "Цвет воды.",
+        },
+        "visuals.water_color_mode": {
+            "description": "\\{review}Какой подводный оттенок использовать. Пока выбран пресет, он удерживает цвет воды ниже; «Свой» оставляет этот цвет вам.",
+            "title": "\\{review}Пресет цвета воды",
+            "values": {
+                "custom": "\\{review}Свой",
+                "dos": "\\{review}DOS",
+                "pc": "\\{review}PC",
+                "pc_hardware": "\\{review}PC (аппаратный)",
+                "pc_software": "\\{review}PC (программный)",
+                "ps1": "\\{review}PS1",
+                "tombati": "\\{review}TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/base_strings.json5
+++ b/data/trx/ship/cfg/base_strings.json5
@@ -1821,6 +1821,19 @@
         "visuals.water_color": {
             "title": "Water color",
             "description": "Color of the water.",
+        },
+        "visuals.water_color_mode": {
+            "description": "Which release's underwater tint to use. While a preset is picked it holds the water color below; Custom leaves that color to you.",
+            "title": "Water color preset",
+            "values": {
+                "custom": "Custom",
+                "dos": "DOS",
+                "pc": "PC",
+                "pc_hardware": "PC (hardware)",
+                "pc_software": "PC (software)",
+                "ps1": "PS1",
+                "tombati": "TombATI",
+            }
         }
     },
     "objects": {

--- a/data/trx/ship/cfg/presets/tr1-pc.json5
+++ b/data/trx/ship/cfg/presets/tr1-pc.json5
@@ -8,5 +8,6 @@
         "audio.enable_ps1_sfx": false,
         "gameplay.restore_ps1_enemies": false,
         "visuals.enable_gun_glow": false,
+        "visuals.water_color_mode": "tombati",
     },
 }

--- a/data/trx/ship/cfg/presets/tr2-pc.json5
+++ b/data/trx/ship/cfg/presets/tr2-pc.json5
@@ -8,5 +8,6 @@
         "audio.enable_ps1_sfx": false,
         "gameplay.restore_ps1_enemies": false,
         "visuals.enable_gun_glow": false,
+        "visuals.water_color_mode": "pc_hardware",
     },
 }

--- a/data/trx/ship/cfg/presets/tr2-ps1.json5
+++ b/data/trx/ship/cfg/presets/tr2-ps1.json5
@@ -8,5 +8,6 @@
         "audio.enable_ps1_sfx": true,
         "gameplay.restore_ps1_enemies": true,
         "visuals.enable_gun_glow": true,
+        "visuals.water_color_mode": "ps1",
     },
 }

--- a/data/trx/ship/cfg/presets/tr3-pc.json5
+++ b/data/trx/ship/cfg/presets/tr3-pc.json5
@@ -8,5 +8,6 @@
         "audio.enable_ps1_sfx": false,
         "gameplay.restore_ps1_enemies": false,
         "gameplay.save_crystal_mode": "heal",
+        "visuals.water_color_mode": "pc",
     },
 }

--- a/data/trx/ship/cfg/presets/tr3-ps1.json5
+++ b/data/trx/ship/cfg/presets/tr3-ps1.json5
@@ -8,5 +8,6 @@
         "audio.enable_ps1_sfx": true,
         "gameplay.restore_ps1_enemies": true,
         "gameplay.save_crystal_mode": "save_pickup",
+        "visuals.water_color_mode": "ps1",
     },
 }

--- a/data/trx/ship/games/tr1-ub/scripts/_game.lua
+++ b/data/trx/ship/games/tr1-ub/scripts/_game.lua
@@ -1,3 +1,11 @@
 trx.events.on_game_start(function()
   trx.rules.set("music.accumulate_trigger_masks", true)
 end)
+
+require("common.water_color").declare({
+  order = { "tombati", "dos", "custom" },
+  modes = {
+    tombati = "72FFFF",
+    dos = "99B2FF",
+  },
+})

--- a/data/trx/ship/games/tr1/scripts/_game.lua
+++ b/data/trx/ship/games/tr1/scripts/_game.lua
@@ -1,3 +1,11 @@
 trx.events.on_game_start(function()
   trx.rules.set("music.accumulate_trigger_masks", true)
 end)
+
+require("common.water_color").declare({
+  order = { "tombati", "dos", "custom" },
+  modes = {
+    tombati = "72FFFF",
+    dos = "99B2FF",
+  },
+})

--- a/data/trx/ship/games/tr2-gm/scripts/_game.lua
+++ b/data/trx/ship/games/tr2-gm/scripts/_game.lua
@@ -1,3 +1,11 @@
 trx.events.on_game_start(function()
   trx.rules.set("music.supports_delay", true)
 end)
+
+require("common.water_color").declare({
+  order = { "pc_hardware", "pc_software", "custom" },
+  modes = {
+    pc_hardware = "80E0FF",
+    pc_software = "AAAAFF",
+  },
+})

--- a/data/trx/ship/games/tr2/scripts/_game.lua
+++ b/data/trx/ship/games/tr2/scripts/_game.lua
@@ -1,3 +1,33 @@
 trx.events.on_game_start(function()
   trx.rules.set("music.supports_delay", true)
 end)
+
+require("common.water_color").declare({
+  order = { "pc_hardware", "pc_software", "ps1", "custom" },
+  modes = {
+    pc_hardware = "80E0FF",
+    pc_software = "AAAAFF",
+    -- stylua: ignore
+    ps1 = {
+      assault  = "80FFFF", -- Lara's Home
+      wall     = "B2E5E5", -- The Great Wall
+      boat     = "CCFF80", -- Venice
+      venice   = "CCFF80", -- Bartoli's Hideout
+      opera    = "CCFF80", -- Opera House
+      rig      = "80FFFF", -- Offshore Rig
+      platform = "80FFFF", -- Diving Area
+      unwater  = "80FFFF", -- 40 Fathoms
+      keel     = "80FFFF", -- Wreck of the Maria Doria
+      living   = "80FFFF", -- Living Quarters
+      deck     = "80FFFF", -- The Deck
+      skidoo   = "B2E5E5", -- Tibetan Foothills
+      monastry = "80FFFF", -- Barkhang Monastery
+      catacomb = "80FFFF", -- Catacombs of the Talion
+      icecave  = "80FFFF", -- Ice Palace
+      emprtomb = "CCFF99", -- Temple of Xian
+      floating = "CCFFCC", -- Floating Islands
+      xian     = "CCFFCC", -- Dragon's Lair
+      house    = "80FFFF", -- Home Sweet Home
+    },
+  },
+})

--- a/data/trx/ship/games/tr3-la/scripts/_game.lua
+++ b/data/trx/ship/games/tr3-la/scripts/_game.lua
@@ -3,3 +3,10 @@ trx.events.on_game_start(function()
   local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
   trx.rules.set("music.is_one_shot_default", use_one_shot)
 end)
+
+require("common.water_color").declare({
+  order = { "pc", "custom" },
+  modes = {
+    pc = "80E0FF",
+  },
+})

--- a/data/trx/ship/games/tr3/scripts/_game.lua
+++ b/data/trx/ship/games/tr3/scripts/_game.lua
@@ -3,3 +3,36 @@ trx.events.on_game_start(function()
   local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
   trx.rules.set("music.is_one_shot_default", use_one_shot)
 end)
+
+require("common.water_color").declare({
+  order = { "pc", "ps1", "custom" },
+  modes = {
+    pc = "80E0FF",
+    -- The two levels with no water carry the PC color, so the mode still has
+    -- an answer for them.
+    -- stylua: ignore
+    ps1 = {
+      house    = "CCFF80", -- Lara's Home
+      jungle   = "CCFF80", -- Jungle
+      temple   = "CCFF80", -- Temple Ruins
+      quadchas = "CCFF80", -- The River Ganges
+      tonyboss = "CCFF80", -- Caves of Kaliya
+      shore    = "80FFFF", -- Coastal Village
+      crash    = "FFFFFF", -- Crash Site
+      rapids   = "FFFFFF", -- Madubu Gorge
+      triboss  = "80E0FF", -- Temple of Puna
+      roofs    = "FFFFFF", -- Thames Wharf
+      sewer    = "CCFF80", -- Aldwych
+      tower    = "CCFF80", -- Lud's Gate
+      office   = "CCFF80", -- City
+      nevada   = "FFFFFF", -- Nevada Desert
+      compound = "FFFFFF", -- High Security Compound
+      area51   = "FFFFFF", -- Area 51
+      antarc   = "80FFFF", -- Antarctica
+      mines    = "CCFFCC", -- RX-Tech Mines
+      city     = "80E0FF", -- Lost City of Tinnos
+      chamber  = "80E0FF", -- Meteorite Cavern
+      stpaul   = "B2E6E6", -- All Hallows
+    },
+  },
+})

--- a/data/trx/ship/modules/water_color.lua
+++ b/data/trx/ship/modules/water_color.lua
@@ -1,0 +1,92 @@
+-- The underwater tint each release shipped with, offered as a setting.
+--
+-- A game calls declare() with its own colors; the colors themselves are the
+-- ones docs/trx/WATER_COLORS.md lists. A mode is worth either one color for the
+-- whole game or, where a release tinted the water per level as the PS1 ones
+-- did, a table of colors keyed by trx.game.Level.key.
+
+-- The setting this declares, and the engine's own color a preset holds while
+-- it is picked.
+local MODE_OPTION = "visuals.water_color_mode"
+local COLOR_OPTION = "visuals.water_color"
+
+-- Every value any game offers, declared here once: the text is the same
+-- wherever it is shown, and a game lists in `order` only the ones it has.
+-- Written out in full because the scanner that carries these into the shipped
+-- strings reads a key only where it is a literal.
+trx.locale.declare({
+  ["settings/visuals.water_color_mode/title"] = "Water color preset",
+  ["settings/visuals.water_color_mode/description"] = "Which release's underwater tint to use. "
+    .. "While a preset is picked it holds the water color below; Custom leaves that color to you.",
+  ["settings/visuals.water_color_mode/values/custom"] = "Custom",
+  ["settings/visuals.water_color_mode/values/dos"] = "DOS",
+  ["settings/visuals.water_color_mode/values/pc"] = "PC",
+  ["settings/visuals.water_color_mode/values/pc_hardware"] = "PC (hardware)",
+  ["settings/visuals.water_color_mode/values/pc_software"] = "PC (software)",
+  ["settings/visuals.water_color_mode/values/ps1"] = "PS1",
+  ["settings/visuals.water_color_mode/values/tombati"] = "TombATI",
+})
+
+-- A preset holds the color rather than writing it: the player's own color stays
+-- underneath, comes back with Custom, and the color row is greyed while the
+-- hold stands. Only ever one override is on, so the last is lifted before the
+-- next goes down.
+local held = false
+
+local function hold(color)
+  -- The flag moves before the call rather than after it: a watcher hears the
+  -- setting move from inside these, so this runs again before either returns,
+  -- and a nested call that read a stale flag would leave its hold behind.
+  if held then
+    held = false
+    trx.config.restore(COLOR_OPTION)
+  end
+  if color ~= nil then
+    held = true
+    trx.config.override(COLOR_OPTION, color)
+  end
+end
+
+local water_color = {}
+
+function water_color.declare(spec)
+  local per_level = false
+  for _, mode in ipairs(spec.order) do
+    if type(spec.modes[mode]) == "table" then
+      per_level = true
+    end
+  end
+
+  trx.config.declare({
+    key = MODE_OPTION,
+    kind = "dynamic_enum",
+    values = spec.order,
+    default = "custom",
+    ui = {
+      tab = "graphic_visuals",
+      before = COLOR_OPTION,
+    },
+  })
+
+  local function apply(mode)
+    local color = spec.modes[mode]
+    if type(color) == "table" then
+      local level = trx.game.current_level
+      color = level ~= nil and color[level.key] or nil
+    end
+    hold(color)
+  end
+
+  -- The watcher hears the saved mode as it attaches, so a preset the player
+  -- picked last session is in force before the first level loads.
+  trx.config.on_change(MODE_OPTION, apply)
+
+  if per_level then
+    -- The color follows the level, so it is picked again as each one starts.
+    trx.events.on_game_start(function()
+      apply(trx.config.get(MODE_OPTION))
+    end)
+  end
+end
+
+return water_color

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -196,6 +196,8 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.config.describe()`, to read a setting's shape and accepted values
 - added `trx.config.format_value()`, the current value spelled the way the console prints it
 - added `trx.config.accepted_values()`, what a setting takes, as text for an error message
+- added `trx.config.declare()`, for a game to add settings of its own: they are saved and loaded with the player's, translated from the game's own strings, and shown in the settings menu where the declaration asks for
+- added `trx.config.on_change()`, to hear what a setting holds now and whenever it moves
 - added `trx.game.Level.key`, what a level is called after the file it loads
 - added `require()` to a game's scripts, taking a name that carries the directory it lives in: `tr1.my_module` for a script belonging to a game, `common.my_module` for one in the shared pool beside the executable
 - added new Lua game state, `trx.game.is_loaded` and `trx.game.is_playable`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added a `/dry` console command, to dry Lara off after a swim
 - added a `/rule` console command, to inspect and change the numbers the game plays by, such as how quickly the cold gets to Lara
 - added an option for the wobbly geometry of the PlayStation releases (Graphic Options → Rendering → Vertex snapping)
+- added a water color preset, offering the underwater tint each release shipped with, per level where the PlayStation ones varied it; picking one holds the water color below it, and Custom gives the player's own back (Graphic Options → Visuals → Water color preset) (#1619)
 - added the ability to clear the gym's best times, by holding the key shown below them
 - added an option to turn off controller support, for players who remap their controller with external software (Gameplay → Controls → Controller support)
 - added internal collision to lifts when they are moving, so that Lara cannot exit through the meshes

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1306,6 +1306,8 @@ If you install everything correctly, your game directory should look more or les
 │       ├── gameflow.json5
 │       ├── strings-it.json5
 │       └── strings.json5
+├── modules
+│   └── water_color.lua
 └── TRX.exe</code></pre>
 </details>
 
@@ -2646,6 +2648,8 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │       ├── gameflow.json5
     │   │       ├── strings-it.json5
     │   │       └── strings.json5
+    │   ├── modules
+    │   │   └── water_color.lua
     │   └── icon.icns
     ├── _CodeSignature
     ├── Frameworks

--- a/docs/trx/lua/GETTING_STARTED.md
+++ b/docs/trx/lua/GETTING_STARTED.md
@@ -38,7 +38,8 @@ INF | 2025-10-04 12:12:23.155 [scripts/level1.lua:2:?] hello from level 1!
 A game can also ship one script that belongs to the game rather than to any of
 its levels. Create `scripts/_game.lua` in the game's directory and it runs once
 as the game starts, with the game flow, the strings and the settings all in
-place. Nothing declares it: the file being there is what runs it.
+place. Nothing declares it: the file being there is what runs it. It is where a
+game declares settings of its own, with `trx.config.declare`.
 
 An expansion that has nothing of its own to set up needs no file: the script of
 the game it extends runs instead. Shipping one replaces that script rather than

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2989,7 +2989,7 @@
       }
     },
     {
-      "description": "What shape a setting has: how a value is entered and shown, beyond the type `trx.config.get` reads back.",
+      "description": "Everything about a setting but the value it holds now: what it is, what it accepts, and what it falls back to. This is the shape `trx.config.declare` takes, so a script can read one setting and declare another like it.",
       "examples": [
         "for _, value in ipairs(trx.config.describe(\"visuals.shadow_type\").values) do\n  trx.log.info(value)\nend"
       ],
@@ -3130,6 +3130,43 @@
       "returns": {
         "description": "True while an override stands, and false once the last is lifted.",
         "type": "boolean"
+      }
+    },
+    {
+      "description": "Adds a setting of the game's own.\n\nThe declaration carries no text. The engine derives `settings/<key>/title`,\n`settings/<key>/description` and, for an enum, `settings/<key>/values/<value>`, and looks each up\nin the game strings, so a declared setting is translated as every other one is.\n\nThe setting comes up holding the player's saved value for it, whether the declaration runs before\nthe settings file is read or after.\n\nRaises where the key is taken, or where the declaration describes a setting that could hold\nnothing it allows: an enum defaulting to a value it does not list, or an integer defaulting\noutside its own bounds.",
+      "examples": [
+        "trx.config.declare({\n  key = \"mod.water_color_mode\",\n  kind = \"dynamic_enum\",\n  values = { \"tombati\", \"dos\", \"custom\" },\n  default = \"custom\",\n  ui = {\n    tab = \"graphic_visuals\",\n    before = \"visuals.water_color\",\n  },\n})"
+      ],
+      "params": [
+        {
+          "description": "The setting's declaration.",
+          "name": "spec",
+          "type": "config.Shape"
+        }
+      ],
+      "path": "config.declare"
+    },
+    {
+      "description": "Calls `fn(value)` whenever the setting changes, and once as the watcher is\nattached with the value it holds now - so a script applies the player's saved value rather than\nwaiting for them to touch it again.\n\nA watcher that changes a setting itself is heard by that setting's watchers too. One that raises\nis logged and the rest still run; it is called again on the next change.\n\nA watcher a level script attaches goes when the level ends, as a `trx.events` listener does. One a\ngame script attaches stays for as long as the game.",
+      "examples": [
+        "local watcher = trx.config.on_change(\"mod.scanlines\", function(value)\n  trx.log.info(\"scanlines are now \" .. tostring(value))\nend)\n-- ... and when the script is done with it:\nwatcher:detach()"
+      ],
+      "params": [
+        {
+          "description": "Dotted path to watch.",
+          "name": "key",
+          "type": "string"
+        },
+        {
+          "description": "Called with the setting's value.",
+          "name": "fn",
+          "type": "function"
+        }
+      ],
+      "path": "config.on_change",
+      "returns": {
+        "description": "The watcher, for dropping it later.",
+        "type": "config.Watcher"
       }
     },
     {
@@ -5654,7 +5691,7 @@
       "order": 8
     },
     {
-      "description": "Module for reading and changing engine settings.\n\nThese are the player's settings, not the level's. `trx.config.set` writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants `trx.config.override` instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.",
+      "description": "Module for reading, changing and declaring engine settings.\n\nThese are the player's settings, not the level's. `trx.config.set` writes to them and keeps the\nchange: it is remembered across saves and relaunches, exactly as if the player had made it\nthemselves. A level that wants to tint the water or pull the fog in wants `trx.config.override`\ninstead, which lasts as long as the script keeps it and leaves the player's own value untouched\nunderneath.\n\nA game can also add settings of its own with `trx.config.declare`: they are saved and loaded with\nthe player's own, and shown in the settings menu where the declaration asks for. A setting a\ngame's `scripts/_game.lua` declares belongs to that game and goes when it does.",
       "name": "config",
       "order": 23
     },
@@ -6608,21 +6645,50 @@
       "path": "assault.Record"
     },
     {
-      "description": "How a setting is entered and shown, beyond the type it reads back as.",
+      "description": "Everything about a setting but the value it holds now.\n\n`trx.config.describe` hands one back and `trx.config.declare` takes one, so what a script reads\nof a setting is what a script writes to make one. The row a declaration asks for is the part\n`trx.config.describe` does not report: see `trx.config.Row`.",
       "extensions": [],
       "fields": [
         {
-          "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
+          "description": "What the setting holds until the player changes it, and what `trx.config.reset` puts back.",
+          "name": "default",
+          "type": "any"
+        },
+        {
+          "description": "Dotted path the setting answers to. The last segment is what the settings file keys it on, so it has to differ from every other setting's.",
+          "name": "key",
+          "type": "string"
+        },
+        {
+          "description": "One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. A declaration writes `boolean`, `integer` or `dynamic_enum`; the rest name storage the engine owns. <!--noref: color, enum, dynamic_enum-->",
           "name": "kind",
           "type": "string"
         },
         {
+          "description": "Highest value a number takes. Absent, it takes as high a number as it can hold.",
+          "name": "max",
+          "optional": true,
+          "type": "integer"
+        },
+        {
+          "description": "Lowest value a number takes. Absent, it takes as low a number as it can hold.",
+          "name": "min",
+          "optional": true,
+          "type": "integer"
+        },
+        {
           "description": "Marks a number stored 0-1 but entered and shown as a 0-100 percentage.",
           "name": "percent",
+          "optional": true,
           "type": "boolean"
         },
         {
-          "description": "What the setting accepts, for the enum kinds.",
+          "description": "The row a declared setting takes in the settings menu. Without one the setting has no row, and is the script's to read and write.",
+          "name": "ui",
+          "optional": true,
+          "type": "config.Row"
+        },
+        {
+          "description": "What the setting accepts, for the enum kinds. A declared `dynamic_enum` needs them, and they have to list the default. <!--noref: dynamic_enum-->",
           "list": true,
           "name": "values",
           "optional": true,
@@ -6633,6 +6699,93 @@
       "methods": [],
       "operators": [],
       "path": "config.Shape"
+    },
+    {
+      "description": "The settings row a declared setting is shown on: where it sits, and what it\ndoes that the setting itself cannot say.\n\nEvery callback below is optional, and one that raises is logged and answered as though it were\nabsent. They are read as the setting is declared and are not reported back by\n`trx.config.describe`.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "Setting the row sits below. The row lands at the end of the tab where neither anchor is given.",
+          "name": "after",
+          "optional": true,
+          "type": "string"
+        },
+        {
+          "description": "Setting the row sits above. Steadier than a position: the row stays put when the tab is reordered.",
+          "name": "before",
+          "optional": true,
+          "type": "string"
+        },
+        {
+          "description": "Called with the value and the direction, `-1` or `1`. Return false to refuse that press.",
+          "name": "can_change_value",
+          "optional": true,
+          "type": "function"
+        },
+        {
+          "description": "How far one press moves a number. One step where it is absent.",
+          "name": "delta_fast",
+          "optional": true,
+          "type": "integer"
+        },
+        {
+          "description": "How far one press moves a number while fine adjustment is held.",
+          "name": "delta_slow",
+          "optional": true,
+          "type": "integer"
+        },
+        {
+          "description": "Called with the value, returning what the row prints in place of it.",
+          "name": "format_value",
+          "optional": true,
+          "type": "function"
+        },
+        {
+          "description": "Called with the value. Return false to grey the row out: it stays visible, and the player cannot move it.",
+          "name": "is_available",
+          "optional": true,
+          "type": "function"
+        },
+        {
+          "description": "Called with the value. Return false to leave the row out of the tab.",
+          "name": "is_visible",
+          "optional": true,
+          "type": "function"
+        },
+        {
+          "description": "Called with the value and the direction. Return true to take the press over; the row is left alone, and moving the setting is the script's to do.",
+          "name": "request_change_value",
+          "optional": true,
+          "type": "function"
+        },
+        {
+          "description": "Settings tab the row sits on: `gameplay_general`, `gameplay_controls`, `gameplay_mods`, `gameplay_fixes`, `graphic_visuals`, `graphic_ui`, `graphic_ui_stats`, `graphic_ui_bars`, `graphic_rendering`, `sound_volume` or `sound_misc`. <!--noref: gameplay_general, gameplay_controls, gameplay_mods, gameplay_fixes, graphic_visuals, graphic_ui, graphic_ui_stats, graphic_ui_bars, graphic_rendering, sound_volume, sound_misc-->",
+          "name": "tab",
+          "type": "string"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "config.Row"
+    },
+    {
+      "description": "A setting being watched. `trx.config.on_change` hands one back, and holding it is what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level spends every one a level script attached.",
+      "extensions": [],
+      "fields": [],
+      "handle": false,
+      "methods": [
+        {
+          "description": "Stops the watcher, which hears of no further change.",
+          "name": "detach",
+          "returns": {
+            "description": "Whether it was still watching.",
+            "type": "boolean"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "config.Watcher"
     },
     {
       "description": "A registered console command, as the help command reads one.",

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -12,20 +12,69 @@ order: 23
 
 ## <a id="config" name="config"></a>Config module
 
-Module for reading and changing engine settings.
+Module for reading, changing and declaring engine settings.
 
-These are the player's settings, not the level's. [`trx.config.set`](#config.set) writes to them and keeps the change: it is remembered across saves and relaunches, exactly as if the player had made it themselves. A level that wants to tint the water or pull the fog in wants [`trx.config.override`](#config.override) instead, which lasts as long as the script keeps it and leaves the player's own value untouched underneath.
+These are the player's settings, not the level's. [`trx.config.set`](#config.set) writes to them and keeps the
+change: it is remembered across saves and relaunches, exactly as if the player had made it
+themselves. A level that wants to tint the water or pull the fog in wants [`trx.config.override`](#config.override)
+instead, which lasts as long as the script keeps it and leaves the player's own value untouched
+underneath.
+
+A game can also add settings of its own with [`trx.config.declare`](#config.declare): they are saved and loaded with
+the player's own, and shown in the settings menu where the declaration asks for. A setting a
+game's `scripts/_game.lua` declares belongs to that game and goes when it does.
 
 ### Structures
 
 - <a id="config.Shape" name="config.Shape"></a>[lua]`trx.config.Shape`
 
-    How a setting is entered and shown, beyond the type it reads back as.
+    Everything about a setting but the value it holds now.
+
+    [`trx.config.describe`](#config.describe) hands one back and [`trx.config.declare`](#config.declare) takes one, so what a script reads
+    of a setting is what a script writes to make one. The row a declaration asks for is the part
+    [`trx.config.describe`](#config.describe) does not report: see [`trx.config.Row`](#config.Row).
 
     Properties:
-    - <a id="config.Shape.kind" name="config.Shape.kind"></a>**`kind`**: string. One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`.
-    - <a id="config.Shape.percent" name="config.Shape.percent"></a>**`percent`**: boolean. Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
-    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: a list of string, optional. What the setting accepts, for the enum kinds.
+    - <a id="config.Shape.default" name="config.Shape.default"></a>**`default`**: any. What the setting holds until the player changes it, and what [`trx.config.reset`](#config.reset) puts back.
+    - <a id="config.Shape.key" name="config.Shape.key"></a>**`key`**: string. Dotted path the setting answers to. The last segment is what the settings file keys it on, so it has to differ from every other setting's.
+    - <a id="config.Shape.kind" name="config.Shape.kind"></a>**`kind`**: string. One of `boolean`, `integer`, `number`, `color`, `enum`, `dynamic_enum` or `string`. A declaration writes `boolean`, `integer` or `dynamic_enum`; the rest name storage the engine owns.
+    - <a id="config.Shape.max" name="config.Shape.max"></a>**`max`**: integer, optional. Highest value a number takes. Absent, it takes as high a number as it can hold.
+    - <a id="config.Shape.min" name="config.Shape.min"></a>**`min`**: integer, optional. Lowest value a number takes. Absent, it takes as low a number as it can hold.
+    - <a id="config.Shape.percent" name="config.Shape.percent"></a>**`percent`**: boolean, optional. Marks a number stored 0-1 but entered and shown as a 0-100 percentage.
+    - <a id="config.Shape.ui" name="config.Shape.ui"></a>**`ui`**: [trx.config.Row](#config.Row), optional. The row a declared setting takes in the settings menu. Without one the setting has no row, and is the script's to read and write.
+    - <a id="config.Shape.values" name="config.Shape.values"></a>**`values`**: a list of string, optional. What the setting accepts, for the enum kinds. A declared `dynamic_enum` needs them, and they have to list the default.
+
+- <a id="config.Row" name="config.Row"></a>[lua]`trx.config.Row`
+
+    The settings row a declared setting is shown on: where it sits, and what it
+    does that the setting itself cannot say.
+
+    Every callback below is optional, and one that raises is logged and answered as though it were
+    absent. They are read as the setting is declared and are not reported back by
+    [`trx.config.describe`](#config.describe).
+
+    Properties:
+    - <a id="config.Row.after" name="config.Row.after"></a>**`after`**: string, optional. Setting the row sits below. The row lands at the end of the tab where neither anchor is given.
+    - <a id="config.Row.before" name="config.Row.before"></a>**`before`**: string, optional. Setting the row sits above. Steadier than a position: the row stays put when the tab is reordered.
+    - <a id="config.Row.can_change_value" name="config.Row.can_change_value"></a>**`can_change_value`**: function, optional. Called with the value and the direction, `-1` or `1`. Return false to refuse that press.
+    - <a id="config.Row.delta_fast" name="config.Row.delta_fast"></a>**`delta_fast`**: integer, optional. How far one press moves a number. One step where it is absent.
+    - <a id="config.Row.delta_slow" name="config.Row.delta_slow"></a>**`delta_slow`**: integer, optional. How far one press moves a number while fine adjustment is held.
+    - <a id="config.Row.format_value" name="config.Row.format_value"></a>**`format_value`**: function, optional. Called with the value, returning what the row prints in place of it.
+    - <a id="config.Row.is_available" name="config.Row.is_available"></a>**`is_available`**: function, optional. Called with the value. Return false to grey the row out: it stays visible, and the player cannot move it.
+    - <a id="config.Row.is_visible" name="config.Row.is_visible"></a>**`is_visible`**: function, optional. Called with the value. Return false to leave the row out of the tab.
+    - <a id="config.Row.request_change_value" name="config.Row.request_change_value"></a>**`request_change_value`**: function, optional. Called with the value and the direction. Return true to take the press over; the row is left alone, and moving the setting is the script's to do.
+    - <a id="config.Row.tab" name="config.Row.tab"></a>**`tab`**: string. Settings tab the row sits on: `gameplay_general`, `gameplay_controls`, `gameplay_mods`, `gameplay_fixes`, `graphic_visuals`, `graphic_ui`, `graphic_ui_stats`, `graphic_ui_bars`, `graphic_rendering`, `sound_volume` or `sound_misc`.
+
+- <a id="config.Watcher" name="config.Watcher"></a>[lua]`trx.config.Watcher`
+
+    A setting being watched. [`trx.config.on_change`](#config.on_change) hands one back, and holding it is what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level spends every one a level script attached.
+
+    Methods:
+
+    - <a id="config.Watcher.detach" name="config.Watcher.detach"></a>[lua]`watcher:detach()`  
+      Stops the watcher, which hears of no further change.
+
+      Returns: boolean. Whether it was still watching.
 
 ### Functions
 
@@ -45,7 +94,7 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   ```
 
 - <a id="config.describe" name="config.describe"></a>[lua]`trx.config.describe(key)`  
-  What shape a setting has: how a value is entered and shown, beyond the type [`trx.config.get`](#config.get) reads back.
+  Everything about a setting but the value it holds now: what it is, what it accepts, and what it falls back to. This is the shape [`trx.config.declare`](#config.declare) takes, so a script can read one setting and declare another like it.
 
   Parameters:
   - <a id="config.describe.key" name="config.describe.key"></a>**`key`** (string). Dotted path.
@@ -130,6 +179,63 @@ These are the player's settings, not the level's. [`trx.config.set`](#config.set
   - <a id="config.is_overridden.key" name="config.is_overridden.key"></a>**`key`** (string). Dotted path.
 
   Returns: boolean. True while an override stands, and false once the last is lifted.
+
+- <a id="config.declare" name="config.declare"></a>[lua]`trx.config.declare(spec)`  
+  Adds a setting of the game's own.
+
+  The declaration carries no text. The engine derives `settings/<key>/title`,
+  `settings/<key>/description` and, for an enum, `settings/<key>/values/<value>`, and looks each up
+  in the game strings, so a declared setting is translated as every other one is.
+
+  The setting comes up holding the player's saved value for it, whether the declaration runs before
+  the settings file is read or after.
+
+  Raises where the key is taken, or where the declaration describes a setting that could hold
+  nothing it allows: an enum defaulting to a value it does not list, or an integer defaulting
+  outside its own bounds.
+
+  Parameters:
+  - <a id="config.declare.spec" name="config.declare.spec"></a>**`spec`** ([trx.config.Shape](#config.Shape)). The setting's declaration.
+
+  Example:
+  ```lua
+  trx.config.declare({
+    key = "mod.water_color_mode",
+    kind = "dynamic_enum",
+    values = { "tombati", "dos", "custom" },
+    default = "custom",
+    ui = {
+      tab = "graphic_visuals",
+      before = "visuals.water_color",
+    },
+  })
+  ```
+
+- <a id="config.on_change" name="config.on_change"></a>[lua]`trx.config.on_change(key, fn)`  
+  Calls `fn(value)` whenever the setting changes, and once as the watcher is
+  attached with the value it holds now - so a script applies the player's saved value rather than
+  waiting for them to touch it again.
+
+  A watcher that changes a setting itself is heard by that setting's watchers too. One that raises
+  is logged and the rest still run; it is called again on the next change.
+
+  A watcher a level script attaches goes when the level ends, as a [`trx.events`](EVENTS.md#events) listener does. One a
+  game script attaches stays for as long as the game.
+
+  Parameters:
+  - <a id="config.on_change.key" name="config.on_change.key"></a>**`key`** (string). Dotted path to watch.
+  - <a id="config.on_change.fn" name="config.on_change.fn"></a>**`fn`** (function). Called with the setting's value.
+
+  Returns: [trx.config.Watcher](#config.Watcher). The watcher, for dropping it later.
+
+  Example:
+  ```lua
+  local watcher = trx.config.on_change("mod.scanlines", function(value)
+    trx.log.info("scanlines are now " .. tostring(value))
+  end)
+  -- ... and when the script is done with it:
+  watcher:detach()
+  ```
 
 - <a id="config.list" name="config.list"></a>[lua]`trx.config.list()`  
   Every setting and its current value.

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -1,16 +1,22 @@
 local raw = trxc.config
+local raw_settings = trxc.settings
 local api = trx.api
 
 require("trx.locale")
 
 api.module("config", {
   order = 23,
-  description = "Module for reading and changing engine settings.\n\n"
-    .. "These are the player's settings, not the level's. `trx.config.set` writes to them and keeps the "
-    .. "change: it is remembered across saves and relaunches, exactly as if the player had made "
-    .. "it themselves. A level that wants to tint the water or pull the fog in wants `trx.config.override` "
-    .. "instead, which lasts as long as the script keeps it and leaves the player's own value "
-    .. "untouched underneath.",
+  description = [[Module for reading, changing and declaring engine settings.
+
+These are the player's settings, not the level's. `trx.config.set` writes to them and keeps the
+change: it is remembered across saves and relaunches, exactly as if the player had made it
+themselves. A level that wants to tint the water or pull the fog in wants `trx.config.override`
+instead, which lasts as long as the script keeps it and leaves the player's own value untouched
+underneath.
+
+A game can also add settings of its own with `trx.config.declare`: they are saved and loaded with
+the player's own, and shown in the settings menu where the declaration asks for. A setting a
+game's `scripts/_game.lua` declares belongs to that game and goes when it does.]],
 })
 
 trx.locale.declare({
@@ -22,23 +28,131 @@ trx.locale.declare({
 
 api.type("config.Shape", {
   record = true,
-  description = "How a setting is entered and shown, beyond the type it reads back as.",
+  description = [[Everything about a setting but the value it holds now.
+
+`trx.config.describe` hands one back and `trx.config.declare` takes one, so what a script reads
+of a setting is what a script writes to make one. The row a declaration asks for is the part
+`trx.config.describe` does not report: see `trx.config.Row`.]],
   fields = {
+    key = {
+      type = "string",
+      description = "Dotted path the setting answers to. The last segment is what the "
+        .. "settings file keys it on, so it has to differ from every other setting's.",
+    },
     kind = {
       type = "string",
       description = "One of `boolean`, `integer`, `number`, `color`, `enum`, "
-        .. "`dynamic_enum` or `string`. <!--noref: color, enum, dynamic_enum-->",
+        .. "`dynamic_enum` or `string`. A declaration writes `boolean`, `integer` or "
+        .. "`dynamic_enum`; the rest name storage the engine owns. "
+        .. "<!--noref: color, enum, dynamic_enum-->",
     },
     percent = {
       type = "boolean",
+      optional = true,
       description = "Marks a number stored 0-1 but entered and shown as a 0-100 "
         .. "percentage.",
+    },
+    default = {
+      type = "any",
+      description = "What the setting holds until the player changes it, and what "
+        .. "`trx.config.reset` puts back.",
     },
     values = {
       type = "string",
       list = true,
       optional = true,
-      description = "What the setting accepts, for the enum kinds.",
+      description = "What the setting accepts, for the enum kinds. A declared "
+        .. "`dynamic_enum` needs them, and they have to list the default. "
+        .. "<!--noref: dynamic_enum-->",
+    },
+    min = {
+      type = "integer",
+      optional = true,
+      description = "Lowest value a number takes. Absent, it takes as low a number as "
+        .. "it can hold.",
+    },
+    max = {
+      type = "integer",
+      optional = true,
+      description = "Highest value a number takes. Absent, it takes as high a number "
+        .. "as it can hold.",
+    },
+    ui = {
+      type = "config.Row",
+      optional = true,
+      description = "The row a declared setting takes in the settings menu. Without "
+        .. "one the setting has no row, and is the script's to read and write.",
+    },
+  },
+})
+
+api.type("config.Row", {
+  record = true,
+  description = [[The settings row a declared setting is shown on: where it sits, and what it
+does that the setting itself cannot say.
+
+Every callback below is optional, and one that raises is logged and answered as though it were
+absent. They are read as the setting is declared and are not reported back by
+`trx.config.describe`.]],
+  fields = {
+    tab = {
+      type = "string",
+      description = "Settings tab the row sits on: `gameplay_general`, `gameplay_controls`, "
+        .. "`gameplay_mods`, `gameplay_fixes`, `graphic_visuals`, `graphic_ui`, "
+        .. "`graphic_ui_stats`, `graphic_ui_bars`, `graphic_rendering`, `sound_volume` or "
+        .. "`sound_misc`. <!--noref: gameplay_general, gameplay_controls, gameplay_mods, "
+        .. "gameplay_fixes, graphic_visuals, graphic_ui, graphic_ui_stats, graphic_ui_bars, "
+        .. "graphic_rendering, sound_volume, sound_misc-->",
+    },
+    before = {
+      type = "string",
+      optional = true,
+      description = "Setting the row sits above. Steadier than a position: the row stays "
+        .. "put when the tab is reordered.",
+    },
+    after = {
+      type = "string",
+      optional = true,
+      description = "Setting the row sits below. The row lands at the end of the tab where "
+        .. "neither anchor is given.",
+    },
+    delta_fast = {
+      type = "integer",
+      optional = true,
+      description = "How far one press moves a number. One step where it is absent.",
+    },
+    delta_slow = {
+      type = "integer",
+      optional = true,
+      description = "How far one press moves a number while fine adjustment is held.",
+    },
+    format_value = {
+      type = "function",
+      optional = true,
+      description = "Called with the value, returning what the row prints in place of it.",
+    },
+    is_available = {
+      type = "function",
+      optional = true,
+      description = "Called with the value. Return false to grey the row out: it stays "
+        .. "visible, and the player cannot move it.",
+    },
+    is_visible = {
+      type = "function",
+      optional = true,
+      description = "Called with the value. Return false to leave the row out of the tab.",
+    },
+    can_change_value = {
+      type = "function",
+      optional = true,
+      description = "Called with the value and the direction, `-1` or `1`. Return false to "
+        .. "refuse that press.",
+    },
+    request_change_value = {
+      type = "function",
+      optional = true,
+      description = "Called with the value and the direction. Return true to take the press "
+        .. "over; the row is left alone, and moving the setting is the script's to do.",
     },
   },
 })
@@ -63,8 +177,9 @@ end]],
 })
 
 api.define("config.describe", {
-  description = "What shape a setting has: how a value is entered and shown, beyond the type "
-    .. "`trx.config.get` reads back.",
+  description = "Everything about a setting but the value it holds now: what it is, what it "
+    .. "accepts, and what it falls back to. This is the shape `trx.config.declare` takes, so a "
+    .. "script can read one setting and declare another like it.",
   params = {
     { name = "key", type = "string", description = "Dotted path." },
   },
@@ -262,6 +377,101 @@ api.define("config.is_overridden", {
     description = "True while an override stands, and false once the last is lifted.",
   },
   impl = raw.is_overridden,
+})
+
+api.define("config.declare", {
+  description = [[Adds a setting of the game's own.
+
+The declaration carries no text. The engine derives `settings/<key>/title`,
+`settings/<key>/description` and, for an enum, `settings/<key>/values/<value>`, and looks each up
+in the game strings, so a declared setting is translated as every other one is.
+
+The setting comes up holding the player's saved value for it, whether the declaration runs before
+the settings file is read or after.
+
+Raises where the key is taken, or where the declaration describes a setting that could hold
+nothing it allows: an enum defaulting to a value it does not list, or an integer defaulting
+outside its own bounds.]],
+  params = {
+    {
+      name = "spec",
+      type = "config.Shape",
+      description = "The setting's declaration.",
+    },
+  },
+  examples = {
+    [[trx.config.declare({
+  key = "mod.water_color_mode",
+  kind = "dynamic_enum",
+  values = { "tombati", "dos", "custom" },
+  default = "custom",
+  ui = {
+    tab = "graphic_visuals",
+    before = "visuals.water_color",
+  },
+})]],
+  },
+  impl = function(spec)
+    raw.declare(spec)
+    if spec.ui ~= nil then
+      raw_settings.add_row(spec.key, spec.ui)
+    end
+  end,
+})
+
+-- What on_change hands back. The engine keys a watcher by a number, and the
+-- number is the module's business rather than a script's.
+local Watcher = api.type("config.Watcher", {
+  description = "A setting being watched. `trx.config.on_change` hands one back, and "
+    .. "holding it is what lets the watcher be dropped later. A watcher is spent "
+    .. "once detached, and the end of a level spends every one a level script "
+    .. "attached.",
+  methods = {
+    detach = {
+      description = "Stops the watcher, which hears of no further change.",
+      returns = {
+        type = "boolean",
+        description = "Whether it was still watching.",
+      },
+      impl = function(self)
+        return raw.off_change(rawget(self, "_id"))
+      end,
+    },
+  },
+})
+
+api.define("config.on_change", {
+  description = [[Calls `fn(value)` whenever the setting changes, and once as the watcher is
+attached with the value it holds now - so a script applies the player's saved value rather than
+waiting for them to touch it again.
+
+A watcher that changes a setting itself is heard by that setting's watchers too. One that raises
+is logged and the rest still run; it is called again on the next change.
+
+A watcher a level script attaches goes when the level ends, as a `trx.events` listener does. One a
+game script attaches stays for as long as the game.]],
+  params = {
+    { name = "key", type = "string", description = "Dotted path to watch." },
+    {
+      name = "fn",
+      type = "function",
+      description = "Called with the setting's value.",
+    },
+  },
+  returns = {
+    type = "config.Watcher",
+    description = "The watcher, for dropping it later.",
+  },
+  examples = {
+    [[local watcher = trx.config.on_change("mod.scanlines", function(value)
+  trx.log.info("scanlines are now " .. tostring(value))
+end)
+-- ... and when the script is done with it:
+watcher:detach()]],
+  },
+  impl = function(key, fn)
+    return setmetatable({ _id = raw.on_change(key, fn) }, Watcher)
+  end,
 })
 
 api.define("config.list", {

--- a/src/meson.build
+++ b/src/meson.build
@@ -859,6 +859,7 @@ common_sources = [
   'trx/game/ui/dialogs/settings.c',
   'trx/game/ui/dialogs/settings_editor.c',
   'trx/game/ui/dialogs/settings_handlers.c',
+  'trx/game/ui/dialogs/settings_lua.c',
   'trx/game/ui/dialogs/settings_rows.c',
   'trx/game/ui/dialogs/settings_tabs.c',
   'trx/game/ui/dialogs/sound_settings.c',

--- a/src/tests/fakes/config.c
+++ b/src/tests/fakes/config.c
@@ -1,12 +1,13 @@
 // A player's config of a handful of options, one of each shape that behaves
-// differently. The options themselves are the real ones, holds and all; what is
-// faked is everything around them - what options exist, how a value reads and
-// writes as a string, and what saving means.
+// differently. The registry and the options are the real ones, holds and all;
+// what is faked is which options exist, how a value reads and writes as a
+// string, and what saving means.
 
 #include <fakes/config.h>
 
 #include <harness/fake_calls.h>
 
+#include <trx/config/common.h>
 #include <trx/config/priv.h>
 #include <trx/config/registry.h>
 #include <trx/core/enum_map.h>
@@ -22,9 +23,6 @@ static double m_Brightness;
 static double m_MasterVolume;
 static char *m_WaterColor;
 static int32_t m_ShadowType;
-
-// Whether anything the player chose has moved since the last update.
-static bool m_PendingPersist;
 
 static const CONFIG_OPTION_DESC m_Descs[] = {
     { .name = "audio.enable_music",
@@ -49,9 +47,7 @@ static const CONFIG_OPTION_DESC m_Descs[] = {
       .enum_map = "FAKE_SHADOW" },
 };
 
-static CONFIG_OPTION m_Options[ARRAY_SIZE(m_Descs)];
-// What Config_GetOptions hands out: the same options, null terminated.
-static CONFIG_OPTION *m_View[ARRAY_SIZE(m_Descs) + 1];
+static int32_t m_Listener = -1;
 
 // The third value carries an underscore, which is what the console's
 // dash-for-underscore spelling is about.
@@ -73,19 +69,25 @@ static void M_DefineEnums(void)
         "extra_dark");
 }
 
+// What the settings file would have taken. A change a hold applies is nobody's
+// to save, so only the ones the player made are recorded.
+static void M_RecordWrite(const EVENT *const event, void *const user_data)
+{
+    if (((const CONFIG_CHANGE *)event->data)->persist) {
+        FAKE_RECORD("config_write");
+    }
+}
+
 static void M_Reset(void)
 {
     M_DefineEnums();
+    Config_DropAllOptions();
     for (size_t i = 0; i < ARRAY_SIZE(m_Descs); i++) {
-        if (m_Options[i].name != nullptr) {
-            Config_Option_Free(&m_Options[i]);
-        }
-        m_Options[i] = (CONFIG_OPTION) {};
-        Config_Option_Init(&m_Options[i], &m_Descs[i]);
-        m_View[i] = &m_Options[i];
+        Config_Register(&m_Descs[i]);
     }
-    m_View[ARRAY_SIZE(m_Descs)] = nullptr;
-    m_PendingPersist = false;
+    if (m_Listener < 0) {
+        m_Listener = Config_SubscribeChanges(M_RecordWrite, nullptr);
+    }
 }
 
 // The value a string spells, borrowing the string for a string-typed option -
@@ -147,48 +149,6 @@ static bool M_Parse(
     return true;
 }
 
-// Which option moved is nobody's business here - a test that cares about a
-// write looks at the setting it landed on. Whether any of it was the player's
-// own doing is, because that is what saving the file turns on.
-void Config_ReportChange(const CONFIG_OPTION *const option, const bool persist)
-{
-    m_PendingPersist |= persist;
-}
-
-CONFIG_OPTION *const *Config_GetOptions(void)
-{
-    return m_View;
-}
-
-CONFIG_OPTION *Config_FindOption(const char *const path)
-{
-    for (size_t i = 0; i < ARRAY_SIZE(m_Options); i++) {
-        if (strcmp(m_Options[i].name, path) == 0) {
-            return &m_Options[i];
-        }
-    }
-    return nullptr;
-}
-
-CONFIG_OPTION *Config_FindOptionByMirror(const void *const mirror)
-{
-    for (size_t i = 0; i < ARRAY_SIZE(m_Options); i++) {
-        if (m_Options[i].mirror == mirror) {
-            return &m_Options[i];
-        }
-    }
-    return nullptr;
-}
-
-bool Config_Update(void)
-{
-    if (m_PendingPersist) {
-        m_PendingPersist = false;
-        FAKE_RECORD("config_write");
-    }
-    return true;
-}
-
 const char *Config_Option_GetValueAsString(
     const CONFIG_OPTION *const option, const bool human_readable)
 {
@@ -242,12 +202,13 @@ FAKE_ON_RESET(M_Reset)
 // on every option rather than standing a flag beside them.
 void FakeConfig_SetEnforced(const bool enforced)
 {
-    for (size_t i = 0; i < ARRAY_SIZE(m_Options); i++) {
+    for (CONFIG_OPTION *const *option = Config_GetOptions(); *option != nullptr;
+         option++) {
         if (enforced) {
             Config_Option_PushHold(
-                &m_Options[i], &m_Options[i].value, CONFIG_HOLD_GAME_FLOW);
+                *option, &(*option)->value, CONFIG_HOLD_GAME_FLOW);
         } else {
-            Config_Option_PopHold(&m_Options[i]);
+            Config_Option_PopHold(*option);
         }
     }
 }

--- a/src/tests/lua/api/config.c
+++ b/src/tests/lua/api/config.c
@@ -4,7 +4,11 @@
 #include <fakes/config.h>
 #include <harness/lua_surface.h>
 
+#include <trx/game/lua/common.h>
+
 #include <lauxlib.h>
+
+static LUA_CONTEXT m_Context = LUA_CONTEXT_GLOBAL;
 
 static int M_FakeSetEnforced(lua_State *const L)
 {
@@ -12,10 +16,37 @@ static int M_FakeSetEnforced(lua_State *const L)
     return 0;
 }
 
+// What a level script's own registrations are made under, and what ends them.
+static int M_FakeAsLevelScript(lua_State *const L)
+{
+    m_Context = lua_toboolean(L, 1) ? LUA_CONTEXT_LEVEL : LUA_CONTEXT_GLOBAL;
+    return 0;
+}
+
+static int M_FakeEndLevel(lua_State *const L)
+{
+    LUA_Config_ClearLevelWatchers();
+    return 0;
+}
+
 static void M_PushFake(lua_State *const L)
 {
     lua_pushcfunction(L, M_FakeSetEnforced);
     lua_setfield(L, -2, "set_enforced");
+    lua_pushcfunction(L, M_FakeAsLevelScript);
+    lua_setfield(L, -2, "as_level_script");
+    lua_pushcfunction(L, M_FakeEndLevel);
+    lua_setfield(L, -2, "end_level");
+}
+
+LUA_CONTEXT LUA_GetScriptContext(void)
+{
+    return m_Context;
+}
+
+void LUA_SetScriptContext(const LUA_CONTEXT context)
+{
+    m_Context = context;
 }
 
 int main(void)

--- a/src/tests/lua/api/config.lua
+++ b/src/tests/lua/api/config.lua
@@ -1,8 +1,9 @@
 -- The config API as a script actually sees it.
 --
--- The override stack underneath is the real one, so what these assert is the
--- thing that matters: a script can hold a setting away from the player's value
--- and give it back, without ever writing to their settings file.
+-- The registry, the override stack and the settings rows underneath are the
+-- real ones, so what these assert is what matters: a script can add a setting
+-- of its own, hear about the ones that move, and hold one away from the
+-- player's value and give it back without ever writing to their settings file.
 
 local h = require("harness")
 local test, raises = h.test, h.raises
@@ -228,6 +229,190 @@ test("list gives every setting, typed", function()
   assert(all["audio.enable_music"] == true, "a bool must be listed as a bool")
   assert(all["visuals.fov"] == 65)
   assert(all["visuals.water_color"] == "ff0000")
+end)
+
+test("describe hands back the shape a declaration takes", function()
+  local shape = trx.config.describe("visuals.fov")
+  assert(shape.key == "visuals.fov")
+  assert(shape.kind == "integer")
+  assert(shape.default == 65, "the default must come back with the shape")
+
+  local color = trx.config.describe("visuals.water_color")
+  assert(color.default == "ff0000")
+end)
+
+test("a game declares a setting of its own", function()
+  trx.config.declare({
+    key = "mod.scanlines",
+    kind = "boolean",
+    default = true,
+  })
+  assert(trx.config.get("mod.scanlines") == true, "the default did not take")
+
+  trx.config.set("mod.scanlines", false)
+  assert(trx.config.get("mod.scanlines") == false, "the write did not take")
+end)
+
+test("a declared setting takes a row on a tab", function()
+  trx.config.declare({
+    key = "mod.grain",
+    kind = "integer",
+    default = 2,
+    min = 0,
+    max = 4,
+    ui = { tab = "graphic_visuals", after = "visuals.fov" },
+  })
+  assert(trx.config.get("mod.grain") == 2)
+end)
+
+test("a row does what its handlers say", function()
+  local available = false
+  trx.config.declare({
+    key = "mod.bloom",
+    kind = "integer",
+    default = 50,
+    min = 0,
+    max = 100,
+    ui = {
+      tab = "graphic_visuals",
+      delta_fast = 5,
+      delta_slow = 1,
+      format_value = function(value)
+        return value .. "%"
+      end,
+      is_available = function()
+        return available
+      end,
+    },
+  })
+  assert(trx.config.get("mod.bloom") == 50)
+  available = true
+end)
+
+test("a tab no dialog shows raises", function()
+  raises(function()
+    trx.config.declare({
+      key = "mod.vignette",
+      kind = "boolean",
+      default = false,
+      ui = { tab = "nowhere" },
+    })
+  end)
+end)
+
+test("a declaration that could hold nothing it allows raises", function()
+  raises(function()
+    trx.config.declare({
+      key = "mod.outside",
+      kind = "integer",
+      default = 9,
+      min = 0,
+      max = 4,
+    })
+  end)
+  raises(function()
+    trx.config.declare({
+      key = "mod.unlisted",
+      kind = "dynamic_enum",
+      values = { "one", "two" },
+      default = "three",
+    })
+  end)
+  raises(function()
+    trx.config.declare({
+      key = "mod.valueless",
+      kind = "dynamic_enum",
+      values = {},
+      default = "one",
+    })
+  end)
+end)
+
+test("a key already taken raises", function()
+  raises(function()
+    trx.config.declare({
+      key = "visuals.fov",
+      kind = "integer",
+      default = 1,
+    })
+  end)
+end)
+
+-- luaL_checkstring would take a number and rewrite the field into a string,
+-- leaving the declaration reading a value that is no longer there.
+test("a declaration names its fields with strings", function()
+  raises(function()
+    trx.config.declare({ key = 42, kind = "boolean", default = true })
+  end)
+end)
+
+test(
+  "a watcher hears the value it is attached to, and the ones after",
+  function()
+    local heard = {}
+    local watcher = trx.config.on_change("visuals.fov", function(value)
+      heard[#heard + 1] = value
+    end)
+    assert(heard[1] == 65, "a watcher must hear the value already in force")
+
+    trx.config.set("visuals.fov", 90)
+    assert(heard[2] == 90, "a watcher must hear a change")
+
+    -- Another setting moving is not this watcher's business.
+    trx.config.set("audio.enable_music", false)
+    assert(#heard == 2, "a watcher heard a setting it does not watch")
+
+    assert(watcher:detach() == true)
+    trx.config.set("visuals.fov", 100)
+    assert(#heard == 2, "a detached watcher still heard a change")
+    assert(watcher:detach() == false, "a watcher is spent once detached")
+  end
+)
+
+test("an override is a change like any other", function()
+  local heard = {}
+  local watcher = trx.config.on_change("visuals.fov", function(value)
+    heard[#heard + 1] = value
+  end)
+  trx.config.override("visuals.fov", 120)
+  assert(heard[#heard] == 120, "an override did not reach the watcher")
+
+  trx.config.restore("visuals.fov")
+  assert(heard[#heard] == 65, "restoring did not reach the watcher")
+  watcher:detach()
+end)
+
+test("a watcher that raises does not silence the rest", function()
+  local heard = false
+  local angry = trx.config.on_change("visuals.fov", function()
+    error("no")
+  end)
+  local calm = trx.config.on_change("visuals.fov", function()
+    heard = true
+  end)
+  trx.config.set("visuals.fov", 90)
+  assert(heard, "the second watcher did not run")
+  angry:detach()
+  calm:detach()
+end)
+
+test("a level script's watcher goes when the level does", function()
+  local heard = 0
+  fake.as_level_script(true)
+  trx.config.on_change("visuals.fov", function()
+    heard = heard + 1
+  end)
+  fake.as_level_script(false)
+  local kept = trx.config.on_change("visuals.fov", function()
+    heard = heard + 100
+  end)
+
+  fake.end_level()
+  trx.config.set("visuals.fov", 90)
+  -- Each watcher hears the value in force as it is attached, so the count
+  -- starts at 101; only the one that outlived its level would raise it by one.
+  assert(heard == 201, "the level's watcher outlived the level: " .. heard)
+  kept:detach()
 end)
 
 return h.report()

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -103,6 +103,25 @@ b_value = {
   'src': ['harness/stubs_enum_map.c'],
 }
 
+# The config layer as the game has it: the registry, the options, the change
+# report. The settings file is stubbed - what the file holds is not what a
+# binding is tested for - and fakes/config.c says which options exist.
+b_config = {
+  'engine': [
+    'config/common.c',
+    'config/legacy.c',
+    'config/option.c',
+    'config/priv.c',
+    'config/registry.c',
+    'config/section.c',
+    'core/event_manager.c',
+    'core/json/base.c',
+    'core/json/parse.c',
+    'version.c',
+  ],
+  'src': ['fakes/config.c', 'harness/stubs_config_file.c'],
+}
+
 # The string bridge, with the real fuzzy matcher and the real regex underneath
 # it. PCRE2 comes with them, so a test cannot take the sources and forget the
 # code unit width the headers insist on.
@@ -605,12 +624,14 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/api/config',
-  'bundles': [b_lua_surface],
-  'src': ['fakes/config.c', 'fakes/locale.c'],
+  'bundles': [b_lua_surface, b_config],
+  'src': ['fakes/locale.c'],
   'engine': [
-    'config/option.c',
     'game/lua/capi/config.c',
     'game/lua/capi/locale.c',
+    'game/ui/dialogs/settings_handlers.c',
+    'game/ui/dialogs/settings_lua.c',
+    'game/ui/dialogs/settings_rows.c',
   ],
 }
 
@@ -733,12 +754,8 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/commands/set',
-  'bundles': [b_lua_surface, b_console, b_lua_strings],
-  'src': ['fakes/config.c'],
-  'engine': [
-    'config/option.c',
-    'game/lua/capi/config.c',
-  ],
+  'bundles': [b_lua_surface, b_console, b_lua_strings, b_config],
+  'engine': ['game/lua/capi/config.c'],
 }
 
 unit_tests += {
@@ -785,6 +802,28 @@ unit_tests += {
     '-DPCRE2_CODE_UNIT_WIDTH=8',
     '-DTEST_SHIP_GAMES_DIR="' + repo_root / 'data/trx/ship/games' + '"',
   ],
+}
+
+# Where a settings row sits: the tab lists and the placement a declared row
+# resolves to. The options are real; nothing draws.
+unit_tests += {
+  'name': 'trx/game/ui/dialogs/settings_rows',
+  'bundles': [b_value],
+  'engine': [
+    'config/common.c',
+    'config/legacy.c',
+    'config/option.c',
+    'config/priv.c',
+    'config/registry.c',
+    'config/section.c',
+    'core/event_manager.c',
+    'core/json/base.c',
+    'core/json/parse.c',
+    'game/ui/dialogs/settings_handlers.c',
+    'game/ui/dialogs/settings_rows.c',
+    'version.c',
+  ],
+  'src': ['harness/stubs_config_file.c'],
 }
 
 # The UI layout test is the widest of the unit tests: it stands up the settings

--- a/src/tests/trx/config/common.c
+++ b/src/tests/trx/config/common.c
@@ -12,6 +12,7 @@
 static bool m_MusicOn;
 static double m_Fov;
 static char *m_Outfit;
+static bool m_Scanlines;
 static bool m_LastPersist;
 // How many times the listener below was told that the FOV moved.
 static int32_t m_FovTold;
@@ -113,4 +114,25 @@ TEST(a_listener_that_changes_a_setting_is_not_told_the_same_report_twice)
     CHECK_EQ_INT(m_FovTold, 1);
 
     Config_UnsubscribeChanges(listener);
+}
+
+// A script's options go when the scripts do; the game's own stay, and so do
+// their values.
+TEST(dropping_the_declared_options_leaves_the_games_own)
+{
+    M_SetUp();
+    CHECK(
+        Config_Register(&(CONFIG_OPTION_DESC) {
+            .name = "mod.scanlines",
+            .default_value = { .type = TVT_BOOL, .as_bool = true },
+            .mirror = &m_Scanlines,
+            .declared = true })
+        != nullptr);
+
+    CHECK(Config_SetValue(&m_Fov, Value_Of(90)));
+    Config_DropDeclaredOptions();
+
+    CHECK(Config_FindOption("mod.scanlines") == nullptr);
+    CHECK(Config_FindOption("visuals.fov") != nullptr);
+    CHECK_EQ_INT((int32_t)m_Fov, 90);
 }

--- a/src/tests/trx/config/common.c
+++ b/src/tests/trx/config/common.c
@@ -13,6 +13,8 @@ static bool m_MusicOn;
 static double m_Fov;
 static char *m_Outfit;
 static bool m_LastPersist;
+// How many times the listener below was told that the FOV moved.
+static int32_t m_FovTold;
 
 static void M_SetUp(void)
 {
@@ -78,6 +80,37 @@ TEST(a_write_while_held_is_not_the_players_to_save)
     m_LastPersist = true;
     CHECK(Config_Update());
     CHECK(!m_LastPersist);
+
+    Config_UnsubscribeChanges(listener);
+}
+
+// A listener that moves a setting of its own, as a script's config watcher
+// does. The cap is there because a report told again would tell it again, on
+// and on, and a test that hangs says less than one that counts.
+static void M_MoveAnother(const EVENT *const event, void *const user_data)
+{
+    if (!Config_Change_HasMirror(event->data, &m_Fov)) {
+        return;
+    }
+    m_FovTold++;
+    if (m_FovTold > 4) {
+        return;
+    }
+    CONFIG_SET(m_MusicOn, false);
+    Config_Update();
+}
+
+// The report is spent once. A listener that moves a setting of its own is
+// heard as a report of its own, rather than being told this one over again.
+TEST(a_listener_that_changes_a_setting_is_not_told_the_same_report_twice)
+{
+    M_SetUp();
+    m_FovTold = 0;
+    const int32_t listener = Config_SubscribeChanges(M_MoveAnother, nullptr);
+
+    CHECK(Config_SetValue(&m_Fov, Value_Of(90)));
+    CHECK(Config_Update());
+    CHECK_EQ_INT(m_FovTold, 1);
 
     Config_UnsubscribeChanges(listener);
 }

--- a/src/tests/trx/config/option.c
+++ b/src/tests/trx/config/option.c
@@ -1,4 +1,4 @@
-// The hold stack, against a config of three options and nothing else. No game,
+// The hold stack, against a config of four options and nothing else. No game,
 // no settings file, no registry: an option is made here from the same
 // description map*.def would give.
 //
@@ -7,11 +7,16 @@
 // player's own value is what comes back - never the default, and never the
 // value some other hold applied. And while a hold is on, that is still the
 // value the settings file would carry.
+//
+// The dynamic enum is here for what it keeps rather than for the stack: its
+// values are not known up front, and one it was never told about is still the
+// player's own.
 
 #include <harness/harness.h>
 
 #include <trx/config/option.h>
 #include <trx/config/priv.h>
+#include <trx/core/dynamic_enum.h>
 #include <trx/core/utils.h>
 
 #include <string.h>
@@ -22,8 +27,9 @@
 static bool m_MusicOn;
 static int32_t m_Fov;
 static char *m_WaterColor;
+static char *m_Outfit;
 
-static CONFIG_OPTION m_Options[3];
+static CONFIG_OPTION m_Options[4];
 
 static const CONFIG_OPTION_DESC m_Descs[] = {
     { .name = "audio.music",
@@ -35,6 +41,9 @@ static const CONFIG_OPTION_DESC m_Descs[] = {
     { .name = "visuals.water_color",
       .default_value = { .type = TVT_STRING, .as_str = "ffffff" },
       .mirror = &m_WaterColor },
+    { .name = "visuals.lara_outfit",
+      .default_value = { .type = TVT_DYNAMIC_ENUM, .as_str = "default" },
+      .mirror = &m_Outfit },
 };
 
 static CONFIG_OPTION *M_Option(const char *const name)
@@ -71,6 +80,17 @@ static void M_Hold(
     const CONFIG_HOLD_SOURCE source)
 {
     CHECK(Config_Option_PushHold(option, &value, source));
+}
+
+// Seeds the values a dynamic enum accepts, as the module that owns them would.
+static void M_SeedOutfits(const char *const *const values)
+{
+    const void *const token =
+        Config_Option_GetEnumKey(M_Option("visuals.lara_outfit"));
+    DynamicEnum_ResetValues(token);
+    for (int32_t i = 0; values[i] != nullptr; i++) {
+        DynamicEnum_AddValue(token, values[i], nullptr);
+    }
 }
 
 // Nothing here is listening for what moved; the report is the module's job, and
@@ -182,6 +202,21 @@ TEST(a_string_option_is_restored_by_value_not_by_pointer)
 
     CHECK(Config_Option_PopHold(color));
     CHECK_EQ_STR(m_WaterColor, "ff0000");
+}
+
+// A value the registered set does not name is a mod's that is not loaded, not
+// a value to refuse. The player chose it, the settings file carries it, and it
+// works again the next time that mod does.
+TEST(a_dynamic_enum_keeps_a_value_nobody_registered)
+{
+    M_SetUp();
+    CONFIG_OPTION *const outfit = M_Option("visuals.lara_outfit");
+
+    Config_Option_Write(
+        outfit, &(TRX_VALUE) { .type = TVT_DYNAMIC_ENUM, .as_str = "cowboy" });
+    M_SeedOutfits((const char *[]) { "default", "wetsuit", nullptr });
+    Config_Option_Sanitize(outfit);
+    CHECK_EQ_STR(m_Outfit, "cowboy");
 }
 
 TEST(a_bool_option_round_trips)

--- a/src/tests/trx/game/lua/common.c
+++ b/src/tests/trx/game/lua/common.c
@@ -219,6 +219,12 @@ bool LUA_API_PushEntrypoint(lua_State *const L, const char *const name)
     return true;
 }
 
+// The config bridge that keeps the watchers is not linked here; a script
+// lifecycle is what these tests are about, and no config exists to watch.
+void LUA_Config_ClearLevelWatchers(void)
+{
+}
+
 void LUA_Guard_Install(lua_State *const L, const double budget_sec)
 {
 }

--- a/src/tests/trx/game/ui/dialogs/settings_rows.c
+++ b/src/tests/trx/game/ui/dialogs/settings_rows.c
@@ -1,0 +1,157 @@
+// Where a settings row sits. The rows a .def names come out in the order they
+// are written in, and a row a script declares lands where the anchor it named
+// puts it - which is a number from that point on, so reordering the tab or
+// dropping the anchor cannot leave it pointing at nothing.
+//
+// The tab used here is the sound volume one, of which only the first three rows
+// are registered: a tab naming a setting this game does not have is a row that
+// is not shown, which is what a game without that option looks like.
+
+#include <harness/harness.h>
+
+#include <trx/config/priv.h>
+#include <trx/config/registry.h>
+#include <trx/game/ui/dialogs/settings_rows.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define M_TAB CONFIG_TAB_SOUND_VOLUME
+
+static double m_MasterVolume;
+static double m_SoundVolume;
+static double m_MusicVolume;
+// What the options a script would declare are kept in. Every option needs a
+// mirror of its own, and what is in them is not what these tests are about.
+static double m_Declared[200];
+
+static void M_Register(const char *const name, void *const mirror)
+{
+    CHECK(
+        Config_Register(&(CONFIG_OPTION_DESC) {
+            .name = name,
+            .default_value = { .type = TVT_DOUBLE, .as_num = 1.0 },
+            .mirror = mirror })
+        != nullptr);
+}
+
+static void M_SetUp(void)
+{
+    UI_Settings_DropDeclaredRows();
+    Config_DropAllOptions();
+    M_Register("audio.master_volume", &m_MasterVolume);
+    M_Register("audio.sound_volume", &m_SoundVolume);
+    M_Register("audio.music_volume", &m_MusicVolume);
+    M_Register("mod.scanlines", &m_Declared[0]);
+}
+
+// Which row shows the option a name names, by position in the tab.
+static int32_t M_RowIndex(const char *const name)
+{
+    for (int32_t i = 0; i < UI_Settings_GetRowCount(M_TAB); i++) {
+        if (strcmp(UI_Settings_GetRow(M_TAB, i)->option->name, name) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+TEST(a_tab_shows_the_rows_it_names_that_this_game_has)
+{
+    M_SetUp();
+    CHECK_EQ_INT(UI_Settings_GetRowCount(M_TAB), 3);
+    CHECK_EQ_INT(M_RowIndex("audio.master_volume"), 0);
+    CHECK_EQ_INT(M_RowIndex("audio.sound_volume"), 1);
+    CHECK_EQ_INT(M_RowIndex("audio.music_volume"), 2);
+}
+
+TEST(a_declared_row_sits_after_the_row_it_names)
+{
+    M_SetUp();
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.scanlines", nullptr, "audio.sound_volume");
+    CHECK_EQ_INT(M_RowIndex("mod.scanlines"), 2);
+}
+
+TEST(a_declared_row_sits_before_the_row_it_names)
+{
+    M_SetUp();
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.scanlines", "audio.master_volume", nullptr);
+    CHECK_EQ_INT(M_RowIndex("mod.scanlines"), 0);
+}
+
+// An anchor is a name, and the name the settings file keys an option on is the
+// last segment of it. Both spellings reach the same row.
+TEST(an_anchor_names_a_row_by_either_spelling)
+{
+    M_SetUp();
+    UI_Settings_AddDeclaredRow(M_TAB, "mod.scanlines", nullptr, "sound_volume");
+    CHECK_EQ_INT(M_RowIndex("mod.scanlines"), 2);
+}
+
+TEST(a_declared_row_naming_no_anchor_lands_at_the_end)
+{
+    M_SetUp();
+    UI_Settings_AddDeclaredRow(M_TAB, "mod.scanlines", nullptr, nullptr);
+    CHECK_EQ_INT(M_RowIndex("mod.scanlines"), 3);
+}
+
+// A tab lists rows for every game, so an anchor naming a row this tab does not
+// show is a row that cannot be placed against it rather than an error.
+TEST(a_declared_row_naming_an_anchor_the_tab_does_not_show_lands_at_the_end)
+{
+    M_SetUp();
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.scanlines", nullptr, "audio.fmv_volume");
+    CHECK_EQ_INT(M_RowIndex("mod.scanlines"), 3);
+}
+
+TEST(rows_declared_against_one_anchor_read_in_the_order_they_arrived)
+{
+    M_SetUp();
+    M_Register("mod.grain", &m_Declared[1]);
+    M_Register("mod.vignette", &m_Declared[2]);
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.scanlines", nullptr, "audio.master_volume");
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.grain", nullptr, "audio.master_volume");
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.vignette", nullptr, "audio.master_volume");
+
+    CHECK_EQ_INT(M_RowIndex("mod.scanlines"), 1);
+    CHECK_EQ_INT(M_RowIndex("mod.grain"), 2);
+    CHECK_EQ_INT(M_RowIndex("mod.vignette"), 3);
+    CHECK_EQ_INT(M_RowIndex("audio.sound_volume"), 4);
+}
+
+// A tab has room for a hundred rows between any two of its own before it has to
+// be numbered again, and the numbering has to leave the order alone.
+TEST(a_tab_that_runs_out_of_room_is_numbered_again)
+{
+    M_SetUp();
+    for (int32_t i = 0; i < 200; i++) {
+        char name[32];
+        snprintf(name, sizeof(name), "mod.filter_%d", i);
+        M_Register(name, &m_Declared[i]);
+        UI_Settings_AddDeclaredRow(M_TAB, name, "audio.sound_volume", nullptr);
+    }
+
+    CHECK_EQ_INT(UI_Settings_GetRowCount(M_TAB), 203);
+    CHECK_EQ_INT(M_RowIndex("audio.master_volume"), 0);
+    CHECK_EQ_INT(M_RowIndex("mod.filter_0"), 1);
+    CHECK_EQ_INT(M_RowIndex("mod.filter_199"), 200);
+    CHECK_EQ_INT(M_RowIndex("audio.sound_volume"), 201);
+}
+
+TEST(dropping_the_declared_rows_leaves_the_tab_as_its_def_names_it)
+{
+    M_SetUp();
+    UI_Settings_AddDeclaredRow(
+        M_TAB, "mod.scanlines", nullptr, "audio.master_volume");
+    CHECK_EQ_INT(UI_Settings_GetRowCount(M_TAB), 4);
+
+    UI_Settings_DropDeclaredRows();
+    CHECK_EQ_INT(UI_Settings_GetRowCount(M_TAB), 3);
+    CHECK_EQ_INT(M_RowIndex("audio.master_volume"), 0);
+}

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -134,12 +134,18 @@ bool Config_Update(void)
         return false;
     }
 
+    // The report is taken before it is spent, not after: a listener that moves
+    // a setting of its own comes back through here, and what it moved is a
+    // report of its own rather than this one told again.
+    VECTOR *const taken = m_Pending;
     const CONFIG_CHANGE change = {
         // A rebound key is the player's doing as much as a setting is.
         .persist = m_PendingPersist || section_changed,
-        .options = m_Pending != nullptr ? Vector_GetData(m_Pending) : nullptr,
-        .count = m_Pending != nullptr ? m_Pending->count : 0,
+        .options = taken != nullptr ? Vector_GetData(taken) : nullptr,
+        .count = taken != nullptr ? taken->count : 0,
     };
+    m_Pending = nullptr;
+    m_PendingPersist = false;
 
     if (m_EventManager != nullptr) {
         const EVENT event = {
@@ -149,7 +155,9 @@ bool Config_Update(void)
         };
         EventManager_Fire(m_EventManager, &event);
     }
-    Config_DiscardPendingChanges();
+    if (taken != nullptr) {
+        Vector_Free(taken);
+    }
     return true;
 }
 

--- a/src/trx/config/option.c
+++ b/src/trx/config/option.c
@@ -116,8 +116,11 @@ void Config_Option_Init(
     option->name = Memory_DupStr(desc->name);
     option->mirror = desc->mirror;
     option->enum_map = desc->enum_map;
-    option->bounds = desc->bounds;
-    option->flags = desc->percent ? CONFIG_OPTION_PERCENT : 0;
+    option->bounds = desc->bounds != nullptr
+        ? Memory_Dup(desc->bounds, sizeof(CONFIG_OPTION_BOUNDS))
+        : nullptr;
+    option->flags = (desc->percent ? CONFIG_OPTION_PERCENT : 0)
+        | (desc->declared ? CONFIG_OPTION_DECLARED : 0);
     M_CopyValue(&option->default_value, &desc->default_value);
     M_NarrowValue(&option->default_value);
     // The value starts as the default, written properly so that g_Config comes
@@ -141,6 +144,7 @@ void Config_Option_Free(CONFIG_OPTION *const option)
         && M_IsStringLike(option->default_value.type)) {
         Memory_FreePointer((char **)option->mirror);
     }
+    Memory_Free((CONFIG_OPTION_BOUNDS *)option->bounds);
     Memory_Free((char *)option->name);
 }
 
@@ -310,4 +314,10 @@ bool Config_Option_IsHidden(const CONFIG_OPTION *const option)
 {
     ASSERT(option != nullptr);
     return (option->flags & CONFIG_OPTION_HIDDEN) != 0;
+}
+
+bool Config_Option_IsDeclared(const CONFIG_OPTION *const option)
+{
+    ASSERT(option != nullptr);
+    return (option->flags & CONFIG_OPTION_DECLARED) != 0;
 }

--- a/src/trx/config/option.h
+++ b/src/trx/config/option.h
@@ -21,6 +21,9 @@ typedef enum {
     // The game flow asked for this option to be absent from the settings
     // dialogs. Not the same as being held, which leaves the row in place.
     CONFIG_OPTION_HIDDEN = 1 << 1,
+    // A script asked for this option rather than the game's own map*.def. It
+    // lives for as long as the scripts that declared it, and goes when they do.
+    CONFIG_OPTION_DECLARED = 1 << 2,
 } CONFIG_OPTION_FLAGS;
 
 // What an option accepts, for the numeric types. Held in the units the value is
@@ -71,7 +74,9 @@ typedef struct CONFIG_OPTION {
     // option itself rather than on a map declared up front.
     const char *enum_map;
 
-    // Null where the option takes anything its storage can hold.
+    // Null where the option takes anything its storage can hold. The option's
+    // own copy: what a declaration pointed at is the caller's, and a script's
+    // declaration is read off a Lua table that is gone by the next call.
     const CONFIG_OPTION_BOUNDS *bounds;
 
     // What the player chose, kept while something holds the option away from
@@ -90,6 +95,8 @@ typedef struct {
     const char *enum_map;
     const CONFIG_OPTION_BOUNDS *bounds;
     bool percent;
+    // Whether a script is asking for this option. See CONFIG_OPTION_DECLARED.
+    bool declared;
 } CONFIG_OPTION_DESC;
 
 // What moved, reported to whoever asked to hear about it.
@@ -129,6 +136,14 @@ void Config_Option_Write(CONFIG_OPTION *option, const TRX_VALUE *value);
 // Holds the option to the bounds it declared. A value outside them is brought
 // to the nearest one it accepts. An option with no bounds takes anything its
 // storage can hold.
+//
+// A dynamic enum is left alone, whether or not its values are registered yet.
+// Its values arrive from whoever owns them - the outfits from the skin module,
+// the bar looks from the UI - and a value they do not name is a mod's that is
+// not loaded rather than a value to refuse: the player chose it, the settings
+// file carries it, and it works again the next time that mod is. What reads
+// the setting falls back on its own until then, and cycling the row lands on a
+// value that is registered.
 void Config_Option_Sanitize(CONFIG_OPTION *option);
 
 // Whether the option still holds what it was declared with.
@@ -165,6 +180,9 @@ bool Config_Option_IsEnforced(const CONFIG_OPTION *option);
 
 // Whether the game flow asked for the option to be absent from the dialogs.
 bool Config_Option_IsHidden(const CONFIG_OPTION *option);
+
+// Whether a script asked for this option rather than the game's own map*.def.
+bool Config_Option_IsDeclared(const CONFIG_OPTION *option);
 
 // Updates the value from a string. Refused on a held option unless forced, in
 // which case the value replaces what the topmost hold applies - so releasing

--- a/src/trx/config/option.h
+++ b/src/trx/config/option.h
@@ -184,6 +184,12 @@ bool Config_Option_IsHidden(const CONFIG_OPTION *option);
 // Whether a script asked for this option rather than the game's own map*.def.
 bool Config_Option_IsDeclared(const CONFIG_OPTION *option);
 
+// Whether the option can take this value as it is spelled. A setting a game
+// declares takes only the values that game offers, so a caller naming one from
+// elsewhere is asking for something this option has no answer to.
+bool Config_Option_AcceptsString(
+    const CONFIG_OPTION *option, const char *value);
+
 // Updates the value from a string. Refused on a held option unless forced, in
 // which case the value replaces what the topmost hold applies - so releasing
 // the hold still restores the player's own.

--- a/src/trx/config/option_text.c
+++ b/src/trx/config/option_text.c
@@ -36,6 +36,14 @@ static bool M_ParseValue(
     return Value_CheckRange(option->value.type, out) == nullptr;
 }
 
+bool Config_Option_AcceptsString(
+    const CONFIG_OPTION *const option, const char *const value)
+{
+    ASSERT(option != nullptr);
+    TRX_VALUE parsed;
+    return M_ParseValue(option, value, &parsed);
+}
+
 bool Config_Option_SetFromString(
     CONFIG_OPTION *const option, const char *const new_value, const bool force)
 {

--- a/src/trx/config/registry.c
+++ b/src/trx/config/registry.c
@@ -86,6 +86,24 @@ void Config_DropAllOptions(void)
     M_RebuildView();
 }
 
+void Config_DropDeclaredOptions(void)
+{
+    // As in Config_DropAllOptions: a report names the options that moved by
+    // address, and the options it names are about to go.
+    Config_DiscardPendingChanges();
+    for (int32_t i = m_Options != nullptr ? m_Options->count - 1 : -1; i >= 0;
+         i--) {
+        CONFIG_OPTION *const option = M_Get(i);
+        if (!Config_Option_IsDeclared(option)) {
+            continue;
+        }
+        Config_Option_Free(option);
+        Memory_Free(option);
+        Vector_RemoveAt(m_Options, i);
+    }
+    M_RebuildView();
+}
+
 CONFIG_OPTION *Config_Register(const CONFIG_OPTION_DESC *const desc)
 {
     ASSERT(desc != nullptr);

--- a/src/trx/config/registry.h
+++ b/src/trx/config/registry.h
@@ -24,6 +24,10 @@ CONFIG_OPTION *Config_Register(const CONFIG_OPTION_DESC *desc);
 // of settings.
 void Config_RegisterBuiltInOptions(void);
 
+// Drops the options a script declared, leaving the game's own in place. The
+// scripts are gone, so what they asked for goes with them.
+void Config_DropDeclaredOptions(void);
+
 // Every option, terminated by a null entry. An option's address does not move,
 // so one taken from here stays good after another is registered.
 CONFIG_OPTION *const *Config_GetOptions(void);

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -3,12 +3,49 @@
 #include <trx/config/registry.h>
 #include <trx/core/dynamic_enum.h>
 #include <trx/core/enum_map.h>
+#include <trx/core/log.h>
+#include <trx/core/memory.h>
 #include <trx/core/vector.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
 
 #include <lauxlib.h>
+#include <stdio.h>
+#include <string.h>
+
+// How deep a watcher writing a setting may go. Answering a change by changing
+// another setting is the point of a watcher; two watchers answering each other
+// is a fight, and this is where it is called off rather than run out of stack.
+#define M_MAX_DISPATCH_DEPTH 8
+
+// What a declaration says, read out in full before any of it is registered. A
+// declaration half of which was refused would leave an option nobody asked for.
+typedef struct {
+    const char *key;
+    TRX_VALUE default_value;
+    CONFIG_OPTION_BOUNDS bounds;
+    bool has_bounds;
+} M_DECLARATION;
+
+// A script waiting to hear that a setting moved. The key is kept rather than
+// the option: an option is dropped and made again with the game, and a watcher
+// has no business holding an address that dies.
+typedef struct {
+    int32_t id;
+    char *key;
+    int32_t fn_ref;
+    // Set up by a level script, so it goes when the level does, as a
+    // trx.events listener does.
+    bool level_scoped;
+    bool dead;
+} M_WATCHER;
+
+static lua_State *m_L = nullptr;
+static VECTOR *m_Watchers = nullptr;
+static int32_t m_NextWatcherId = 1;
+static int32_t m_ChangeListener = -1;
+static int32_t m_DispatchDepth = 0;
 
 static CONFIG_OPTION *M_GetOption(lua_State *const L, const int32_t arg)
 {
@@ -18,22 +55,6 @@ static CONFIG_OPTION *M_GetOption(lua_State *const L, const int32_t arg)
         luaL_error(L, "unknown option: %s", key);
     }
     return option;
-}
-
-// The option's declared type is what a script gets back: a bool reads as a bool
-// and a number as a number. Colors and enums stay strings, which is what they
-// are on the way in as well.
-static void M_PushValue(lua_State *const L, const CONFIG_OPTION *const option)
-{
-    // Colours, enums, strings and dynamic enums read back as their name or
-    // display string, which is also how a script gives them on the way in.
-    const TRX_VALUE_TYPE type = option->value.type;
-    if (type == TVT_RGB_888 || type == TVT_ENUM || type == TVT_STRING
-        || type == TVT_DYNAMIC_ENUM) {
-        lua_pushstring(L, Config_Option_GetValueAsString(option, false));
-        return;
-    }
-    LUA_PushValue(L, &option->value);
 }
 
 // A value is handed to the config string parser, so it is spelled the way that
@@ -53,7 +74,7 @@ static const char *M_ValueAsString(lua_State *const L, const int32_t arg)
 // trxc.config.get(key)
 static int M_L_ConfigGet(lua_State *const L)
 {
-    M_PushValue(L, M_GetOption(L, 1));
+    LUA_Config_PushOptionValue(L, M_GetOption(L, 1));
     return 1;
 }
 
@@ -88,15 +109,41 @@ static const char *M_KindName(const TRX_VALUE_TYPE type)
     return "";
 }
 
+// The default reads back the way the value does, so what describes a setting
+// is what declares one.
+static void M_PushDefault(lua_State *const L, const CONFIG_OPTION *const option)
+{
+    const TRX_VALUE *const value = &option->default_value;
+    if (value->type == TVT_RGB_888 || value->type == TVT_ENUM
+        || value->type == TVT_STRING || value->type == TVT_DYNAMIC_ENUM) {
+        lua_pushstring(
+            L,
+            Value_Format(
+                value->type, Config_Option_GetEnumKey(option), value, false));
+        return;
+    }
+    LUA_PushValue(L, value);
+}
+
 // trxc.config.describe(key) -> table
 static int M_L_ConfigDescribe(lua_State *const L)
 {
     const CONFIG_OPTION *const option = M_GetOption(L, 1);
     lua_newtable(L);
+    lua_pushstring(L, option->name);
+    lua_setfield(L, -2, "key");
     lua_pushstring(L, M_KindName(option->value.type));
     lua_setfield(L, -2, "kind");
     lua_pushboolean(L, (option->flags & CONFIG_OPTION_PERCENT) != 0);
     lua_setfield(L, -2, "percent");
+    M_PushDefault(L, option);
+    lua_setfield(L, -2, "default");
+    if (option->bounds != nullptr) {
+        lua_pushnumber(L, option->bounds->min);
+        lua_setfield(L, -2, "min");
+        lua_pushnumber(L, option->bounds->max);
+        lua_setfield(L, -2, "max");
+    }
 
     if (option->value.type == TVT_ENUM) {
         VECTOR *const values = EnumMap_ListValues(option->enum_map);
@@ -194,9 +241,292 @@ static int M_L_ConfigList(lua_State *const L)
     lua_newtable(L);
     for (CONFIG_OPTION *const *option = Config_GetOptions(); *option != nullptr;
          option++) {
-        M_PushValue(L, *option);
+        LUA_Config_PushOptionValue(L, *option);
         lua_setfield(L, -2, (*option)->name);
     }
+    return 1;
+}
+
+// A string field of a declaration. A number is refused rather than coerced:
+// luaL_checkstring would rewrite the table's own field into a string and hand
+// back a pointer into the stack slot this pops.
+static const char *M_StrField(
+    lua_State *const L, const int32_t idx, const char *const name,
+    const bool required)
+{
+    lua_getfield(L, idx, name);
+    if (lua_isnil(L, -1) && !required) {
+        lua_pop(L, 1);
+        return nullptr;
+    }
+    if (lua_type(L, -1) != LUA_TSTRING) {
+        luaL_error(L, "option field '%s' must be a string", name);
+    }
+    // Handed back rather than copied: the string belongs to the spec table,
+    // which is an argument of the call being read.
+    const char *const result = lua_tostring(L, -1);
+    lua_pop(L, 1);
+    return result;
+}
+
+// The kinds a script may declare, named the way trxc.config.describe reports
+// them back. The rest of the taxonomy names storage the engine owns.
+static TRX_VALUE_TYPE M_ReadKind(lua_State *const L, const char *const kind)
+{
+    if (strcmp(kind, "boolean") == 0) {
+        return TVT_BOOL;
+    }
+    if (strcmp(kind, "integer") == 0) {
+        return TVT_S32;
+    }
+    if (strcmp(kind, "dynamic_enum") == 0) {
+        return TVT_DYNAMIC_ENUM;
+    }
+    luaL_error(L, "unknown option kind: %s", kind);
+    return TVT_BOOL;
+}
+
+// Whether the values the declaration lists name the one it defaults to. An
+// option defaulting to a value it does not offer has nothing to fall back on.
+static bool M_ListsDefault(
+    lua_State *const L, const int32_t idx, const char *const default_value)
+{
+    bool found = false;
+    const int32_t count = (int32_t)lua_rawlen(L, idx);
+    for (int32_t i = 1; i <= count && !found; i++) {
+        lua_rawgeti(L, idx, i);
+        if (lua_type(L, -1) != LUA_TSTRING) {
+            luaL_error(L, "option values must be strings");
+        }
+        found = strcmp(lua_tostring(L, -1), default_value) == 0;
+        lua_pop(L, 1);
+    }
+    return found;
+}
+
+static M_DECLARATION M_ReadDeclaration(lua_State *const L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    M_DECLARATION spec = {};
+    spec.key = M_StrField(L, 1, "key", true);
+    const TRX_VALUE_TYPE type = M_ReadKind(L, M_StrField(L, 1, "kind", true));
+
+    lua_getfield(L, 1, "default");
+    switch (type) {
+    case TVT_BOOL:
+        luaL_checktype(L, -1, LUA_TBOOLEAN);
+        spec.default_value =
+            (TRX_VALUE) { .type = TVT_BOOL, .as_bool = lua_toboolean(L, -1) };
+        break;
+    case TVT_S32:
+        spec.default_value =
+            (TRX_VALUE) { .type = TVT_S32, .as_int = luaL_checkinteger(L, -1) };
+        break;
+    default:
+        spec.default_value = (TRX_VALUE) { .type = TVT_DYNAMIC_ENUM };
+        break;
+    }
+    lua_pop(L, 1);
+    if (type == TVT_DYNAMIC_ENUM) {
+        spec.default_value.as_str = M_StrField(L, 1, "default", true);
+    }
+
+    // Each bound stands on its own: naming a floor is not asking for a ceiling
+    // of zero, so what the declaration leaves out is as far as the storage
+    // goes.
+    lua_getfield(L, 1, "min");
+    lua_getfield(L, 1, "max");
+    spec.has_bounds = !lua_isnil(L, -2) || !lua_isnil(L, -1);
+    spec.bounds.min = (double)luaL_optinteger(L, -2, INT32_MIN);
+    spec.bounds.max = (double)luaL_optinteger(L, -1, INT32_MAX);
+    lua_pop(L, 2);
+    if (type != TVT_S32) {
+        spec.has_bounds = false;
+    }
+    if (spec.has_bounds && spec.bounds.min > spec.bounds.max) {
+        luaL_error(
+            L, "option %s takes nothing: min %d is above max %d", spec.key,
+            (int32_t)spec.bounds.min, (int32_t)spec.bounds.max);
+    }
+    if (spec.has_bounds
+        && (spec.default_value.as_int < (int64_t)spec.bounds.min
+            || spec.default_value.as_int > (int64_t)spec.bounds.max)) {
+        luaL_error(
+            L, "option %s defaults to %d, outside %d..%d", spec.key,
+            (int32_t)spec.default_value.as_int, (int32_t)spec.bounds.min,
+            (int32_t)spec.bounds.max);
+    }
+
+    if (type == TVT_DYNAMIC_ENUM) {
+        lua_getfield(L, 1, "values");
+        if (!lua_istable(L, -1) || lua_rawlen(L, -1) == 0) {
+            luaL_error(
+                L, "option %s is an enum but declares no values", spec.key);
+        }
+        if (!M_ListsDefault(L, lua_gettop(L), spec.default_value.as_str)) {
+            luaL_error(
+                L, "option %s defaults to %s, which it does not list", spec.key,
+                spec.default_value.as_str);
+        }
+        lua_pop(L, 1);
+    }
+    return spec;
+}
+
+// Seeds a declared enum's values. Each label is a game string key derived from
+// the option, so a declared value is translated as every other one is.
+static void M_SeedValues(lua_State *const L, const CONFIG_OPTION *const option)
+{
+    const void *const token = Config_Option_GetEnumKey(option);
+    DynamicEnum_ResetValues(token);
+    lua_getfield(L, 1, "values");
+    const int32_t count = (int32_t)lua_rawlen(L, -1);
+    for (int32_t i = 1; i <= count; i++) {
+        lua_rawgeti(L, -1, i);
+        const char *const value = lua_tostring(L, -1);
+        char label[128];
+        snprintf(
+            label, sizeof(label), "settings/%s/values/%s", option->name, value);
+        DynamicEnum_AddValue(token, value, label);
+        lua_pop(L, 1);
+    }
+    lua_pop(L, 1);
+}
+
+// trxc.config.declare(spec)
+static int M_L_ConfigDeclare(lua_State *const L)
+{
+    const M_DECLARATION spec = M_ReadDeclaration(L);
+    CONFIG_OPTION *const option = Config_Register(&(CONFIG_OPTION_DESC) {
+        .name = spec.key,
+        .default_value = spec.default_value,
+        .bounds = spec.has_bounds ? &spec.bounds : nullptr,
+        .declared = true,
+    });
+    if (option == nullptr) {
+        return luaL_error(L, "option already declared: %s", spec.key);
+    }
+    if (option->value.type == TVT_DYNAMIC_ENUM) {
+        M_SeedValues(L, option);
+    }
+    return 0;
+}
+
+// Tells one watcher what a setting holds. A watcher that raises must not take
+// the rest of them with it: the setting has moved either way, and the others
+// still have to hear about it.
+static void M_CallWatcher(
+    lua_State *const L, const M_WATCHER *const watcher,
+    const CONFIG_OPTION *const option)
+{
+    lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->fn_ref);
+    LUA_Config_PushOptionValue(L, option);
+    if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
+        LOG_ERROR(
+            "config watcher for %s failed: %s", option->name,
+            lua_tostring(L, -1));
+        lua_pop(L, 1);
+    }
+}
+
+static void M_FreeWatcher(lua_State *const L, M_WATCHER *const watcher)
+{
+    luaL_unref(L, LUA_REGISTRYINDEX, watcher->fn_ref);
+    Memory_FreePointer(&watcher->key);
+}
+
+// Drops the watchers marked dead. Removing one mid-dispatch would move the
+// ones after it out from under the walk, so a watcher goes as soon as the last
+// dispatch is over and not before.
+static void M_CompactWatchers(lua_State *const L)
+{
+    for (int32_t i = m_Watchers->count - 1; i >= 0; i--) {
+        M_WATCHER *const watcher = Vector_Get(m_Watchers, i);
+        if (watcher->dead) {
+            M_FreeWatcher(L, watcher);
+            Vector_RemoveAt(m_Watchers, i);
+        }
+    }
+}
+
+// Says a setting moved, to whoever asked about that one.
+static void M_HandleChange(const EVENT *const event, void *const user_data)
+{
+    lua_State *const L = m_L;
+    const CONFIG_CHANGE *const change = event->data;
+    if (L == nullptr || m_Watchers == nullptr || change == nullptr) {
+        return;
+    }
+    if (m_DispatchDepth >= M_MAX_DISPATCH_DEPTH) {
+        LOG_ERROR(
+            "config watchers are still changing settings %d calls deep; "
+            "giving up on this change",
+            m_DispatchDepth);
+        return;
+    }
+
+    m_DispatchDepth++;
+    // The watchers as they stand: one attached from inside another has already
+    // been told what the setting holds, and has nothing to hear from this
+    // round.
+    const int32_t count = m_Watchers->count;
+    for (int32_t i = 0; i < change->count; i++) {
+        const CONFIG_OPTION *const option = change->options[i];
+        for (int32_t j = 0; j < count && j < m_Watchers->count; j++) {
+            const M_WATCHER *const watcher = Vector_Get(m_Watchers, j);
+            if (watcher->dead || strcmp(watcher->key, option->name) != 0) {
+                continue;
+            }
+            M_CallWatcher(L, watcher, option);
+        }
+    }
+    m_DispatchDepth--;
+    if (m_DispatchDepth == 0) {
+        M_CompactWatchers(L);
+    }
+}
+
+// trxc.config.on_change(key, fn) -> id
+static int M_L_ConfigOnChange(lua_State *const L)
+{
+    const CONFIG_OPTION *const option = M_GetOption(L, 1);
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+    if (m_Watchers == nullptr) {
+        m_Watchers = Vector_Create(sizeof(M_WATCHER));
+    }
+    lua_pushvalue(L, 2);
+    Vector_Add(
+        m_Watchers,
+        &(M_WATCHER) {
+            .id = m_NextWatcherId++,
+            .key = Memory_DupStr(option->name),
+            .fn_ref = luaL_ref(L, LUA_REGISTRYINDEX),
+            .level_scoped = LUA_GetScriptContext() == LUA_CONTEXT_LEVEL,
+        });
+    // The setting already holds something, and a script asking to hear about it
+    // is asking about the value in force as much as the ones to come.
+    M_CallWatcher(L, Vector_Get(m_Watchers, m_Watchers->count - 1), option);
+    lua_pushinteger(L, m_NextWatcherId - 1);
+    return 1;
+}
+
+// trxc.config.off_change(id) -> bool
+static int M_L_ConfigOffChange(lua_State *const L)
+{
+    const int32_t id = (int32_t)luaL_checkinteger(L, 1);
+    for (int32_t i = 0; m_Watchers != nullptr && i < m_Watchers->count; i++) {
+        M_WATCHER *const watcher = Vector_Get(m_Watchers, i);
+        if (watcher->id != id || watcher->dead) {
+            continue;
+        }
+        watcher->dead = true;
+        if (m_DispatchDepth == 0) {
+            M_CompactWatchers(L);
+        }
+        lua_pushboolean(L, true);
+        return 1;
+    }
+    lua_pushboolean(L, false);
     return 1;
 }
 
@@ -209,12 +539,70 @@ static const luaL_Reg m_Module[] = {
     { "restore", M_L_ConfigRestore },
     { "is_overridden", M_L_ConfigIsOverridden },
     { "list", M_L_ConfigList },
+    { "declare", M_L_ConfigDeclare },
+    { "on_change", M_L_ConfigOnChange },
+    { "off_change", M_L_ConfigOffChange },
     { nullptr, nullptr },
 };
 
 static void M_Create(lua_State *const L)
 {
+    m_L = L;
+    m_ChangeListener = Config_SubscribeChanges(M_HandleChange, nullptr);
     LUA_RegisterModule(L, "config", m_Module);
 }
 
-REGISTER_LUA_CAPI(.create = M_Create)
+// A ref names a slot in the registry of the state that is going, and the next
+// state numbers its own from scratch. Kept, it would name whatever landed
+// there.
+static void M_Shutdown(void)
+{
+    for (int32_t i = 0; m_Watchers != nullptr && i < m_Watchers->count; i++) {
+        M_WATCHER *const watcher = Vector_Get(m_Watchers, i);
+        Memory_FreePointer(&watcher->key);
+    }
+    if (m_Watchers != nullptr) {
+        Vector_Free(m_Watchers);
+        m_Watchers = nullptr;
+    }
+    if (m_ChangeListener >= 0) {
+        Config_UnsubscribeChanges(m_ChangeListener);
+        m_ChangeListener = -1;
+    }
+    m_DispatchDepth = 0;
+    m_L = nullptr;
+}
+
+// The option's declared type is what a script gets back: a bool reads as a bool
+// and a number as a number. Colors and enums stay strings, which is what they
+// are on the way in as well.
+void LUA_Config_PushOptionValue(
+    lua_State *const L, const CONFIG_OPTION *const option)
+{
+    // Colours, enums, strings and dynamic enums read back as their name or
+    // display string, which is also how a script gives them on the way in.
+    const TRX_VALUE_TYPE type = option->value.type;
+    if (type == TVT_RGB_888 || type == TVT_ENUM || type == TVT_STRING
+        || type == TVT_DYNAMIC_ENUM) {
+        lua_pushstring(L, Config_Option_GetValueAsString(option, false));
+        return;
+    }
+    LUA_PushValue(L, &option->value);
+}
+
+void LUA_Config_ClearLevelWatchers(void)
+{
+    lua_State *const L = m_L;
+    if (L == nullptr || m_Watchers == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < m_Watchers->count; i++) {
+        M_WATCHER *const watcher = Vector_Get(m_Watchers, i);
+        watcher->dead = watcher->dead || watcher->level_scoped;
+    }
+    if (m_DispatchDepth == 0) {
+        M_CompactWatchers(L);
+    }
+}
+
+REGISTER_LUA_CAPI(.create = M_Create, .shutdown = M_Shutdown)

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -500,6 +500,7 @@ void LUA_DropLevelScript(void)
     // A probe leaves listeners behind as readily as a level does, and they go
     // here whether anything was told about it or not.
     LUA_ClearLevelListeners();
+    LUA_Config_ClearLevelWatchers();
     LUA_DropLevelModules(p->state);
 }
 

--- a/src/trx/game/lua/common.h
+++ b/src/trx/game/lua/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/config/option.h>
 #include <trx/game/game_flow/types.h>
 
 #include <lualib.h>
@@ -59,6 +60,14 @@ void LUA_DropLevelModules(lua_State *L);
 
 // Runs the per-game script (scripts/_game.lua), if the game ships one.
 void LUA_RunGameScript(void);
+
+// Pushes what a setting holds, in the shape a script reads it as: a bool as a
+// bool, a number as a number, and a color, an enum or a string as text.
+void LUA_Config_PushOptionValue(lua_State *L, const CONFIG_OPTION *option);
+
+// Drops the config watchers a level script set up, as the level's listeners
+// are dropped. A watcher a game script set up stays.
+void LUA_Config_ClearLevelWatchers(void);
 
 // Let go of the outgoing level's script: what it set up hears about it, and
 // then its listeners go. Level_Unload does this for a level change; a path that

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -320,8 +320,6 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
     M_DumpHeader(p->file);
     M_DumpStartup(p->file);
     M_DumpArguments(p->file, original_args);
-    M_DumpConfig(p->file);
-    M_DumpBindings(p->file);
 
     p->listeners[0] = GameEvent_Subscribe(
         GAME_EVENT_SCREENSHOT, nullptr, M_HandleGameEvent, nullptr);
@@ -329,6 +327,20 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
         GAME_EVENT_COMMAND, nullptr, M_HandleGameEvent, nullptr);
 
     LOG_INFO("Starting recording");
+}
+
+// What the settings were as the game started. A game declares settings of its
+// own as its script runs, so this waits for that: an option nothing knows
+// about yet is one the recording would not carry, and its default is not
+// there to compare against either.
+void TestRecorder_WriteConfig(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file == nullptr) {
+        return;
+    }
+    M_DumpConfig(p->file);
+    M_DumpBindings(p->file);
 }
 
 bool TestRecorder_IsOpened(void)

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -242,11 +242,15 @@ static void M_DumpConfig(MYFILE *const fp)
         raw_opts, opts->count, sizeof(CONFIG_OPTION *), M_CompareConfigOption);
     for (int32_t i = 0; i < opts->count; i++) {
         const CONFIG_OPTION *opt = raw_opts[i];
+        // A value that is spelled rather than counted is quoted: what the
+        // spelling carries - a hex color, the spaces in a vector - is not for
+        // the parser to read as the next field.
         const TRX_VALUE_TYPE type = opt->value.type;
+        const bool is_spelled = type == TVT_ENUM || type == TVT_STRING
+            || type == TVT_DYNAMIC_ENUM || type == TVT_RGB_888
+            || type == TVT_XYZ_16 || type == TVT_XYZ_32;
         const char *const fmt =
-            type == TVT_ENUM || type == TVT_STRING || type == TVT_DYNAMIC_ENUM
-            ? "config %s \"%s\"\n"
-            : "config %s %s\n";
+            is_spelled ? "config %s \"%s\"\n" : "config %s %s\n";
         File_WriteString(
             fp, fmt, opt->name, Config_Option_GetValueAsString(opt, false));
     }

--- a/src/trx/game/replay/test_recorder.h
+++ b/src/trx/game/replay/test_recorder.h
@@ -12,6 +12,10 @@
 // @param path  Path to the recording to write to.
 void TestRecorder_Open(const char *path, VECTOR *original_args);
 
+// Write the settings the recording starts from. Called once the game's script
+// has run, so that the settings it declares are carried too.
+void TestRecorder_WriteConfig(void);
+
 // Close the recorder.
 void TestRecorder_Close(void);
 

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -50,11 +50,19 @@ typedef struct {
     VECTOR *events; // vector of char*
 } M_FRAME;
 
+// A setting the recording asks for that no option answers to yet, kept until
+// the game's script has declared its own.
+typedef struct {
+    char *key;
+    char *value;
+} M_DEFERRED_OPTION;
+
 // Replay private state
 typedef struct {
     char *data; // Replay file data buffer
     size_t size; // Size of data buffer
     VECTOR *headers; // Vector of char* header lines
+    VECTOR *deferred_config; // Vector of M_DEFERRED_OPTION
     VECTOR *frames; // Vector of M_FRAME frames to play
     int32_t frame_idx; // Current playback frame index
     int32_t next_frame_idx; // Next frame to process
@@ -877,11 +885,23 @@ static bool M_ParseConfig(const char *const line, M_PARSE_CTX *const ctx)
             memmove(valbuf, valbuf + 1, vlen - 1);
         }
         CONFIG_OPTION *opt = Config_FindOption(keybuf);
-        if (opt) {
+        if (opt != nullptr) {
             Config_Option_SetFromString(opt, valbuf, false);
-        } else {
-            LOG_WARNING("Unknown option: %s", keybuf);
+            return true;
         }
+        // A game declares its own settings as its script runs, which is after
+        // the header is read. The name is kept rather than refused, and tried
+        // again once those options exist.
+        M_PRIV *const p = &m_Priv;
+        if (p->deferred_config == nullptr) {
+            p->deferred_config = Vector_Create(sizeof(M_DEFERRED_OPTION));
+        }
+        Vector_Add(
+            p->deferred_config,
+            &(M_DEFERRED_OPTION) {
+                .key = Memory_DupStr(keybuf),
+                .value = Memory_DupStr(valbuf),
+            });
         return true;
     }
     return false;
@@ -1084,6 +1104,32 @@ SHELL_ARGS *TestReplay_Open(const char *path)
     }
     M_FreeStartupSnapshot(&ctx.startup);
     return ctx.args;
+}
+
+// The settings the recording named that no option answered to when the header
+// was read. A game's script has run by now, so its own settings are here.
+void TestReplay_ApplyDeferredConfig(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->deferred_config == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < p->deferred_config->count; i++) {
+        M_DEFERRED_OPTION *const deferred = Vector_Get(p->deferred_config, i);
+        CONFIG_OPTION *const option = Config_FindOption(deferred->key);
+        if (option == nullptr) {
+            LOG_WARNING("Unknown option: %s", deferred->key);
+        } else {
+            Config_Option_SetFromString(option, deferred->value, false);
+        }
+        Memory_FreePointer(&deferred->key);
+        Memory_FreePointer(&deferred->value);
+    }
+    Vector_Free(p->deferred_config);
+    p->deferred_config = nullptr;
+    // As in TestReplay_Start: this is where the replay starts from, not
+    // something that moved while it ran.
+    Config_DiscardPendingChanges();
 }
 
 void TestReplay_Start(void)

--- a/src/trx/game/replay/test_replay.h
+++ b/src/trx/game/replay/test_replay.h
@@ -15,6 +15,11 @@ SHELL_ARGS *TestReplay_Open(const char *path);
 // initializing.
 void TestReplay_Start(void);
 
+// Apply the settings the recording named that no option answered to when its
+// header was read: the ones a game's script declares. Called once that script
+// has run.
+void TestReplay_ApplyDeferredConfig(void);
+
 // Shutdown test replay.
 void TestReplay_Close(void);
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -434,6 +434,15 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     UI_SettingsLua_DropDeclaredRows();
     LUA_RunGameScript();
 
+    // The settings a recording carries are the ones that exist by now, the
+    // game's own among them.
+    if (TestReplay_IsOpened()) {
+        TestReplay_ApplyDeferredConfig();
+    }
+    if (TestRecorder_IsOpened()) {
+        TestRecorder_WriteConfig();
+    }
+
     Stats_CalculateMaxStats();
     GF_COMMAND gf_cmd = GF_DoFrontendSequence();
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -45,6 +45,7 @@
 #include <trx/game/shell/state.h>
 #include <trx/game/sound.h>
 #include <trx/game/stats.h>
+#include <trx/game/ui/dialogs/settings_lua.h>
 #include <trx/game/ui/settings.h>
 #include <trx/game/ui/touch_overlay.h>
 #include <trx/gl/context.h>
@@ -427,6 +428,10 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     Savegame_Init();
     SG_Manager_ScanSavedGames();
 
+    // What the last game's script declared goes before this one's script runs,
+    // so a game never inherits another's settings or the rows that show them.
+    Config_DropDeclaredOptions();
+    UI_SettingsLua_DropDeclaredRows();
     LUA_RunGameScript();
 
     Stats_CalculateMaxStats();

--- a/src/trx/game/ui/dialogs/config_presets.c
+++ b/src/trx/game/ui/dialogs/config_presets.c
@@ -87,6 +87,17 @@ static char *M_FormatTitle(UI_CONFIG_PRESETS_STATE *const s)
     return String_Format(GS("general/config_presets/title_fmt"), preset_name);
 }
 
+// Whether a preset's entry is one this game answers to. Every preset is
+// offered whichever game is running, and a setting a game declares takes only
+// the values that game offers, so what this one cannot take is passed over
+// rather than shown as a change it would not make.
+static bool M_IsSettingApplicable(
+    const CONFIG_OPTION *const opt, const char *const value)
+{
+    return opt != nullptr && Config_Option_AcceptsString(opt, value)
+        && strcmp(Config_Option_GetValueAsString(opt, false), value) != 0;
+}
+
 static int32_t M_GetChangedSettingCount(const int32_t preset_idx)
 {
     const CONFIG_PRESET *const preset = Config_Presets_Get(preset_idx);
@@ -97,12 +108,7 @@ static int32_t M_GetChangedSettingCount(const int32_t preset_idx)
     int32_t changed_count = 0;
     for (int32_t i = 0; i < preset->setting_count; i++) {
         const CONFIG_OPTION *const opt = Config_FindOption(preset->keys[i]);
-        if (opt == nullptr) {
-            continue;
-        }
-        const char *const current_value =
-            Config_Option_GetValueAsString(opt, false);
-        if (strcmp(current_value, preset->values[i]) != 0) {
+        if (M_IsSettingApplicable(opt, preset->values[i])) {
             changed_count++;
         }
     }
@@ -185,11 +191,7 @@ static float M_GetConfirmContentWidth(UI_CONFIG_PRESETS_STATE *const s)
     if (s->phase == M_PHASE_CONFIRM && preset != nullptr) {
         for (int32_t i = 0; i < preset->setting_count; i++) {
             const CONFIG_OPTION *const opt = Config_FindOption(preset->keys[i]);
-            if (opt == nullptr
-                || strcmp(
-                       Config_Option_GetValueAsString(opt, false),
-                       preset->values[i])
-                    == 0) {
+            if (!M_IsSettingApplicable(opt, preset->values[i])) {
                 continue;
             }
             char *const value_change =
@@ -216,12 +218,7 @@ static void M_DrawConfirmRows(
 
     for (int32_t i = 0; i < preset->setting_count; i++) {
         const CONFIG_OPTION *const opt = Config_FindOption(preset->keys[i]);
-        if (opt == nullptr) {
-            continue;
-        }
-        const char *const current_value_raw =
-            Config_Option_GetValueAsString(opt, false);
-        if (strcmp(current_value_raw, preset->values[i]) == 0) {
+        if (!M_IsSettingApplicable(opt, preset->values[i])) {
             continue;
         }
         char *const value_change = M_FormatValueChange(opt, preset->values[i]);

--- a/src/trx/game/ui/dialogs/settings_editor.c
+++ b/src/trx/game/ui/dialogs/settings_editor.c
@@ -548,11 +548,13 @@ static void M_OptionLabel(
 {
     const UI_SETTING_HANDLER *const handler =
         row != nullptr ? row->handler : nullptr;
-    const bool is_available = handler == nullptr
-        || handler->is_available == nullptr
-        || handler->is_available(row->option, handler->user_data);
-    const bool is_enforced =
-        star_if_enforced && row != nullptr && M_IsOptionHeld(row);
+    const bool is_held = M_IsOptionHeld(row);
+    // A held row is not the player's to move, so it reads as one they cannot
+    // move rather than only carrying the star that says who took it.
+    const bool is_available = !is_held
+        && (handler == nullptr || handler->is_available == nullptr
+            || handler->is_available(row->option, handler->user_data));
+    const bool is_enforced = star_if_enforced && is_held;
     const char *const suffix = is_enforced ? "*" : "";
 
     if (!is_available) {

--- a/src/trx/game/ui/dialogs/settings_lua.c
+++ b/src/trx/game/ui/dialogs/settings_lua.c
@@ -1,0 +1,278 @@
+// A settings row a script asked for: where it sits, and what it does that data
+// cannot say.
+//
+// The rest of what a script declares is the config layer's, and the binding for
+// it lives with the other Lua modules. A row is not: it belongs to the dialogs,
+// and the dialogs sit above the game, so the calls that place one and answer
+// for it live here rather than reaching up from there.
+//
+// One handler is registered per declared row, holding the script's own
+// functions by reference. Every callback the dialogs make comes back through
+// here, into the function the declaration named.
+
+#include <trx/game/ui/dialogs/settings_lua.h>
+
+#include <trx/core/log.h>
+#include <trx/core/memory.h>
+#include <trx/core/utils.h>
+#include <trx/core/vector.h>
+#include <trx/game/lua/common.h>
+#include <trx/game/lua/registry.h>
+#include <trx/game/lua/utils.h>
+#include <trx/game/ui/dialogs/settings_handlers.h>
+#include <trx/game/ui/dialogs/settings_rows.h>
+
+#include <lauxlib.h>
+
+typedef enum {
+    M_CB_FORMAT_VALUE,
+    M_CB_IS_AVAILABLE,
+    M_CB_IS_VISIBLE,
+    M_CB_CAN_CHANGE_VALUE,
+    M_CB_REQUEST_CHANGE_VALUE,
+    M_CB_COUNT,
+} M_CALLBACK;
+
+// A row a script declared, for as long as the game that declared it. The
+// handler is what the dialogs hold, so this never moves: the vector holds
+// pointers to these rather than the structs themselves.
+typedef struct {
+    UI_SETTING_HANDLER handler;
+    char *key;
+    int32_t refs[M_CB_COUNT];
+    // What format_value last handed back. The dialogs read the string after the
+    // call returns, and Lua's own copy is gone by then.
+    char *formatted;
+} M_DECLARED_ROW;
+
+// The names a declaration gives them, in the order above.
+static const char *const m_CallbackNames[M_CB_COUNT] = {
+    "format_value",     "is_available",         "is_visible",
+    "can_change_value", "request_change_value",
+};
+
+static lua_State *m_L = nullptr;
+static VECTOR *m_Rows = nullptr;
+
+// Pushes the callback and the option's value, ready for the arguments a
+// particular one takes. False where the declaration named no such function, and
+// nothing is left on the stack.
+static bool M_PushCall(
+    const M_DECLARED_ROW *const row, const M_CALLBACK cb,
+    const CONFIG_OPTION *const option, const bool with_value)
+{
+    if (m_L == nullptr || row->refs[cb] == LUA_NOREF) {
+        return false;
+    }
+    lua_rawgeti(m_L, LUA_REGISTRYINDEX, row->refs[cb]);
+    if (with_value) {
+        LUA_Config_PushOptionValue(m_L, option);
+    }
+    return true;
+}
+
+// Makes the call and hands back what it returned, or nothing where it raised.
+// A script's own mistake is logged and answered as if it had said nothing: a
+// settings row that stops drawing is a worse answer than one that ignores a
+// handler.
+static bool M_Call(
+    const M_DECLARED_ROW *const row, const M_CALLBACK cb, const int32_t nargs)
+{
+    if (lua_pcall(m_L, nargs, 1, 0) == LUA_OK) {
+        return true;
+    }
+    LOG_ERROR(
+        "settings row %s: %s handler failed: %s", row->key, m_CallbackNames[cb],
+        lua_tostring(m_L, -1));
+    lua_pop(m_L, 1);
+    return false;
+}
+
+static bool M_CallPredicate(
+    const M_DECLARED_ROW *const row, const M_CALLBACK cb,
+    const CONFIG_OPTION *const option, const int32_t dir, const bool with_dir,
+    const bool absent)
+{
+    if (!M_PushCall(row, cb, option, true)) {
+        return absent;
+    }
+    if (with_dir) {
+        lua_pushinteger(m_L, dir);
+    }
+    if (!M_Call(row, cb, with_dir ? 2 : 1)) {
+        return absent;
+    }
+    const bool result = lua_toboolean(m_L, -1);
+    lua_pop(m_L, 1);
+    return result;
+}
+
+static const char *M_FormatValue(
+    const CONFIG_OPTION *const option, void *const user_data)
+{
+    M_DECLARED_ROW *const row = user_data;
+    if (!M_PushCall(row, M_CB_FORMAT_VALUE, option, true)) {
+        return nullptr;
+    }
+    if (!M_Call(row, M_CB_FORMAT_VALUE, 1)) {
+        return nullptr;
+    }
+    const char *const text = lua_tostring(m_L, -1);
+    Memory_FreePointer(&row->formatted);
+    row->formatted = Memory_DupStr(text != nullptr ? text : "");
+    lua_pop(m_L, 1);
+    return row->formatted;
+}
+
+static bool M_IsAvailable(
+    const CONFIG_OPTION *const option, void *const user_data)
+{
+    return M_CallPredicate(
+        user_data, M_CB_IS_AVAILABLE, option, 0, false, true);
+}
+
+static bool M_IsVisible(
+    const CONFIG_OPTION *const option, void *const user_data)
+{
+    return M_CallPredicate(user_data, M_CB_IS_VISIBLE, option, 0, false, true);
+}
+
+static bool M_CanChangeValue(
+    const CONFIG_OPTION *const option, const int32_t dir, void *const user_data)
+{
+    return M_CallPredicate(
+        user_data, M_CB_CAN_CHANGE_VALUE, option, dir, true, true);
+}
+
+// False where the script did not take the press, so the dialogs move the
+// setting themselves.
+static bool M_RequestChangeValue(
+    CONFIG_OPTION *const option, const int32_t dir, void *const user_data)
+{
+    return M_CallPredicate(
+        user_data, M_CB_REQUEST_CHANGE_VALUE, option, dir, true, false);
+}
+
+// The one field of a callback table that is not a function.
+static int32_t M_ReadDelta(
+    lua_State *const L, const int32_t idx, const char *const name)
+{
+    lua_getfield(L, idx, name);
+    const int32_t result = (int32_t)luaL_optinteger(L, -1, 0);
+    lua_pop(L, 1);
+    return result;
+}
+
+static void M_ReadCallbacks(
+    lua_State *const L, const int32_t idx, M_DECLARED_ROW *const row)
+{
+    for (int32_t i = 0; i < M_CB_COUNT; i++) {
+        lua_getfield(L, idx, m_CallbackNames[i]);
+        if (lua_isnil(L, -1)) {
+            lua_pop(L, 1);
+            row->refs[i] = LUA_NOREF;
+            continue;
+        }
+        luaL_checktype(L, -1, LUA_TFUNCTION);
+        row->refs[i] = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+}
+
+static void M_FreeRow(lua_State *const L, M_DECLARED_ROW *const row)
+{
+    UI_Settings_RemoveHandler(&row->handler);
+    for (int32_t i = 0; i < M_CB_COUNT; i++) {
+        if (L != nullptr && row->refs[i] != LUA_NOREF) {
+            luaL_unref(L, LUA_REGISTRYINDEX, row->refs[i]);
+        }
+    }
+    Memory_FreePointer(&row->formatted);
+    Memory_FreePointer(&row->key);
+    Memory_Free(row);
+}
+
+// trxc.settings.add_row(key, ui)
+static int M_L_SettingsAddRow(lua_State *const L)
+{
+    const char *const key = luaL_checkstring(L, 1);
+    luaL_checktype(L, 2, LUA_TTABLE);
+
+    lua_getfield(L, 2, "tab");
+    const char *const tab_name = luaL_checkstring(L, -1);
+    CONFIG_TAB tab;
+    if (!UI_Settings_FindTab(tab_name, &tab)) {
+        return luaL_error(L, "unknown settings tab: %s", tab_name);
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, 2, "before");
+    lua_getfield(L, 2, "after");
+    const char *const before = lua_isnil(L, -2) ? nullptr : lua_tostring(L, -2);
+    const char *const after = lua_isnil(L, -1) ? nullptr : lua_tostring(L, -1);
+
+    M_DECLARED_ROW *const row = Memory_Alloc(sizeof(M_DECLARED_ROW));
+    row->key = Memory_DupStr(key);
+    M_ReadCallbacks(L, 2, row);
+    row->handler = (UI_SETTING_HANDLER) {
+        .key = row->key,
+        .user_data = row,
+        .delta_slow = M_ReadDelta(L, 2, "delta_slow"),
+        .delta_fast = M_ReadDelta(L, 2, "delta_fast"),
+        .format_value =
+            row->refs[M_CB_FORMAT_VALUE] != LUA_NOREF ? M_FormatValue : nullptr,
+        .is_available =
+            row->refs[M_CB_IS_AVAILABLE] != LUA_NOREF ? M_IsAvailable : nullptr,
+        .is_visible =
+            row->refs[M_CB_IS_VISIBLE] != LUA_NOREF ? M_IsVisible : nullptr,
+        .can_change_value = row->refs[M_CB_CAN_CHANGE_VALUE] != LUA_NOREF
+            ? M_CanChangeValue
+            : nullptr,
+        .request_change_value =
+            row->refs[M_CB_REQUEST_CHANGE_VALUE] != LUA_NOREF
+            ? M_RequestChangeValue
+            : nullptr,
+    };
+
+    if (m_Rows == nullptr) {
+        m_Rows = Vector_Create(sizeof(M_DECLARED_ROW *));
+    }
+    Vector_Add(m_Rows, &row);
+    UI_Settings_AddHandler(&row->handler);
+    UI_Settings_AddDeclaredRow(tab, key, before, after);
+    lua_pop(L, 2);
+    return 0;
+}
+
+static const luaL_Reg m_Module[] = {
+    { "add_row", M_L_SettingsAddRow },
+    { nullptr, nullptr },
+};
+
+static void M_Create(lua_State *const L)
+{
+    m_L = L;
+    LUA_RegisterModule(L, "settings", m_Module);
+}
+
+static void M_Shutdown(void)
+{
+    UI_SettingsLua_DropDeclaredRows();
+    if (m_Rows != nullptr) {
+        Vector_Free(m_Rows);
+        m_Rows = nullptr;
+    }
+    m_L = nullptr;
+}
+
+void UI_SettingsLua_DropDeclaredRows(void)
+{
+    for (int32_t i = 0; m_Rows != nullptr && i < m_Rows->count; i++) {
+        M_FreeRow(m_L, *(M_DECLARED_ROW **)Vector_Get(m_Rows, i));
+    }
+    if (m_Rows != nullptr) {
+        Vector_Clear(m_Rows);
+    }
+    UI_Settings_DropDeclaredRows();
+}
+
+REGISTER_LUA_CAPI(.create = M_Create, .shutdown = M_Shutdown)

--- a/src/trx/game/ui/dialogs/settings_lua.h
+++ b/src/trx/game/ui/dialogs/settings_lua.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Drops every settings row a script asked for, along with the handler each one
+// registered. A game's rows go when the game does, before the next game's
+// script runs; see settings_lua.c.
+void UI_SettingsLua_DropDeclaredRows(void);

--- a/src/trx/game/ui/dialogs/settings_rows.c
+++ b/src/trx/game/ui/dialogs/settings_rows.c
@@ -1,12 +1,30 @@
 #include <trx/game/ui/dialogs/settings_rows.h>
 
+#include <trx/config/common.h>
 #include <trx/config/registry.h>
+#include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/ui/dialogs/settings_handlers.h>
 
+#include <string.h>
+
 #define X_UI_ROW(KEY_) QUOTE(KEY_),
+
+// How far apart the rows a .def names are numbered, which is how many rows can
+// be declared between any two of them before the tab has to be numbered again.
+#define M_ROW_SPACING 100
+
+// A row before it has an option: where it sits, and which setting it is for.
+// This is what a tab is made of - the rows themselves are worked out from it
+// whenever the options or the handlers move underneath.
+typedef struct {
+    // Owned where the row was declared; the .def's own string otherwise.
+    const char *key;
+    int32_t place;
+    bool declared;
+} M_ROW_SPEC;
 
 static const char *const m_GameplayGeneralKeys[] = {
 #include <trx/game/ui/dialogs/setting_tabs/gameplay_general.def>
@@ -77,27 +95,146 @@ static const char *const *const m_TabKeys[CONFIG_TAB_COUNT] = {
     [CONFIG_TAB_SOUND_MISC] = m_SoundMiscKeys,
 };
 
+// What a tab is called from outside the engine, which is the name of the .def
+// its rows are written in.
+static const char *const m_TabNames[CONFIG_TAB_COUNT] = {
+    [CONFIG_TAB_GAMEPLAY_GENERAL] = "gameplay_general",
+    [CONFIG_TAB_GAMEPLAY_CONTROLS] = "gameplay_controls",
+    [CONFIG_TAB_GAMEPLAY_MODS] = "gameplay_mods",
+    [CONFIG_TAB_GAMEPLAY_FIXES] = "gameplay_fixes",
+    [CONFIG_TAB_GRAPHIC_VISUALS] = "graphic_visuals",
+    [CONFIG_TAB_GRAPHIC_UI] = "graphic_ui",
+    [CONFIG_TAB_GRAPHIC_UI_STATS] = "graphic_ui_stats",
+    [CONFIG_TAB_GRAPHIC_UI_BARS] = "graphic_ui_bars",
+    [CONFIG_TAB_GRAPHIC_RENDERING] = "graphic_rendering",
+    [CONFIG_TAB_SOUND_VOLUME] = "sound_volume",
+    [CONFIG_TAB_SOUND_MISC] = "sound_misc",
+};
+
+// Every tab's rows, in the order they are shown. Kept sorted by place.
+static VECTOR *m_Specs[CONFIG_TAB_COUNT] = {};
 static VECTOR *m_Rows[CONFIG_TAB_COUNT] = {};
 // What the rows were arranged against: the options, which are dropped and made
-// again when the game changes, and the handlers, which a row keeps one of.
+// again when the game changes, the handlers, which a row keeps one of, and the
+// specs, which a script adds to.
 static int32_t m_ConfigGeneration = -1;
 static int32_t m_HandlerGeneration = -1;
+static int32_t m_SpecGeneration = 0;
+static int32_t m_ArrangedSpecGeneration = -1;
+
+static M_ROW_SPEC *M_GetSpec(const CONFIG_TAB tab, const int32_t idx)
+{
+    return Vector_Get(m_Specs[tab], idx);
+}
+
+static void M_EnsureSpecs(const CONFIG_TAB tab)
+{
+    if (m_Specs[tab] != nullptr) {
+        return;
+    }
+    m_Specs[tab] = Vector_Create(sizeof(M_ROW_SPEC));
+    const char *const *const keys = m_TabKeys[tab];
+    ASSERT(keys != nullptr);
+    for (int32_t i = 0; keys[i] != nullptr; i++) {
+        Vector_Add(
+            m_Specs[tab],
+            &(M_ROW_SPEC) { .key = keys[i], .place = i * M_ROW_SPACING });
+    }
+}
+
+// The row for the option a name names, by the key the settings file knows the
+// option by. A row's key and an anchor may spell the same option differently -
+// one by the whole path, one by its last segment - and that segment is unique
+// across the options, so it is what they are compared by.
+static int32_t M_FindSpec(const CONFIG_TAB tab, const char *const key)
+{
+    if (key == nullptr) {
+        return -1;
+    }
+    const char *const leaf = Config_ResolveOptionName(key);
+    for (int32_t i = 0; i < m_Specs[tab]->count; i++) {
+        if (strcmp(Config_ResolveOptionName(M_GetSpec(tab, i)->key), leaf)
+            == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Numbers a tab's rows afresh, spaced as the .def's own are, for a tab that has
+// no room left between two of its rows.
+static void M_Renumber(const CONFIG_TAB tab)
+{
+    for (int32_t i = 0; i < m_Specs[tab]->count; i++) {
+        M_GetSpec(tab, i)->place = i * M_ROW_SPACING;
+    }
+}
+
+// The place a row takes to land between the two rows an index sits between.
+// The same number as the row below it means the gap is closed.
+static int32_t M_PlaceBetween(
+    const CONFIG_TAB tab, const int32_t below_idx, const int32_t above_idx)
+{
+    const int32_t count = m_Specs[tab]->count;
+    const int32_t below = below_idx >= 0
+        ? M_GetSpec(tab, below_idx)->place
+        : M_GetSpec(tab, above_idx)->place - 2 * M_ROW_SPACING;
+    const int32_t above = above_idx < count
+        ? M_GetSpec(tab, above_idx)->place
+        : M_GetSpec(tab, below_idx)->place + 2 * M_ROW_SPACING;
+    return below + (above - below) / 2;
+}
+
+static int32_t M_ResolvePlace(
+    const CONFIG_TAB tab, const char *const before, const char *const after)
+{
+    const int32_t count = m_Specs[tab]->count;
+    if (count == 0) {
+        return 0;
+    }
+
+    const int32_t anchor_idx =
+        before != nullptr ? M_FindSpec(tab, before) : M_FindSpec(tab, after);
+    if (anchor_idx < 0) {
+        return M_GetSpec(tab, count - 1)->place + M_ROW_SPACING;
+    }
+
+    int32_t below_idx = anchor_idx - 1;
+    if (before == nullptr) {
+        // A row already declared against this anchor sits between it and the
+        // next row the .def names. A second one goes after that one rather than
+        // between the two, so several rows declared against one anchor read in
+        // the order they were declared in.
+        below_idx = anchor_idx;
+        while (below_idx + 1 < count
+               && M_GetSpec(tab, below_idx + 1)->declared) {
+            below_idx++;
+        }
+    }
+    int32_t place = M_PlaceBetween(tab, below_idx, below_idx + 1);
+    if (below_idx >= 0 && place == M_GetSpec(tab, below_idx)->place) {
+        M_Renumber(tab);
+        place = M_PlaceBetween(tab, below_idx, below_idx + 1);
+    }
+    return place;
+}
 
 static void M_Arrange(void)
 {
     m_ConfigGeneration = Config_GetGeneration();
     m_HandlerGeneration = UI_Settings_GetHandlerGeneration();
+    m_ArrangedSpecGeneration = m_SpecGeneration;
     for (int32_t tab = 0; tab < CONFIG_TAB_COUNT; tab++) {
+        M_EnsureSpecs(tab);
         if (m_Rows[tab] == nullptr) {
             m_Rows[tab] = Vector_Create(sizeof(UI_SETTINGS_ROW));
         }
         Vector_Clear(m_Rows[tab]);
-        const char *const *const keys = m_TabKeys[tab];
-        ASSERT(keys != nullptr);
-        for (int32_t i = 0; keys[i] != nullptr; i++) {
+        for (int32_t i = 0; i < m_Specs[tab]->count; i++) {
             // A tab naming a setting this game does not have is not an error:
             // one tab list serves every game, as one handler registration does.
-            CONFIG_OPTION *const option = Config_FindOption(keys[i]);
+            CONFIG_OPTION *const option =
+                Config_FindOption(M_GetSpec(tab, i)->key);
             if (option != nullptr) {
                 Vector_Add(
                     m_Rows[tab],
@@ -111,19 +248,78 @@ static void M_Arrange(void)
 static void M_Ensure(void)
 {
     if (m_ConfigGeneration != Config_GetGeneration()
-        || m_HandlerGeneration != UI_Settings_GetHandlerGeneration()) {
+        || m_HandlerGeneration != UI_Settings_GetHandlerGeneration()
+        || m_ArrangedSpecGeneration != m_SpecGeneration) {
         M_Arrange();
     }
 }
 
 __attribute__((destructor)) static void M_Shutdown(void)
 {
+    UI_Settings_DropDeclaredRows();
     for (int32_t tab = 0; tab < CONFIG_TAB_COUNT; tab++) {
         if (m_Rows[tab] != nullptr) {
             Vector_Free(m_Rows[tab]);
             m_Rows[tab] = nullptr;
         }
+        if (m_Specs[tab] != nullptr) {
+            Vector_Free(m_Specs[tab]);
+            m_Specs[tab] = nullptr;
+        }
     }
+}
+
+bool UI_Settings_FindTab(const char *const name, CONFIG_TAB *const out)
+{
+    ASSERT(out != nullptr);
+    if (name == nullptr) {
+        return false;
+    }
+    for (int32_t tab = 0; tab < CONFIG_TAB_COUNT; tab++) {
+        if (strcmp(m_TabNames[tab], name) == 0) {
+            *out = tab;
+            return true;
+        }
+    }
+    return false;
+}
+
+void UI_Settings_AddDeclaredRow(
+    const CONFIG_TAB tab, const char *const key, const char *const before,
+    const char *const after)
+{
+    ASSERT(tab >= 0 && tab < CONFIG_TAB_COUNT);
+    ASSERT(key != nullptr);
+    M_EnsureSpecs(tab);
+
+    const int32_t place = M_ResolvePlace(tab, before, after);
+    int32_t idx = m_Specs[tab]->count;
+    while (idx > 0 && M_GetSpec(tab, idx - 1)->place > place) {
+        idx--;
+    }
+    Vector_Insert(
+        m_Specs[tab], idx,
+        &(M_ROW_SPEC) {
+            .key = Memory_DupStr(key), .place = place, .declared = true });
+    m_SpecGeneration++;
+}
+
+void UI_Settings_DropDeclaredRows(void)
+{
+    for (int32_t tab = 0; tab < CONFIG_TAB_COUNT; tab++) {
+        if (m_Specs[tab] == nullptr) {
+            continue;
+        }
+        for (int32_t i = m_Specs[tab]->count - 1; i >= 0; i--) {
+            M_ROW_SPEC *const spec = M_GetSpec(tab, i);
+            if (!spec->declared) {
+                continue;
+            }
+            Memory_Free((char *)spec->key);
+            Vector_RemoveAt(m_Specs[tab], i);
+        }
+    }
+    m_SpecGeneration++;
 }
 
 int32_t UI_Settings_GetRowCount(const CONFIG_TAB tab)

--- a/src/trx/game/ui/dialogs/settings_rows.h
+++ b/src/trx/game/ui/dialogs/settings_rows.h
@@ -6,6 +6,9 @@
 // arrangement lives here rather than beside the option. A tab is declared as an
 // ordered list of names in a .def; the options themselves are made afresh
 // whenever the game changes, and the arrangement is rebuilt with them.
+//
+// A script's option has no .def to be named in, so it says where it goes as it
+// is declared - see UI_Settings_AddDeclaredRow.
 
 #include <trx/config/option.h>
 #include <trx/game/ui/dialogs/settings_handlers.h>
@@ -40,3 +43,23 @@ int32_t UI_Settings_GetRowCount(CONFIG_TAB tab);
 
 // A tab's row, by position in the order the tab shows them.
 const UI_SETTINGS_ROW *UI_Settings_GetRow(CONFIG_TAB tab, int32_t index);
+
+// The tab a name names, which is the name of the .def its rows are written in.
+// False where no tab answers to it.
+bool UI_Settings_FindTab(const char *name, CONFIG_TAB *out);
+
+// Adds a row for a setting no .def names, showing the option `key` names.
+//
+// The row sits directly before or after the row for the option an anchor
+// names, and at the end of the tab where neither anchor is given or the option
+// named is not one this tab shows. Several rows declared against one anchor
+// read in the order they were declared in.
+//
+// The anchors are read here and not kept: a place is a number from this point
+// on, so a row is never left naming one that has gone, and two rows cannot name
+// each other.
+void UI_Settings_AddDeclaredRow(
+    CONFIG_TAB tab, const char *key, const char *before, const char *after);
+
+// Drops every row a script asked for, leaving the ones the .defs name.
+void UI_Settings_DropDeclaredRows(void);

--- a/tools/lint/checks/preset_keys
+++ b/tools/lint/checks/preset_keys
@@ -17,6 +17,17 @@ CONFIG_KEY_RE = re.compile(
     r"""^X_CFG_[A-Z0-9_]+(?:_EX)?\(\s*(?:"([^"]+)"|([a-zA-Z0-9_.]+))\s*,"""
 )
 
+# A setting a shipped script declares, as trx.config.declare reads it. The key
+# is written either as a string or as a constant the same file spells out:
+#   trx.config.declare({ key = "visuals.water_color_mode", ... })
+#   local MODE_OPTION = "visuals.water_color_mode"
+# A key a script builds from pieces is not one a preset can name either, so
+# nothing is lost by passing over it.
+DECLARED_KEY_RE = re.compile(r"""\bkey\s*=\s*(?:["']([a-zA-Z0-9_.]+)["']|(\w+))""")
+LUA_CONSTANT_RE = re.compile(
+    r"""^\s*local\s+(\w+)\s*=\s*["']([a-zA-Z0-9_.]+)["']\s*$""", re.MULTILINE
+)
+
 
 def _known_config_keys(config_map_paths: list[Path]) -> set[str]:
     known_keys: set[str] = set()
@@ -34,6 +45,20 @@ def _known_config_keys(config_map_paths: list[Path]) -> set[str]:
             if key:
                 known_keys.add(key)
     return known_keys
+
+
+def _declared_config_keys(lua_paths: list[Path]) -> set[str]:
+    declared_keys: set[str] = set()
+    for lua_path in lua_paths:
+        text = lua_path.read_text(encoding="utf-8")
+        if "trx.config.declare" not in text:
+            continue
+        constants = dict(LUA_CONSTANT_RE.findall(text))
+        for literal, name in DECLARED_KEY_RE.findall(text):
+            key = literal or constants.get(name)
+            if key is not None:
+                declared_keys.add(key)
+    return declared_keys
 
 
 def _preset_config_entries(preset_path: Path) -> dict[str, Any]:
@@ -59,6 +84,12 @@ def check():
     if not known_keys:
         yield LintWarning(config_dir / "map.def", "unable to parse config keys")
         return
+
+    # A game adds settings of its own as its script runs, so a preset may name
+    # one that no map*.def knows.
+    known_keys |= _declared_config_keys(
+        sorted(CommonPaths.shipped_data_dir.rglob("*.lua"))
+    )
 
     presets_dir = CommonPaths.shipped_data_dir / "cfg/presets"
     if not presets_dir.exists():


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A game's own scripts can now add settings with `trx.config.declare()`. A declared setting is saved and loaded with the player's own, takes its text from the game strings, and appears in the settings menu on the tab the declaration names. Before this, a game could read and write the settings the engine defines but could not add one, so anything a mod wanted the player to set had to ride on an existing setting.

```lua
-- add a setting of the game's own, and the row that shows it
trx.config.declare(spec)

-- called with the value now, and whenever the setting moves
local watcher = trx.config.on_change(key, fn)
-- drop a watcher before the script that made it is done
watcher:detach()
```

- A declaration carries no text: the engine derives `settings/<key>/title` and its neighbours from the key and looks them up in the game strings.
- A row names the setting it sits before or after rather than a position, so it stays put when the tab is reordered.
- `format_value`, `is_available`, `is_visible`, `can_change_value` and `request_change_value` are callbacks a row can carry, for what data cannot say.
- A game's declarations go when the game does.

The water color preset is the first feature to use this, and it demonstrates why it belongs in a script: every game has its own tints, and the feature is too small to justify building into the engine for every custom level to carry. To support this, the game ships with a `common.water_color` script beside the executable. It declares the setting and stores the color while a preset is selected, and each game simply calls it with its own colors.

Using that script, players get a water color preset under Graphic Options → Visuals, offering the underwater tints from TR1, TR2, and TR3, shipped per level where the PlayStation releases varied them. Picking one holds the water color below it; Custom gives the player's own back.

Resolves #1619

#### Testing

**TR1**

- [x] The preset changes the water color from the settings menu
- [x] The console rejects a preset the game does not offer (`/set visuals.water-color-mode ps1`)
- [x] "Custom" gives the player's own color back, and the color row is greyed while a preset is picked
- [x] Try to apply TR2/TR3 PS1/PC presets – shouldn't offer anything regarding water settings

**TR2 / TR3**

- [x] The PS1 preset follows the level
- [x] A preset survives a relaunch
- [x] A replay that uses a PS1 preset is loaded correctly, when main game is set to use PC
- [x] Try to apply TR2/TR3 PS1/PC presets – should work within the same game engine