### PR TITLE
Fix the preset dialogs' wrapping and order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 - changed the `/tp` console command to place Lara better at what she is sent to
 - changed the developer console to accept the numpad Enter key for issuing commands (#6056)
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
+- changed the presets to be listed by name rather than in the order they were found (Gameplay → Presets)
 - changed the save crystals option to a mode: crystals can save on the spot, be collected to save from the inventory as on PS1 TR3, heal, or be collectibles (Gameplay → General → Crystal mode) (#5939)
 - changed the Target change option to allow selecting TR4 behavior, where tapping Look switches target and holding it looks around (Gameplay → Controls → Target change)
 - changed lift collision to force Lara out of her climbing and vaulting animations if one collides with her (#5899, #5911)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -762,6 +762,31 @@ unit_tests += {
   'engine': ['game/lua/capi/items.c'],
 }
 
+# Word wrapping, over the shipped font.bin of a single game: what the wrapper
+# decides rests on glyph widths, so a stub font would agree with anything.
+unit_tests += {
+  'name': 'trx/game/ui/text',
+  'src': ['fakes/ui.c', 'fakes/ui_draw.c', 'harness/font_bin.c'],
+  'engine': [
+    'core/enum_map.c',
+    'core/memory.c',
+    'core/strings/case_funcs.c',
+    'core/strings/common.c',
+    'core/vector.c',
+    'game/enum.c',
+    'game/game_strings/entries.c',
+    'game/objects/vars.c',
+    'game/ui/scaler.c',
+    'game/ui/text.c',
+    'version.c',
+  ],
+  'deps': [dep_pcre2, dep_zlib],
+  'args': [
+    '-DPCRE2_CODE_UNIT_WIDTH=8',
+    '-DTEST_SHIP_GAMES_DIR="' + repo_root / 'data/trx/ship/games' + '"',
+  ],
+}
+
 # The UI layout test is the widest of the unit tests: it stands up the settings
 # dialogs and runs the real measure and layout passes over them. It reads the
 # shipped font.bin for glyph metrics and the shipped config for the strings -

--- a/src/tests/trx/game/ui/text.c
+++ b/src/tests/trx/game/ui/text.c
@@ -1,0 +1,82 @@
+// Word wrapping, with the glyph widths the game measures by.
+//
+// A line the wrapper breaks in two still has to read as the one entry it was.
+// The dialogs indent under a heading - the values a preset would change sit
+// below the setting they belong to - and a continuation that starts at the
+// margin reads as the next heading instead.
+
+#include <fakes/ui.h>
+#include <harness/harness.h>
+
+#include <trx/config/vars.h>
+#include <trx/core/memory.h>
+#include <trx/game/ui/text.h>
+
+#include <string.h>
+
+// Narrow enough that every line below breaks, wide enough to hold a word.
+#define M_WRAP_W 60.0f
+
+static void M_SetUp(void)
+{
+    FakeUI_SetGame(1);
+    FakeUI_SetViewport(640, 480);
+    g_ConfigStorage.ui.text_scale = 1.0f;
+    UI_LoadText();
+}
+
+// The indentation the given line opens with.
+static int32_t M_GetIndent(const char *const line)
+{
+    int32_t indent = 0;
+    while (line[indent] == ' ') {
+        indent++;
+    }
+    return indent;
+}
+
+// Wrap the text and check that it broke, and that every line it broke into
+// opens at the indentation the caller expects.
+static void M_CheckWrap(const char *const text, const int32_t expected_indent)
+{
+    char *const wrapped = UI_Text_WordWrap(text, 1.0f, M_WRAP_W);
+    if (wrapped == nullptr) {
+        TEST_FAIL("\"%s\": nothing came back", text);
+        return;
+    }
+    if (strchr(wrapped, '\n') == nullptr) {
+        TEST_FAIL(
+            "\"%s\": did not wrap, so it says nothing about indent", text);
+        Memory_Free(wrapped);
+        return;
+    }
+
+    const char *line = wrapped;
+    bool first = true;
+    while (line != nullptr) {
+        const char *const end = strchr(line, '\n');
+        if (!first) {
+            const int32_t indent = M_GetIndent(line);
+            if (indent != expected_indent) {
+                TEST_FAIL(
+                    "\"%s\": continuation opens at %d spaces, expected %d",
+                    text, indent, expected_indent);
+                break;
+            }
+        }
+        first = false;
+        line = end != nullptr ? end + 1 : nullptr;
+    }
+    Memory_Free(wrapped);
+}
+
+TEST(ui_text_wrap_keeps_indent)
+{
+    UI_InitText();
+    M_SetUp();
+    M_CheckWrap("Bars appearance and the rest of it", 0);
+    M_CheckWrap("  Saving pickups becomes healing", 2);
+    M_CheckWrap("- one bullet holding several words", 2);
+    M_CheckWrap("  - an indented bullet holding several words", 4);
+    UI_ShutdownText();
+}

--- a/src/trx/config/presets.c
+++ b/src/trx/config/presets.c
@@ -9,7 +9,11 @@
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/vector.h>
+#include <trx/game/game_strings/entries.h>
 #include <trx/game/shell/paths.h>
+
+#include <stdlib.h>
+#include <string.h>
 
 static VECTOR *m_Presets = nullptr; // CONFIG_PRESET
 
@@ -116,6 +120,17 @@ static bool M_LoadPreset(const char *const path)
     return true;
 }
 
+static const char *M_GetTitle(const CONFIG_PRESET *const preset)
+{
+    const char *const title = GameString_Get(preset->name_gs);
+    return title != nullptr ? title : preset->name_gs;
+}
+
+static int M_CompareByTitle(const void *const a, const void *const b)
+{
+    return strcmp(M_GetTitle(a), M_GetTitle(b));
+}
+
 static void __attribute__((destructor)) M_Shutdown(void)
 {
     M_FreeAllPresets();
@@ -158,8 +173,19 @@ void Config_Presets_ScanFiles(void)
     }
     File_CloseDirectory(dir);
     Memory_FreePointer(&presets_dir);
+    Config_Presets_Sort();
 
     LOG_INFO("Loaded %d config preset(s)", m_Presets->count);
+}
+
+void Config_Presets_Sort(void)
+{
+    if (m_Presets == nullptr || m_Presets->count < 2) {
+        return;
+    }
+    qsort(
+        Vector_GetData(m_Presets), m_Presets->count, m_Presets->item_size,
+        M_CompareByTitle);
 }
 
 int32_t Config_Presets_GetCount(void)

