### PR TITLE
Let modules register their own lifecycles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - changed the ammunition keys in `weapons.json5` to say what they count; refer to migration notes
 - changed boxes of ammunition in the inventory to always show what Lara is really carrying, where finishing a level could round them down
 - fixed settings belonging to another game being dropped from the settings file
+- fixed touch controls not turning themselves on the first time the game is launched on a device that has a touchscreen
 - fixed the alternative ammunition pickups, such as the second kind of shotgun ammunition, going into the inventory without loading the weapon
 - changed the gameflow's `main_menu_picture` to be optional: a game that names no picture shows its title level behind the menu, and its title script says what plays there
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing

--- a/src/meson.build
+++ b/src/meson.build
@@ -263,6 +263,7 @@ common_sources = [
   'trx/core/strings/case_funcs.c',
   'trx/core/strings/common.c',
   'trx/core/strings/fuzzy_match.c',
+  'trx/core/subsystem.c',
   'trx/core/thread_pool.c',
   'trx/core/value.c',
   'trx/core/vector.c',

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -38,8 +38,15 @@
 #include <string.h>
 #include <sys/stat.h>
 
+typedef struct M_RESOLVED_PATH {
+    char *value;
+    struct M_RESOLVED_PATH *next;
+} M_RESOLVED_PATH;
+
 INPUT_STATE g_Input = {};
 INPUT_STATE g_InputDB = {};
+
+static M_RESOLVED_PATH *m_ResolvedPaths = nullptr;
 
 // Every path variable resolves to the shipped config directory, which is where
 // the presets live.
@@ -52,6 +59,26 @@ char *TRXPath_ExpandVars(const char *const path)
         return Memory_DupStr(path);
     }
     return String_Format("%s%s", TEST_SHIP_CFG_DIR, closing + 1);
+}
+
+// Cached and valid for the run, as the engine's is: a caller may hold what it
+// was given.
+const char *TRXPath_Resolve(const TRX_DYNAMIC_PATH path, const char *const rel)
+{
+    char *const resolved = String_Format("%s/%s", TEST_SHIP_CFG_DIR, rel);
+    for (const M_RESOLVED_PATH *entry = m_ResolvedPaths; entry != nullptr;
+         entry = entry->next) {
+        if (strcmp(entry->value, resolved) == 0) {
+            Memory_Free(resolved);
+            return entry->value;
+        }
+    }
+
+    M_RESOLVED_PATH *const entry = Memory_Alloc(sizeof(M_RESOLVED_PATH));
+    entry->value = resolved;
+    entry->next = m_ResolvedPaths;
+    m_ResolvedPaths = entry;
+    return entry->value;
 }
 
 bool File_Load(

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -103,6 +103,11 @@ bool ConfigFile_Read(
     return false;
 }
 
+bool ConfigFile_WasFound(void)
+{
+    return false;
+}
+
 JSON_OBJECT *ConfigFile_GetRoot(void)
 {
     return nullptr;

--- a/src/tests/harness/lua_surface.c
+++ b/src/tests/harness/lua_surface.c
@@ -1,6 +1,7 @@
 #include <harness/lua_surface.h>
 
 #include <harness/fake_calls.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/sandbox.h>
 #include <trx/game/lua/utils.h>
@@ -210,6 +211,9 @@ int LuaSurface_Run(const LUA_SURFACE_TEST *const test)
     lua_newtable(L);
     lua_setglobal(L, "trx");
 
+    // The bridges subscribe to the modules they wrap as they are created, so
+    // the modules stand first.
+    Subsystem_InitAll();
     LUA_Registry_CreateAll(L);
     if (test->setup_extra != nullptr) {
         test->setup_extra(L);
@@ -308,5 +312,6 @@ int LuaSurface_Run(const LUA_SURFACE_TEST *const test)
     // closed state.
     LUA_Registry_ShutdownAll();
     lua_close(L);
+    Subsystem_ShutdownAll();
     return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/tests/harness/stubs_config_file.c
+++ b/src/tests/harness/stubs_config_file.c
@@ -15,6 +15,11 @@ bool ConfigFile_Read(
     return true;
 }
 
+bool ConfigFile_WasFound(void)
+{
+    return false;
+}
+
 JSON_OBJECT *ConfigFile_GetRoot(void)
 {
     return nullptr;

--- a/src/tests/lua/api/random.c
+++ b/src/tests/lua/api/random.c
@@ -1,18 +1,24 @@
 // The random surface. The assertions live in random.lua.
 //
 // There is no fake engine: the real generator is what the module reports. The
-// seed is fixed here so that the first case can name the numbers it produces.
+// seed is fixed once the modules are up - standing them up seeds the generator
+// from the clock - so that the first case can name the numbers it produces.
 
 #include <harness/lua_surface.h>
 
 #include <trx/game/random.h>
 
-int main(void)
+static void M_Seed(lua_State *const L)
 {
     Random_SeedControl(1234);
+}
+
+int main(void)
+{
     const LUA_SURFACE_TEST test = {
         .module = "random",
         .tests = "api/random",
+        .setup_extra = M_Seed,
     };
     return LuaSurface_Run(&test);
 }

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -68,6 +68,7 @@ b_lua_surface = {
     'core/enum_map.c',
     'core/handle.c',
     'core/memory.c',
+    'core/subsystem.c',
     'core/value.c',
     'core/vector.c',
     'game/enum.c',
@@ -189,7 +190,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'trx/game/cutseq/pak',
-  'engine': ['game/cutseq/pak.c', 'core/memory.c'],
+  'engine': ['game/cutseq/pak.c', 'core/memory.c', 'core/subsystem.c'],
   'deps': [dep_zlib],
 }
 
@@ -264,6 +265,7 @@ unit_tests += {
     'game/console/completion.c',
     'game/console/registry.c',
     'core/memory.c',
+    'core/subsystem.c',
     'core/vector.c',
   ],
 }
@@ -302,6 +304,7 @@ unit_tests += {
     'core/event_manager.c',
     'core/json/base.c',
     'core/json/parse.c',
+    'core/subsystem.c',
     'version.c',
   ],
   'src': ['harness/stubs_config_file.c'],
@@ -443,7 +446,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/random',
   'bundles': [b_lua_surface, b_lua_math],
-  'engine': ['game/lua/capi/random.c', 'game/random.c'],
+  'engine': ['core/subsystem.c', 'game/lua/capi/random.c', 'game/random.c'],
 }
 
 unit_tests += {
@@ -797,6 +800,7 @@ unit_tests += {
     'core/memory.c',
     'core/strings/case_funcs.c',
     'core/strings/common.c',
+    'core/subsystem.c',
     'core/vector.c',
     'game/enum.c',
     'game/game_strings/entries.c',
@@ -827,6 +831,7 @@ unit_tests += {
     'core/event_manager.c',
     'core/json/base.c',
     'core/json/parse.c',
+    'core/subsystem.c',
     'game/ui/dialogs/settings_handlers.c',
     'game/ui/dialogs/settings_rows.c',
     'version.c',
@@ -870,6 +875,7 @@ unit_tests += {
     'core/memory.c',
     'core/strings/case_funcs.c',
     'core/strings/common.c',
+    'core/subsystem.c',
     'core/value.c',
     'core/vector.c',
     'game/enum.c',

--- a/src/tests/trx/config/common.c
+++ b/src/tests/trx/config/common.c
@@ -8,6 +8,7 @@
 #include <trx/config/common.h>
 #include <trx/config/priv.h>
 #include <trx/config/registry.h>
+#include <trx/core/subsystem.h>
 
 static bool m_MusicOn;
 static double m_Fov;
@@ -18,9 +19,13 @@ static int32_t m_FovTold;
 
 static void M_SetUp(void)
 {
+    // The config module keeps its change event manager with the session, and
+    // a write reports through it.
+    Subsystem_ShutdownAll();
+    Subsystem_InitAll();
+
     // Each test starts from the same three options, as a game change would
     // leave them.
-    Config_DropAllOptions();
     Config_Register(&(CONFIG_OPTION_DESC) {
         .name = "audio.music",
         .default_value = { .type = TVT_BOOL, .as_bool = true },

--- a/src/tests/trx/game/ui.c
+++ b/src/tests/trx/game/ui.c
@@ -17,6 +17,7 @@
 #include <trx/core/json.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/ui.h>
 #include <trx/game/input.h>
@@ -175,8 +176,7 @@ static M_OVERFLOW M_MeasureDialogOverflow(const M_DIALOG *const dialog)
 
 static void M_SetUp(const int32_t tr_version, const char *const lang)
 {
-    GameString_Clear();
-    GameString_Init();
+    GameString_Reset();
     M_LoadLanguage(lang);
     FakeUI_SetGame(tr_version);
     FakeUI_SetViewport(640, 480);
@@ -202,7 +202,7 @@ TEST(ui_font_metrics)
         { 4, 275.0f },
     };
 
-    UI_InitText();
+    Subsystem_InitAll();
     for (size_t i = 0; i < ARRAY_SIZE(expected); i++) {
         M_SetUp(expected[i].tr_version, nullptr);
         float width = 0.0f;
@@ -215,7 +215,7 @@ TEST(ui_font_metrics)
                 expected[i].width, width);
         }
     }
-    UI_ShutdownText();
+    Subsystem_ShutdownAll();
 }
 
 // The list of settings a preset would change is the longest text in any of
@@ -223,7 +223,7 @@ TEST(ui_font_metrics)
 // preset touches. It wraps rather than sizing the dialog to the widest of them.
 TEST(ui_config_presets_confirm_fits_4_3)
 {
-    UI_InitText();
+    Subsystem_InitAll();
     Config_Presets_ScanFiles();
 
     for (int32_t tr_version = 1; tr_version <= TR_VERSION_COUNT; tr_version++) {
@@ -269,12 +269,12 @@ TEST(ui_config_presets_confirm_fits_4_3)
             }
         }
     }
-    UI_ShutdownText();
+    Subsystem_ShutdownAll();
 }
 
 TEST(ui_settings_dialogs_fit_4_3)
 {
-    UI_InitText();
+    Subsystem_InitAll();
     for (int32_t tr_version = 1; tr_version <= TR_VERSION_COUNT; tr_version++) {
         for (size_t i = 0; i < ARRAY_SIZE(m_Languages); i++) {
             M_SetUp(tr_version, m_Languages[i]);
@@ -295,5 +295,5 @@ TEST(ui_settings_dialogs_fit_4_3)
             }
         }
     }
-    UI_ShutdownText();
+    Subsystem_ShutdownAll();
 }

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -23,6 +23,7 @@ static bool m_PendingPersist = false;
 static char *m_DefaultPath = nullptr;
 static char *m_EnforcedPath = nullptr;
 static bool m_Loaded = false;
+static bool m_FileFound = false;
 
 __attribute__((constructor)) static void M_Init(void)
 {
@@ -111,6 +112,7 @@ bool Config_Read(
     LOG_DEBUG("  enforced_path=%s", m_EnforcedPath);
 
     const bool result = ConfigFile_Read(m_DefaultPath, m_EnforcedPath);
+    m_FileFound = ConfigFile_WasFound();
     if (result) {
         LOG_DEBUG("Config loaded");
     } else {
@@ -172,6 +174,11 @@ void Config_DiscardPendingChanges(void)
 bool Config_IsLoaded(void)
 {
     return m_Loaded;
+}
+
+bool Config_IsFirstRun(void)
+{
+    return m_Loaded && !m_FileFound;
 }
 
 bool Config_Write(void)

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -6,6 +6,7 @@
 #include <trx/config/section.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 
@@ -25,12 +26,12 @@ static char *m_EnforcedPath = nullptr;
 static bool m_Loaded = false;
 static bool m_FileFound = false;
 
-__attribute__((constructor)) static void M_Init(void)
+static void M_Init(void)
 {
     m_EventManager = EventManager_Create();
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     EventManager_Free(m_EventManager);
     m_EventManager = nullptr;
@@ -40,6 +41,9 @@ __attribute__((destructor)) static void M_Shutdown(void)
     }
     Memory_FreePointer(&m_DefaultPath);
     Memory_FreePointer(&m_EnforcedPath);
+    m_Loaded = false;
+    m_FileFound = false;
+    m_PendingPersist = false;
 }
 
 // What a type converts as. An enum is int32 storage that happens to spell its
@@ -249,3 +253,5 @@ bool Config_PopHold(const void *const mirror)
     CONFIG_OPTION *const option = Config_FindOptionByMirror(mirror);
     return option != nullptr && Config_Option_PopHold(option);
 }
+
+REGISTER_BASE_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/config/common.h
+++ b/src/trx/config/common.h
@@ -10,6 +10,11 @@ bool Config_Read(const char *default_path, const char *enforced_path);
 // Whether the settings file has been read. Until it has, what the options hold
 // is their defaults rather than the player's own choices.
 bool Config_IsLoaded(void);
+
+// Whether this is the first the player has launched the game: the settings
+// have been read and there was no file to read them from. False where nothing
+// has been read at all, as in a test replay.
+bool Config_IsFirstRun(void);
 bool Config_Write(void);
 
 // Holds every option to its bounds, then announces which have moved since the

--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -9,6 +9,7 @@
 #include <trx/core/json/util/value.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 
 #include <string.h>
@@ -35,7 +36,7 @@ static void M_FreeRetained(void)
     }
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     M_FreeRetained();
 }
@@ -231,3 +232,5 @@ void ConfigFile_DumpOptions(JSON_OBJECT *const root_obj)
             Config_Option_GetEnumKey(option), value);
     }
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -4,6 +4,7 @@
 #include <trx/config/legacy.h>
 #include <trx/config/registry.h>
 #include <trx/config/section.h>
