### PR TITLE
objects: extend animated interaction support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,9 @@
 - added an option to turn off controller support, for players who remap their controller with external software (Gameplay → Controls → Controller support)
 - added internal collision to lifts when they are moving, so that Lara cannot exit through the meshes
 - added an option for Lara to collect stacked pickups individually, as per OG TR4 (Gameplay → Controls → Multiple pickups)
-- added support for Lara to use animated interactions when picking up thrown flares
+- added support for Lara to use animated interactions for the following:
+  - picking up thrown flares
+  - grabbing zipline handles
 - added a `damage` property to the `O_POWER_SAW` object
 - added a bindable hotkey for using the binoculars
 - added the ability to rebind switching between fullscreen and windowed mode, which stays Alt+Enter unless changed (#2251)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
   - grabbing zipline handles
   - using detonators
   - using gongs
+  - elevated scion pickups (i.e. Tomb of Qualopec/Sanctuary of the Scion)
 - added a `damage` property to the `O_POWER_SAW` object
 - added a bindable hotkey for using the binoculars
 - added the ability to rebind switching between fullscreen and windowed mode, which stays Alt+Enter unless changed (#2251)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - added support for Lara to use animated interactions for the following:
   - picking up thrown flares
   - grabbing zipline handles
+  - using detonators
 - added a `damage` property to the `O_POWER_SAW` object
 - added a bindable hotkey for using the binoculars
 - added the ability to rebind switching between fullscreen and windowed mode, which stays Alt+Enter unless changed (#2251)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
   - picking up thrown flares
   - grabbing zipline handles
   - using detonators
+  - using gongs
 - added a `damage` property to the `O_POWER_SAW` object
 - added a bindable hotkey for using the binoculars
 - added the ability to rebind switching between fullscreen and windowed mode, which stays Alt+Enter unless changed (#2251)

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -985,6 +985,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── antarc_door134_frames.bin
 │   │   │   ├── antarc_sky.bin
 │   │   │   ├── antarc_textures.bin
+│   │   │   ├── antarc_wheel_frames.bin
 │   │   │   ├── area51_animating_bounds.bin
 │   │   │   ├── area51_patrol.bin
 │   │   │   ├── area51_sky.bin
@@ -1005,6 +1006,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── coastal_sky.bin
 │   │   │   ├── coastal_spike_sfx.bin
 │   │   │   ├── coastal_textures.bin
+│   │   │   ├── coastal_wheel_frames.bin
 │   │   │   ├── common_pickup_meshes.bin
 │   │   │   ├── compound_animating_bounds.bin
 │   │   │   ├── compound_cine.bin
@@ -1085,6 +1087,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── undersea_pickup_meshes.bin
 │   │   │   ├── undersea_textures.bin
 │   │   │   ├── undersea_train.bin
+│   │   │   ├── undersea_wheel_frames.bin
 │   │   │   ├── water_sfx.bin
 │   │   │   ├── willsden_heli.bin
 │   │   │   ├── willsden_textures.bin
@@ -2328,6 +2331,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── antarc_door134_frames.bin
     │   │   │   │   ├── antarc_sky.bin
     │   │   │   │   ├── antarc_textures.bin
+    │   │   │   │   ├── antarc_wheel_frames.bin
     │   │   │   │   ├── area51_animating_bounds.bin
     │   │   │   │   ├── area51_patrol.bin
     │   │   │   │   ├── area51_sky.bin
@@ -2348,6 +2352,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── coastal_sky.bin
     │   │   │   │   ├── coastal_spike_sfx.bin
     │   │   │   │   ├── coastal_textures.bin
+    │   │   │   │   ├── coastal_wheel_frames.bin
     │   │   │   │   ├── common_pickup_meshes.bin
     │   │   │   │   ├── compound_animating_bounds.bin
     │   │   │   │   ├── compound_cine.bin
@@ -2428,6 +2433,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── undersea_pickup_meshes.bin
     │   │   │   │   ├── undersea_textures.bin
     │   │   │   │   ├── undersea_train.bin
+    │   │   │   │   ├── undersea_wheel_frames.bin
     │   │   │   │   ├── water_sfx.bin
     │   │   │   │   ├── willsden_heli.bin
     │   │   │   │   ├── willsden_textures.bin

--- a/src/trx/game/objects/general/detonator_box.c
+++ b/src/trx/game/objects/general/detonator_box.c
@@ -1,10 +1,9 @@
+#include <trx/config.h>
 #include <trx/game/camera.h>
-#include <trx/game/game_flow.h>
 #include <trx/game/input.h>
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
-#include <trx/game/objects/general/pickup.h>
 #include <trx/game/output.h>
 #include <trx/game/sound.h>
 
@@ -74,6 +73,53 @@ static void M_Control(const int16_t item_num)
     }
 }
 
+static bool M_ShowInventory(const ITEM *const item)
+{
+    if (!GF_ShowInventoryKeys(item->object_id)) {
+        Lara_RefuseInteraction();
+        return false;
+    }
+
+    return true;
+}
+
+static void M_CollisionControlled(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    if (!Lara_Interact_CanControl(LARA_INTERACT_RECEPTACLE, item_num)) {
+        Object_Collision(item_num, lara_item, coll);
+        return;
+    }
+
+    ITEM *const item = Item_Get(item_num);
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const OBJECT *const obj = Object_Get(item->object_id);
+
+    if (Lara_TestPosition(item, obj->bounds_func())) {
+        if (!lara->interact_target.is_moving
+            && (!M_ShowInventory(item)
+                || !Lara_Interact_HasActiveTarget(Item_GetIndex(item)))) {
+            return;
+        }
+
+        if (lara_item->current_anim_state == LS(LS_STOP)) {
+            lara->interact_target.is_moving = false;
+        }
+
+        if (Lara_MovePosition(item, &m_Position)) {
+            Lara_Interact_FinishControl(LARA_INTERACT_RECEPTACLE);
+            M_Use(lara_item, item);
+        } else {
+            lara->interact_target.item_num = item_num;
+        }
+    } else if (
+        lara->interact_target.is_moving
+        && lara->interact_target.item_num == item_num) {
+        lara->interact_target.is_moving = false;
+        lara->gun_status = LGS_ARMLESS;
+    }
+}
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -83,15 +129,21 @@ static void M_Collision(
     }
 
     ITEM *const item = Item_Get(item_num);
-    const OBJECT *const obj = Object_Get(item->object_id);
+    if (!Item_IsInactive(item)) {
+        goto normal_collision;
+    }
+
+    if (g_Config.gameplay.enable_walk_to_items) {
+        M_CollisionControlled(item_num, lara_item, coll);
+        return;
+    }
 
     if (Lara_Interact_HasActiveTarget(item_num)) {
         M_Use(lara_item, item);
         return;
     }
 
-    if (!Item_IsInactive(item) || !g_Input.action
-        || lara->gun_status != LGS_ARMLESS || lara_item->gravity
+    if (!g_Input.action || lara->gun_status != LGS_ARMLESS || lara_item->gravity
         || !Lara_Interact_CanBegin(LARA_INTERACT_RECEPTACLE)) {
         goto normal_collision;
     }
@@ -101,6 +153,7 @@ static void M_Collision(
     item->rot.y = lara_item->rot.y;
     item->rot.z = 0;
 
+    const OBJECT *const obj = Object_Get(item->object_id);
     if (!Lara_TestPosition(item, obj->bounds_func())) {
         item->rot = old_rot;
         goto normal_collision;
@@ -108,10 +161,7 @@ static void M_Collision(
 
     item->rot = old_rot;
 
-    if (!GF_ShowInventoryKeys(item->object_id)) {
-        Lara_RefuseInteraction();
-    }
-
+    M_ShowInventory(item);
     return;
 
 normal_collision:

--- a/src/trx/game/objects/general/gong.c
+++ b/src/trx/game/objects/general/gong.c
@@ -1,15 +1,29 @@
-#include <trx/game/game_flow.h>
+#include <trx/config.h>
 #include <trx/game/input.h>
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
-#include <trx/game/objects/general/pickup.h>
 
-static XYZ_32 m_Position = { .x = 0, .y = 0, .z = 0 };
+static XYZ_32 m_DefaultPosition = {};
+static XYZ_32 m_ControlledPosition = { .x = WALL_L / 2,
+                                       .y = 0,
+                                       .z = -STEP_L * 3 };
 
-static const OBJECT_BOUNDS m_Bounds = {
+static const OBJECT_BOUNDS m_DefaultBounds = {
     .shift = {
         .min = { .x = -WALL_L / 2, .y = -100, .z = -WALL_L / 2 - 300, },
+        .max = { .x = +WALL_L, .y = +100, .z = -WALL_L / 2 + 100, },
+    },
+    .rot = {
+        .min = { .x = -30 * DEG_1, .y = 0, .z = 0, },
+        .max = { .x = +30 * DEG_1, .y = 0, .z = 0, },
+    },
+    .ignore_rot = true,
+};
+
+static const OBJECT_BOUNDS m_ControlledBounds = {
+    .shift = {
+        .min = { .x = -WALL_L / 2, .y = -100, .z = -WALL_L, },
         .max = { .x = +WALL_L, .y = +100, .z = -WALL_L / 2 + 100, },
     },
     .rot = {
@@ -52,7 +66,7 @@ static void M_CreateGongBonger(ITEM *const lara_item)
 
 static void M_Use(ITEM *const lara_item, ITEM *const receptacle_item)
 {
-    Lara_AlignPosition(receptacle_item, &m_Position);
+    Lara_AlignPosition(receptacle_item, &m_DefaultPosition);
     lara_item->rot.y += DEG_180;
 
     Lara_SwitchToExtraState(LS_EXTRA_GONG_BONG);
@@ -72,7 +86,65 @@ static void M_Use(ITEM *const lara_item, ITEM *const receptacle_item)
 
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
-    return &m_Bounds;
+    return g_Config.gameplay.enable_walk_to_items ? &m_ControlledBounds
+                                                  : &m_DefaultBounds;
+}
+
+static bool M_ShowInventory(const ITEM *const item)
+{
+    if (!GF_ShowInventoryKeys(item->object_id)) {
+        Lara_RefuseInteraction();
+        return false;
+    }
+
+    return true;
+}
+
+static void M_CollisionControlled(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    if (!Lara_Interact_CanControl(LARA_INTERACT_RECEPTACLE, item_num)) {
+        Object_Collision(item_num, lara_item, coll);
+        return;
+    }
+
+    ITEM *const item = Item_Get(item_num);
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const OBJECT *const obj = Object_Get(item->object_id);
+
+    const XYZ_16 old_rot = item->rot;
+    item->rot.x = 0;
+    item->rot.y += DEG_180;
+    item->rot.z = 0;
+
+    if (Lara_TestPosition(item, obj->bounds_func())) {
+        item->rot = old_rot;
+        if (!lara->interact_target.is_moving
+            && (!M_ShowInventory(item)
+                || !Lara_Interact_HasActiveTarget(Item_GetIndex(item)))) {
+            return;
+        }
+
+        if (lara_item->current_anim_state == LS(LS_STOP)) {
+            lara->interact_target.is_moving = false;
+        }
+
+        item->rot.y = old_rot.y + DEG_180;
+        if (Lara_MovePosition(item, &m_ControlledPosition)) {
+            Lara_Interact_FinishControl(LARA_INTERACT_RECEPTACLE);
+            item->rot = old_rot;
+            M_Use(lara_item, item);
+        } else {
+            lara->interact_target.item_num = item_num;
+        }
+    } else if (
+        lara->interact_target.is_moving
+        && lara->interact_target.item_num == item_num) {
+        lara->interact_target.is_moving = false;
+        lara->gun_status = LGS_ARMLESS;
+    }
+
+    item->rot = old_rot;
 }
 
 static void M_Collision(
@@ -84,15 +156,21 @@ static void M_Collision(
     }
 
     ITEM *const item = Item_Get(item_num);
-    const OBJECT *const obj = Object_Get(item->object_id);
+    if (!Item_IsInactive(item)) {
+        goto normal_collision;
+    }
+
+    if (g_Config.gameplay.enable_walk_to_items) {
+        M_CollisionControlled(item_num, lara_item, coll);
+        return;
+    }
 
     if (Lara_Interact_HasActiveTarget(item_num)) {
         M_Use(lara_item, item);
         return;
     }
 
-    if (!Item_IsInactive(item) || !g_Input.action
-        || lara->gun_status != LGS_ARMLESS || lara_item->gravity
+    if (!g_Input.action || lara->gun_status != LGS_ARMLESS || lara_item->gravity
         || !Lara_Interact_CanBegin(LARA_INTERACT_RECEPTACLE)) {
         goto normal_collision;
     }
@@ -102,6 +180,7 @@ static void M_Collision(
     item->rot.y = lara_item->rot.y;
     item->rot.z = 0;
 
+    const OBJECT *const obj = Object_Get(item->object_id);
     if (!Lara_TestPosition(item, obj->bounds_func())) {
         item->rot = old_rot;
         goto normal_collision;
@@ -109,10 +188,7 @@ static void M_Collision(
 
     item->rot = old_rot;
 
-    if (!GF_ShowInventoryKeys(item->object_id)) {
-        Lara_RefuseInteraction();
-    }
-
+    M_ShowInventory(item);
     return;
 
 normal_collision:

--- a/src/trx/game/objects/general/scion1.c
+++ b/src/trx/game/objects/general/scion1.c
@@ -1,20 +1,18 @@
 // Tomb of Qualopec and Sanctuary Scion pickup.
 // Triggers O_LARA_EXTRA pedestal pickup animation.
+// TODO: merge into pickup.c as PICKUP_MODE_SCION.
 
+#include <trx/config.h>
 #include <trx/game/camera.h>
-#include <trx/game/game.h>
 #include <trx/game/input.h>
-#include <trx/game/inventory.h>
 #include <trx/game/lara.h>
-#include <trx/game/level.h>
 #include <trx/game/objects/common.h>
-#include <trx/game/overlay.h>
-#include <trx/game/savegame.h>
-#include <trx/game/stats.h>
+#include <trx/game/rooms.h>
 
-static XYZ_32 m_Scion1_Position = { 0, 640, -310 };
+static XYZ_32 m_DefaultPosition = { 0, 640, -310 };
+static XYZ_32 m_ControlledPosition = { 0, 0, -380 };
 
-static const OBJECT_BOUNDS m_Scion1_Bounds = {
+static const OBJECT_BOUNDS m_DefaultBounds = {
     .shift = {
         .min = { .x = -256, .y = +640 - 100, .z = -350, },
         .max = { .x = +256, .y = +640 + 100, .z = -200, },
@@ -25,9 +23,21 @@ static const OBJECT_BOUNDS m_Scion1_Bounds = {
     },
 };
 
+static const OBJECT_BOUNDS m_ControlledBounds = {
+    .shift = {
+        .min = { .x = -256, .y = -640 - 100, .z = -511, },
+        .max = { .x = +256, .y = +640 + 100, .z = 320, },
+    },
+    .rot = {
+        .min = { .x = -10 * DEG_1, .y = -30 * DEG_1, .z = 0, },
+        .max = { .x = +10 * DEG_1, .y = +30 * DEG_1, .z = 0, },
+    },
+};
+
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
-    return &m_Scion1_Bounds;
+    return g_Config.gameplay.enable_walk_to_items ? &m_ControlledBounds
+                                                  : &m_DefaultBounds;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
@@ -40,29 +50,121 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
     }
 }
 
-static void M_Collision(
-    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+static XYZ_16 M_PrepareAndCacheRot(
+    ITEM *const item, const ITEM *const lara_item)
 {
-    ITEM *const item = Item_Get(item_num);
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    const OBJECT *const obj = Object_Get(item->object_id);
-
     const XYZ_16 old_rot = item->rot;
     item->rot.y = lara_item->rot.y;
     item->rot.x = 0;
     item->rot.z = 0;
+    return old_rot;
+}
 
+static void M_Collect(const ITEM *const item, const ITEM *const lara_item)
+{
+    Lara_GetLaraInfo()->interact_target.item_num = Item_GetIndex(item);
+    Lara_AlignPosition(item, &m_DefaultPosition);
+    Lara_SwitchToExtraState(LS_EXTRA_SCION_PICKUP_1);
+    Camera_InvokeCinematic(lara_item, 0, 0);
+}
+
+static const BOUNDS_16 *M_FindPlinthBounds(const ITEM *const item)
+{
+    const ROOM *const room = Room_Get(item->room_num);
+    const BOUNDS_16 *const item_bounds = Item_GetBoundsAccurate(item);
+    for (int32_t i = 0; i < room->num_static_meshes; i++) {
+        const STATIC_MESH *const mesh = &room->static_meshes[i];
+        const STATIC_OBJECT_3D *const obj =
+            Object_Get3DStatic(mesh->static_num);
+        if (!obj->visible || mesh->pos.x != item->pos.x
+            || mesh->pos.z != item->pos.z) {
+            continue;
+        }
+
+        const BOUNDS_16 *const obj_bounds = &obj->collision_bounds;
+        if (item_bounds->min.x <= obj_bounds->max.x
+            && item_bounds->max.x >= obj_bounds->min.x
+            && item_bounds->min.z <= obj_bounds->max.z
+            && item_bounds->max.z >= obj_bounds->min.z
+            && (obj_bounds->min.x != 0 || obj_bounds->max.x != 0)) {
+            return obj_bounds;
+        }
+    }
+
+    return nullptr;
+}
+
+static void M_CollisionControlled(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    ITEM *const item = Item_Get(item_num);
+    const XYZ_16 old_rot = M_PrepareAndCacheRot(item, lara_item);
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+
+    if (Lara_Interact_CanControl(LARA_INTERACT_PICKUP, item_num)) {
+        const OBJECT *const obj = Object_Get(item->object_id);
+        OBJECT_BOUNDS bounds = *obj->bounds_func();
+        bounds.shift.max.y = lara_item->pos.y - item->pos.y + 100;
+        const BOUNDS_16 *const plinth_bounds = M_FindPlinthBounds(item);
+        if (plinth_bounds != nullptr) {
+            bounds.shift.min.x = plinth_bounds->min.x;
+            bounds.shift.max.x = plinth_bounds->max.x;
+            bounds.shift.max.z = plinth_bounds->max.z;
+        }
+
+        if (Lara_TestPosition(item, &bounds)) {
+            XYZ_32 pos = m_ControlledPosition;
+            pos.y = Lara_GetItem()->pos.y - item->pos.y;
+            if (plinth_bounds != nullptr) {
+                pos.z = -200 - plinth_bounds->max.z;
+            }
+
+            if (Lara_MovePosition(item, &pos)) {
+                Lara_Interact_FinishControl(LARA_INTERACT_PICKUP);
+                M_Collect(item, lara_item);
+            }
+            lara->interact_target.item_num = item_num;
+        } else if (Lara_Interact_HasActiveTarget(item_num)) {
+            lara->interact_target.is_moving = false;
+            lara->interact_target.item_num = NO_ITEM;
+            lara->gun_status = LGS_ARMLESS;
+        }
+    } else if (
+        !lara->interact_target.is_moving
+        && lara->interact_target.item_num == item_num) {
+        lara->interact_target.item_num = NO_ITEM;
+    }
+
+cleanup:
+    item->rot = old_rot;
+}
+
+static void M_Collision(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (lara->extra_anim) {
+        return;
+    }
+
+    if (g_Config.gameplay.enable_walk_to_items) {
+        M_CollisionControlled(item_num, lara_item, coll);
+        return;
+    }
+
+    ITEM *const item = Item_Get(item_num);
+    const XYZ_16 old_rot = M_PrepareAndCacheRot(item, lara_item);
+
+    const OBJECT *const obj = Object_Get(item->object_id);
     if (!Lara_TestPosition(item, obj->bounds_func())) {
         goto cleanup;
     }
 
     if (g_Input.action && lara->gun_status == LGS_ARMLESS && !lara_item->gravity
         && Lara_Interact_CanBegin(LARA_INTERACT_RECEPTACLE)) {
-        lara->interact_target.item_num = item_num;
-        Lara_AlignPosition(item, &m_Scion1_Position);
-        Lara_SwitchToExtraState(LS_EXTRA_SCION_PICKUP_1);
-        Camera_InvokeCinematic(lara_item, 0, 0);
+        M_Collect(item, lara_item);
     }
+
 cleanup:
     item->rot = old_rot;
 }

--- a/src/trx/game/objects/general/scion4.c
+++ b/src/trx/game/objects/general/scion4.c
@@ -4,11 +4,9 @@
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 
-#define EXTRA_ANIM_HOLDER_SCION 0
+static XYZ_32 m_Position = { 0, 280, -512 + 105 };
 
-static XYZ_32 m_Scion4_Position = { 0, 280, -512 + 105 };
-
-static const OBJECT_BOUNDS m_Scion4_Bounds = {
+static const OBJECT_BOUNDS m_Bounds = {
     .shift = {
         .min = { .x = -256, .y = +256 - 50, .z = -512 - 350, },
         .max = { .x = +256, .y = +256 + 50, .z = -200, },
@@ -21,7 +19,7 @@ static const OBJECT_BOUNDS m_Scion4_Bounds = {
 
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
-    return &m_Scion4_Bounds;
+    return &m_Bounds;
 }
 
 static void M_Control(const int16_t item_num)
@@ -36,9 +34,7 @@ static void M_Collision(
     LARA_INFO *const lara = Lara_GetLaraInfo();
     const OBJECT *const obj = Object_Get(item->object_id);
 
-    int16_t rotx = item->rot.x;
-    int16_t roty = item->rot.y;
-    int16_t rotz = item->rot.z;
+    const XYZ_16 old_rot = item->rot;
     item->rot.y = lara_item->rot.y;
     item->rot.x = 0;
     item->rot.z = 0;
@@ -49,14 +45,13 @@ static void M_Collision(
 
     if (g_Input.action && lara->gun_status == LGS_ARMLESS && !lara_item->gravity
         && Lara_Interact_CanBegin(LARA_INTERACT_RECEPTACLE)) {
-        Lara_AlignPosition(item, &m_Scion4_Position);
+        Lara_AlignPosition(item, &m_Position);
         Lara_SwitchToExtraState(LS_EXTRA_SCION_PICKUP_2);
         Camera_InvokeCinematic(lara_item, 0, -DEG_90);
     }
+
 cleanup:
-    item->rot.x = rotx;
-    item->rot.y = roty;
-    item->rot.z = rotz;
+    item->rot = old_rot;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -1,3 +1,4 @@
+#include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
@@ -17,13 +18,13 @@ typedef enum {
     M_STATE_HANG,
 } M_STATE;
 
-static const XYZ_32 m_ZiplineHandlePosition = {
+static const XYZ_32 m_Position = {
     .x = 0,
     .y = 0,
     .z = WALL_L / 2 - 141,
 };
 
-static const OBJECT_BOUNDS m_ZiplineHandleBounds = {
+static const OBJECT_BOUNDS m_DefaultBounds = {
     .shift = {
         .min = { .x = -WALL_L / 4, .y = -100, .z = +WALL_L / 4, },
         .max = { .x = +WALL_L / 4, .y = +100, .z = +WALL_L / 2, },
@@ -34,9 +35,21 @@ static const OBJECT_BOUNDS m_ZiplineHandleBounds = {
     },
 };
 
+static const OBJECT_BOUNDS m_ControlledBounds = {
+    .shift = {
+        .min = { .x = -WALL_L / 4, .y = -100, .z = +0, },
+        .max = { .x = +WALL_L / 4, .y = +100, .z = +WALL_L / 2, },
+    },
+    .rot = {
+        .min = { .x = +0, .y = -25 * DEG_1, .z = +0, },
+        .max = { .x = +0, .y = +25 * DEG_1, .z = +0, },
+    },
+};
+
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
-    return &m_ZiplineHandleBounds;
+    return g_Config.gameplay.enable_walk_to_items ? &m_ControlledBounds
+                                                  : &m_DefaultBounds;
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -124,17 +137,61 @@ static void M_Control(const int16_t item_num)
     item->trigger.spent = false;
 }
 
-static void M_Collision(
+static void M_Grab(
+    ITEM *const zip_item, ITEM *const lara_item, LARA_INFO *const lara)
+{
+    Item_SwitchToAnim(lara_item, LA(LA_ZIPLINE_GRAB), 0);
+    lara_item->current_anim_state == LS(LS_PULL_UP);
+    lara_item->goal_anim_state = LS(LS_ZIPLINE);
+    lara->gun_status = LGS_HANDS_BUSY;
+
+    Item_AddSimulated(Item_GetIndex(zip_item));
+    zip_item->trigger.spent = true;
+}
+
+static void M_CollisionControlled(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (!g_Input.action || lara->gun_status != LGS_ARMLESS || lara_item->gravity
-        || lara_item->current_anim_state != LS(LS_STOP)) {
+    if (!Lara_Interact_CanControl(LARA_INTERACT_SWITCH, item_num)) {
+        Object_Collision(item_num, lara_item, coll);
         return;
     }
 
     ITEM *const item = Item_Get(item_num);
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const OBJECT *const obj = Object_Get(item->object_id);
+
+    if (Lara_TestPosition(item, obj->bounds_func())) {
+        if (Lara_MovePosition(item, &m_Position)) {
+            Lara_Interact_FinishControl(LARA_INTERACT_SWITCH);
+            M_Grab(item, lara_item, lara);
+        } else {
+            lara->interact_target.item_num = item_num;
+        }
+    } else if (
+        lara->interact_target.is_moving
+        && lara->interact_target.item_num == item_num) {
+        lara->interact_target.is_moving = false;
+        lara->gun_status = LGS_ARMLESS;
+    }
+}
+
+static void M_Collision(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    ITEM *const item = Item_Get(item_num);
     if (!Item_IsInactive(item)) {
+        return;
+    }
+
+    if (g_Config.gameplay.enable_walk_to_items) {
+        M_CollisionControlled(item_num, lara_item, coll);
+        return;
+    }
+
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (!g_Input.action || lara->gun_status != LGS_ARMLESS || lara_item->gravity
+        || lara_item->current_anim_state != LS(LS_STOP)) {
         return;
     }
 
@@ -143,19 +200,8 @@ static void M_Collision(
         return;
     }
 
-    Lara_AlignPosition(item, &m_ZiplineHandlePosition);
-    lara->gun_status = LGS_HANDS_BUSY;
-
-    lara_item->goal_anim_state = LS(LS_ZIPLINE);
-    do {
-        Item_Animate(lara_item);
-    } while (lara_item->current_anim_state != LS(LS_PULL_UP));
-
-    if (!item->is_simulated) {
-        Item_AddSimulated(item_num);
-    }
-
-    item->trigger.spent = true;
+    Lara_AlignPosition(item, &m_Position);
+    M_Grab(item, lara_item, lara);
 }
 
 static void M_Setup(OBJECT *const obj)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This extends animation interaction support to scions, ziplines, detonator boxes and the gong. The Atlantis scion remains excluded as it's much too awkward - the holder interferes with the controlled movement, plus the slope and the step prevent Lara reaching the target position.

I'm thinking we should merge `O_SCION_ITEM_1` into the pickup module, as for now I've just replicated the plinth handling code from there. I'll follow up with that later.

Resolves TRX949.