--- a/src/trx/config/presets.h
+++ b/src/trx/config/presets.h
@@ -16,6 +16,12 @@ typedef struct {
 // Load all presets from the game's cfg/presets/ directory.
 void Config_Presets_ScanFiles(void);
 
+// Order the presets by the titles they show, so the list reads the same however
+// the directory hands its files over. A preset whose title has not been loaded
+// yet sorts by its string key, so scanning before the strings are in still
+// gives a settled order; sort again once they are.
+void Config_Presets_Sort(void);
+
 // Number of loaded presets.
 int32_t Config_Presets_GetCount(void);
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -65,6 +65,10 @@ static bool m_PrevQuiet = false;
 // the subscription is given back rather than left to gather a copy per switch.
 static int32_t m_ConfigListener = -1;
 
+// The presets are listed by the titles they show, so a new language reorders
+// them. Given back with the config subscription above, and for the same reason.
+static int32_t m_StringsListener = -1;
+
 static void M_CreateGameWindow(void)
 {
     if (m_Window != nullptr) {
@@ -106,6 +110,11 @@ static void M_ShowWindow(void)
 static void M_HandleConfigChange(const EVENT *const event, void *const data)
 {
     Shell_HandleConfigChange(event->data);
+}
+
+static void M_HandleLanguageReload(const EVENT *const event, void *const data)
+{
+    Config_Presets_Sort();
 }
 
 static void M_SetupSDL(void)
@@ -151,6 +160,8 @@ static void M_InitModules(void)
 
     GameString_Init();
     GameStringManager_Init();
+    m_StringsListener =
+        GameStringManager_SubscribeReload(M_HandleLanguageReload, nullptr);
     UI_Init();
     Overlay_Init();
     GameEvent_Init();
@@ -173,6 +184,10 @@ static void M_ShutdownModules(void)
     if (m_ConfigListener >= 0) {
         Config_UnsubscribeChanges(m_ConfigListener);
         m_ConfigListener = -1;
+    }
+    if (m_StringsListener >= 0) {
+        GameStringManager_UnsubscribeReload(m_StringsListener);
+        m_StringsListener = -1;
     }
 
     if (TestReplay_IsOpened()) {

--- a/src/trx/game/ui/dialogs/config_presets.c
+++ b/src/trx/game/ui/dialogs/config_presets.c
@@ -33,6 +33,10 @@
 #define M_CONFIRM_MIN_W 72.0f
 #define M_CONFIRM_PAD 6.0f
 #define M_LIST_ROW_SPACING 5.0f
+// Measuring a text leaves off the spacing after its final glyph, which the
+// wrapper still counts. Without this, a line given exactly its own measured
+// width loses its last word to a second line.
+#define M_MEASURE_SLACK 1.0f
 
 typedef enum {
     M_PHASE_BROWSE,
@@ -58,6 +62,29 @@ static const char *M_GetPresetKeyLabel(const char *const key)
         }
     }
     return key;
+}
+
+// The single line the dialog shows once there is nothing left to confirm, or
+// nullptr in the phases that show a list instead.
+static const char *M_GetPhaseMessage(const M_PHASE phase)
+{
+    switch (phase) {
+    case M_PHASE_APPLIED:
+        return GS("general/config_presets/applied");
+    case M_PHASE_NO_CHANGES:
+        return GS("general/config_presets/no_changes");
+    default:
+        return nullptr;
+    }
+}
+
+// The result is the caller's to free.
+static char *M_FormatTitle(UI_CONFIG_PRESETS_STATE *const s)
+{
+    const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
+    const char *const preset_name =
+        preset != nullptr ? GameString_Get(preset->name_gs) : "";
+    return String_Format(GS("general/config_presets/title_fmt"), preset_name);
 }
 
 static int32_t M_GetChangedSettingCount(const int32_t preset_idx)
@@ -133,16 +160,29 @@ static void M_WrappedLabel(const char *const text, const float max_width)
 
 // The width the dialog's text may occupy, in the units the layout sizes in. The
 // modal's padding and the window's chrome come off what the screen allows, and
-// a list of short rows keeps the dialog narrow rather than stretching it.
+// what the phase actually shows sets the width below that, so a narrow list of
+// changes keeps the dialog narrow rather than stretching it.
 static float M_GetConfirmContentWidth(UI_CONFIG_PRESETS_STATE *const s)
 {
     const float scale = UI_Scaler_GetTextScale();
-    const float budget = UI_GetSafeCanvasWidth()
+    float budget = UI_GetSafeCanvasWidth()
         - (2.0f * M_CONFIRM_PAD + UI_Window_GetChromeWidth()) * scale;
 
-    const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
     float natural = M_CONFIRM_MIN_W * scale;
-    if (preset != nullptr) {
+
+    char *const title = M_FormatTitle(s);
+    natural = MAX(natural, UI_Label_MeasureW(title));
+    Memory_Free(title);
+
+    const char *const message = M_GetPhaseMessage(s->phase);
+    if (message != nullptr) {
+        // The message carries a pad of its own inside the window.
+        budget -= 2.0f * M_CONFIRM_PAD * scale;
+        natural = MAX(natural, UI_Label_MeasureW(message));
+    }
+
+    const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
+    if (s->phase == M_PHASE_CONFIRM && preset != nullptr) {
         for (int32_t i = 0; i < preset->setting_count; i++) {
             const CONFIG_OPTION *const opt = Config_FindOption(preset->keys[i]);
             if (opt == nullptr
@@ -162,6 +202,7 @@ static float M_GetConfirmContentWidth(UI_CONFIG_PRESETS_STATE *const s)
         }
     }
 
+    natural += M_MEASURE_SLACK * scale;
     return MIN(natural, MAX(budget, M_CONFIRM_MIN_W * scale));
 }
 
@@ -386,11 +427,7 @@ void UI_ConfigPresetsApplyModal(UI_CONFIG_PRESETS_STATE *const s)
 
     const float content_width = M_GetConfirmContentWidth(s);
 
-    const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
-    const char *const preset_name =
-        preset != nullptr ? GameString_Get(preset->name_gs) : "";
-    char *const title =
-        String_Format(GS("general/config_presets/title_fmt"), preset_name);
+    char *const title = M_FormatTitle(s);
     char *const wrapped_title = UI_Text_WordWrap(title, 1.0f, content_width);
 
     UI_BeginModal(0.5f, 0.5f);
@@ -407,13 +444,10 @@ void UI_ConfigPresetsApplyModal(UI_CONFIG_PRESETS_STATE *const s)
         .reserve_scroll_space = true,
     });
 
-    if (s->phase == M_PHASE_APPLIED) {
+    const char *const message = M_GetPhaseMessage(s->phase);
+    if (message != nullptr) {
         UI_BeginPad(M_CONFIRM_PAD, M_CONFIRM_PAD);
-        M_WrappedLabel(GS("general/config_presets/applied"), content_width);
-        UI_EndPad();
-    } else if (s->phase == M_PHASE_NO_CHANGES) {
-        UI_BeginPad(M_CONFIRM_PAD, M_CONFIRM_PAD);
-        M_WrappedLabel(GS("general/config_presets/no_changes"), content_width);
+        M_WrappedLabel(message, content_width);
         UI_EndPad();
     } else if (s->phase == M_PHASE_CONFIRM) {
         UI_BeginScrollableStack(

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -296,7 +296,11 @@ static float M_GetLayoutWidth(
     return resolved->width[glyph_font];
 }
 
-static int32_t M_DetectBulletIndent(
+// How far the continuations of a line are indented, so that a line broken in
+// two still reads as one entry rather than as two at different depths. A line
+// indented by spaces keeps that indentation; a bullet adds the width of its
+// dash and the space after it, putting the continuation under the text.
+static int32_t M_DetectHangingIndent(
     const M_GLYPH_INFO **glyphs, const size_t glyph_count, const size_t idx)
 {
     size_t scan = idx;
@@ -310,7 +314,7 @@ static int32_t M_DetectBulletIndent(
         && glyphs[scan + 1]->role == GLYPH_SPACE) {
         return leading_spaces + 2;
     }
-    return 0;
+    return leading_spaces;
 }
 
 static void M_EmitIndent(
@@ -346,7 +350,7 @@ static size_t M_WordWrap(
 {
     size_t out_len = 0;
     float cur_width = 0.0f;
-    int32_t bullet_indent = 0;
+    int32_t hanging_indent = 0;
 
     const float space_width = M_WORD_SPACING * scale_f;
 
@@ -370,8 +374,8 @@ static size_t M_WordWrap(
             continue;
         }
 
-        if (cur_width == 0.0f && bullet_indent == 0) {
-            bullet_indent = M_DetectBulletIndent(glyphs, glyph_count, i);
+        if (cur_width == 0.0f && hanging_indent == 0) {
+            hanging_indent = M_DetectHangingIndent(glyphs, glyph_count, i);
         }
 
         if (glyph->role == GLYPH_FONT_MARKER) {
@@ -379,16 +383,16 @@ static size_t M_WordWrap(
         } else if (glyph->role == GLYPH_NEW_LINE) {
             L_CONCAT_CHAR('\n')
             cur_width = 0.0f;
-            bullet_indent = 0;
+            hanging_indent = 0;
         } else if (glyph->role == GLYPH_NEW_PAGE) {
             L_CONCAT_CHAR('\f')
             cur_width = 0.0f;
-            bullet_indent = 0;
+            hanging_indent = 0;
         } else if (glyph->role == GLYPH_SPACE) {
             const float w = M_WORD_SPACING * scale_f;
             if (cur_width + w > max_width) {
                 M_EmitNewline(
-                    dst, &out_len, bullet_indent, space_width, &cur_width);
+                    dst, &out_len, hanging_indent, space_width, &cur_width);
             } else {
                 L_CONCAT_CHAR(' ')
                 cur_width += w;
@@ -423,7 +427,7 @@ static size_t M_WordWrap(
             if (cur_width + word_width > max_width) {
                 if (cur_width > 0.0f) {
                     M_EmitNewline(
-                        dst, &out_len, bullet_indent, space_width, &cur_width);
+                        dst, &out_len, hanging_indent, space_width, &cur_width);
                 }
 
                 // Break word if longer than line
@@ -436,7 +440,7 @@ static size_t M_WordWrap(
                             * scale_f;
                         if (cur_width + glyph_width > max_width) {
                             M_EmitNewline(
-                                dst, &out_len, bullet_indent, space_width,
+                                dst, &out_len, hanging_indent, space_width,
                                 &cur_width);
                         }
                         L_CONCAT_STR(next_glyph->text)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Three fixes to the presets screen under Gameplay Options.

- "Preset applied." and "No changes to apply.", and the title above them, no longer break after every word or two. Those popups took their width from the list of settings the preset would change, which is empty by the time either one shows, so they fell back to the dialog's minimum width. The title was sized from the body rather than from its own length.
- A line the wrapper breaks now keeps the indentation it started with. The confirmation indents a setting's values under its name, and a value line that wrapped put its tail at the margin, where it read as the name of another setting. Bullets already carried their indent forward; now any leading indentation does.
- The presets are listed by name rather than in the order the directory handed the files over, and they are sorted again when the language changes.

The wrapping change comes with a unit test that wraps against the shipped `font.bin` and checks where each continuation opens.

Everything here is player-facing; nothing changes for mod authors.

Resolves TRX950