+#include <trx/core/filesystem.h>
 #include <trx/core/json/util/file.h>
 #include <trx/core/json/util/value.h>
 #include <trx/core/log.h>
@@ -19,9 +20,11 @@
 // what they held for it, so they outlive the read itself.
 static JSON_VALUE *m_CfgRoot = nullptr;
 static JSON_VALUE *m_EnfRoot = nullptr;
+static bool m_CfgFound = false;
 
 static void M_FreeRetained(void)
 {
+    m_CfgFound = false;
     if (m_CfgRoot != nullptr) {
         JSON_ValueFree(m_CfgRoot);
         m_CfgRoot = nullptr;
@@ -99,11 +102,17 @@ void ConfigFile_Forget(void)
     M_FreeRetained();
 }
 
+bool ConfigFile_WasFound(void)
+{
+    return m_CfgFound;
+}
+
 bool ConfigFile_Read(
     const char *const default_path, const char *const enforced_path)
 {
     ASSERT(default_path != nullptr);
     M_FreeRetained();
+    m_CfgFound = File_Exists(default_path);
 
     bool result = false;
     m_CfgRoot = JSONFile_Read(default_path);

--- a/src/trx/config/file.h
+++ b/src/trx/config/file.h
@@ -12,6 +12,10 @@
 
 bool ConfigFile_Read(const char *default_path, const char *enforced_path);
 
+// Whether the settings file was there for the last read, apart from whether it
+// parsed.
+bool ConfigFile_WasFound(void);
+
 // Lets go of both documents, for a set of options being dropped: what one
 // game's file said is nothing to the next game's settings.
 void ConfigFile_Forget(void);

--- a/src/trx/config/presets.c
+++ b/src/trx/config/presets.c
@@ -8,14 +8,17 @@
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/game/game_strings/entries.h>
+#include <trx/game/game_strings/manager.h>
 #include <trx/game/shell/paths.h>
 
 #include <stdlib.h>
 #include <string.h>
 
 static VECTOR *m_Presets = nullptr; // CONFIG_PRESET
+static int32_t m_StringsListener = -1;
 
 static void M_FreePreset(CONFIG_PRESET *const preset)
 {
@@ -131,8 +134,23 @@ static int M_CompareByTitle(const void *const a, const void *const b)
     return strcmp(M_GetTitle(a), M_GetTitle(b));
 }
 
-static void __attribute__((destructor)) M_Shutdown(void)
+static void M_HandleLanguageReload(const EVENT *const event, void *const data)
 {
+    Config_Presets_Sort();
+}
+
+static void M_Init(void)
+{
+    m_StringsListener =
+        GameStringManager_SubscribeReload(M_HandleLanguageReload, nullptr);
+}
+
+static void M_Shutdown(void)
+{
+    if (m_StringsListener >= 0) {
+        GameStringManager_UnsubscribeReload(m_StringsListener);
+        m_StringsListener = -1;
+    }
     M_FreeAllPresets();
 }
 
@@ -218,3 +236,7 @@ void Config_Presets_Apply(const int32_t idx)
     Config_Update();
     Config_Write();
 }
+
+REGISTER_SUBSYSTEM(
+        .init = M_Init, .load = Config_Presets_ScanFiles,
+        .shutdown = M_Shutdown)

--- a/src/trx/config/registry.c
+++ b/src/trx/config/registry.c
@@ -5,6 +5,7 @@
 #include <trx/config/priv.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 
@@ -54,7 +55,7 @@ static bool M_IsNameTaken(const char *const name)
     return false;
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     Config_DropAllOptions();
     if (m_Options != nullptr) {
@@ -161,3 +162,5 @@ void Config_ClearHolds(void)
         Config_Option_ReleaseHolds(M_Get(i));
     }
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/core/subsystem.c
+++ b/src/trx/core/subsystem.c
@@ -1,0 +1,82 @@
+#include <trx/core/subsystem.h>
+
+#include <trx/debug.h>
+
+#include <stdint.h>
+
+typedef enum {
+    M_PHASE_INIT,
+    M_PHASE_LOAD,
+    M_PHASE_APPLY_CONFIG,
+    M_PHASE_SHUTDOWN,
+} M_PHASE;
+
+static SUBSYSTEM *m_First = nullptr;
+static SUBSYSTEM *m_Last = nullptr;
+
+static SUBSYSTEM_FUNC M_GetPhaseFunc(
+    const SUBSYSTEM *const subsystem, const M_PHASE phase)
+{
+    switch (phase) {
+    case M_PHASE_INIT:
+        return subsystem->init;
+    case M_PHASE_LOAD:
+        return subsystem->load;
+    case M_PHASE_APPLY_CONFIG:
+        return subsystem->apply_config;
+    case M_PHASE_SHUTDOWN:
+        return subsystem->shutdown;
+    }
+    return nullptr;
+}
+
+static void M_RunPhase(const M_PHASE phase, const bool reverse)
+{
+    for (int32_t t = 0; t < SUBSYSTEM_TIER_NUMBER_OF; t++) {
+        const int32_t tier = reverse ? SUBSYSTEM_TIER_NUMBER_OF - 1 - t : t;
+        for (SUBSYSTEM *subsystem = reverse ? m_Last : m_First;
+             subsystem != nullptr;
+             subsystem = reverse ? subsystem->prev : subsystem->next) {
+            if ((int32_t)subsystem->tier != tier) {
+                continue;
+            }
+            const SUBSYSTEM_FUNC func = M_GetPhaseFunc(subsystem, phase);
+            if (func != nullptr) {
+                func();
+            }
+        }
+    }
+}
+
+void Subsystem_Register(SUBSYSTEM *const subsystem)
+{
+    ASSERT(subsystem->tier < SUBSYSTEM_TIER_NUMBER_OF);
+    subsystem->prev = m_Last;
+    subsystem->next = nullptr;
+    if (m_Last != nullptr) {
+        m_Last->next = subsystem;
+    } else {
+        m_First = subsystem;
+    }
+    m_Last = subsystem;
+}
+
+void Subsystem_InitAll(void)
+{
+    M_RunPhase(M_PHASE_INIT, false);
+}
+
+void Subsystem_LoadAll(void)
+{
+    M_RunPhase(M_PHASE_LOAD, false);
+}
+
+void Subsystem_ApplyConfigAll(void)
+{
+    M_RunPhase(M_PHASE_APPLY_CONFIG, false);
+}
+
+void Subsystem_ShutdownAll(void)
+{
+    M_RunPhase(M_PHASE_SHUTDOWN, true);
+}

--- a/src/trx/core/subsystem.h
+++ b/src/trx/core/subsystem.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// The lifecycle of a module that stands itself up and needs no other module to
+// have been brought up first.
+//
+// A module that registers here comes up when a session starts and goes down
+// when it ends, so what it holds lasts a session. That matters because a mod
+// switch restarts the game in place: state left from the last mod is state the
+// next one never asked for. A load-time constructor gives the module the
+// lifetime of the process instead.
+//
+// A module that does need another one up first is stood up by the shell by
+// name, where the order can be read.
+
+typedef void (*SUBSYSTEM_FUNC)(void);
+
+// A tier comes up before the tiers after it and goes down after them. Within a
+// tier the order is the linker's, which is the order the source list happens to
+// be in, so nothing may rest on it.
+typedef enum {
+    // Memory, lookups and reporting that the tiers above hold on to.
+    SUBSYSTEM_TIER_BASE,
+    SUBSYSTEM_TIER_MAIN,
+    SUBSYSTEM_TIER_NUMBER_OF,
+} SUBSYSTEM_TIER;
+
+// A module names only the phases it has.
+typedef struct SUBSYSTEM {
+    SUBSYSTEM_TIER tier;
+    // Stand the module up. Only the tiers below this one are up.
+    SUBSYSTEM_FUNC init;
+    // Read what the module keeps on disk. The mod's paths are resolved by now.
+    SUBSYSTEM_FUNC load;
+    // Take the config as first read. This is the work the module already does
+    // when one of its options is written later.
+    SUBSYSTEM_FUNC apply_config;
+    // Give back what the module holds. One session can ask twice, so a second
+    // call has to be a no-op rather than a second free.
+    SUBSYSTEM_FUNC shutdown;
+    // The registry's, filled in by Subsystem_Register.
+    struct SUBSYSTEM *prev;
+    struct SUBSYSTEM *next;
+} SUBSYSTEM;
+
+// The registry links the struct itself rather than copying it, so what is
+// passed here lives as long as the process.
+void Subsystem_Register(SUBSYSTEM *subsystem);
+
+// Bring every registered subsystem up, a tier at a time.
+void Subsystem_InitAll(void);
+
+// Read what each subsystem keeps on disk, once the mod's paths are resolved.
+void Subsystem_LoadAll(void);
+
+// Hand each subsystem the config the session starts with.
+void Subsystem_ApplyConfigAll(void);
+
+// Take them down again, in the reverse of the order they came up in.
+void Subsystem_ShutdownAll(void);
+
+#define M_REGISTER_SUBSYSTEM(tier_, ...)                                       \
+    __attribute__((constructor)) static void M_RegisterSubsystem(void)         \
+    {                                                                          \
+        static SUBSYSTEM m_Subsystem = { .tier = (tier_), __VA_ARGS__ };       \
+        Subsystem_Register(&m_Subsystem);                                      \
+    }
+
+// One registration to a file: the symbol is the same every time, so a second
+// one in the same file is a duplicate the compiler names. A module spread over
+// several files can register from more than one of them, and each registration
+// is its own subsystem.
+#define REGISTER_SUBSYSTEM(...)                                                \
+    M_REGISTER_SUBSYSTEM(SUBSYSTEM_TIER_MAIN, __VA_ARGS__)
+
+// As REGISTER_SUBSYSTEM, at the base tier.
+#define REGISTER_BASE_SUBSYSTEM(...)                                           \
+    M_REGISTER_SUBSYSTEM(SUBSYSTEM_TIER_BASE, __VA_ARGS__)

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -4,6 +4,7 @@
 #include <trx/core/filesystem.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/game/items/actions/ids.h>
 #include <trx/game/lara/enum.h>
@@ -119,6 +120,21 @@ static void M_Initialize(void)
     m_Initialized = true;
 }
 
+static void M_Shutdown(void)
+{
+    if (!m_Initialized) {
+        return;
+    }
+    for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
+        M_ClearGameIDMap(&m_GameID2EnumMap[ctx]);
+        M_ClearNameMap(&m_Name2EnumMap[ctx]);
+        Memory_Free(m_CatalogGameIDs[ctx]);
+    }
+    Memory_Free(m_CatalogGameIDs);
+    m_CatalogGameIDs = nullptr;
+    m_Initialized = false;
+}
+
 bool Catalog_Load(
     const CATALOG_CONTEXT context, const char *const csv_path,
     const bool allow_duplicates)
@@ -220,17 +236,4 @@ bool Catalog_GameIDToEnum(
     return false;
 }
 
