### PR TITLE
Restore the backpack cutscene in Angkor Wat

### DIFF
--- a/data/trx/ship/games/tr4/scripts/angkor1.lua
+++ b/data/trx/ship/games/tr4/scripts/angkor1.lua
@@ -5,3 +5,14 @@ trx.events.on_game_start(function(is_save)
   trx.objects.animating_16.properties.collidable = false
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
 end)
+
+local BACKPACK_CUTSCENE = 5
+
+trx.events.on_cutscene_start(function(cutscene_num)
+  if cutscene_num == BACKPACK_CUTSCENE then
+    -- The scene starts while Lara is crawling, and the crawlspace she triggers
+    -- it from is no place to stand up in. The original engine carries her out
+    -- to the floor beyond it.
+    trx.cutscenes.set_lara_return({ x = 100938, y = 768, z = 58040 }, -32552)
+  end
+end)

--- a/data/trx/ship/games/tr4/scripts/angkor1.lua
+++ b/data/trx/ship/games/tr4/scripts/angkor1.lua
@@ -7,6 +7,59 @@ trx.events.on_game_start(function(is_save)
 end)
 
 local BACKPACK_CUTSCENE = 5
+local BACKPACK_FRAME = 1350
+local YOUNG_OUTFIT = "tr4_young"
+local BARE_TORSO_MESH = 7
+
+-- Young Lara carries no backpack until she picks one up part-way through the
+-- cutscene the crawlspace triggers. The outfit she wears carries the torso she
+-- ends up with, and the level carries the one she starts in, so the level's is
+-- what she wears until the scene hands the backpack over.
+local has_backpack = false
+
+local function dress(outfit)
+  outfit = outfit or trx.lara.outfit
+  if outfit ~= YOUNG_OUTFIT or has_backpack then
+    trx.lara.clear_mesh(trx.lara.Mesh.TORSO)
+  else
+    trx.lara.set_mesh(
+      trx.lara.Mesh.TORSO,
+      trx.catalog.objects.lara_skin,
+      BARE_TORSO_MESH
+    )
+  end
+end
+
+-- Nothing records whether she is carrying it: the cutscene having run says so,
+-- and that is what a savegame already remembers.
+trx.events.on_game_start(function()
+  has_backpack = trx.cutscenes.is_played(BACKPACK_CUTSCENE)
+  dress()
+end)
+
+-- The trigger marks the scene played before it starts, so the frame is what
+-- answers once it is on screen.
+trx.events.after_control(function()
+  if
+    not has_backpack
+    and trx.cutscenes.current == BACKPACK_CUTSCENE
+    and trx.cutscenes.frame_num >= BACKPACK_FRAME
+  then
+    has_backpack = true
+    dress()
+  end
+end)
+
+-- The outfit being put on, rather than the one still on her: a watcher is told
+-- before the skin is applied, and applying it is what reads the override. The
+-- setting reads as an empty string while the player has chosen nothing, and
+-- the engine dresses her in the one the level asks for.
+trx.config.on_change("visuals.lara_outfit", function(outfit)
+  if outfit == nil or outfit == "" then
+    outfit = trx.game.current_level.lara_outfit
+  end
+  dress(outfit)
+end)
 
 trx.events.on_cutscene_start(function(cutscene_num)
   if cutscene_num == BACKPACK_CUTSCENE then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -248,6 +248,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.lara.dry()` and `trx.lara.is_wet`, to dry Lara off after a swim and to check whether she needs it
 - added `trx.lara.is_flying`, to read and toggle the fly-mode cheat
 - added `trx.lara.teleport()`, to move Lara to a position, as `/tp` does
+- added `trx.lara.set_mesh()` and `trx.lara.clear_mesh()`, to put another object's mesh on one of Lara's own and to take it back off, so that a level can dress her from its own geometry
 - added a new Lua module, `trx.inventory`, for reading and changing what Lara carries: it counts and walks her inventory an entry at a time, says what she holds of each weapon and how many shots she has for it, and reaches any level's own inventory the same way through `trx.game.Level.inventory`
 - added a new Lua module, `trx.weapons`, for what a weapon is rather than what Lara has of it: whether the game allows it, which pickup it is, and what a box of its ammunition is worth
 - added `trx.camera.play_flyby()`, to start a flyby camera sequence, and `trx.events.on_flyby_end()`, which happens when one reaches its last camera

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -4560,6 +4560,41 @@
       "path": "lara.dry"
     },
     {
+      "description": "Puts another object's mesh on one of Lara's own, in place of whatever her\noutfit gives her there.\n\nIt outlives an outfit change, because applying an outfit reads it, which is\nwhat lets a level dress her from its own geometry rather than from the\noutfit. Her head is the exception: a combat or speech face replaces it\ndirectly, and takes it back from an override with it.\n\nThe override is dropped when the level ends, along with the meshes it could\nname.",
+      "examples": [
+        "-- the torso young Lara wears before she picks up her backpack\ntrx.lara.set_mesh(trx.lara.Mesh.TORSO, trx.catalog.objects.lara_skin, 7)"
+      ],
+      "params": [
+        {
+          "description": "Which of Lara's meshes.",
+          "name": "mesh",
+          "type": "lara.Mesh"
+        },
+        {
+          "description": "The object to take a mesh from. Raises if this level does not carry it.",
+          "name": "object",
+          "type": "catalog.Id"
+        },
+        {
+          "description": "Which of that object's meshes.",
+          "name": "mesh_num",
+          "type": "objects.MeshNum"
+        }
+      ],
+      "path": "lara.set_mesh"
+    },
+    {
+      "description": "Takes the override back off, leaving the mesh Lara's outfit gives her.",
+      "params": [
+        {
+          "description": "Which of Lara's meshes.",
+          "name": "mesh",
+          "type": "lara.Mesh"
+        }
+      ],
+      "path": "lara.clear_mesh"
+    },
+    {
       "description": "Takes the extra mesh back off, leaving Lara's own.",
       "params": [
         {

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6039,6 +6039,11 @@
     },
     {
       "base": 0,
+      "description": "A frame's number within the cutscene it belongs to.",
+      "path": "cutscenes.FrameNum"
+    },
+    {
+      "base": 0,
       "description": "A flip effect number, as a level editor numbers them. Not the id space of `trx.rooms.flip_effect`, which takes `trx.catalog.flip_effects` names.",
       "path": "events.FlipEffectNum"
     },
@@ -6176,6 +6181,12 @@
       "description": "Number of the cutscene playing, or `nil` if none is.",
       "path": "cutscenes.current",
       "type": "cutscenes.Num",
+      "writable": false
+    },
+    {
+      "description": "Which frame of the running cutscene is on screen, or `nil` if none is\nrunning. A cutscene's actors are animation tracks rather than items, so\nnothing in it can be triggered or listened to; naming a frame is how a\nscript acts part-way through one, as the original game does.",
+      "path": "cutscenes.frame_num",
+      "type": "cutscenes.FrameNum",
       "writable": false
     },
     {

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -21,6 +21,10 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
 ### Properties
 
 - <a id="cutscenes.current" name="cutscenes.current"></a>**`trx.cutscenes.current`** ([trx.cutscenes.Num](#cutscenes.Num)). Number of the cutscene playing, or `nil` if none is. *(read-only)*
+- <a id="cutscenes.frame_num" name="cutscenes.frame_num"></a>**`trx.cutscenes.frame_num`** ([trx.cutscenes.FrameNum](#cutscenes.FrameNum)). Which frame of the running cutscene is on screen, or `nil` if none is
+  running. A cutscene's actors are animation tracks rather than items, so
+  nothing in it can be triggered or listened to; naming a frame is how a
+  script acts part-way through one, as the original game does. *(read-only)*
 - <a id="cutscenes.is_playing" name="cutscenes.is_playing"></a>**`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
 - <a id="cutscenes.fov" name="cutscenes.fov"></a>**`trx.cutscenes.fov`** ([trx.math.Angle](MATH.md#math.Angle)). Field of view a cutscene plays at. TR4 uses 11488, against 14560 for ordinary play.
 - <a id="cutscenes.letterbox" name="cutscenes.letterbox"></a>**`trx.cutscenes.letterbox`** (number). Depth of each cinematic bar, as a fraction of the screen height. `0` removes them.
@@ -30,6 +34,10 @@ lists and `/cut` plays, are a different thing: see [`trx.game.cutscenes`](GAME.m
 - <a id="cutscenes.Num" name="cutscenes.Num"></a>[lua]`trx.cutscenes.Num`
 
     Cutscene number, as a cutscene trigger names it. Counted from 0.
+
+- <a id="cutscenes.FrameNum" name="cutscenes.FrameNum"></a>[lua]`trx.cutscenes.FrameNum`
+
+    A frame's number within the cutscene it belongs to. Counted from 0.
 
 ### Functions
 

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -213,6 +213,35 @@ Her position, room and hit points are not here: she is an item like any other an
 - <a id="lara.dry" name="lara.dry"></a>[lua]`trx.lara.dry()`  
   Dries Lara off, clearing the wetness that sheds droplets after she leaves water.
 
+- <a id="lara.set_mesh" name="lara.set_mesh"></a>[lua]`trx.lara.set_mesh(mesh, object, mesh_num)`  
+  Puts another object's mesh on one of Lara's own, in place of whatever her
+  outfit gives her there.
+
+  It outlives an outfit change, because applying an outfit reads it, which is
+  what lets a level dress her from its own geometry rather than from the
+  outfit. Her head is the exception: a combat or speech face replaces it
+  directly, and takes it back from an override with it.
+
+  The override is dropped when the level ends, along with the meshes it could
+  name.
+
+  Parameters:
+  - <a id="lara.set_mesh.mesh" name="lara.set_mesh.mesh"></a>**`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.
+  - <a id="lara.set_mesh.object" name="lara.set_mesh.object"></a>**`object`** ([trx.catalog.Id](CATALOG.md#catalog.Id)). The object to take a mesh from. Raises if this level does not carry it.
+  - <a id="lara.set_mesh.mesh_num" name="lara.set_mesh.mesh_num"></a>**`mesh_num`** ([trx.objects.MeshNum](OBJECTS.md#objects.MeshNum)). Which of that object's meshes.
+
+  Example:
+  ```lua
+  -- the torso young Lara wears before she picks up her backpack
+  trx.lara.set_mesh(trx.lara.Mesh.TORSO, trx.catalog.objects.lara_skin, 7)
+  ```
+
+- <a id="lara.clear_mesh" name="lara.clear_mesh"></a>[lua]`trx.lara.clear_mesh(mesh)`  
+  Takes the override back off, leaving the mesh Lara's outfit gives her.
+
+  Parameters:
+  - <a id="lara.clear_mesh.mesh" name="lara.clear_mesh.mesh"></a>**`mesh`** ([trx.lara.Mesh](#lara.Mesh)). Which of Lara's meshes.
+
 - <a id="lara.clear_equipment" name="lara.clear_equipment"></a>[lua]`trx.lara.clear_equipment(mesh)`  
   Takes the extra mesh back off, leaving Lara's own.
 

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -17,6 +17,11 @@ api.number("cutscenes.Num", {
   description = "Cutscene number, as a cutscene trigger names it.",
 })
 
+api.number("cutscenes.FrameNum", {
+  base = 0,
+  description = "A frame's number within the cutscene it belongs to.",
+})
+
 api.define("cutscenes.play", {
   description = "Plays a cutscene, fading the scene out first. Does nothing if one is already "
     .. "playing or the game has no cutscene data.",
@@ -31,6 +36,24 @@ api.property("cutscenes.current", {
   type = "cutscenes.Num",
   description = "Number of the cutscene playing, or `nil` if none is.",
   get = raw.get_current,
+})
+
+api.property("cutscenes.frame_num", {
+  type = "cutscenes.FrameNum",
+  description = [[
+    Which frame of the running cutscene is on screen, or `nil` if none is
+    running. A cutscene's actors are animation tracks rather than items, so
+    nothing in it can be triggered or listened to; naming a frame is how a
+    script acts part-way through one, as the original game does.
+  ]],
+  examples = {
+    [[trx.events.after_control(function()
+  if trx.cutscenes.current == 5 and trx.cutscenes.frame_num == 1350 then
+    -- something happens here
+  end
+end)]],
+  },
+  get = raw.get_frame_num,
 })
 
 api.property("cutscenes.is_playing", {

--- a/src/lua/api/lara.lua
+++ b/src/lua/api/lara.lua
@@ -317,6 +317,55 @@ api.define("lara.dry", {
   impl = raw.dry,
 })
 
+api.define("lara.set_mesh", {
+  description = [[
+    Puts another object's mesh on one of Lara's own, in place of whatever her
+    outfit gives her there.
+
+    It outlives an outfit change, because applying an outfit reads it, which is
+    what lets a level dress her from its own geometry rather than from the
+    outfit. Her head is the exception: a combat or speech face replaces it
+    directly, and takes it back from an override with it.
+
+    The override is dropped when the level ends, along with the meshes it could
+    name.
+  ]],
+  params = {
+    {
+      name = "mesh",
+      type = "lara.Mesh",
+      description = "Which of Lara's meshes.",
+    },
+    {
+      name = "object",
+      type = "catalog.Id",
+      description = "The object to take a mesh from. Raises if this level does not carry it.",
+    },
+    {
+      name = "mesh_num",
+      type = "objects.MeshNum",
+      description = "Which of that object's meshes.",
+    },
+  },
+  examples = {
+    [[-- the torso young Lara wears before she picks up her backpack
+trx.lara.set_mesh(trx.lara.Mesh.TORSO, trx.catalog.objects.lara_skin, 7)]],
+  },
+  impl = raw.set_mesh,
+})
+
+api.define("lara.clear_mesh", {
+  description = "Takes the override back off, leaving the mesh Lara's outfit gives her.",
+  params = {
+    {
+      name = "mesh",
+      type = "lara.Mesh",
+      description = "Which of Lara's meshes.",
+    },
+  },
+  impl = raw.clear_mesh,
+})
+
 api.define("lara.clear_equipment", {
   description = "Takes the extra mesh back off, leaving Lara's own.",
   params = {

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -533,6 +533,14 @@ OBJECT *Object_Get(const OBJECT_ID object_id)
     return &m_Objects[object_id];
 }
 
+OBJECT_MESH *Object_GetMesh(const int32_t index)
+{
+    // The fake level stages no geometry. Callers hand the result straight back
+    // to another fake, which records that it was asked rather than reading it.
+    static OBJECT_MESH m_Mesh = {};
+    return &m_Mesh;
+}
+
 const VECTOR *Object_GetNames(const OBJECT_ID obj_id)
 {
     // The fake level localizes nothing, so a lookup always takes the

--- a/src/tests/fakes/lara.c
+++ b/src/tests/fakes/lara.c
@@ -375,6 +375,17 @@ void Lara_Skin_SetExtraEquipment(
     FAKE_RECORD("set_equipment", FV(mesh), FV(extra_mesh));
 }
 
+void Lara_Skin_SetMeshOverride(
+    const LARA_MESH mesh, OBJECT_MESH *const mesh_ptr)
+{
+    FAKE_RECORD("set_mesh_override", FV(mesh), FV(mesh_ptr != nullptr));
+}
+
+OBJECT_MESH *Lara_Skin_GetMeshOverride(const LARA_MESH mesh)
+{
+    return nullptr;
+}
+
 bool Lara_Skin_IsOutfitAvailable(const LARA_SKIN_TYPE skin_type)
 {
     return true;

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -184,6 +184,17 @@ unit_tests += {
 }
 
 unit_tests += {
+  'name': 'trx/game/matrix',
+  'engine': [
+    'game/matrix.c',
+    'core/math/func.c',
+    'core/math/geom.c',
+    'core/math/trig.c',
+  ],
+  'deps': [dep_mathlibrary],
+}
+
+unit_tests += {
   'name': 'trx/game/cutseq/decoder',
   'engine': ['game/cutseq/decoder.c'],
 }

--- a/src/tests/trx/game/matrix.c
+++ b/src/tests/trx/game/matrix.c
@@ -1,0 +1,116 @@
+#include <harness/harness.h>
+
+#include <trx/core/math/const.h>
+#include <trx/game/matrix.h>
+
+// Rotations reach the renderer as three angles, and the tempting way to meet
+// two of them in the middle is to meet each angle in the middle. That is not
+// the same rotation: the TR4 cutscene tracks quantize to ten bits per axis, and
+// near a quarter turn on X the exporter switches between two triples half a
+// turn apart on Y and Z that name the same pose. These pin the arc.
+
+// The matrix is built from a 14-bit trig table and read back through a double,
+// so a rotation only survives the round trip to about a thousandth.
+#define M_TOLERANCE 0.002
+
+// Where a rotation sends the three unit axes, which is the whole of what it
+// does, and what the renderer sees. Comparing angles instead would call two
+// spellings of one rotation different.
+typedef struct {
+    double v[3][3];
+} M_AXES;
+
+static M_AXES M_Apply(const XYZ_16 rot)
+{
+    M_AXES out;
+    const double scale = 1 << W2V_SHIFT;
+    const XYZ_32 axes[3] = {
+        { .x = 1, .y = 0, .z = 0 },
+        { .x = 0, .y = 1, .z = 0 },
+        { .x = 0, .y = 0, .z = 1 },
+    };
+    for (int32_t i = 0; i < 3; i++) {
+        Matrix_ResetStack();
+        *g_MatrixPtr = g_IDMatrix;
+        *g_WMatrixPtr = g_IDMatrix;
+        Matrix_Rot16(rot);
+        Matrix_TranslateRel32(axes[i]);
+        out.v[i][0] = g_MatrixPtr->_03 / scale;
+        out.v[i][1] = g_MatrixPtr->_13 / scale;
+        out.v[i][2] = g_MatrixPtr->_23 / scale;
+    }
+    return out;
+}
+
+// How far apart two rotations point, in units of the axis length.
+static double M_Distance(const M_AXES a, const M_AXES b)
+{
+    double worst = 0.0;
+    for (int32_t i = 0; i < 3; i++) {
+        for (int32_t j = 0; j < 3; j++) {
+            const double d = a.v[i][j] - b.v[i][j];
+            worst = worst > d ? worst : d;
+            worst = worst > -d ? worst : -d;
+        }
+    }
+    return worst;
+}
+
+#define M_CHECK_NEAR(rot_1_, rot_2_, tolerance_)                               \
+    do {                                                                       \
+        const XYZ_16 r1_ = (rot_1_);                                           \
+        const XYZ_16 r2_ = (rot_2_);                                           \
+        const double d_ = M_Distance(M_Apply(r1_), M_Apply(r2_));              \
+        if (!(d_ <= (tolerance_))) {                                           \
+            TEST_FAIL(                                                         \
+                "(%d,%d,%d) and (%d,%d,%d) are %.4f apart, over %.4f", r1_.x,  \
+                r1_.y, r1_.z, r2_.x, r2_.y, r2_.z, d_, (double)(tolerance_));  \
+        }                                                                      \
+    } while (0)
+
+TEST(test_slerp_rot16_keeps_the_ends)
+{
+    const XYZ_16 from = { .x = 1000, .y = -20000, .z = 3000 };
+    const XYZ_16 to = { .x = -8000, .y = 25000, .z = -4000 };
+    M_CHECK_NEAR(Matrix_SlerpRot16(from, to, 0.0), from, M_TOLERANCE);
+    M_CHECK_NEAR(Matrix_SlerpRot16(from, to, 1.0), to, M_TOLERANCE);
+}
+
+TEST(test_slerp_rot16_halves_a_turn)
+{
+    const XYZ_16 from = { .y = 0 };
+    const XYZ_16 to = { .y = DEG_90 };
+    M_CHECK_NEAR(
+        Matrix_SlerpRot16(from, to, 0.5), (XYZ_16) { .y = DEG_45 },
+        M_TOLERANCE);
+}
+
+TEST(test_slerp_rot16_takes_the_short_way_around)
+{
+    // Two degrees apart across the wrap, not 358 the other way.
+    const XYZ_16 from = { .y = DEG_1 * -1 };
+    const XYZ_16 to = { .y = DEG_1 * 1 };
+    M_CHECK_NEAR(Matrix_SlerpRot16(from, to, 0.5), (XYZ_16) {}, M_TOLERANCE);
+}
+
+TEST(test_slerp_rot16_holds_still_between_two_spellings)
+{
+    // What the TR4 backpack cutscene hands the left forearm: X just short of a
+    // quarter turn, and Y and Z both half a turn on one side and zero on the
+    // other. Both name the same rotation, so the middle is that rotation too -
+    // interpolating the angles apart from each other points it backwards.
+    const XYZ_16 from = { .x = 15616, .y = 0, .z = 0 };
+    const XYZ_16 to = { .x = 15936, .y = 32704, .z = -32768 };
+    M_CHECK_NEAR(from, to, 0.15);
+    for (int32_t i = 0; i <= 10; i++) {
+        M_CHECK_NEAR(Matrix_SlerpRot16(from, to, i / 10.0), from, 0.15);
+    }
+}
+
+TEST(test_slerp_rot16_reads_back_a_locked_rotation)
+{
+    // At exactly a quarter turn on X, Y and Z describe one turn between them
+    // and cannot be told apart. Any spelling of it has to survive the trip.
+    const XYZ_16 rot = { .x = DEG_90, .y = DEG_45, .z = DEG_45 };
+    M_CHECK_NEAR(Matrix_SlerpRot16(rot, rot, 0.5), rot, M_TOLERANCE);
+}

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -124,6 +124,18 @@ static void M_SetLaraPose(const CUTSEQ_POSE *const pose)
     Lara_Pose_SetOverride(&m_State.lara_pose);
 }
 
+// An actor names its object by the number its level gives it. The catalog
+// answers for the ones TRX has an entry for, and the level's own slots for the
+// rest: a TR4 wad parks cutscene-only geometry wherever it had a slot spare.
+static const OBJECT *M_GetActorObject(const CUTSEQ_ACTOR_INFO *const actor_info)
+{
+    const OBJECT *const obj = Object_TryGet(actor_info->obj_id);
+    if (obj != nullptr && obj->loaded) {
+        return obj;
+    }
+    return Object_GetUncatalogedSlot(actor_info->game_obj_slot);
+}
+
 static float M_GetDefaultLetterbox(void)
 {
     const GF_LEVEL *const level = GF_GetCurrentLevel();
@@ -213,9 +225,7 @@ static bool M_Begin(const int32_t num)
             .pos = info->origin,
         };
 
-        if (i > 0
-            && (actor_info->obj_id == NO_OBJECT
-                || !Object_Get(actor_info->obj_id)->loaded)) {
+        if (i > 0 && M_GetActorObject(actor_info) == nullptr) {
             LOG_WARNING(
                 "Cutscene %d actor %d (TR4 slot %d) has no loaded object", num,
                 i, actor_info->game_obj_slot);
@@ -618,8 +628,8 @@ void CutSeq_DrawActors(void)
     const CUTSEQ_INFO *const info = &m_State.info;
     for (int32_t i = 1; i < info->num_actors; i++) {
         M_ACTOR *const actor = &m_State.actors[i];
-        const OBJECT *const obj = Object_TryGet(info->actors[i].obj_id);
-        if (obj == nullptr || !obj->loaded) {
+        const OBJECT *const obj = M_GetActorObject(&info->actors[i]);
+        if (obj == nullptr) {
             continue;
         }
         const CUTSEQ_POSE *const pose = &actor->pose_draw;

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -82,12 +82,6 @@ static struct {
     .letterbox = M_DEFAULT_LETTERBOX,
 };
 
-static int16_t M_LerpAngle(
-    const int16_t from, const int16_t to, const double alpha)
-{
-    return from + (int16_t)((int16_t)(to - from) * alpha);
-}
-
 // Root offsets are truncated to int16 to match the original engine, so a
 // track running past the boundary wraps in a single frame. Interpolating the
 // short way around turns that into a step rather than a sweep back across the
@@ -106,9 +100,7 @@ static void M_LerpPose(
     out->offset.y = M_LerpOffset(from->offset.y, to->offset.y, alpha);
     out->offset.z = M_LerpOffset(from->offset.z, to->offset.z, alpha);
     for (int32_t i = 0; i < mesh_count; i++) {
-        out->rots[i].x = M_LerpAngle(from->rots[i].x, to->rots[i].x, alpha);
-        out->rots[i].y = M_LerpAngle(from->rots[i].y, to->rots[i].y, alpha);
-        out->rots[i].z = M_LerpAngle(from->rots[i].z, to->rots[i].z, alpha);
+        out->rots[i] = Matrix_SlerpRot16(from->rots[i], to->rots[i], alpha);
     }
 }
 

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -24,6 +24,7 @@
 #include <trx/version.h>
 
 #define M_NO_CUTSCENE (-1)
+#define M_NO_FRAME (-1)
 // The OG cutscene FOV; normal gameplay uses 14560.
 #define M_DEFAULT_FOV 11488
 #define M_FADE_DURATION 0.5f
@@ -397,6 +398,11 @@ bool CutSeq_IsPlaying(void)
 int32_t CutSeq_GetCurrent(void)
 {
     return CutSeq_IsPlaying() ? m_State.num : M_NO_CUTSCENE;
+}
+
+int32_t CutSeq_GetFrame(void)
+{
+    return CutSeq_IsPlaying() ? m_State.frame : M_NO_FRAME;
 }
 
 void CutSeq_Request(const int32_t num)

--- a/src/trx/game/cutseq/playback.h
+++ b/src/trx/game/cutseq/playback.h
@@ -29,6 +29,11 @@ int32_t CutSeq_GetCount(void);
 bool CutSeq_IsActive(void);
 bool CutSeq_IsPlaying(void);
 int32_t CutSeq_GetCurrent(void);
+// Which frame of the running scene is on screen, or -1 when none is. A scene
+// has no other clock: its actors are pose tracks rather than items, so a
+// script with something to do part-way through has only the frame to name it
+// by, as the original engine does.
+int32_t CutSeq_GetFrame(void);
 
 // Fades out, then plays the cutscene.
 void CutSeq_Request(int32_t num);

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -23,6 +23,7 @@ static bool m_UseCombatFace = false;
 static LARA_GUN_TYPE m_HolsterType_L = LGT_UNARMED;
 static LARA_GUN_TYPE m_HolsterType_R = LGT_UNARMED;
 static LARA_SKIN_EQUIPMENT m_Equipment[LM_NUMBER_OF] = {};
+static OBJECT_MESH *m_MeshOverrides[LM_NUMBER_OF] = {};
 
 static inline const LARA_SKIN_OUTFIT *M_GetCurrentOutfit(void)
 {
@@ -182,6 +183,11 @@ static inline int32_t M_GetMeshIdx(
 static inline void M_ApplyMeshIfValid(
     const LARA_MESH mesh, const LARA_SKIN_OUTFIT *const outfit)
 {
+    if (m_MeshOverrides[mesh] != nullptr) {
+        Lara_Mesh_Set(mesh, m_MeshOverrides[mesh]);
+        return;
+    }
+
     const int32_t mesh_idx = M_GetMeshIdx(mesh, outfit);
     if (mesh_idx != M_NO_MESH) {
         Lara_Mesh_Set(mesh, Object_GetMesh(mesh_idx));
@@ -341,6 +347,8 @@ void Lara_Skin_Initialise(void)
     m_HolstersVisible = true;
     for (int32_t i = 0; i < LM_NUMBER_OF; i++) {
         m_Equipment[i].visible = true;
+        // Before the clear, which applies a mesh and would read it.
+        m_MeshOverrides[i] = nullptr;
         Lara_Skin_ClearEquipment(i);
     }
 
@@ -524,6 +532,23 @@ void Lara_Skin_ApplyOutfit(void)
     M_UpdateSunglasses();
     Lara_Joints_Initialise(outfit);
     Lara_Hair_InitJoints(outfit);
+}
+
+void Lara_Skin_SetMeshOverride(
+    const LARA_MESH mesh, OBJECT_MESH *const mesh_ptr)
+{
+    m_MeshOverrides[mesh] = mesh_ptr;
+    // A level script runs before she has been dressed, and an outfit that is
+    // not applied yet names meshes that are not loaded. Applying an outfit
+    // reads the override, so the one set here still reaches her.
+    if (M_CanDress()) {
+        M_ApplyMeshIfValid(mesh, M_GetCurrentOutfit());
+    }
+}
+
+OBJECT_MESH *Lara_Skin_GetMeshOverride(const LARA_MESH mesh)
+{
+    return m_MeshOverrides[mesh];
 }
 
 void Lara_Skin_SetCombatFace(const bool enabled)

--- a/src/trx/game/lara/skin/common.h
+++ b/src/trx/game/lara/skin/common.h
@@ -12,6 +12,16 @@ bool Lara_Skin_IsDefaultType(void);
 void Lara_Skin_SetType(LARA_SKIN_TYPE skin_type);
 void Lara_Skin_ApplyOutfit(void);
 
+// Put another mesh on one of Lara's own, in place of whatever her outfit gives
+// her there. It outlives an outfit change, because applying an outfit reads it,
+// which is what lets a level dress her from its own geometry - TR4's Angkor Wat
+// carries the torso young Lara wears before she picks up her backpack. nullptr
+// gives the outfit's mesh back. The head is the exception: a combat or speech
+// face replaces it directly, and takes the head back from an override with it.
+// Dropped at level end, along with the meshes it could name.
+void Lara_Skin_SetMeshOverride(LARA_MESH mesh, OBJECT_MESH *mesh_ptr);
+OBJECT_MESH *Lara_Skin_GetMeshOverride(LARA_MESH mesh);
+
 void Lara_Skin_SetCombatFace(bool enabled);
 void Lara_Skin_SetSpeechFace(int32_t index);
 void Lara_Skin_SwapAllExtra(LARA_EXTRA_STATE state);

--- a/src/trx/game/level/sections/objects.c
+++ b/src/trx/game/level/sections/objects.c
@@ -45,14 +45,15 @@ void Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, VFILE *const file)
     const int32_t num_objects = VFile_ReadS32(file);
     LOG_INFO("objects: %d", num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
-        OBJECT fallback_obj = {};
+        OBJECT spare_obj = {};
         const int32_t game_obj_id = VFile_ReadS32(file);
         OBJECT *obj = Object_GetByGameID(game_obj_id);
-        if (obj == nullptr) {
+        const bool is_cataloged = obj != nullptr;
+        if (!is_cataloged) {
             if (loader->game_version == 3 || loader->game_version == 4) {
                 // Direct-level support can encounter slots that do not have a
                 // stable TRX catalog entry yet.
-                obj = &fallback_obj;
+                obj = &spare_obj;
             } else {
                 Shell_ExitSystemFmt("Invalid object ID: %d", game_obj_id);
             }
@@ -64,6 +65,9 @@ void Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, VFILE *const file)
         obj->frame_base = nullptr;
         obj->anim_idx = VFile_ReadS16(file);
         obj->loaded = true;
+        if (!is_cataloged) {
+            Object_StoreUncatalogedSlot(game_obj_id, obj);
+        }
     }
 
     Benchmark_End(&benchmark, nullptr);

--- a/src/trx/game/lua/capi/cutscenes.c
+++ b/src/trx/game/lua/capi/cutscenes.c
@@ -6,6 +6,7 @@
 #include <lauxlib.h>
 
 #define M_NO_CUTSCENE (-1)
+#define M_NO_FRAME (-1)
 
 // A cutscene a script asks to play has to be one this game can actually play,
 // or the call would do nothing and say nothing about why.
@@ -41,6 +42,13 @@ static int M_L_CutscenesPlay(lua_State *const L)
 static int M_L_CutscenesGetCurrent(lua_State *const L)
 {
     LUA_PushOptIndex(L, CutSeq_GetCurrent(), M_NO_CUTSCENE);
+    return 1;
+}
+
+// trxc.cutscenes.get_frame_num() → int or nil
+static int M_L_CutscenesGetFrameNum(lua_State *const L)
+{
+    LUA_PushOptIndex(L, CutSeq_GetFrame(), M_NO_FRAME);
     return 1;
 }
 
@@ -116,6 +124,7 @@ static int M_L_CutscenesSetLetterbox(lua_State *const L)
 static const luaL_Reg m_Module[] = {
     { "play", M_L_CutscenesPlay },
     { "get_current", M_L_CutscenesGetCurrent },
+    { "get_frame_num", M_L_CutscenesGetFrameNum },
     { "is_playing", M_L_CutscenesIsPlaying },
     { "is_played", M_L_CutscenesIsPlayed },
     { "set_played", M_L_CutscenesSetPlayed },

--- a/src/trx/game/lua/capi/lara.c
+++ b/src/trx/game/lua/capi/lara.c
@@ -12,6 +12,7 @@
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/struct.h>
 #include <trx/game/lua/utils.h>
+#include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 
 #include <lauxlib.h>
@@ -152,6 +153,30 @@ static int M_L_LaraSetExtraEquipment(lua_State *const L)
     return 0;
 }
 
+// trxc.lara.set_mesh(lara_mesh, object_id, mesh_num)
+static int M_L_LaraSetMesh(lua_State *const L)
+{
+    const LARA_MESH lara_mesh = M_CheckLaraMesh(L, 1);
+    const OBJECT_ID object_id = LUA_CheckObjectID(L, 2);
+    const OBJECT *const obj = Object_Get(object_id);
+    if (!obj->loaded) {
+        return luaL_error(L, "this level does not carry that object");
+    }
+    const int32_t mesh_num =
+        LUA_CheckRange(L, 3, obj->mesh_count, "no such mesh on this object");
+    Lara_Skin_SetMeshOverride(
+        lara_mesh, Object_GetMesh(obj->mesh_idx + mesh_num));
+    return 0;
+}
+
+// trxc.lara.clear_mesh(lara_mesh)
+static int M_L_LaraClearMesh(lua_State *const L)
+{
+    const LARA_MESH lara_mesh = M_CheckLaraMesh(L, 1);
+    Lara_Skin_SetMeshOverride(lara_mesh, nullptr);
+    return 0;
+}
+
 // trxc.lara.clear_equipment(lara_mesh)
 static int M_L_LaraClearEquipment(lua_State *const L)
 {
@@ -276,6 +301,8 @@ static const luaL_Reg m_Module[] = {
     { "set_outfit", M_L_LaraSetOutfit },
     { "set_extra_equipment", M_L_LaraSetExtraEquipment },
     { "clear_equipment", M_L_LaraClearEquipment },
+    { "set_mesh", M_L_LaraSetMesh },
+    { "clear_mesh", M_L_LaraClearMesh },
     { "cure_poison", M_L_LaraCurePoison },
     { "extinguish", M_L_LaraExtinguish },
     { "dry", M_L_LaraDry },

--- a/src/trx/game/matrix.c
+++ b/src/trx/game/matrix.c
@@ -349,6 +349,37 @@ static void M_RotYXZ(MATRIX *const m, const XYZ_16 rotation)
     M_RotZ(m, rotation.z);
 }
 
+// Reads a rotation back out of a matrix in the Y, X, Z order M_RotYXZ puts it
+// in. Both remaining pairs are scaled by cos(X), so at a quarter turn on X
+// they say nothing apart: Y and Z describe a single turn between them there,
+// and it reads out as Y alone.
+static XYZ_16 M_ToRot16(const MATRIX *const m)
+{
+    double e[3][3];
+    M_Double3x3FromMatrix(m, e);
+    M_Double3x3RemoveScale(e);
+
+    double sin_x = -e[1][2];
+    CLAMP(sin_x, -1.0, 1.0);
+    const double x = asin(sin_x);
+    double y;
+    double z;
+    if (fabs(sin_x) < 1.0 - 1e-9) {
+        y = atan2(e[0][2], e[2][2]);
+        z = atan2(e[1][0], e[1][1]);
+    } else {
+        y = atan2(-e[2][0], e[0][0]);
+        z = 0.0;
+    }
+
+    const double scale = DEG_360 / (2.0 * M_PI);
+    return (XYZ_16) {
+        .x = (int16_t)(int32_t)lround(x * scale),
+        .y = (int16_t)(int32_t)lround(y * scale),
+        .z = (int16_t)(int32_t)lround(z * scale),
+    };
+}
+
 static void M_TranslateRel(MATRIX *const m, const XYZ_32 offset)
 {
     m->_03 += offset.x * m->_00 + offset.y * m->_01 + offset.z * m->_02;
@@ -585,6 +616,17 @@ void Matrix_RotY_M(MATRIX *const m, const int16_t angle)
 void Matrix_RotZ_M(MATRIX *const m, const int16_t angle)
 {
     M_RotZ(m, angle);
+}
+
+XYZ_16 Matrix_SlerpRot16(
+    const XYZ_16 rotation_1, const XYZ_16 rotation_2, const double t)
+{
+    MATRIX m1 = g_IDMatrix;
+    M_RotYXZ(&m1, rotation_1);
+    MATRIX m2 = g_IDMatrix;
+    M_RotYXZ(&m2, rotation_2);
+    Matrix_Slerp3x3_M(&m1, &m2, t);
+    return M_ToRot16(&m1);
 }
 
 void Matrix_Slerp3x3_M(

--- a/src/trx/game/matrix.h
+++ b/src/trx/game/matrix.h
@@ -48,6 +48,14 @@ void Matrix_RotY_M(MATRIX *m, int16_t ry);
 void Matrix_RotZ_M(MATRIX *m, int16_t rz);
 void Matrix_Mul3x3_M(MATRIX *out, const MATRIX *lhs, const MATRIX *rhs);
 void Matrix_Slerp3x3_M(MATRIX *lhs_out, const MATRIX *rhs, double t);
+
+// Interpolates between two rotations along the arc between them, and gives the
+// result back as angles Matrix_Rot16 takes. Interpolating the three angles
+// apart from each other instead does not follow that arc: near a quarter turn
+// on X, two triples half a turn apart on Y and Z can name the same rotation,
+// and meeting them in the middle points the other way.
+XYZ_16 Matrix_SlerpRot16(XYZ_16 rotation_1, XYZ_16 rotation_2, double t);
+
 void Matrix_Mul3x3(const MATRIX *rhs);
 
 void Matrix_TranslateRel(int32_t x, int32_t y, int32_t z);

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -11,6 +11,11 @@
 #include <trx/game/objects/vars.h>
 #include <trx/game/output/common.h>
 
+typedef struct {
+    int32_t game_id;
+    OBJECT obj;
+} M_UNCATALOGED_SLOT;
+
 static OBJECT m_Objects[O_NUMBER_OF] = {};
 static STATIC_OBJECT_3D *m_StaticObjects3D = nullptr;
 static STATIC_OBJECT_2D *m_StaticObjects2D = nullptr;
@@ -19,6 +24,8 @@ static int32_t m_StaticObjects2DCount = 0;
 static OBJECT_MESH **m_MeshPointers = nullptr;
 static int32_t m_MeshCount = 0;
 static int32_t m_MeshCapacity = 0;
+
+static VECTOR *m_UncatalogedSlots = nullptr;
 
 void Object_Reset(void)
 {
@@ -34,6 +41,11 @@ void Object_Reset(void)
     m_MeshPointers = nullptr;
     m_MeshCount = 0;
     m_MeshCapacity = 0;
+
+    if (m_UncatalogedSlots != nullptr) {
+        Vector_Free(m_UncatalogedSlots);
+        m_UncatalogedSlots = nullptr;
+    }
 }
 
 void Object_InitialiseStaticObjects3D(const int32_t count)
@@ -83,6 +95,30 @@ OBJECT *Object_GetByGameID(const int32_t game_id)
         return nullptr;
     }
     return &m_Objects[object_id];
+}
+
+void Object_StoreUncatalogedSlot(const int32_t game_id, const OBJECT *const obj)
+{
+    if (m_UncatalogedSlots == nullptr) {
+        m_UncatalogedSlots = Vector_Create(sizeof(M_UNCATALOGED_SLOT));
+    }
+    const M_UNCATALOGED_SLOT slot = { .game_id = game_id, .obj = *obj };
+    Vector_Add(m_UncatalogedSlots, &slot);
+}
+
+const OBJECT *Object_GetUncatalogedSlot(const int32_t game_id)
+{
+    if (m_UncatalogedSlots == nullptr) {
+        return nullptr;
+    }
+    for (int32_t i = 0; i < m_UncatalogedSlots->count; i++) {
+        const M_UNCATALOGED_SLOT *const slot =
+            Vector_Get(m_UncatalogedSlots, i);
+        if (slot->game_id == game_id) {
+            return &slot->obj;
+        }
+    }
+    return nullptr;
 }
 
 STATIC_OBJECT_3D *Object_Get3DStatic(const int32_t static_id)

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -22,6 +22,16 @@ OBJECT *Object_TryGet(OBJECT_ID object_id);
 // Retrieve an object by its game ID. Returns nullptr if not found.
 OBJECT *Object_GetByGameID(int32_t game_id);
 
+// Keep an object slot the catalog has no entry for, under the number the level
+// gives it. TR4 wads park geometry that only a cutscene ever draws in whichever
+// slots they left free, so the meshes have to survive a load that nothing in
+// the catalog names. Dropped with the level.
+void Object_StoreUncatalogedSlot(int32_t game_id, const OBJECT *obj);
+
+// Retrieve a slot kept that way, or nullptr when the level carries none under
+// that number.
+const OBJECT *Object_GetUncatalogedSlot(int32_t game_id);
+
 // Convert a game ID to OBJECT_ID.
 OBJECT_ID Object_FromGameID(int32_t game_id);
 

--- a/src/trx/game/output/lights/tr4.c
+++ b/src/trx/game/output/lights/tr4.c
@@ -29,6 +29,9 @@
 #include <string.h>
 
 #define M_MAX_ITEM_LIGHTS 21 // the OG ITEM_LIGHT current/prev list capacity
+// Enough for a cutscene's cast, which is what asks to be lit without living
+// in the item pool.
+#define M_MAX_LOOSE_LIGHTS 16
 #define M_FADE_FRAMES 8
 
 // Room light baked at level load (the OG PCLIGHT_INFO, drawroom.cpp
@@ -98,6 +101,8 @@ static int32_t m_RoomBakeCount = 0;
 
 static M_ITEM_LIGHT m_ItemLights[MAX_ITEMS] = {};
 static M_ITEM_LIGHT m_ScratchLight = {}; // the OG StaticMeshLightItem
+static const ITEM *m_LooseLightKeys[M_MAX_LOOSE_LIGHTS] = {};
+static M_ITEM_LIGHT m_LooseLights[M_MAX_LOOSE_LIGHTS] = {};
 static M_ITEM_LIGHT *m_CurrentItemLight = nullptr;
 static bool m_CurrentIsPickup = false; // the OG SetupLight_thing
 static bool m_CurrentHasList = false;
@@ -564,15 +569,41 @@ static void M_StageDynamicLights(
     }
 }
 
-static M_ITEM_LIGHT *M_GetItemLight(const ITEM *const item)
+// An item outside the pool - a cutscene actor is posed from a track rather
+// than living in a room - has no slot of its own, and the scratch it would
+// otherwise fall to is shared with every effect and static drawn that frame.
+// This state fades between frames, so sharing it makes an actor's light jump
+// with whatever else was drawn. The original engine keeps it on the item, so
+// one is handed out per item here instead.
+static M_ITEM_LIGHT *M_GetLooseItemLight(const ITEM *const item)
 {
-    if (item != nullptr) {
-        const int16_t item_num = Item_GetIndex(item);
-        if (item_num >= 0 && item_num < MAX_ITEMS) {
-            return &m_ItemLights[item_num];
+    for (int32_t i = 0; i < M_MAX_LOOSE_LIGHTS; i++) {
+        if (m_LooseLightKeys[i] == item) {
+            return &m_LooseLights[i];
+        }
+    }
+    for (int32_t i = 0; i < M_MAX_LOOSE_LIGHTS; i++) {
+        if (m_LooseLightKeys[i] == nullptr) {
+            m_LooseLightKeys[i] = item;
+            m_LooseLights[i] = (M_ITEM_LIGHT) {};
+            return &m_LooseLights[i];
         }
     }
     return &m_ScratchLight;
+}
+
+static M_ITEM_LIGHT *M_GetItemLight(const ITEM *const item)
+{
+    if (item == nullptr) {
+        return &m_ScratchLight;
+    }
+    // Measured against the pool rather than through Item_GetIndex, whose
+    // int16_t result would wrap a stray pointer into a real item's slot.
+    const ITEM *const pool = Item_Get(0);
+    if (pool != nullptr && item >= pool && item < pool + MAX_ITEMS) {
+        return &m_ItemLights[item - pool];
+    }
+    return M_GetLooseItemLight(item);
 }
 
 static void M_PrepareItemLight(M_ITEM_LIGHT *const il)
@@ -843,6 +874,8 @@ static void M_ObserveLevelLoad(void)
 {
     memset(m_ItemLights, 0, sizeof(m_ItemLights));
     memset(&m_ScratchLight, 0, sizeof(m_ScratchLight));
+    memset(m_LooseLightKeys, 0, sizeof(m_LooseLightKeys));
+    memset(m_LooseLights, 0, sizeof(m_LooseLights));
     m_CurrentItemLight = nullptr;
     m_CurrentHasList = false;
     if (m_StagedPool != nullptr) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Angkor Wat's backpack cutscene now plays as it does in the original game. The backpack and the skelly's hand beside it appear, young Lara wears no backpack until she picks one up part-way through, and the scene leaves her on the floor beyond the crawlspace rather than standing inside it.

To achieve this:

- The level loader now keeps object slots the catalog cannot name, because a cutscene reaches its actors by slot number.
- The level script tells the engine where to place Lara after the crawlspace scene.
- Young Lara uses the level’s torso until frame 1350, when she gets the backpack. The skin system handles the swap correctly across outfit changes without affecting custom outfits with a new mesh-swap API.
- Two small Lua additions support that behavior and are useful on their own:
    ```lua
    trx.cutscenes.frame_num                    -- frame on screen, nil if none is playing
    trx.lara.set_mesh(mesh, object, mesh_num)  -- put another object's mesh on one of Lara's
    trx.lara.clear_mesh(mesh)                  -- give her own back
    ```

Everything specific to the scene lives in `angkor1.lua`. The engine knows nothing about backpacks :)
