### PR TITLE
Fix small miscellaneous issues

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6770,7 +6770,7 @@
       "path": "config.Row"
     },
     {
-      "description": "A setting being watched. `trx.config.on_change` hands one back, and holding it is what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level spends every one a level script attached.",
+      "description": "A setting being watched. `trx.config.on_change` hands one back, and holding it\nis what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level\nspends every one a level script attached.",
       "extensions": [],
       "fields": [],
       "handle": false,

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -67,7 +67,9 @@ game's `scripts/_game.lua` declares belongs to that game and goes when it does.
 
 - <a id="config.Watcher" name="config.Watcher"></a>[lua]`trx.config.Watcher`
 
-    A setting being watched. [`trx.config.on_change`](#config.on_change) hands one back, and holding it is what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level spends every one a level script attached.
+    A setting being watched. [`trx.config.on_change`](#config.on_change) hands one back, and holding it
+    is what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level
+    spends every one a level script attached.
 
     Methods:
 

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -422,10 +422,9 @@ outside its own bounds.]],
 -- What on_change hands back. The engine keys a watcher by a number, and the
 -- number is the module's business rather than a script's.
 local Watcher = api.type("config.Watcher", {
-  description = "A setting being watched. `trx.config.on_change` hands one back, and "
-    .. "holding it is what lets the watcher be dropped later. A watcher is spent "
-    .. "once detached, and the end of a level spends every one a level script "
-    .. "attached.",
+  description = [[A setting being watched. `trx.config.on_change` hands one back, and holding it
+is what lets the watcher be dropped later. A watcher is spent once detached, and the end of a level
+spends every one a level script attached.]],
   methods = {
     detach = {
       description = "Stops the watcher, which hears of no further change.",

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -624,7 +624,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/api/config',
-  'bundles': [b_lua_surface, b_config],
+  'bundles': [b_lua_surface, b_config, b_lua_strings],
   'src': ['fakes/locale.c'],
   'engine': [
     'game/lua/capi/config.c',

--- a/src/tests/trx/config/common.c
+++ b/src/tests/trx/config/common.c
@@ -12,7 +12,6 @@
 static bool m_MusicOn;
 static double m_Fov;
 static char *m_Outfit;
-static bool m_Scanlines;
 static bool m_LastPersist;
 // How many times the listener below was told that the FOV moved.
 static int32_t m_FovTold;
@@ -114,25 +113,4 @@ TEST(a_listener_that_changes_a_setting_is_not_told_the_same_report_twice)
     CHECK_EQ_INT(m_FovTold, 1);
 
     Config_UnsubscribeChanges(listener);
-}
-
-// A script's options go when the scripts do; the game's own stay, and so do
-// their values.
-TEST(dropping_the_declared_options_leaves_the_games_own)
-{
-    M_SetUp();
-    CHECK(
-        Config_Register(&(CONFIG_OPTION_DESC) {
-            .name = "mod.scanlines",
-            .default_value = { .type = TVT_BOOL, .as_bool = true },
-            .mirror = &m_Scanlines,
-            .declared = true })
-        != nullptr);
-
-    CHECK(Config_SetValue(&m_Fov, Value_Of(90)));
-    Config_DropDeclaredOptions();
-
-    CHECK(Config_FindOption("mod.scanlines") == nullptr);
-    CHECK(Config_FindOption("visuals.fov") != nullptr);
-    CHECK_EQ_INT((int32_t)m_Fov, 90);
 }

--- a/src/tests/trx/game/ui/text.c
+++ b/src/tests/trx/game/ui/text.c
@@ -25,7 +25,6 @@ static void M_SetUp(void)
     UI_LoadText();
 }
 
-// The indentation the given line opens with.
 static int32_t M_GetIndent(const char *const line)
 {
     int32_t indent = 0;
@@ -35,8 +34,6 @@ static int32_t M_GetIndent(const char *const line)
     return indent;
 }
 
-// Wrap the text and check that it broke, and that every line it broke into
-// opens at the indentation the caller expects.
 static void M_CheckWrap(const char *const text, const int32_t expected_indent)
 {
     char *const wrapped = UI_Text_WordWrap(text, 1.0f, M_WRAP_W);

--- a/src/trx/config/option.c
+++ b/src/trx/config/option.c
@@ -119,8 +119,7 @@ void Config_Option_Init(
     option->bounds = desc->bounds != nullptr
         ? Memory_Dup(desc->bounds, sizeof(CONFIG_OPTION_BOUNDS))
         : nullptr;
-    option->flags = (desc->percent ? CONFIG_OPTION_PERCENT : 0)
-        | (desc->declared ? CONFIG_OPTION_DECLARED : 0);
+    option->flags = desc->percent ? CONFIG_OPTION_PERCENT : 0;
     M_CopyValue(&option->default_value, &desc->default_value);
     M_NarrowValue(&option->default_value);
     // The value starts as the default, written properly so that g_Config comes
@@ -314,10 +313,4 @@ bool Config_Option_IsHidden(const CONFIG_OPTION *const option)
 {
     ASSERT(option != nullptr);
     return (option->flags & CONFIG_OPTION_HIDDEN) != 0;
-}
-
-bool Config_Option_IsDeclared(const CONFIG_OPTION *const option)
-{
-    ASSERT(option != nullptr);
-    return (option->flags & CONFIG_OPTION_DECLARED) != 0;
 }

--- a/src/trx/config/option.h
+++ b/src/trx/config/option.h
@@ -21,9 +21,6 @@ typedef enum {
     // The game flow asked for this option to be absent from the settings
     // dialogs. Not the same as being held, which leaves the row in place.
     CONFIG_OPTION_HIDDEN = 1 << 1,
-    // A script asked for this option rather than the game's own map*.def. It
-    // lives for as long as the scripts that declared it, and goes when they do.
-    CONFIG_OPTION_DECLARED = 1 << 2,
 } CONFIG_OPTION_FLAGS;
 
 // What an option accepts, for the numeric types. Held in the units the value is
@@ -95,8 +92,6 @@ typedef struct {
     const char *enum_map;
     const CONFIG_OPTION_BOUNDS *bounds;
     bool percent;
-    // Whether a script is asking for this option. See CONFIG_OPTION_DECLARED.
-    bool declared;
 } CONFIG_OPTION_DESC;
 
 // What moved, reported to whoever asked to hear about it.
@@ -180,9 +175,6 @@ bool Config_Option_IsEnforced(const CONFIG_OPTION *option);
 
 // Whether the game flow asked for the option to be absent from the dialogs.
 bool Config_Option_IsHidden(const CONFIG_OPTION *option);
-
-// Whether a script asked for this option rather than the game's own map*.def.
-bool Config_Option_IsDeclared(const CONFIG_OPTION *option);
 
 // Whether the option can take this value as it is spelled. A setting a game
 // declares takes only the values that game offers, so a caller naming one from

--- a/src/trx/config/registry.c
+++ b/src/trx/config/registry.c
@@ -86,24 +86,6 @@ void Config_DropAllOptions(void)
     M_RebuildView();
 }
 
-void Config_DropDeclaredOptions(void)
-{
-    // As in Config_DropAllOptions: a report names the options that moved by
-    // address, and the options it names are about to go.
-    Config_DiscardPendingChanges();
-    for (int32_t i = m_Options != nullptr ? m_Options->count - 1 : -1; i >= 0;
-         i--) {
-        CONFIG_OPTION *const option = M_Get(i);
-        if (!Config_Option_IsDeclared(option)) {
-            continue;
-        }
-        Config_Option_Free(option);
-        Memory_Free(option);
-        Vector_RemoveAt(m_Options, i);
-    }
-    M_RebuildView();
-}
-
 CONFIG_OPTION *Config_Register(const CONFIG_OPTION_DESC *const desc)
 {
     ASSERT(desc != nullptr);

--- a/src/trx/config/registry.h
+++ b/src/trx/config/registry.h
@@ -24,10 +24,6 @@ CONFIG_OPTION *Config_Register(const CONFIG_OPTION_DESC *desc);
 // of settings.
 void Config_RegisterBuiltInOptions(void);
 
-// Drops the options a script declared, leaving the game's own in place. The
-// scripts are gone, so what they asked for goes with them.
-void Config_DropDeclaredOptions(void);
-
 // Every option, terminated by a null entry. An option's address does not move,
 // so one taken from here stays good after another is registered.
 CONFIG_OPTION *const *Config_GetOptions(void);

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -5,13 +5,13 @@
 #include <trx/core/enum_map.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/core/vector.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
 
 #include <lauxlib.h>
-#include <stdio.h>
 #include <string.h>
 
 // How deep a watcher writing a setting may go. Answering a change by changing
@@ -384,10 +384,10 @@ static void M_SeedValues(lua_State *const L, const CONFIG_OPTION *const option)
     for (int32_t i = 1; i <= count; i++) {
         lua_rawgeti(L, -1, i);
         const char *const value = lua_tostring(L, -1);
-        char label[128];
-        snprintf(
-            label, sizeof(label), "settings/%s/values/%s", option->name, value);
+        char *label =
+            String_Format("settings/%s/values/%s", option->name, value);
         DynamicEnum_AddValue(token, value, label);
+        Memory_FreePointer(&label);
         lua_pop(L, 1);
     }
     lua_pop(L, 1);

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -401,7 +401,6 @@ static int M_L_ConfigDeclare(lua_State *const L)
         .name = spec.key,
         .default_value = spec.default_value,
         .bounds = spec.has_bounds ? &spec.bounds : nullptr,
-        .declared = true,
     });
     if (option == nullptr) {
         return luaL_error(L, "option already declared: %s", spec.key);

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -495,10 +495,13 @@ static int M_L_ConfigOnChange(lua_State *const L)
         m_Watchers = Vector_Create(sizeof(M_WATCHER));
     }
     lua_pushvalue(L, 2);
+    // Taken before the call below, which may attach a watcher of its own and
+    // leave the counter naming that one instead.
+    const int32_t id = m_NextWatcherId++;
     Vector_Add(
         m_Watchers,
         &(M_WATCHER) {
-            .id = m_NextWatcherId++,
+            .id = id,
             .key = Memory_DupStr(option->name),
             .fn_ref = luaL_ref(L, LUA_REGISTRYINDEX),
             .level_scoped = LUA_GetScriptContext() == LUA_CONTEXT_LEVEL,
@@ -506,7 +509,7 @@ static int M_L_ConfigOnChange(lua_State *const L)
     // The setting already holds something, and a script asking to hear about it
     // is asking about the value in force as much as the ones to come.
     M_CallWatcher(L, Vector_Get(m_Watchers, m_Watchers->count - 1), option);
-    lua_pushinteger(L, m_NextWatcherId - 1);
+    lua_pushinteger(L, id);
     return 1;
 }
 

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -1180,6 +1180,16 @@ void TestReplay_Close(void)
         Vector_Free(p->headers);
         p->headers = nullptr;
     }
+    if (p->deferred_config != nullptr) {
+        for (int32_t i = 0; i < p->deferred_config->count; i++) {
+            M_DEFERRED_OPTION *const deferred =
+                Vector_Get(p->deferred_config, i);
+            Memory_FreePointer(&deferred->key);
+            Memory_FreePointer(&deferred->value);
+        }
+        Vector_Free(p->deferred_config);
+        p->deferred_config = nullptr;
+    }
     if (p->frames) {
         for (int32_t i = 0; i < p->frames->count; i++) {
             M_FRAME *const f = Vector_Get(p->frames, i);

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -35,6 +35,10 @@ typedef struct {
     SHELL_ARGS *args;
     M_STARTUP_SNAPSHOT startup;
     bool used_deprecated_args;
+    // The headers are read twice: once for the startup settings the shell
+    // needs before it registers any option, and again once the options exist.
+    // Only the second pass has anywhere to put a setting.
+    bool apply_config;
 } M_PARSE_CTX;
 
 typedef struct {
@@ -878,6 +882,9 @@ static bool M_ParseConfig(const char *const line, M_PARSE_CTX *const ctx)
     char keybuf[64];
     char valbuf[128];
     if (sscanf(line, "config %63s %127s", keybuf, valbuf) == 2) {
+        if (!ctx->apply_config) {
+            return true;
+        }
         // Strip surrounding quotes from the value, if present
         size_t vlen = strlen(valbuf);
         if (vlen >= 2 && valbuf[0] == '"' && valbuf[vlen - 1] == '"') {
@@ -1127,14 +1134,16 @@ void TestReplay_ApplyDeferredConfig(void)
     }
     Vector_Free(p->deferred_config);
     p->deferred_config = nullptr;
-    // As in TestReplay_Start: this is where the replay starts from, not
-    // something that moved while it ran.
-    Config_DiscardPendingChanges();
+    // Announced rather than discarded as in TestReplay_Start: the game's script
+    // has run, so a trx.config.on_change watcher is already attached and was
+    // told the option's default. It hears the recorded value from here.
+    Config_Update();
 }
 
 void TestReplay_Start(void)
 {
     M_PARSE_CTX ctx = M_ParseCtxInit();
+    ctx.apply_config = true;
     M_PRIV *const p = &m_Priv;
     for (int32_t i = 0; i < p->headers->count; i++) {
         const char *const ln = *(const char **)Vector_Get(p->headers, i);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -45,7 +45,6 @@
 #include <trx/game/shell/state.h>
 #include <trx/game/sound.h>
 #include <trx/game/stats.h>
-#include <trx/game/ui/dialogs/settings_lua.h>
 #include <trx/game/ui/settings.h>
 #include <trx/game/ui/touch_overlay.h>
 #include <trx/gl/context.h>
@@ -428,10 +427,6 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     Savegame_Init();
     SG_Manager_ScanSavedGames();
 
-    // What the last game's script declared goes before this one's script runs,
-    // so a game never inherits another's settings or the rows that show them.
-    Config_DropDeclaredOptions();
-    UI_SettingsLua_DropDeclaredRows();
     LUA_RunGameScript();
 
     // The settings a recording carries are the ones that exist by now, the

--- a/src/trx/game/ui/dialogs/config_presets.c
+++ b/src/trx/game/ui/dialogs/config_presets.c
@@ -64,8 +64,6 @@ static const char *M_GetPresetKeyLabel(const char *const key)
     return key;
 }
 
-// The single line the dialog shows once there is nothing left to confirm, or
-// nullptr in the phases that show a list instead.
 static const char *M_GetPhaseMessage(const M_PHASE phase)
 {
     switch (phase) {

--- a/src/trx/game/ui/dialogs/settings_lua.c
+++ b/src/trx/game/ui/dialogs/settings_lua.c
@@ -10,8 +10,6 @@
 // functions by reference. Every callback the dialogs make comes back through
 // here, into the function the declaration named.
 
-#include <trx/game/ui/dialogs/settings_lua.h>
-
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
@@ -273,17 +271,7 @@ static void M_Create(lua_State *const L)
     LUA_RegisterModule(L, "settings", m_Module);
 }
 
-static void M_Shutdown(void)
-{
-    UI_SettingsLua_DropDeclaredRows();
-    if (m_Rows != nullptr) {
-        Vector_Free(m_Rows);
-        m_Rows = nullptr;
-    }
-    m_L = nullptr;
-}
-
-void UI_SettingsLua_DropDeclaredRows(void)
+static void M_DropDeclaredRows(void)
 {
     for (int32_t i = 0; m_Rows != nullptr && i < m_Rows->count; i++) {
         M_FreeRow(m_L, *(M_DECLARED_ROW **)Vector_Get(m_Rows, i));
@@ -292,6 +280,16 @@ void UI_SettingsLua_DropDeclaredRows(void)
         Vector_Clear(m_Rows);
     }
     UI_Settings_DropDeclaredRows();
+}
+
+static void M_Shutdown(void)
+{
+    M_DropDeclaredRows();
+    if (m_Rows != nullptr) {
+        Vector_Free(m_Rows);
+        m_Rows = nullptr;
+    }
+    m_L = nullptr;
 }
 
 REGISTER_LUA_CAPI(.create = M_Create, .shutdown = M_Shutdown)

--- a/src/trx/game/ui/dialogs/settings_lua.c
+++ b/src/trx/game/ui/dialogs/settings_lua.c
@@ -23,6 +23,7 @@
 #include <trx/game/ui/dialogs/settings_rows.h>
 
 #include <lauxlib.h>
+#include <string.h>
 
 typedef enum {
     M_CB_FORMAT_VALUE,
@@ -163,18 +164,29 @@ static int32_t M_ReadDelta(
     return result;
 }
 
+// The table is checked in full before a single reference is taken, so a
+// declaration naming something that is not a function leaves nothing behind.
 static void M_ReadCallbacks(
-    lua_State *const L, const int32_t idx, M_DECLARED_ROW *const row)
+    lua_State *const L, const int32_t idx, int32_t *const refs)
 {
+    for (int32_t i = 0; i < M_CB_COUNT; i++) {
+        lua_getfield(L, idx, m_CallbackNames[i]);
+        if (!lua_isnil(L, -1) && !lua_isfunction(L, -1)) {
+            luaL_error(
+                L, "settings row field '%s' must be a function",
+                m_CallbackNames[i]);
+        }
+        lua_pop(L, 1);
+    }
+
     for (int32_t i = 0; i < M_CB_COUNT; i++) {
         lua_getfield(L, idx, m_CallbackNames[i]);
         if (lua_isnil(L, -1)) {
             lua_pop(L, 1);
-            row->refs[i] = LUA_NOREF;
+            refs[i] = LUA_NOREF;
             continue;
         }
-        luaL_checktype(L, -1, LUA_TFUNCTION);
-        row->refs[i] = luaL_ref(L, LUA_REGISTRYINDEX);
+        refs[i] = luaL_ref(L, LUA_REGISTRYINDEX);
     }
 }
 
@@ -205,6 +217,13 @@ static int M_L_SettingsAddRow(lua_State *const L)
     }
     lua_pop(L, 1);
 
+    // The table is read out in full before the row is made, so nothing an
+    // ill-formed declaration raises on is left half built.
+    const int32_t delta_slow = M_ReadDelta(L, 2, "delta_slow");
+    const int32_t delta_fast = M_ReadDelta(L, 2, "delta_fast");
+    int32_t refs[M_CB_COUNT];
+    M_ReadCallbacks(L, 2, refs);
+
     lua_getfield(L, 2, "before");
     lua_getfield(L, 2, "after");
     const char *const before = lua_isnil(L, -2) ? nullptr : lua_tostring(L, -2);
@@ -212,12 +231,12 @@ static int M_L_SettingsAddRow(lua_State *const L)
 
     M_DECLARED_ROW *const row = Memory_Alloc(sizeof(M_DECLARED_ROW));
     row->key = Memory_DupStr(key);
-    M_ReadCallbacks(L, 2, row);
+    memcpy(row->refs, refs, sizeof(refs));
     row->handler = (UI_SETTING_HANDLER) {
         .key = row->key,
         .user_data = row,
-        .delta_slow = M_ReadDelta(L, 2, "delta_slow"),
-        .delta_fast = M_ReadDelta(L, 2, "delta_fast"),
+        .delta_slow = delta_slow,
+        .delta_fast = delta_fast,
         .format_value =
             row->refs[M_CB_FORMAT_VALUE] != LUA_NOREF ? M_FormatValue : nullptr,
         .is_available =

--- a/src/trx/game/ui/dialogs/settings_lua.h
+++ b/src/trx/game/ui/dialogs/settings_lua.h
@@ -1,6 +1,0 @@
-#pragma once
-
-// Drops every settings row a script asked for, along with the handler each one
-// registered. A game's rows go when the game does, before the next game's
-// script runs; see settings_lua.c.
-void UI_SettingsLua_DropDeclaredRows(void);

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -297,9 +297,7 @@ static float M_GetLayoutWidth(
 }
 
 // How far the continuations of a line are indented, so that a line broken in
-// two still reads as one entry rather than as two at different depths. A line
-// indented by spaces keeps that indentation; a bullet adds the width of its
-// dash and the space after it, putting the continuation under the text.
+// two still reads as one entry rather than as two at different depths.
 static int32_t M_DetectHangingIndent(
     const M_GLYPH_INFO **glyphs, const size_t glyph_count, const size_t idx)
 {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds a couple of follow-up fixes to `trx.config.declare`, `trx.config.on_change`, and the settings rows that use them.

- Replay settings could apply twice on startup and overwrite game-script changes.
- Replayed game settings could fail to notify watchers.
- `trx.config.on_change` could return the wrong watcher.
- Invalid settings rows are now validated before allocation.
- Long enum string keys could collide due to truncation.
- Closing a replay could leave deferred settings behind.
- Removed dead config cleanup code, the unused `CONFIG_OPTION_DECLARED` flag, and `settings_lua.h`.