-void Catalog_Shutdown(void)
-{
-    if (!m_Initialized) {
-        return;
-    }
-    for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
-        M_ClearGameIDMap(&m_GameID2EnumMap[ctx]);
-        M_ClearNameMap(&m_Name2EnumMap[ctx]);
-        Memory_Free(m_CatalogGameIDs[ctx]);
-    }
-    Memory_Free(m_CatalogGameIDs);
-    m_CatalogGameIDs = nullptr;
-    m_Initialized = false;
-}
+REGISTER_BASE_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -36,6 +36,3 @@ bool Catalog_EnumToGameID(
 // Returns false if not found.
 bool Catalog_GameIDToEnum(
     CATALOG_CONTEXT context, int32_t game_id, CATALOG_ID *out_id);
-
-// Free internal resources.
-void Catalog_Shutdown(void);

--- a/src/trx/game/clock/common.c
+++ b/src/trx/game/clock/common.c
@@ -1,9 +1,11 @@
 #include <trx/game/clock/common.h>
 
 #include <trx/config.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/clock/const.h>
 #include <trx/game/clock/timer.h>
 #include <trx/game/clock/turbo.h>
+#include <trx/game/shell/common.h>
 
 #include <SDL2/SDL_stdinc.h>
 #include <SDL2/SDL_timer.h>
@@ -37,10 +39,23 @@ static double M_GetHighPrecisionCounter(void)
     return (SDL_GetPerformanceCounter() - m_InitCounter) / (double)m_Frequency;
 }
 
-void Clock_Init(void)
+static void M_Init(void)
 {
     m_Frequency = SDL_GetPerformanceFrequency();
     m_InitCounter = SDL_GetPerformanceCounter();
+}
+
+static void M_ApplyConfig(void)
+{
+    Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
+
+    const SHELL_ARGS *const args = Shell_GetArgs();
+    if (!args->headless) {
+        return;
+    }
+    Clock_DisableWait();
+    Clock_EnableHeadlessFixedFPS(
+        args->headless_fps > 0 ? args->headless_fps : Clock_GetCurrentFPS());
 }
 
 void Clock_DisableWait(void)
@@ -178,3 +193,5 @@ void Clock_SetSimSpeed(const double new_speed)
     m_Priv.sim_time_at_last_change = prev_sim_time;
     m_Priv.sim_speed = new_speed;
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init, .apply_config = M_ApplyConfig)

--- a/src/trx/game/clock/common.h
+++ b/src/trx/game/clock/common.h
@@ -3,8 +3,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void Clock_Init(void);
-
 // Disables any kind of waiting in Clock_WaitTick
 void Clock_DisableWait(void);
 

--- a/src/trx/game/console/common.c
+++ b/src/trx/game/console/common.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/console/internal.h>
 #include <trx/game/console/registry.h>
@@ -18,20 +19,20 @@ static UI_CONSOLE_STATE m_UIState = {};
 // Controls whether console commands emit log events to the UI console
 static bool m_Verbose = true;
 
-void Console_Init(void)
-{
-    UI_Console_Init(&m_UIState);
-
-    Console_History_Init();
-}
-
-void Console_Shutdown(void)
+static void M_Shutdown(void)
 {
     UI_Console_Free(&m_UIState);
 
     Console_History_Shutdown();
 
     m_IsOpened = false;
+}
+
+static void M_Load(void)
+{
+    UI_Console_Init(&m_UIState);
+
+    Console_History_Init();
 }
 
 void Console_Open(void)
@@ -168,3 +169,5 @@ void Console_Draw(void)
 {
     UI_Console(&m_UIState);
 }
+
+REGISTER_SUBSYSTEM(.load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/game/console/common.h
+++ b/src/trx/game/console/common.h
@@ -14,9 +14,6 @@
     Console_LogGeneric(LOG_LEVEL_WARNING, __VA_ARGS__)
 #define Console_LogError(...) Console_LogGeneric(LOG_LEVEL_ERROR, __VA_ARGS__)
 
-void Console_Init(void);
-void Console_Shutdown(void);
-
 void Console_Open(void);
 void Console_Close(void);
 bool Console_IsOpened(void);

--- a/src/trx/game/console/registry.c
+++ b/src/trx/game/console/registry.c
@@ -1,6 +1,7 @@
 #include <trx/game/console/registry.h>
 
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 
 #include <ctype.h>
 #include <stdlib.h>
@@ -13,9 +14,10 @@ typedef struct M_NODE {
 
 static M_NODE *m_List = nullptr;
 
-// A run that ends without the Lua state shutting down first still leaves the
-// list behind, so the process drops it on the way out.
-__attribute__((destructor)) static void M_Shutdown(void)
+// A backstop: the Lua state closes ahead of the subsystems and clears the
+// commands it registered, but a session that never opened it still leaves the
+// list behind.
+static void M_Shutdown(void)
 {
     Console_Registry_Clear();
 }
@@ -219,3 +221,5 @@ VECTOR *Console_Registry_GetAll(void)
     }
     return vec;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/creature/behavior.c
+++ b/src/trx/game/creature/behavior.c
@@ -1,4 +1,5 @@
 #include <trx/config.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/game/creature.h>
 #include <trx/game/objects/vars.h>
@@ -10,13 +11,13 @@ static bool m_AlliesHostile = false;
 static VECTOR *m_AllyObjects = nullptr;
 static VECTOR *m_AllyTargetingObjects = nullptr;
 
-__attribute__((constructor)) static void M_Init(void)
+static void M_Init(void)
 {
     m_AllyObjects = Vector_Create(sizeof(OBJECT_ID));
     m_AllyTargetingObjects = Vector_Create(sizeof(OBJECT_ID));
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
 #define L_DELETE_VECTOR(vec)                                                   \
     if (vec != nullptr) {                                                      \
@@ -128,3 +129,5 @@ void Creature_AddAllyTargetingEnemy(const OBJECT_ID obj_id)
 {
     Vector_Add(m_AllyTargetingObjects, (void *)&obj_id);
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/cutseq/pak.c
+++ b/src/trx/game/cutseq/pak.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/filesystem.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/objects.h>
 #include <trx/game/shell/paths.h>
@@ -199,3 +200,5 @@ bool CutSeq_Pak_GetCutscene(const int32_t num, CUTSEQ_INFO *const info)
 
     return true;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = CutSeq_Pak_Unload)

--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -1,6 +1,7 @@
 #include <trx/game/demo.h>
 
 #include <trx/config.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/game.h>
@@ -49,6 +50,12 @@ typedef struct {
 static int32_t m_LastDemoNum = 0;
 static M_PRIV m_Priv;
 
+static void M_Shutdown(void)
+{
+    m_Priv = (M_PRIV) {};
+    m_LastDemoNum = 0;
+}
+
 static void M_PrepareConfig(M_PRIV *const p)
 {
     // Changing certains settings affects negatively the original game demo
@@ -69,12 +76,6 @@ static void M_RestoreConfig(M_PRIV *const p)
     L_MODIFY_CONFIG();
 #undef X_PROCESS_CONFIG
     Config_Update();
-}
-
-void Demo_Shutdown(void)
-{
-    m_Priv = (M_PRIV) {};
-    m_LastDemoNum = 0;
 }
 
 void Demo_LoadData(VFILE *const file, const size_t size)
@@ -281,3 +282,5 @@ void Demo_StopFlashing(void)
         .flash_enabled = false,
     });
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/demo.h
+++ b/src/trx/game/demo.h
@@ -3,10 +3,6 @@
 #include <trx/core/virtual_file.h>
 #include <trx/game/game_flow/types.h>
 
-// Forgets which demo comes next, and the level data behind the last one.
-// Switching mods restarts the shell in place, so neither can be carried over.
-void Demo_Shutdown(void);
-
 void Demo_LoadData(VFILE *file, size_t size);
 uint32_t *Demo_GetData(void);
 

--- a/src/trx/game/events.c
+++ b/src/trx/game/events.c
@@ -1,16 +1,17 @@
 #include <trx/game/events.h>
 
 #include <trx/config/common.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 
 static EVENT_MANAGER *m_GameEventManager = nullptr;
 
-void GameEvent_Init(void)
+static void M_Init(void)
 {
     m_GameEventManager = EventManager_Create();
 }
 
-void GameEvent_Shutdown(void)
+static void M_Shutdown(void)
 {
     EventManager_Free(m_GameEventManager);
     m_GameEventManager = nullptr;
@@ -38,3 +39,5 @@ void GameEvent_Fire(const EVENT event)
         EventManager_Fire(m_GameEventManager, &event);
     }
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/events.h
+++ b/src/trx/game/events.h
@@ -8,9 +8,6 @@
 
 typedef void (*GAME_EVENT_LISTENER)(const EVENT *event, void *user_data);
 
-void GameEvent_Init(void);
-void GameEvent_Shutdown(void);
-
 int32_t GameEvent_Subscribe(
     const char *event_name, const void *sender, GAME_EVENT_LISTENER listener,
     void *user_data);

--- a/src/trx/game/game_buf.c
+++ b/src/trx/game/game_buf.c
@@ -2,13 +2,21 @@
 
 #include <trx/core/enum_map.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 
 static MEMORY_ARENA_ALLOCATOR m_Allocator[GBUF_NUM_MALLOC_TYPES] = {};
 
-void GameBuf_Init(void)
+static void M_Init(void)
 {
     for (int32_t i = 0; i < GBUF_NUM_MALLOC_TYPES; i++) {
         m_Allocator[i].default_chunk_size = 2048;
+    }
+}
+
+static void M_Shutdown(void)
+{
+    for (int32_t i = 0; i < GBUF_NUM_MALLOC_TYPES; i++) {
+        Memory_ArenaFree(&m_Allocator[i]);
     }
 }
 
@@ -24,15 +32,10 @@ void GameBuf_ResetSingle(const GAME_BUFFER buffer)
     Memory_ArenaReset(&m_Allocator[buffer]);
 }
 
-void GameBuf_Shutdown(void)
-{
-    for (int32_t i = 0; i < GBUF_NUM_MALLOC_TYPES; i++) {
-        Memory_ArenaFree(&m_Allocator[i]);
-    }
-}
-
 void *GameBuf_Alloc(const size_t alloc_size, const GAME_BUFFER buffer)
 {
     const size_t aligned_size = Memory_Align(alloc_size);
     return Memory_ArenaAlloc(&m_Allocator[buffer], aligned_size);
 }
+
+REGISTER_BASE_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/game_buf.h
+++ b/src/trx/game/game_buf.h
@@ -55,8 +55,6 @@ typedef enum {
     // clang-format on
 } GAME_BUFFER;
 
-void GameBuf_Init(void);
-void GameBuf_Shutdown(void);
 void GameBuf_ResetSingle(GAME_BUFFER buffer);
 void GameBuf_Reset(void);
 

--- a/src/trx/game/game_flow/common.c
+++ b/src/trx/game/game_flow/common.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/vars.h>
@@ -349,3 +350,5 @@ void GF_SetLevelTitle(GF_LEVEL *const level, const char *const title)
     Memory_FreePointer(&level->title);
     level->title = title != nullptr ? Memory_DupStr(title) : nullptr;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = GF_Shutdown)

--- a/src/trx/game/game_flow/sequencer.h
+++ b/src/trx/game/game_flow/sequencer.h
@@ -14,6 +14,10 @@ GF_COMMAND GF_RunCutscene(int32_t cutscene_num, bool cross_fade_in);
 GF_COMMAND GF_RunGame(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);
 GF_COMMAND GF_RunGlobeSelect(const char *background_path);
 
+// Act on what the flow asks for, starting from the given command, until it
+// asks to leave the game or switch mod. Leaves no level loaded.
+void GF_RunUntilExit(GF_COMMAND gf_cmd);
+
 GF_COMMAND GF_DoFrontendSequence(void);
 GF_COMMAND GF_DoDemoSequence(int32_t demo_num);
 GF_COMMAND GF_DoCutsceneSequence(int32_t cutscene_num, bool cross_fade_in);

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -1,6 +1,8 @@
 #include <trx/config.h>
+#include <trx/core/enum_map.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/debug.h>
 #include <trx/game/demo.h>
 #include <trx/game/fmv.h>
 #include <trx/game/game.h>
@@ -320,4 +322,97 @@ bool GF_HasAvailableStory(const SAVEGAME_SLOT_REF slot)
         }
     }
     return false;
