### PR TITLE
Fix Lara voiding when a door shuts as she climbs up

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,7 @@
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
 - fixed Lara not getting killed by lifts if standing on top of one and the ceiling space becomes too low
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
+- fixed Lara being teleported into the ceiling if a door shuts on the ledge she is climbing onto (Gameplay → Fixes → Wall glitch mode) (#6047)
 - fixed Lara being able to light a free/ghost flare by selecting one from the inventory while crawling (Gameplay → Fixes → Fix free flare glitch)
 - fixed Lara leaving ripples on ceilings that lie below the waterline (regression from 1.1)
 - fixed shoals of fish and piranhas jumping back to their starting spot when loading a save

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -1,6 +1,7 @@
 #include <trx/game/items/anim.h>
 
 #include <trx/config.h>
+#include <trx/core/math/geom.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items/actions.h>
 #include <trx/game/lara.h>
@@ -40,6 +41,24 @@ static bool M_ShouldPlaySFXAlways(
 ANIM *Item_GetAnim(const ITEM *const item)
 {
     return Anim_GetAnim(item->anim_num);
+}
+
+bool Item_GetPendingOrigin(const ITEM *const item, XYZ_32 *const out_pos)
+{
+    const ANIM *const anim = Item_GetAnim(item);
+    for (int32_t i = 0; i < anim->num_commands; i++) {
+        const ANIM_COMMAND *const command = &anim->commands[i];
+        if (command->type != AC_MOVE_ORIGIN) {
+            continue;
+        }
+        const XYZ_16 *const offset = (XYZ_16 *)command->data;
+        XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, offset->z);
+        pos = XYZ_32_OffsetYaw(pos, item->rot.y + DEG_90, offset->x);
+        pos.y += offset->y;
+        *out_pos = pos;
+        return true;
+    }
+    return false;
 }
 
 bool Item_TestAnimEqual(const ITEM *const item, const int16_t anim_idx)

--- a/src/trx/game/items/anim.h
+++ b/src/trx/game/items/anim.h
@@ -4,6 +4,11 @@
 #include <trx/game/items/types.h>
 
 ANIM *Item_GetAnim(const ITEM *item);
+
+// Returns the position the item's current animation will re-base it to when it
+// ends, if any. The animation itself does not move the item, so this is where
+// it is committed to landing.
+bool Item_GetPendingOrigin(const ITEM *item, XYZ_32 *out_pos);
 bool Item_TestAnimEqual(const ITEM *item, int16_t anim_idx);
 bool Item_TestObjAnimEqual(
     const ITEM *item, int16_t anim_idx, OBJECT_ID obj_id);

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -1,5 +1,6 @@
 #include <trx/game/objects/general/door.h>
 
+#include <trx/config.h>
 #include <trx/game/const.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/game_flow/sequencer.h>
@@ -77,17 +78,34 @@ static SECTOR *M_GetRoomRelSector(
     return Room_GetUnitSector(room, sector.x, sector.z);
 }
 
-static bool M_LaraDoorCollision(const SECTOR *const sector)
+static bool M_TestBlockedSector(
+    const M_PRIV *const p, const XYZ_32 pos, int16_t room_num)
 {
-    // Check if Lara is on the same tile as the invisible block.
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    return sector == p->d1.sector || sector == p->d2.sector
+        || sector == p->d1flip.sector || sector == p->d2flip.sector;
+}
+
+static bool M_LaraDoorCollision(const M_PRIV *const p)
+{
+    // Check if Lara is on, or is climbing onto, the same tile as the invisible
+    // block.
     const ITEM *const lara = Lara_GetItem();
     if (lara == nullptr) {
         return false;
     }
 
-    int16_t room_num = lara->room_num;
-    const SECTOR *const lara_sector = Room_GetSector(lara->pos, &room_num);
-    return lara_sector == sector;
+    if (M_TestBlockedSector(p, lara->pos, lara->room_num)) {
+        return true;
+    }
+
+    if (g_Config.gameplay.wall_glitch_mode != WALL_GLITCH_FIXED) {
+        return false;
+    }
+
+    XYZ_32 pending_pos;
+    return Item_GetPendingOrigin(lara, &pending_pos)
+        && M_TestBlockedSector(p, pending_pos, lara->room_num);
 }
 
 static void M_CopySectorProperties(
@@ -118,14 +136,15 @@ static void M_Open(M_DOOR_POS *const d)
     }
 }
 
-static void M_Check(M_DOOR_POS *const d)
+static void M_Check(ITEM *const item)
 {
     // Forcefully remove the invisible block if Lara happens to occupy the same
     // tile. This ensures that Lara doesn't void if a timed door happens to
     // close right on her, or the player loads the game while standing on a
-    // closed door's block tile.
-    if (M_LaraDoorCollision(d->sector)) {
-        M_Open(d);
+    // closed door's block tile. Both sides of the doorway are opened so that
+    // she can cross it in one piece.
+    if (M_LaraDoorCollision(item->priv)) {
+        Door_OpenPortals(item);
     }
 }
 
@@ -190,10 +209,7 @@ static void M_ControlLift(ITEM *const item)
         }
     }
 
-    M_Check(&p->d1);
-    M_Check(&p->d2);
-    M_Check(&p->d1flip);
-    M_Check(&p->d2flip);
+    M_Check(item);
 }
 
 static void M_Control(const int16_t item_num)
@@ -226,10 +242,7 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    M_Check(&p->d1);
-    M_Check(&p->d2);
-    M_Check(&p->d1flip);
-    M_Check(&p->d2flip);
+    M_Check(item);
     Item_Animate(item);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A door that shut while Lara was pulling up onto its tile teleported her into the ceiling. Her position is only re-based at the end of the pull-up animation, so by then the doorway was blocked and she landed inside the wall, where normal wall glitch mechanics took over.

The invisible block is now lifted while she is climbing onto the tile as well as while she stands on it, and both sides of the doorway open together so that she crosses it in one piece.

https://github.com/user-attachments/assets/78de0f84-d733-4f39-be4a-8cfdab4e8d9c


Resolves #6047