### PR TITLE
Fire on_title_start for every title screen

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3435,7 +3435,7 @@
       }
     },
     {
-      "description": "Happens when the title screen's scene starts playing behind the menu, once\nits level is loaded and its items are set up. The handler takes no\narguments. `trx.events.on_game_start` does not fire for the title level.",
+      "description": "Happens when the title screen comes up, once its level is loaded and its\nitems are set up. The handler takes no arguments.\n`trx.events.on_game_start` does not fire for the title level.\n\nA title that shows a picture rather than playing its level behind the menu\ndoes not run its logic, so `trx.events.before_control` and\n`trx.events.after_control` handlers attached here never fire there. This\nsays the menu is up; it does not promise a scene playing behind it.",
       "examples": [
         "trx.events.on_title_start(function()\n  trx.log.info(\"the menu is up\")\nend)"
       ],

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -67,9 +67,14 @@ An event that carries a default the script may take over says so in its descript
   ```
 
 - <a id="events.on_title_start" name="events.on_title_start"></a>[lua]`trx.events.on_title_start(callback)`  
-  Happens when the title screen's scene starts playing behind the menu, once
-  its level is loaded and its items are set up. The handler takes no
-  arguments. [`trx.events.on_game_start`](#events.on_game_start) does not fire for the title level.
+  Happens when the title screen comes up, once its level is loaded and its
+  items are set up. The handler takes no arguments.
+  [`trx.events.on_game_start`](#events.on_game_start) does not fire for the title level.
+
+  A title that shows a picture rather than playing its level behind the menu
+  does not run its logic, so [`trx.events.before_control`](#events.before_control) and
+  [`trx.events.after_control`](#events.after_control) handlers attached here never fire there. This
+  says the menu is up; it does not promise a scene playing behind it.
 
   Parameters:
   - <a id="events.on_title_start.callback" name="events.on_title_start.callback"></a>**`callback`** (function). What to run when it happens.

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -117,9 +117,14 @@ end)]],
 
 api.define("events.on_title_start", {
   description = [[
-    Happens when the title screen's scene starts playing behind the menu, once
-    its level is loaded and its items are set up. The handler takes no
-    arguments. `trx.events.on_game_start` does not fire for the title level.
+    Happens when the title screen comes up, once its level is loaded and its
+    items are set up. The handler takes no arguments.
+    `trx.events.on_game_start` does not fire for the title level.
+
+    A title that shows a picture rather than playing its level behind the menu
+    does not run its logic, so `trx.events.before_control` and
+    `trx.events.after_control` handlers attached here never fire there. This
+    says the menu is up; it does not promise a scene playing behind it.
   ]],
   params = {
     {

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -1033,7 +1033,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
 
     g_InvRing_Mode = mode;
 
-    if (ring->live_scene) {
+    if (mode == INV_TITLE_MODE) {
         LUA_FireEvent(LUA_EVENT_TITLE_START);
     }
 


### PR DESCRIPTION

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`trx.events.on_title_start` was fired only where the title level played behind the menu, so a title showing a picture instead never raised it, even though its level and script were loaded either way. It now fires for any title screen.

The documentation keeps things clear – the event tells a script the menu is up, and a picture-backed title runs no logic, so `before_control` and `after_control` handlers attached from it never fire there.