+}
+
+void GF_RunUntilExit(GF_COMMAND gf_cmd)
+{
+    bool loop_continue = !Shell_IsExiting();
+    while (loop_continue) {
+        LOG_INFO(
+            "action=%s param=%d", ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action),
+            gf_cmd.param);
+
+        switch (gf_cmd.action) {
+        case GF_START_GAME:
+        case GF_SELECT_GAME: {
+            const int32_t level_num = gf_cmd.param;
+            const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
+            const GF_SEQUENCE_CONTEXT seq_ctx =
+                gf_cmd.action == GF_SELECT_GAME ? GFSC_SELECT : GFSC_NORMAL;
+            if (level != nullptr) {
+                gf_cmd = GF_DoLevelSequence(level, seq_ctx);
+            }
+            break;
+        }
+
+        case GF_GLOBE_SELECT:
+            gf_cmd = GF_RunGlobeSelect(nullptr);
+            break;
+
+        case GF_START_SAVED_GAME: {
+            const SAVEGAME_SLOT_REF slot =
+                SG_Manager_SlotFromParam(gf_cmd.param);
+            const int32_t level_num = SG_Manager_GetLevelNumber(slot);
+            if (level_num < 0) {
+                LOG_ERROR("Corrupt save file!");
+                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            } else {
+                SG_Manager_BindSlot(slot);
+                const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
+                gf_cmd = GF_DoLevelSequence(level, GFSC_SAVED);
+            }
+            break;
+        }
+
+        case GF_RESTART_GAME: {
+            const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, gf_cmd.param);
+            gf_cmd = GF_InterpretSequence(level, GFSC_RESTART, nullptr);
+            break;
+        }
+
+        case GF_STORY_SO_FAR:
+            gf_cmd =
+                GF_PlayAvailableStory(SG_Manager_SlotFromParam(gf_cmd.param));
+            break;
+
+        case GF_START_CINE:
+            gf_cmd = GF_DoCutsceneSequence(gf_cmd.param, false);
+            break;
+
+        case GF_START_DEMO:
+            gf_cmd = GF_DoDemoSequence(gf_cmd.param);
+            break;
+
+        case GF_NOOP:
+        case GF_LEVEL_COMPLETE:
+            gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            break;
+
+        case GF_EXIT_TO_TITLE:
+            if (Shell_GetArgs()->startup.level_request.path != nullptr) {
+                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
+            } else if (g_GameFlow.title_level == nullptr) {
+                Shell_ExitSystem("Missing title level");
+            } else {
+                gf_cmd = GF_RunTitle();
+            }
+            break;
+
+        case GF_EXIT_GAME:
+        case GF_SWITCH_MOD:
+            loop_continue = false;
+            break;
+
+        default:
+            ASSERT_FAIL_FMT(
+                "invalid action (action=%s, param=%d)",
+                ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action), gf_cmd.param);
+        }
+    }
+
+    if (GF_GetCurrentLevel() != nullptr) {
+        Level_Unload();
+    }
+    Game_SetCurrentLevel(nullptr);
+    GF_SetCurrentLevel(nullptr);
 }

--- a/src/trx/game/game_strings/entries.c
+++ b/src/trx/game/game_strings/entries.c
@@ -1,6 +1,7 @@
 #include <trx/game/game_strings/entries.h>
 
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 
 #include <uthash.h>
 
@@ -17,14 +18,10 @@ typedef struct {
 
 static M_STRING_ENTRY *m_StringTable = nullptr;
 
-void GameString_Init(void)
-{
-#include <trx/game/game_strings/entries.def>
-}
-
-void GameString_Shutdown(void)
+void GameString_Reset(void)
 {
     GameString_Clear();
+#include <trx/game/game_strings/entries.def>
 }
 
 void GameString_Define(const char *const key, const char *value)
@@ -78,3 +75,5 @@ void GameString_Clear(void)
         Memory_Free(entry);
     }
 }
+
+REGISTER_SUBSYSTEM(.init = GameString_Reset, .shutdown = GameString_Clear)

--- a/src/trx/game/game_strings/entries.h
+++ b/src/trx/game/game_strings/entries.h
@@ -16,12 +16,9 @@
 
 typedef const char *GAME_STRING_ID;
 
-// Initialize the GameString subsystem.
-// Must be called before any GameString_* functions.
-void GameString_Init(void);
-
-// Shutdown the GameString subsystem and free all associated resources.
-void GameString_Shutdown(void);
+// The strings as the build defines them, dropping anything a language file laid
+// over them.
+void GameString_Reset(void);
 
 // Define a new game string mapping.
 // @param key   Identifier for the string (e.g. "GAME_OVER").

--- a/src/trx/game/game_strings/manager.c
+++ b/src/trx/game/game_strings/manager.c
@@ -1,5 +1,6 @@
 #include <trx/game/game_strings/manager.h>
 
+#include <trx/config.h>
 #include <trx/core/filesystem.h>
 #include <trx/core/json.h>
 #include <trx/core/memory.h>
@@ -10,6 +11,7 @@
 #include <trx/debug.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/game_strings/table.h>
+#include <trx/game/shell.h>
 
 #include <string.h>
 
@@ -223,8 +225,7 @@ static void M_Shutdown(void)
 }
 
 // Clear all previously set source strings files.
-// Must be called before GameStringManager_AddSourceFile.
-void GameStringManager_ClearSourceFiles(void)
+static void M_ClearSourceFiles(void)
 {
     M_ClearManager();
     m_SourceFiles = Vector_Create(sizeof(M_FILE_ENTRY));
@@ -233,8 +234,7 @@ void GameStringManager_ClearSourceFiles(void)
 // Add a source strings file for language discovery and loading.
 // base_path: path to a base strings JSON5 file.
 // load_levels: true to load level entries from this source; false otherwise.
-void GameStringManager_AddSourceFile(
-    const char *const base_path, const bool load_levels)
+static void M_AddSourceFile(const char *const base_path, const bool load_levels)
 {
     ASSERT(m_SourceFiles != nullptr);
     if (base_path == nullptr) {
@@ -247,7 +247,7 @@ void GameStringManager_AddSourceFile(
     Vector_Add(m_SourceFiles, &fe);
 }
 
-void GameStringManager_DiscoverLanguages(void)
+static void M_DiscoverLanguages(void)
 {
     if (m_SourceFiles == nullptr) {
         return;
@@ -303,6 +303,38 @@ void GameStringManager_DiscoverLanguages(void)
 
     M_LoadLanguageNames();
     M_ReorderLanguages();
+}
+
+void GameStringManager_LoadForMod(const SHELL_MOD *const mod)
+{
+    M_ClearSourceFiles();
+
+    const char *const common_strings_path = Shell_GetCommonStringsPath();
+    if (common_strings_path == nullptr) {
+        Shell_ExitSystem("Missing common strings file");
+    }
+    M_AddSourceFile(common_strings_path, false);
+
+    if (mod->base_mod != nullptr) {
+        char *base_strings_path = Shell_GetBaseGameStringsPath(mod);
+        if (base_strings_path == nullptr) {
+            Shell_ExitSystemFmt(
+                "Missing base mod strings file for '%s'", mod->name);
+        }
+        M_AddSourceFile(base_strings_path, false);
+        Memory_FreePointer(&base_strings_path);
+    }
+
+    char *mod_strings_path = Shell_GetGameStringsPath(mod);
+    if (mod_strings_path == nullptr) {
+        Shell_ExitSystemFmt(
+            "Missing strings file for selected mod '%s'", mod->name);
+    }
+    M_AddSourceFile(mod_strings_path, true);
+    Memory_FreePointer(&mod_strings_path);
+
+    M_DiscoverLanguages();
+    GameStringManager_ReloadLanguage(g_Config.language);
 }
 
 VECTOR *GameStringManager_GetAvailableLanguages(void)

--- a/src/trx/game/game_strings/manager.c
+++ b/src/trx/game/game_strings/manager.c
@@ -4,6 +4,7 @@
 #include <trx/core/json.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
@@ -204,14 +205,14 @@ static bool M_ReloadLangRec(const char *const lang, VECTOR *const visited)
     return true;
 }
 
-void GameStringManager_Init(void)
+static void M_Init(void)
 {
     m_EventManager = EventManager_Create();
     M_ClearManager();
     m_SourceFiles = Vector_Create(sizeof(M_FILE_ENTRY));
 }
 
-void GameStringManager_Shutdown(void)
+static void M_Shutdown(void)
 {
     if (m_EventManager != nullptr) {
         EventManager_Free(m_EventManager);
@@ -368,3 +369,5 @@ void GameStringManager_UnsubscribeReload(const int32_t listener_id)
         EventManager_Unsubscribe(m_EventManager, listener_id);
     }
 }
+
+REGISTER_BASE_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/game_strings/manager.h
+++ b/src/trx/game/game_strings/manager.h
@@ -4,19 +4,12 @@
 
 #include <trx/core/event_manager.h>
 #include <trx/core/vector.h>
+#include <trx/game/shell/mod.h>
 
-// Clear all previously set source strings files.
-// Must be called before GameStringManager_AddSourceFile.
-void GameStringManager_ClearSourceFiles(void);
-
-// Add a source strings file for language discovery and loading.
-// base_path: path to a base strings JSON5 file (e.g. cfg/common_strings.json5).
-// load_levels: true to load level names from this source; false otherwise.
-void GameStringManager_AddSourceFile(const char *base_path, bool load_levels);
-
-// Discover all available languages from the added source files.
-// Must be called after AddSourceFile calls and before ReloadLanguage.
-void GameStringManager_DiscoverLanguages(void);
+// Point the manager at the files the given mod takes its strings from - the
+// common file, the base mod's where it has one, and the mod's own - and load
+// the configured language.
+void GameStringManager_LoadForMod(const SHELL_MOD *mod);
 
 // Returns a vector of char* of available language codes discovered.
 // Caller owns the returned VECTOR and must free it via Vector_Free and free

--- a/src/trx/game/game_strings/manager.h
+++ b/src/trx/game/game_strings/manager.h
@@ -5,12 +5,6 @@
 #include <trx/core/event_manager.h>
 #include <trx/core/vector.h>
 
-// Initialize the string bundle manager.
-void GameStringManager_Init(void);
-
-// Shutdown the string bundle manager.
-void GameStringManager_Shutdown(void);
-
 // Clear all previously set source strings files.
 // Must be called before GameStringManager_AddSourceFile.
 void GameStringManager_ClearSourceFiles(void);

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -52,7 +52,7 @@ static const LARA_TRX_STATE m_CrawlStates[] = {
     LS_CRAWL_TURN_LEFT,
     LS_CRAWL_TURN_RIGHT,
     LS_CRAWL_TO_CLIMB,
-    LS_INVALID, // sentinel
+    LS_TRX_INVALID, // sentinel
     // clang-format on
 };
 

--- a/src/trx/game/gun/vars.c
+++ b/src/trx/game/gun/vars.c
@@ -3,9 +3,11 @@
 #include <trx/core/enum_map.h>
 #include <trx/core/json/util/file.h>
 #include <trx/core/log.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/catalog/manager.h>
 #include <trx/game/const.h>
 #include <trx/game/shell/common.h>
+#include <trx/game/shell/paths.h>
 
 #include <string.h>
 
@@ -88,8 +90,10 @@ static void M_ReadAmmoInfo(JSON_OBJECT *const obj, const int32_t type)
     ammo->infinite = JSON_ObjectGetBool(ammo_obj, "infinite", ammo->infinite);
 }
 
-void Gun_LoadVars(const char *const path)
+static void M_Load(void)
 {
+    const char *const path =
+        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "weapons.json5");
 #define L_READ_ANGLE(name, target)                                             \
     target = JSON_ObjectGetInt(obj, name, target) * DEG_1;
 #define L_READ_DIST(name, target)                                              \
@@ -211,3 +215,5 @@ void Gun_LoadVars(const char *const path)
 #undef L_READ_DIST
 #undef L_READ_INT
 }
+
+REGISTER_SUBSYSTEM(.load = M_Load)

--- a/src/trx/game/gun/vars.h
+++ b/src/trx/game/gun/vars.h
@@ -4,5 +4,3 @@
 #include <trx/game/lara/enum.h>
 
 extern WEAPON_INFO g_Weapons[NUM_WEAPONS];
-
-void Gun_LoadVars(const char *path);

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/config/section.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/const.h>
@@ -55,6 +56,11 @@ static M_PRIV m_Priv = M_PRIV_INITIAL;
 // reset whenever a course starts.
 static GYM_TRACK_STATS m_AssaultStats = {};
 static GYM_TRACK_STATS m_RacetrackStats = {};
+
+static void M_Shutdown(void)
+{
+    m_Priv = (M_PRIV)M_PRIV_INITIAL;
+}
 
 static int32_t M_CountAssaultTargets(void)
 {
@@ -328,11 +334,6 @@ static void M_SaveRacetrackSection(JSON_OBJECT *const obj)
     if (Gym_TrackManager_HasStats(GYM_TRACK_QUAD)) {
         M_SaveStats(obj, &m_RacetrackStats);
     }
-}
-
-void Gym_Shutdown(void)
-{
-    m_Priv = (M_PRIV)M_PRIV_INITIAL;
 }
 
 void Gym_SetInventoryOpenEnabled(const bool enabled)
@@ -724,3 +725,5 @@ REGISTER_CONFIG_SECTION(
 REGISTER_CONFIG_SECTION(
         .key = "racetrack_stats", .load = M_LoadRacetrackSection,
         .save = M_SaveRacetrackSection)
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/gym.h
+++ b/src/trx/game/gym.h
@@ -14,10 +14,6 @@ typedef enum {
     GYM_TRACK_NUMBER_OF
 } GYM_TRACK_TYPE;
 
-// Drops the state gathered over a play session. The gym holds nothing that
-// should outlive it, and switching mods restarts the shell in place.
-void Gym_Shutdown(void);
-
 void Gym_SetInventoryOpenEnabled(bool enabled);
 bool Gym_IsInventoryOpenEnabled(void);
 

--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -4,6 +4,7 @@
 #include <trx/config/section.h>
 #include <trx/core/enum_map.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/clock.h>
 #include <trx/game/game_strings/entries.h>
@@ -253,6 +254,41 @@ static void M_SaveSection(JSON_OBJECT *const input_obj)
     }
 }
 
