### PR TITLE
Make enemy drop placement a rule

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed New Game+ in TR1 so that flares Lara has collected are kept between levels rather than taken away at the start of each one
 - changed engine-specific music trigger behavior by defining rules settable in Lua; refer to documentation
+- changed where an item a defeated enemy carried lands, and which way it faces, by defining rules settable in Lua; refer to documentation (#5883)
 - added an `ammo.infinite` key to `weapons.json5`, saying which weapons and flares never run out; a game that takes it away from the pistols makes their clips worth collecting
 - changed the ammunition keys in `weapons.json5` to say what they count; refer to migration notes
 - changed boxes of ammunition in the inventory to always show what Lara is really carrying, where finishing a level could round them down

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5872,6 +5872,11 @@
     {
       "callable": false,
       "implicit": true,
+      "path": "rules.carrier"
+    },
+    {
+      "callable": false,
+      "implicit": true,
       "path": "rules.music"
     }
   ],
@@ -6251,6 +6256,18 @@
       "description": "How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.",
       "path": "rules.corpse.fade_speed",
       "type": "integer",
+      "writable": true
+    },
+    {
+      "description": "Whether an item a defeated enemy carried lands in the middle of the sector\nthe enemy stood on, rather than at its feet. Quest items are left where\nthey fall either way.",
+      "path": "rules.carrier.snap_to_sector",
+      "type": "boolean",
+      "writable": true
+    },
+    {
+      "description": "Whether an item a defeated enemy carried turns to face the way the enemy\ndid, rather than keeping the rotation the level gave it. This only reaches\ndrops the level data places on the enemy; a drop the gameflow names always\ntakes the enemy's facing.",
+      "path": "rules.carrier.inherit_facing",
+      "type": "boolean",
       "writable": true
     },
     {

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -32,6 +32,13 @@ that wants the defaults back asks for them.
 - <a id="rules.exposure.recovery" name="rules.exposure.recovery"></a>**`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
 - <a id="rules.exposure.damage" name="rules.exposure.damage"></a>**`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
 - <a id="rules.corpse.fade_speed" name="rules.corpse.fade_speed"></a>**`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
+- <a id="rules.carrier.snap_to_sector" name="rules.carrier.snap_to_sector"></a>**`trx.rules.carrier.snap_to_sector`** (boolean). Whether an item a defeated enemy carried lands in the middle of the sector
+  the enemy stood on, rather than at its feet. Quest items are left where
+  they fall either way.
+- <a id="rules.carrier.inherit_facing" name="rules.carrier.inherit_facing"></a>**`trx.rules.carrier.inherit_facing`** (boolean). Whether an item a defeated enemy carried turns to face the way the enemy
+  did, rather than keeping the rotation the level gave it. This only reaches
+  drops the level data places on the enemy; a drop the gameflow names always
+  takes the enemy's facing.
 - <a id="rules.music.accumulate_trigger_masks" name="rules.music.accumulate_trigger_masks"></a>**`trx.rules.music.accumulate_trigger_masks`** (boolean). Whether non-ambient tracks triggered from floor data should react to trigger masks, requiring all bits to be set for the music to play. Current playing music whose mask becomes unset will stop.
 - <a id="rules.music.is_one_shot_default" name="rules.music.is_one_shot_default"></a>**`trx.rules.music.is_one_shot_default`** (boolean). Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.
 - <a id="rules.music.supports_delay" name="rules.music.supports_delay"></a>**`trx.rules.music.supports_delay`** (boolean). Whether timers used for non-ambient tracks triggered from floor data should be interpreted as a delay before playing the track.

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -67,6 +67,25 @@ rule("corpse.fade_speed", {
     .. "away once nothing is left. `0` leaves it where it lies.",
 })
 
+rule("carrier.snap_to_sector", {
+  type = "boolean",
+  description = [[
+    Whether an item a defeated enemy carried lands in the middle of the sector
+    the enemy stood on, rather than at its feet. Quest items are left where
+    they fall either way.
+  ]],
+})
+
+rule("carrier.inherit_facing", {
+  type = "boolean",
+  description = [[
+    Whether an item a defeated enemy carried turns to face the way the enemy
+    did, rather than keeping the rotation the level gave it. This only reaches
+    drops the level data places on the enemy; a drop the gameflow names always
+    takes the enemy's facing.
+  ]],
+})
+
 rule("music.accumulate_trigger_masks", {
   type = "boolean",
   description = "Whether non-ambient tracks triggered from floor data should "

--- a/src/trx/game/items/carrier.c
+++ b/src/trx/game/items/carrier.c
@@ -9,7 +9,7 @@
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 #include <trx/game/rooms/utils.h>
-#include <trx/version.h>
+#include <trx/game/rules.h>
 
 #define M_DROP_FAST_RATE GRAVITY
 #define M_DROP_SLOW_RATE 1
@@ -24,29 +24,20 @@ static const GAME_OBJECT_PAIR m_LegacyMap[] = {
     { NO_OBJECT, NO_OBJECT },
 };
 
-static bool M_ShouldCenterDrop(const OBJECT_ID obj_id)
+static bool M_ShouldSnapDrop(const OBJECT_ID obj_id)
 {
-    switch (obj_id) {
-    case O_QUEST_ITEM_1:
-    case O_QUEST_ITEM_2:
-    case O_QUEST_ITEM_3:
-    case O_QUEST_ITEM_4:
-    case O_QUEST_ITEM_5:
-    case O_QUEST_ITEM_6:
+    if (Object_IsType(obj_id, g_QuestObjects)) {
         return false;
-
-    default:
-        return g_TRVersion == 3;
     }
+
+    return g_Rules.carrier.snap_to_sector;
 }
 
 static void M_Drop(ITEM *const pickup)
 {
+    Item_SetVisible(pickup, true);
     if (Object_IsType(pickup->object_id, g_QuestObjects)) {
-        Item_SetVisible(pickup, true);
         Item_AddSimulated(Item_GetIndex(pickup));
-    } else {
-        Item_SetVisible(pickup, true);
     }
 }
 
@@ -404,14 +395,14 @@ void Carrier_TestItemDrops(const int16_t item_num)
             Item_UpdateRoom(item->spawn_num, carrier->room_num);
             ITEM *const pickup = Item_Get(item->spawn_num);
             pickup->pos = carrier->pos;
-            if (g_TRVersion != 3) {
+            if (g_Rules.carrier.inherit_facing) {
                 pickup->rot = carrier->rot;
             }
             M_Drop(pickup);
         }
 
         ITEM *const pickup = Item_Get(item->spawn_num);
-        if (M_ShouldCenterDrop(pickup->object_id)) {
+        if (M_ShouldSnapDrop(pickup->object_id)) {
             int16_t room_num = carrier->room_num;
             pickup->pos.x = ROUND_TO_SECTOR(carrier->pos.x) + WALL_L / 2;
             pickup->pos.z = ROUND_TO_SECTOR(carrier->pos.z) + WALL_L / 2;

--- a/src/trx/game/rules.c
+++ b/src/trx/game/rules.c
@@ -43,6 +43,8 @@ static const RULE m_Rules[] = {
 static void M_ApplyGameDefaults(void)
 {
     m_Defaults.corpse.fade_speed = g_TRVersion >= 4 ? 2 : 0;
+    m_Defaults.carrier.snap_to_sector = g_TRVersion >= 3;
+    m_Defaults.carrier.inherit_facing = g_TRVersion < 3;
 }
 
 const RULE *Rules_GetMap(void)

--- a/src/trx/game/rules.def
+++ b/src/trx/game/rules.def
@@ -26,6 +26,14 @@ X_GROUP_BEGIN(corpse)
 X_RULE(int16_t, corpse, fade_speed, 0)
 X_GROUP_END(corpse)
 
+// Where an item a defeated enemy carried comes to rest, and which way it
+// faces. The games differ on both, so the shipped values are replaced with the
+// game's own defaults in Rules_Reset.
+X_GROUP_BEGIN(carrier)
+X_RULE(bool, carrier, snap_to_sector, false)
+X_RULE(bool, carrier, inherit_facing, true)
+X_GROUP_END(carrier)
+
 // Determines how music triggered from floor data is played and the
 // interpretation of their state flags.
 X_GROUP_BEGIN(music)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Where an item a defeated enemy carried lands, and which way it faces, are now rules a script can set:

```lua
trx.rules.set("carrier.snap_to_sector", true)   -- land in the middle of the sector, not at the enemy's feet
trx.rules.set("carrier.inherit_facing", false)  -- keep the rotation the level gave the item
```

Defaults stay unchanged, except TR4 drops now preserve their original level-facing direction.
Quest items remain hardcoded to be placed where they fall to accommodate TR3 meteor artifacts.

Resolves #5883 / TRX719