+static void M_Load(void)
+{
+    for (int32_t i = 0; m_HoldChecks[i].role != (INPUT_ROLE)-1; i++) {
+        m_HoldChecks[i].delay_timer.type = CLOCK_TIMER_REAL;
+        m_HoldChecks[i].repeat_timer.type = CLOCK_TIMER_REAL;
+    }
+    Input_Reset();
+    for (INPUT_BACKEND backend = 0; backend < INPUT_BACKEND_NUMBER_OF;
+         backend++) {
+        const INPUT_BACKEND_IMPL *const impl = Input_GetBackendImpl(backend);
+        if (impl->init != nullptr) {
+            impl->init();
+        }
+    }
+}
+
+static void M_ApplyConfig(void)
+{
+    // Devices are acquired only now: the backends come up before the config is
+    // read, so input.enable_controller still holds its default there.
+    Input_Discover();
+}
+
+static void M_Shutdown(void)
+{
+    Input_Reset();
+    for (INPUT_BACKEND backend = 0; backend < INPUT_BACKEND_NUMBER_OF;
+         backend++) {
+        const INPUT_BACKEND_IMPL *const impl = Input_GetBackendImpl(backend);
+        if (impl->shutdown != nullptr) {
+            impl->shutdown();
+        }
+    }
+}
+
 const INPUT_BACKEND_IMPL *Input_GetBackendImpl(const INPUT_BACKEND backend)
 {
     switch (backend) {
@@ -278,34 +314,6 @@ void Input_Reset(void)
         hold_check->state = HOLD_INACTIVE;
         ClockTimer_Sync(&hold_check->delay_timer);
         ClockTimer_Sync(&hold_check->repeat_timer);
-    }
-}
-
-void Input_Init(void)
-{
-    for (int32_t i = 0; m_HoldChecks[i].role != (INPUT_ROLE)-1; i++) {
-        m_HoldChecks[i].delay_timer.type = CLOCK_TIMER_REAL;
-        m_HoldChecks[i].repeat_timer.type = CLOCK_TIMER_REAL;
-    }
-    Input_Reset();
-    for (INPUT_BACKEND backend = 0; backend < INPUT_BACKEND_NUMBER_OF;
-         backend++) {
-        const INPUT_BACKEND_IMPL *const impl = Input_GetBackendImpl(backend);
-        if (impl->init != nullptr) {
-            impl->init();
-        }
-    }
-}
-
-void Input_Shutdown(void)
-{
-    Input_Reset();
-    for (INPUT_BACKEND backend = 0; backend < INPUT_BACKEND_NUMBER_OF;
-         backend++) {
-        const INPUT_BACKEND_IMPL *const impl = Input_GetBackendImpl(backend);
-        if (impl->shutdown != nullptr) {
-            impl->shutdown();
-        }
     }
 }
 
@@ -680,3 +688,6 @@ void InputState_ClearRole(INPUT_STATE *const state, const INPUT_ROLE role)
 
 REGISTER_CONFIG_SECTION(
         .key = "input", .load = M_LoadSection, .save = M_SaveSection)
+
+REGISTER_SUBSYSTEM(
+        .load = M_Load, .apply_config = M_ApplyConfig, .shutdown = M_Shutdown)

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -24,8 +24,6 @@ extern INPUT_STATE g_Input;
 extern INPUT_STATE g_InputDB;
 extern INPUT_STATE g_OldInputDB;
 
-void Input_Init(void);
-void Input_Shutdown(void);
 void Input_Update(void);
 
 // Reconciles the connected devices with the current configuration: enabled

--- a/src/trx/game/inventory_ring/vars.c
+++ b/src/trx/game/inventory_ring/vars.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/json/util/file.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/catalog/manager.h>
 #include <trx/game/shell.h>
@@ -11,24 +12,28 @@ CAMERA_INFO g_InvRing_OldCamera = {};
 VECTOR *g_InvRing_Items = nullptr;
 INV_RING_SOURCE g_InvRing_Source[RT_NUMBER_OF] = {};
 
-__attribute__((constructor)) static void M_Init(void)
+static void M_Init(void)
 {
     g_InvRing_Items = Vector_Create(sizeof(INVENTORY_ITEM *));
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
-    for (int32_t i = 0; i < g_InvRing_Items->count; i++) {
-        INVENTORY_ITEM *const item =
-            *(INVENTORY_ITEM **)Vector_Get(g_InvRing_Items, i);
-        Memory_Free(item);
+    if (g_InvRing_Items != nullptr) {
+        for (int32_t i = 0; i < g_InvRing_Items->count; i++) {
+            INVENTORY_ITEM *const item =
+                *(INVENTORY_ITEM **)Vector_Get(g_InvRing_Items, i);
+            Memory_Free(item);
+        }
+        Vector_Free(g_InvRing_Items);
+        g_InvRing_Items = nullptr;
     }
-    Vector_Free(g_InvRing_Items);
-    g_InvRing_Items = nullptr;
 }
 
-void InvRing_LoadVars(const char *const path)
+static void M_Load(void)
 {
+    const char *const path =
+        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "inv_ring.json5");
 #define L_READ_INT(key, target) target = JSON_ObjectGetInt(obj, key, target);
 
     for (int32_t i = 0; i < g_InvRing_Items->count; i++) {
@@ -85,3 +90,5 @@ void InvRing_LoadVars(const char *const path)
     JSON_ValueFree(root);
 #undef L_READ_INT
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init, .load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/game/inventory_ring/vars.h
+++ b/src/trx/game/inventory_ring/vars.h
@@ -11,5 +11,3 @@ extern INVENTORY_MODE g_InvRing_Mode;
 extern CAMERA_INFO g_InvRing_OldCamera;
 extern INV_RING_SOURCE g_InvRing_Source[RT_NUMBER_OF];
 extern VECTOR *g_InvRing_Items;
-
-void InvRing_LoadVars(const char *path);

--- a/src/trx/game/items/walkable.c
+++ b/src/trx/game/items/walkable.c
@@ -1,6 +1,7 @@
 #include <trx/game/items/walkable.h>
 
 #include <trx/core/log.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/items.h>
@@ -24,6 +25,12 @@ typedef struct {
 
 static M_SETUP *m_Setup = nullptr;
 static int32_t m_SetupCount = 0;
+
+static void M_Shutdown(void)
+{
+    m_Setup = nullptr;
+    m_SetupCount = 0;
+}
 
 static SECTOR *M_GetItemPitSector(const XYZ_32 pos, int16_t room_num)
 {
@@ -238,8 +245,4 @@ void Walkable_ResetLevel(void)
     }
 }
 
-void Walkable_Shutdown(void)
-{
-    m_Setup = nullptr;
-    m_SetupCount = 0;
-}
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/items/walkable.h
+++ b/src/trx/game/items/walkable.h
@@ -10,6 +10,5 @@ void Walkable_Add(int16_t item_num, XYZ_32 pos);
 void Walkable_Remove(int16_t item_num);
 void Walkable_Reset(void);
 void Walkable_ResetLevel(void);
-void Walkable_Shutdown(void);
 void Walkable_Reposition(
     int16_t item_num, GAME_VECTOR start, GAME_VECTOR target);

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/core/math/geom.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/game.h>
@@ -513,7 +514,7 @@ static void M_ResetJoints(void)
     }
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     Memory_FreePointer(&m_Joints.scratch.pos);
     Memory_FreePointer(&m_Joints.scratch.normal);
@@ -992,3 +993,5 @@ HAIR_SEGMENT *Lara_Hair_GetSegment(
     ASSERT(segment_idx >= 0 && segment_idx < M_HAIR_SEGMENTS);
     return &m_HairSegments[braid_idx][segment_idx];
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/lara/pose.c
+++ b/src/trx/game/lara/pose.c
@@ -5,6 +5,7 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow.h>
@@ -76,6 +77,9 @@ static bool M_LoadPosesArray(JSON_READ_IO *const io, VECTOR *const poses)
 
 static void M_LoadPoses(void)
 {
+    if (m_Poses != nullptr) {
+        return;
+    }
     m_Poses = Vector_Create(sizeof(LARA_POSE));
     ASSERT(m_Poses != nullptr);
 
@@ -97,14 +101,7 @@ static void M_LoadPoses(void)
     JSON_ValueFree(doc);
 }
 
-void Lara_Pose_Init(void)
-{
-    if (m_Poses == nullptr) {
-        M_LoadPoses();
-    }
-}
-
-void Lara_Pose_Shutdown(void)
+static void M_Shutdown(void)
 {
     if (m_Poses != nullptr) {
         Vector_Free(m_Poses);
@@ -162,3 +159,5 @@ void Lara_Pose_SetOverride(const LARA_POSE *const pose)
         m_Override = *pose;
     }
 }
+
+REGISTER_SUBSYSTEM(.load = M_LoadPoses, .shutdown = M_Shutdown)

--- a/src/trx/game/lara/pose.h
+++ b/src/trx/game/lara/pose.h
@@ -8,9 +8,6 @@ typedef struct {
     XYZ_16 rots[LM_NUMBER_OF];
 } LARA_POSE;
 
-void Lara_Pose_Init();
-void Lara_Pose_Shutdown();
-
 bool Lara_Pose_IsAvailable(void);
 void Lara_Pose_Clear(void);
 void Lara_Pose_Cycle(int32_t dir);

--- a/src/trx/game/lara/skin/joints.c
+++ b/src/trx/game/lara/skin/joints.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/math/geom.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/skin/seam.h>
@@ -136,7 +137,7 @@ static void M_Reset(void)
     m_State = (M_STATE) {};
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     M_Reset();
 }
@@ -303,3 +304,5 @@ void Lara_Joints_Draw(
         Output_DrawObjectMesh(mesh, clip);
     }
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -8,6 +8,7 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/catalog/manager.h>
@@ -443,29 +444,20 @@ static bool M_LoadFile(JSON_READ_IO *const io)
     JSON_FINISH();
 }
 
-LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
+static void M_Shutdown(void)
 {
-    if (name == nullptr) {
-        return LARA_SKIN_TYPE_DEFAULT;
+    if (m_GunMaps != nullptr) {
+        Vector_Free(m_GunMaps);
+        m_GunMaps = nullptr;
     }
 
-    M_OUTFIT_LOOKUP *entry = nullptr;
-    HASH_FIND_STR(m_OutfitLookup, name, entry);
-    if (entry == nullptr) {
-        return -1;
-    }
-
-    return entry->index;
+    M_ResetOutfits();
 }
 
-LARA_SKIN_TYPE Lara_Skin_GetDefaultType(void)
+static void M_Load(void)
 {
-    return m_OutfitCount > 0 ? 0 : LARA_SKIN_TYPE_DEFAULT;
-}
-
-void Lara_Skin_LoadFromFile(const char *const path)
-{
-    char *source_path = Memory_DupStr(path);
+    char *source_path = Memory_DupStr(
+        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "outfits.json5"));
     JSON_READ_IO *io = nullptr;
 
     if (m_GunMaps != nullptr) {
@@ -503,14 +495,24 @@ cleanup:
     Memory_FreePointer(&source_path);
 }
 
-void Lara_Skin_Shutdown(void)
+LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
 {
-    if (m_GunMaps != nullptr) {
-        Vector_Free(m_GunMaps);
-        m_GunMaps = nullptr;
+    if (name == nullptr) {
+        return LARA_SKIN_TYPE_DEFAULT;
     }
 
-    M_ResetOutfits();
+    M_OUTFIT_LOOKUP *entry = nullptr;
+    HASH_FIND_STR(m_OutfitLookup, name, entry);
+    if (entry == nullptr) {
+        return -1;
+    }
+
+    return entry->index;
+}
+
+LARA_SKIN_TYPE Lara_Skin_GetDefaultType(void)
+{
+    return m_OutfitCount > 0 ? 0 : LARA_SKIN_TYPE_DEFAULT;
 }
 
 int32_t Lara_Skin_GetOutfitCount(void)
@@ -543,3 +545,5 @@ int32_t Lara_Skin_GetExtraMeshOffset(const LARA_SKIN_EXTRA_MESH mesh)
     ASSERT(mesh >= 0 && mesh < NUM_EXTRA_MESHES);
     return m_ExtraMeshOffsets[mesh];
 }
+
+REGISTER_SUBSYSTEM(.load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/game/lara/skin/storage.h
+++ b/src/trx/game/lara/skin/storage.h
@@ -2,8 +2,6 @@
 
 #include <trx/game/lara/skin/types.h>
 
-void Lara_Skin_LoadFromFile(const char *path);
-void Lara_Skin_Shutdown(void);
 int32_t Lara_Skin_GetOutfitCount(void);
 bool Lara_Skin_IsOutfitAvailable(LARA_SKIN_TYPE skin_type);
 const LARA_SKIN_OUTFIT *Lara_Skin_GetOutfit(LARA_SKIN_TYPE skin_type);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -4,6 +4,7 @@
 #include <trx/config.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/game/const.h>
 #include <trx/game/game.h>
@@ -15,6 +16,7 @@
 #include <trx/game/music/backend_cdaudio_wad.h>
 #include <trx/game/music/backend_files.h>
 #include <trx/game/rules.h>
+#include <trx/game/shell/common.h>
 #include <trx/game/shell/paths.h>
 #include <trx/version.h>
 
@@ -326,6 +328,28 @@ static bool M_IsSpeechTrack(const MUSIC_ID track_id)
     }
 }
 
+static void M_Shutdown(void)
+{
+    m_Initialised = false;
+    M_StopMainStream();
+    M_StopOverlayStreams();
+    M_ResetStreamState();
+    if (m_Backend != nullptr) {
+        m_Backend->shutdown(m_Backend);
+        m_Backend = nullptr;
+    }
+    Audio_Shutdown();
+}
+
+static void M_ApplyConfig(void)
+{
+    if (Shell_GetArgs()->headless) {
+        return;
+    }
+    Music_Init();
+    Music_SetVolume(g_Config.audio.music_volume);
+}
+
 bool Music_Init(void)
 {
     m_Initialised = true;
@@ -350,19 +374,6 @@ finish:
     m_TrackLastLooped = MX_INACTIVE;
     M_ResetStreamState();
     return Audio_Init();
-}
-
-void Music_Shutdown(void)
-{
-    m_Initialised = false;
-    M_StopMainStream();
-    M_StopOverlayStreams();
-    M_ResetStreamState();
-    if (m_Backend != nullptr) {
-        m_Backend->shutdown(m_Backend);
-        m_Backend = nullptr;
-    }
-    Audio_Shutdown();
 }
 
 // Returns the stream slot the track plays in - the main stream is slot 0, the
@@ -807,3 +818,5 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
         Music_Play_Direct(track_id, play_mode);
     }
 }
+
+REGISTER_SUBSYSTEM(.apply_config = M_ApplyConfig, .shutdown = M_Shutdown)

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -15,7 +15,6 @@ typedef struct {
 } MUSIC_STREAM_STATE;
 
 bool Music_Init(void);
-void Music_Shutdown(void);
 
 // Stops playing current track and plays a single track.
 //

--- a/src/trx/game/objects/names.c
+++ b/src/trx/game/objects/names.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/memory.h>
 #include <trx/core/strings/fuzzy_match.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_strings/entries.h>
@@ -92,7 +93,7 @@ static void M_ClearAllNames(void)
     }
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     M_ClearAllNames();
 }
@@ -282,3 +283,5 @@ OBJECT_ID Object_IdFromKey(const char *const key)
     }
     return NO_OBJECT;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -4,6 +4,7 @@
 #include <trx/core/json/util/value.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/items.h>
 #include <trx/game/objects.h>
@@ -38,7 +39,7 @@ static void M_FreeSet(OBJECT_PROPERTY_SET *const set)
     set->count = 0;
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     for (int32_t i = O_FIRST; i < O_NUMBER_OF; i++) {
         ObjectProperty_ResetObject(Object_Get(i));
@@ -418,3 +419,5 @@ fail:
     JSON_POP(io);
     return false;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/option/common.c
+++ b/src/trx/game/option/common.c
@@ -1,5 +1,6 @@
 #include <trx/game/option/common.h>
 
+#include <trx/core/subsystem.h>
 #include <trx/game/input.h>
 #include <trx/game/objects.h>
 #include <trx/game/option/controls.h>
@@ -13,18 +14,18 @@
 #include <trx/game/option/stats.h>
 #include <trx/version.h>
 
-void Option_Reset(void)
-{
-    Option_Shutdown();
-}
-
-void Option_Shutdown(void)
+static void M_Shutdown(void)
 {
     Option_Gameplay_Shutdown();
     Option_Graphics_Shutdown();
     Option_Sound_Shutdown();
     Option_Controls_Shutdown();
     Option_GlobeSelect_Shutdown();
+}
+
+void Option_Reset(void)
+{
+    M_Shutdown();
 }
 
 void Option_Control(INVENTORY_ITEM *const inv_item, const bool is_busy)
@@ -179,3 +180,5 @@ void Option_Close(const INVENTORY_ITEM *const inv_item)
         break;
     }
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/option/common.h
+++ b/src/trx/game/option/common.h
@@ -8,6 +8,3 @@ void Option_Close(const INVENTORY_ITEM *inv_item);
 
 // Reset internal positioning of option UIs.
 void Option_Reset(void);
-
-// Free up resources associated with option UIs.
-void Option_Shutdown(void);

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -1,6 +1,7 @@
 #include <trx/game/output/common.h>
 
 #include <trx/config.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/level.h>
 #include <trx/game/output/binocular_mask.h>
 #include <trx/game/output/func.h>
@@ -31,34 +32,7 @@ static OUTPUT_UNIFORMS *m_Uniforms = nullptr;
 static OUTPUT_MESH_SHADER *m_ShaderWorld = nullptr;
 static OUTPUT_UI_SHADER *m_ShaderUI = nullptr;
 
-void Output_Init(void)
-{
-    SceneCompositor_Init();
-    Output_Textures_Init();
-
-    m_Uniforms = Output_Uniforms_Create();
-    m_ShaderWorld = Output_MeshShader_Create();
-    m_ShaderUI = Output_UIShader_Create();
-    m_Batcher = MeshBatcher_Create();
-    OutputSource_Sky_Init();
-    SceneCompositor_AddSource(MeshBatcher_AsSource(m_Batcher));
-    OutputSource_Rooms_Init(m_Batcher);
-    OutputSource_RoomsDebug_Init();
-    OutputSource_Objects_Init(m_Batcher);
-    OutputSource_Sprites_Init(m_Batcher);
-    OutputSource_Lightnings_Init();
-    OutputSource_PolyFX_Init();
-    OutputSource_Shadows_Init(m_Batcher);
-    OutputSource_Misc_Init();
-    OutputSource_Overlay_Init();
-
-    Output_Lights_Init();
-    OutputSource_UI_Init();
-
-    Output_ApplyRenderSettings();
-}
-
-void Output_Shutdown(void)
+static void M_Shutdown(void)
 {
     SceneCompositor_Shutdown();
     OutputSource_Rooms_Shutdown();
@@ -92,6 +66,33 @@ void Output_Shutdown(void)
 
     Output_Textures_Shutdown();
     Output_Lights_Shutdown();
+}
+
+void Output_Init(void)
+{
+    SceneCompositor_Init();
+    Output_Textures_Init();
+
+    m_Uniforms = Output_Uniforms_Create();
+    m_ShaderWorld = Output_MeshShader_Create();
+    m_ShaderUI = Output_UIShader_Create();
+    m_Batcher = MeshBatcher_Create();
+    OutputSource_Sky_Init();
+    SceneCompositor_AddSource(MeshBatcher_AsSource(m_Batcher));
+    OutputSource_Rooms_Init(m_Batcher);
+    OutputSource_RoomsDebug_Init();
+    OutputSource_Objects_Init(m_Batcher);
+    OutputSource_Sprites_Init(m_Batcher);
+    OutputSource_Lightnings_Init();
+    OutputSource_PolyFX_Init();
+    OutputSource_Shadows_Init(m_Batcher);
+    OutputSource_Misc_Init();
+    OutputSource_Overlay_Init();
+
+    Output_Lights_Init();
+    OutputSource_UI_Init();
+
+    Output_ApplyRenderSettings();
 }
 
 bool Output_IsHeadless(void)
@@ -232,3 +233,5 @@ void Output_DispatchObjectMeshGeometry(
     OutputSource_Objects_ObserveObjectMeshGeometry(
         mesh_idx, positions, normals);
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/output/common.h
+++ b/src/trx/game/output/common.h
@@ -8,7 +8,6 @@
 #include <trx/game/viewport.h>
 
 void Output_Init(void);
-void Output_Shutdown(void);
 bool Output_IsHeadless(void);
 
 const OUTPUT_UNIFORMS *Output_GetUniforms(void);

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -644,7 +644,7 @@ void Output_Textures_Shutdown(void)
         m_Priv.tex_env_map = 0;
     }
 
-    // These are GameBuf-backed and become invalid once GameBuf_Shutdown runs.
+    // These are GameBuf-backed and become invalid once its arenas are freed.
     m_TexturePageCount = 0;
     m_TexturePages8 = nullptr;
     m_TexturePages32 = nullptr;

--- a/src/trx/game/overlay.c
+++ b/src/trx/game/overlay.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/camera.h>
 #include <trx/game/const.h>
 #include <trx/game/game.h>
@@ -454,14 +455,14 @@ static void M_AnimatePickups(const int32_t frames)
     }
 }
 
-void Overlay_Init(void)
+static void M_Init(void)
 {
     if (m_UI == nullptr) {
         m_UI = UI_Overlay_Init();
     }
 }
 
-void Overlay_Shutdown(void)
+static void M_Shutdown(void)
 {
     if (m_UI != nullptr) {
         UI_Overlay_Free(m_UI);
@@ -625,3 +626,5 @@ void Overlay_AddDisplayPickup(const OBJECT_ID obj_id)
         return;
     }
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/overlay.h
+++ b/src/trx/game/overlay.h
@@ -5,9 +5,6 @@
 
 typedef UI_OVERLAY_TEXT OVERLAY_TEXT;
 
-void Overlay_Init(void);
-void Overlay_Shutdown(void);
-
 void Overlay_Reset(void);
 void Overlay_Control(void);
 void Overlay_Animate(int32_t num_frames);

--- a/src/trx/game/random.c
+++ b/src/trx/game/random.c
@@ -1,6 +1,7 @@
 #include <trx/game/random.h>
 
 #include <trx/core/log.h>
+#include <trx/core/subsystem.h>
 
 #include <time.h>
 
@@ -8,7 +9,7 @@ static uint32_t m_RandControl = 0xD371F947U;
 static uint32_t m_RandDraw = 0xD371F947U;
 static bool m_IsDrawFrozen = false;
 
-void Random_Seed(void)
+static void M_Init(void)
 {
     time_t lt = time(0);
     struct tm *tptr = localtime(&lt);
@@ -59,3 +60,5 @@ void Random_FreezeDraw(bool is_frozen)
 {
     m_IsDrawFrozen = is_frozen;
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init)

--- a/src/trx/game/random.h
+++ b/src/trx/game/random.h
@@ -5,7 +5,6 @@
 // How wide one draw is: a draw returns 0 to RANDOM_SPAN - 1.
 #define RANDOM_SPAN 0x8000
 
-void Random_Seed(void);
 void Random_SeedControl(int32_t seed);
 void Random_SeedDraw(int32_t seed);
 

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -1,6 +1,7 @@
 #include <trx/game/rooms/common.h>
 
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
@@ -37,6 +38,23 @@ static int32_t m_OutsideGridX = 0;
 static int32_t m_OutsideGridZ = 0;
 static int32_t m_OutsideOriginCellX = 0;
 static int32_t m_OutsideOriginCellZ = 0;
+
+static void M_Shutdown(void)
+{
+    m_RoomCount = 0;
+    m_Rooms = nullptr;
+    m_FlipStatus = false;
+    m_FlipEffect = -1;
+    m_FlipTimer = 0;
+    memset(m_FlipSlots, 0, sizeof(m_FlipSlots));
+
+    m_OutsideRoomTable = nullptr;
+    m_OutsideRoomOffsets = nullptr;
+    m_OutsideGridX = 0;
+    m_OutsideGridZ = 0;
+    m_OutsideOriginCellX = 0;
+    m_OutsideOriginCellZ = 0;
+}
 
 static void M_AddFlipItems(const ROOM *const room)
 {
@@ -90,23 +108,6 @@ void Room_InitialiseRooms(const int32_t num_rooms)
     m_Rooms = num_rooms == 0
         ? nullptr
         : GameBuf_Alloc(sizeof(ROOM) * num_rooms, GBUF_ROOMS);
-
-    m_OutsideRoomTable = nullptr;
-    m_OutsideRoomOffsets = nullptr;
-    m_OutsideGridX = 0;
-    m_OutsideGridZ = 0;
-    m_OutsideOriginCellX = 0;
-    m_OutsideOriginCellZ = 0;
-}
-
-void Room_Shutdown(void)
-{
-    m_RoomCount = 0;
-    m_Rooms = nullptr;
-    m_FlipStatus = false;
-    m_FlipEffect = -1;
-    m_FlipTimer = 0;
-    memset(m_FlipSlots, 0, sizeof(m_FlipSlots));
 
     m_OutsideRoomTable = nullptr;
     m_OutsideRoomOffsets = nullptr;
@@ -747,3 +748,5 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
 
     return true;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -5,7 +5,6 @@
 #include <trx/game/rooms/types.h>
 
 void Room_InitialiseRooms(int32_t num_rooms);
-void Room_Shutdown(void);
 int32_t Room_GetCount(void);
 ROOM *Room_Get(int32_t room_num);
 

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -1,4 +1,5 @@
 #include <trx/config.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/game/camera.h>
@@ -426,7 +427,7 @@ static void M_DrawSingleRoom(const ROOM *const room)
     bind->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     Vector_Free(m_RoomsToDraw);
     m_RoomsToDraw = nullptr;
@@ -557,3 +558,5 @@ void Room_RemoveDrawnItem(const int16_t room_num, const int16_t item_num)
         M_DrawSet_Remove(&room->drawn_items, item_num);
     }
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -1,4 +1,5 @@
 #include <trx/config.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
@@ -48,6 +49,12 @@ static void M_LoadPostprocess(void)
     }
 }
 
+static void M_Shutdown(void)
+{
+    SG_Manager_Shutdown();
+    SG_Resume_Shutdown();
+}
+
 SAVEGAME_VERSION Savegame_GetInitialVersion(void)
 {
     return m_InitialVersion;
@@ -62,12 +69,6 @@ void Savegame_Init(void)
 {
     SG_Resume_Init();
     SG_Manager_Init();
-}
-
-void Savegame_Shutdown(void)
-{
-    SG_Manager_Shutdown();
-    SG_Resume_Shutdown();
 }
 
 bool Savegame_IsManualSaveAllowed(void)
@@ -183,3 +184,5 @@ bool Savegame_RestartAvailable(const SAVEGAME_SLOT_REF slot)
     const SAVEGAME_INFO *const savegame_info = SG_Manager_GetSavegameInfo(slot);
     return savegame_info->features.restart;
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/savegame/common.h
+++ b/src/trx/game/savegame/common.h
@@ -10,7 +10,6 @@
 // what actually sets Lara's health, creatures status, triggers, inventory etc.
 
 void Savegame_Init(void);
-void Savegame_Shutdown(void);
 
 SAVEGAME_VERSION Savegame_GetInitialVersion(void);
 void Savegame_SetInitialVersion(SAVEGAME_VERSION version);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -293,33 +293,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     GF_Init();
     GF_LoadFromFile(Shell_GetGameFlowPath(s->args->startup.mod));
 
-    GameStringManager_ClearSourceFiles();
-    const char *const common_strings_path = Shell_GetCommonStringsPath();
-    if (common_strings_path == nullptr) {
-        Shell_ExitSystem("Missing common strings file");
-    }
-    GameStringManager_AddSourceFile(common_strings_path, false);
-    if (s->args->startup.mod->base_mod != nullptr) {
-        char *base_strings_path =
-            Shell_GetBaseGameStringsPath(s->args->startup.mod);
-        if (base_strings_path == nullptr) {
-            Shell_ExitSystemFmt(
-                "Missing base mod strings file for '%s'",
-                s->args->startup.mod->name);
-        }
-        GameStringManager_AddSourceFile(base_strings_path, false);
-        Memory_FreePointer(&base_strings_path);
-    }
-    char *mod_strings_path = Shell_GetGameStringsPath(s->args->startup.mod);
-    if (mod_strings_path == nullptr) {
-        Shell_ExitSystemFmt(
-            "Missing strings file for selected mod '%s'",
-            s->args->startup.mod->name);
-    }
-    GameStringManager_AddSourceFile(mod_strings_path, true);
-    Memory_FreePointer(&mod_strings_path);
-    GameStringManager_DiscoverLanguages();
-    GameStringManager_ReloadLanguage(g_Config.language);
+    GameStringManager_LoadForMod(s->args->startup.mod);
 
     Savegame_Init();
     SG_Manager_ScanSavedGames();

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -1,52 +1,25 @@
 #include <trx/config.h>
-#include <trx/config/presets.h>
 #include <trx/config/registry.h>
 #include <trx/core/enum_map.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
-#include <trx/core/strings.h>
-#include <trx/core/utils.h>
+#include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/catalog/manager.h>
-#include <trx/game/clock.h>
-#include <trx/game/console.h>
-#include <trx/game/cutseq.h>
-#include <trx/game/demo.h>
-#include <trx/game/events.h>
-#include <trx/game/fmv.h>
 #include <trx/game/game.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/game_flow.h>
-#include <trx/game/game_strings/entries.h>
 #include <trx/game/game_strings/manager.h>
-#include <trx/game/gun.h>
-#include <trx/game/gym.h>
-#include <trx/game/input.h>
-#include <trx/game/input/backends/touch.h>
-#include <trx/game/inventory_ring.h>
-#include <trx/game/items/walkable.h>
-#include <trx/game/lara/pose.h>
-#include <trx/game/lara/skin.h>
 #include <trx/game/level.h>
 #include <trx/game/lua.h>
-#include <trx/game/music.h>
-#include <trx/game/objects.h>
-#include <trx/game/option.h>
 #include <trx/game/output.h>
-#include <trx/game/overlay.h>
-#include <trx/game/random.h>
 #include <trx/game/replay/test_recorder.h>
 #include <trx/game/replay/test_replay.h>
-#include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 #include <trx/game/shell.h>
 #include <trx/game/shell/platform.h>
 #include <trx/game/shell/session.h>
 #include <trx/game/shell/state.h>
-#include <trx/game/sound.h>
 #include <trx/game/stats.h>
-#include <trx/game/ui/settings.h>
-#include <trx/game/ui/touch_overlay.h>
 #include <trx/gl/context.h>
 #include <trx/version.h>
 
@@ -61,13 +34,9 @@ static char *m_PendingMod = nullptr;
 static bool m_PrevHeadless = false;
 static bool m_PrevQuiet = false;
 
-// The config module outlives a mod switch, which restarts the game in place, so
-// the subscription is given back rather than left to gather a copy per switch.
+// Given back before the config module goes down, so a mod switch does not
+// leave a copy behind.
 static int32_t m_ConfigListener = -1;
-
-// The presets are listed by the titles they show, so a new language reorders
-// them. Given back with the config subscription above, and for the same reason.
-static int32_t m_StringsListener = -1;
 
 static void M_CreateGameWindow(void)
 {
@@ -112,11 +81,6 @@ static void M_HandleConfigChange(const EVENT *const event, void *const data)
     Shell_HandleConfigChange(event->data);
 }
 
-static void M_HandleLanguageReload(const EVENT *const event, void *const data)
-{
-    Config_Presets_Sort();
-}
-
 static void M_SetupSDL(void)
 {
     SDL_version compiled;
@@ -158,18 +122,10 @@ static void M_InitModules(void)
     M_SetupSDL();
     M_SetupGL();
 
-    GameString_Init();
-    GameStringManager_Init();
-    m_StringsListener =
-        GameStringManager_SubscribeReload(M_HandleLanguageReload, nullptr);
-    UI_Init();
-    Overlay_Init();
-    GameEvent_Init();
+    // Some of the subsystems read the clock or the video state as they come
+    // up, so the platform stands first.
+    Subsystem_InitAll();
 
-    GameBuf_Init();
-    Random_Seed();
-
-    Clock_Init();
     LUA_Init();
 
     const SHELL_ARGS *const args = Shell_GetArgs();
@@ -185,10 +141,6 @@ static void M_ShutdownModules(void)
         Config_UnsubscribeChanges(m_ConfigListener);
         m_ConfigListener = -1;
     }
-    if (m_StringsListener >= 0) {
-        GameStringManager_UnsubscribeReload(m_StringsListener);
-        m_StringsListener = -1;
-    }
 
     if (TestReplay_IsOpened()) {
         TestReplay_Close();
@@ -197,33 +149,11 @@ static void M_ShutdownModules(void)
         TestRecorder_Close();
     }
 
-    Lara_Pose_Shutdown();
-    Lara_Skin_Shutdown();
-
-    CutSeq_Pak_Unload();
-    Console_Shutdown();
-    Savegame_Shutdown();
-    Gym_Shutdown();
-    Demo_Shutdown();
-
-    GF_Shutdown();
+    // The Lua bridges are subscribed to the modules they wrap and unsubscribe
+    // here, so the modules have to still be standing.
     LUA_Shutdown();
-    Overlay_Shutdown();
-    Option_Shutdown();
-    Output_Shutdown();
 
-    Input_Shutdown();
-    Music_Shutdown();
-    Sound_Shutdown();
-    UI_Shutdown();
-    GameEvent_Shutdown();
-
-    GameStringManager_Shutdown();
-    GameString_Shutdown();
-    Walkable_Shutdown();
-    Room_Shutdown();
-    GameBuf_Shutdown();
-    Catalog_Shutdown();
+    Subsystem_ShutdownAll();
 }
 
 static void M_PrepareSystem(void)
@@ -270,24 +200,15 @@ static void M_PrepareSystem(void)
 
     TRXPath_Init(s->args);
 
-    Input_Init();
-    Console_Init();
+    // The catalogs name the objects, samples and music the subsystem loads
+    // look themselves up in.
     M_LoadCatalog(CATALOG_OBJECTS, "catalog_objects.csv", false);
     M_LoadCatalog(CATALOG_MUSIC, "catalog_music.csv", false);
     M_LoadCatalog(CATALOG_SAMPLES, "catalog_samples.csv", true);
     M_LoadCatalog(CATALOG_LARA_STATES, "catalog_lara_states.csv", false);
     M_LoadCatalog(CATALOG_LARA_ANIMS, "catalog_lara_anims.csv", false);
     M_LoadCatalog(CATALOG_ITEM_ACTIONS, "catalog_item_actions.csv", false);
-    Lara_Pose_Init();
-    InvRing_LoadVars(
-        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "inv_ring.json5"));
-    Gun_LoadVars(
-        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "weapons.json5"));
-    UI_Settings_LoadFromFile(
-        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "ui.json5"));
-    Lara_Skin_LoadFromFile(
-        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "outfits.json5"));
-    Config_Presets_ScanFiles();
+    Subsystem_LoadAll();
 
     if (test_replay_path != nullptr) {
         TestReplay_Start();
@@ -308,28 +229,7 @@ static void M_PrepareSystem(void)
     }
     m_ConfigListener = Config_SubscribeChanges(M_HandleConfigChange, nullptr);
 
-    // Auto-enable touch controls on first run if touch hardware is present.
-    if (Config_IsFirstRun() && Touch_HasHardwareSupport()) {
-        CONFIG_SET(g_Config.input.enable_touch_controls, true);
-    }
-    TouchOverlay_SetVisible(g_Config.input.enable_touch_controls);
-
-    // Devices are acquired only now: Input_Init() runs before the config is
-    // read, so input.enable_controller still holds its default there.
-    Input_Discover();
-
-    Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
-    if (!s->args->headless) {
-        Sound_Init();
-        Music_Init();
-        Sound_SetMasterVolume(g_Config.audio.sound_volume);
-        Music_SetVolume(g_Config.audio.music_volume);
-    } else {
-        Clock_DisableWait();
-        const int32_t fps = s->args->headless_fps > 0 ? s->args->headless_fps
-                                                      : Clock_GetCurrentFPS();
-        Clock_EnableHeadlessFixedFPS(fps);
-    }
+    Subsystem_ApplyConfigAll();
 }
 
 void Shell_RequestModSwitch(const char *const mod_name)

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -309,7 +309,7 @@ static void M_PrepareSystem(void)
     m_ConfigListener = Config_SubscribeChanges(M_HandleConfigChange, nullptr);
 
     // Auto-enable touch controls on first run if touch hardware is present.
-    if (!Config_IsLoaded() && Touch_HasHardwareSupport()) {
+    if (Config_IsFirstRun() && Touch_HasHardwareSupport()) {
         CONFIG_SET(g_Config.input.enable_touch_controls, true);
     }
     TouchOverlay_SetVisible(g_Config.input.enable_touch_controls);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -1,15 +1,12 @@
 #include <trx/config.h>
 #include <trx/config/registry.h>
-#include <trx/core/enum_map.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/catalog/manager.h>
-#include <trx/game/game.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_strings/manager.h>
-#include <trx/game/level.h>
 #include <trx/game/lua.h>
 #include <trx/game/output.h>
 #include <trx/game/replay/test_recorder.h>
@@ -339,97 +336,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     }
 
     Stats_CalculateMaxStats();
-    GF_COMMAND gf_cmd = GF_DoFrontendSequence();
-
-    bool loop_continue = !Shell_IsExiting();
-    while (loop_continue) {
-        LOG_INFO(
-            "action=%s param=%d", ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action),
-            gf_cmd.param);
-
-        switch (gf_cmd.action) {
-        case GF_START_GAME:
-        case GF_SELECT_GAME: {
-            const int32_t level_num = gf_cmd.param;
-            const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
-            const GF_SEQUENCE_CONTEXT seq_ctx =
-                gf_cmd.action == GF_SELECT_GAME ? GFSC_SELECT : GFSC_NORMAL;
-            if (level != nullptr) {
-                gf_cmd = GF_DoLevelSequence(level, seq_ctx);
-            }
-            break;
-        }
-
-        case GF_GLOBE_SELECT:
-            gf_cmd = GF_RunGlobeSelect(nullptr);
-            break;
-
-        case GF_START_SAVED_GAME: {
-            const SAVEGAME_SLOT_REF slot =
-                SG_Manager_SlotFromParam(gf_cmd.param);
-            const int32_t level_num = SG_Manager_GetLevelNumber(slot);
-            if (level_num < 0) {
-                LOG_ERROR("Corrupt save file!");
-                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
-            } else {
-                SG_Manager_BindSlot(slot);
-                const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
-                gf_cmd = GF_DoLevelSequence(level, GFSC_SAVED);
-            }
-            break;
-        }
-
-        case GF_RESTART_GAME: {
-            const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, gf_cmd.param);
-            gf_cmd = GF_InterpretSequence(level, GFSC_RESTART, nullptr);
-            break;
-        }
-
-        case GF_STORY_SO_FAR:
-            gf_cmd =
-                GF_PlayAvailableStory(SG_Manager_SlotFromParam(gf_cmd.param));
-            break;
-
-        case GF_START_CINE:
-            gf_cmd = GF_DoCutsceneSequence(gf_cmd.param, false);
-            break;
-
-        case GF_START_DEMO:
-            gf_cmd = GF_DoDemoSequence(gf_cmd.param);
-            break;
-
-        case GF_NOOP:
-        case GF_LEVEL_COMPLETE:
-            gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
-            break;
-
-        case GF_EXIT_TO_TITLE:
-            if (s->args->startup.level_request.path != nullptr) {
-                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
-            } else if (g_GameFlow.title_level == nullptr) {
-                Shell_ExitSystem("Missing title level");
-            } else {
-                gf_cmd = GF_RunTitle();
-            }
-            break;
-
-        case GF_EXIT_GAME:
-        case GF_SWITCH_MOD:
-            loop_continue = false;
-            break;
-
-        default:
-            ASSERT_FAIL_FMT(
-                "invalid action (action=%s, param=%d)",
-                ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action), gf_cmd.param);
-        }
-    }
-
-    if (GF_GetCurrentLevel() != nullptr) {
-        Level_Unload();
-    }
-    Game_SetCurrentLevel(nullptr);
-    GF_SetCurrentLevel(nullptr);
+    GF_RunUntilExit(GF_DoFrontendSequence());
 
     if (m_PendingMod != nullptr) {
         if (TestReplay_IsOpened()) {

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -5,6 +5,7 @@
 #include <trx/core/log.h>
 #include <trx/core/math/geom.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/camera.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/lara.h>
@@ -299,6 +300,22 @@ static M_ACTIVE_SOUND *M_GetActiveSlot(const int32_t slot)
     return &m_ActiveSounds[slot];
 }
 
+static void M_Shutdown(void)
+{
+    m_Initialised = false;
+    Audio_Shutdown();
+    M_ClearSampleMaps();
+}
+
+static void M_ApplyConfig(void)
+{
+    if (Shell_GetArgs()->headless) {
+        return;
+    }
+    Sound_Init();
+    Sound_SetMasterVolume(g_Config.audio.sound_volume);
+}
+
 bool Sound_Init(void)
 {
     m_MasterVolume = g_Config.audio.sound_volume;
@@ -330,13 +347,6 @@ bool Sound_Init(void)
     }
     M_ClearAllActiveSounds();
     return true;
-}
-
-void Sound_Shutdown(void)
-{
-    m_Initialised = false;
-    Audio_Shutdown();
-    M_ClearSampleMaps();
 }
 
 bool Sound_IsInitialised(void)
@@ -763,3 +773,5 @@ void Sound_UnpauseActiveSlot(const int32_t slot)
         Audio_Sample_Unpause(sound->handle);
     }
 }
+
+REGISTER_SUBSYSTEM(.apply_config = M_ApplyConfig, .shutdown = M_Shutdown)

--- a/src/trx/game/sound/common.h
+++ b/src/trx/game/sound/common.h
@@ -12,7 +12,6 @@
 #define SOUND_DEFAULT_PITCH 0x10000
 
 bool Sound_Init(void);
-void Sound_Shutdown(void);
 bool Sound_IsInitialised(void);
 
 void Sound_SetMasterVolume(float volume);

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -6,6 +6,7 @@
 #include <trx/core/json.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/virtual_file.h>
 #include <trx/debug.h>
 #include <trx/game/creature.h>
@@ -284,7 +285,7 @@ static void M_WriteCache(
     JSON_ValueFree(root_value);
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     if (m_Stats != nullptr) {
         Memory_Free(m_Stats);
@@ -417,3 +418,5 @@ finish:
     LOG_INFO("Max secrets: %d", final_stats.max_stats.maxes[STATS_CAT_SECRETS]);
     Benchmark_End(&benchmark, nullptr);
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/config/registry.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/console/common.h>
@@ -68,6 +69,21 @@ static void M_DrawNode(const UI_NODE *const node)
 
     node->ops.draw(node);
     // Recursing to children is a responsibility of the draw function.
+}
+
+static void M_Init(void)
+{
+    UI_InitEvents();
+    UI_InitText();
+    UI_InitDraw();
+}
+
+static void M_Shutdown(void)
+{
+    UI_ShutdownDraw();
+    UI_ShutdownText();
+    Memory_ArenaFree(&m_Priv.alloc);
+    UI_ShutdownEvents();
 }
 
 // Allocate a new node
@@ -147,21 +163,6 @@ void UI_EndScene(void)
     ASSERT(m_Priv.root == nullptr);
 }
 
-void UI_Init(void)
-{
-    UI_InitEvents();
-    UI_InitText();
-    UI_InitDraw();
-}
-
-void UI_Shutdown(void)
-{
-    UI_ShutdownDraw();
-    UI_ShutdownText();
-    Memory_ArenaFree(&m_Priv.alloc);
-    UI_ShutdownEvents();
-}
-
 void UI_ToggleState(const bool *const config_setting)
 {
     CONFIG_OPTION *const option = Config_FindOptionByMirror(config_setting);
@@ -201,3 +202,5 @@ float UI_ScaleY(const float y)
 {
     return UI_Scaler_Calc(y * 0x10000, UI_SCALER_TARGET_GENERIC) / 0x10000.p0;
 }
+
+REGISTER_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/ui/common.h
+++ b/src/trx/game/ui/common.h
@@ -65,8 +65,6 @@ const UI_NODE *UI_GetCurrent(void);
 // until the next UI_BeginScene resets the arena they live in.
 const UI_NODE *UI_GetSceneRoot(void);
 
-void UI_Init(void);
-void UI_Shutdown(void);
 void UI_ToggleState(const bool *config_setting);
 
 void UI_HandleKeyDown(uint32_t key);

--- a/src/trx/game/ui/dialogs/settings_rows.c
+++ b/src/trx/game/ui/dialogs/settings_rows.c
@@ -3,6 +3,7 @@
 #include <trx/config/common.h>
 #include <trx/config/registry.h>
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
@@ -254,7 +255,7 @@ static void M_Ensure(void)
     }
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     UI_Settings_DropDeclaredRows();
     for (int32_t tab = 0; tab < CONFIG_TAB_COUNT; tab++) {
@@ -339,3 +340,5 @@ const UI_SETTINGS_ROW *UI_Settings_GetRow(
     }
     return Vector_Get(m_Rows[tab], index);
 }
+
+REGISTER_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/ui/settings.c
+++ b/src/trx/game/ui/settings.c
@@ -7,7 +7,9 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/subsystem.h>
 #include <trx/game/game_strings/entries.h>
+#include <trx/game/shell/paths.h>
 #include <trx/version.h>
 
 #include <uthash.h>
@@ -615,7 +617,7 @@ static bool M_LoadMenuColors(JSON_READ_IO *const io)
     JSON_FINISH();
 }
 
-__attribute__((destructor)) static void M_Shutdown(void)
+static void M_Shutdown(void)
 {
     M_FreeBarThemes();
 }
@@ -656,8 +658,10 @@ static const UI_BAR_THEME *M_FindThemeByName(
     return nullptr;
 }
 
-void UI_Settings_LoadFromFile(const char *const path)
+static void M_Load(void)
 {
+    const char *const path =
+        TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "ui.json5");
     JSON_VALUE *const root = JSONFile_ReadEx(path, true);
     JSON_READ_IO *const io = JSON_ReadIO_Create(root, 0, path);
 
@@ -708,3 +712,5 @@ const UI_MENU_COLORS_PS1 *UI_Settings_GetMenuColorsPS1(void)
 {
     return &m_MenuColorsPS1[g_TRVersion - 1];
 }
+
+REGISTER_SUBSYSTEM(.load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/game/ui/settings.h
+++ b/src/trx/game/ui/settings.h
@@ -64,8 +64,6 @@ typedef struct {
     RGBA_8888 heading_outline;
 } UI_MENU_COLORS_PS1;
 
-void UI_Settings_LoadFromFile(const char *path);
-
 const UI_BAR_THEME *UI_Settings_GetBarTheme(UI_BAR_TYPE type);
 bool UI_Settings_IsCurrentBarLookPS1(void);
 

--- a/src/trx/game/ui/touch_overlay.c
+++ b/src/trx/game/ui/touch_overlay.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/core/colors.h>
+#include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/game/game/state.h>
 #include <trx/game/input/backends/touch.h>
@@ -654,6 +655,14 @@ static void M_HandleFingerUp(const SDL_TouchFingerEvent *const ev)
     M_SyncButtonStates();
 }
 
+static void M_ApplyConfig(void)
+{
+    if (Config_IsFirstRun() && Touch_HasHardwareSupport()) {
+        CONFIG_SET(g_Config.input.enable_touch_controls, true);
+    }
+    TouchOverlay_SetVisible(g_Config.input.enable_touch_controls);
+}
+
 bool TouchOverlay_HasAnyFingerDown(void)
 {
     if (m_SelectionMode) {
@@ -803,3 +812,5 @@ int32_t TouchOverlay_GetSelectedPosition(void)
     m_SelectedPosition = -1;
     return pos;
 }
+
+REGISTER_SUBSYSTEM(.apply_config = M_ApplyConfig)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Game modules can now register their own lifecycle:

```c
REGISTER_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)
REGISTER_SUBSYSTEM(.load = M_Load)
REGISTER_SUBSYSTEM(.apply_config = M_ApplyConfig)
REGISTER_BASE_SUBSYSTEM(.init = M_Init)
```

A subsystem is a normal module; a base subsystem is core infrastructure that starts first and shuts down last.
Game flow now owns its command loop, and the strings manager owns its mod string files.
This also fixes modules surviving across mod switches when they shouldn't.

Touch controls now turn on by default on first launch when a touchscreen is present. This no longer incorrectly happens under `--test-replay`.

#### Testing

Just a regression test around startup:

- [x] Launching with no settings file
- [x] Launching with settings present
- [x] Switching mods from the title screen
- [x] Launching an expansion pack under a different language
- [x] A `--test-replay` run
- [x] A `--test-replay --headless` run – no crashes expected
