### PR TITLE
Take the language from the system on first launch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)
 - added the ability for Lara to turn on the spot by pressing walk and roll (Gameplay → Controls → Alternative turns) (#5756)
 - added the ability for Lara to turn on the spot on monkeybars by pressing roll (Gameplay → Controls → Alternative turns)
+- added the language being taken from the operating system on the first launch, where the game ships it (#4460)
 - improved error messages related to bad command invocations
 - improved state change handling when shimmying is requested while in the slow swing-in state on thin ledges (#5161)
 - changed a multi-key shortcut to answer only to the side of Ctrl, Shift or Alt it was bound to, where a shortcut of a single key still takes either

--- a/src/meson.build
+++ b/src/meson.build
@@ -332,6 +332,7 @@ common_sources = [
   'trx/game/game_flow/util.c',
   'trx/game/game_flow/vars.c',
   'trx/game/game_strings/entries.c',
+  'trx/game/game_strings/lang_match.c',
   'trx/game/game_strings/manager.c',
   'trx/game/game_strings/table/common.c',
   'trx/game/game_strings/table/priv.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -200,6 +200,20 @@ unit_tests += {
 }
 
 unit_tests += {
+  'name': 'trx/game/game_strings/lang_match',
+  'engine': [
+    'core/memory.c',
+    'core/strings/case_funcs.c',
+    'core/strings/common.c',
+    'core/strings/fuzzy_match.c',
+    'core/vector.c',
+    'game/game_strings/lang_match.c',
+  ],
+  'deps': [dep_pcre2],
+  'args': ['-DPCRE2_CODE_UNIT_WIDTH=8'],
+}
+
+unit_tests += {
   'name': 'trx/core/bson',
   'engine': [
     'core/bson/parse.c',

--- a/src/tests/trx/game/game_strings/lang_match.c
+++ b/src/tests/trx/game/game_strings/lang_match.c
@@ -1,0 +1,102 @@
+#include <harness/harness.h>
+
+#include <trx/core/vector.h>
+#include <trx/game/game_strings/lang_match.h>
+
+// The codes on either side are the ones the strings files are discovered
+// under - "en", "en-gb", "pl" - and the ones the player's system reports.
+
+static VECTOR *M_Codes(const char *const *const codes, const int32_t count)
+{
+    VECTOR *const out = Vector_Create(sizeof(char *));
+    for (int32_t i = 0; i < count; i++) {
+        Vector_Add(out, &codes[i]);
+    }
+    return out;
+}
+
+#define CODES(...)                                                             \
+    M_Codes(                                                                   \
+        (const char *[]) { __VA_ARGS__ },                                      \
+        sizeof((const char *[]) { __VA_ARGS__ }) / sizeof(const char *))
+
+TEST(the_wanted_language_is_taken_where_it_ships)
+{
+    VECTOR *const available = CODES("en", "de", "pl");
+    VECTOR *const preferred = CODES("pl");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "pl");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(nothing_is_taken_where_no_wanted_language_ships)
+{
+    VECTOR *const available = CODES("en", "de");
+    VECTOR *const preferred = CODES("ja", "ko");
+    CHECK_NULL(GameStringLang_MatchPreferred(available, preferred));
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(the_second_choice_is_taken_where_the_first_does_not_ship)
+{
+    VECTOR *const available = CODES("en", "de");
+    VECTOR *const preferred = CODES("ja", "de");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "de");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(a_region_is_honoured_before_it_is_discarded)
+{
+    VECTOR *const available = CODES("en", "en-gb");
+    VECTOR *const preferred = CODES("en-gb");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "en-gb");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(the_language_alone_answers_a_region_that_does_not_ship)
+{
+    VECTOR *const available = CODES("en", "en-gb");
+    VECTOR *const preferred = CODES("en-au");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "en");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(another_region_answers_last)
+{
+    VECTOR *const available = CODES("en", "pt-br");
+    VECTOR *const preferred = CODES("pt-pt");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "pt-br");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(an_exact_later_choice_beats_a_region_match_on_an_earlier_one)
+{
+    VECTOR *const available = CODES("pt-br", "de");
+    VECTOR *const preferred = CODES("pt-pt", "de");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "de");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(case_does_not_matter)
+{
+    VECTOR *const available = CODES("en", "pt-br");
+    VECTOR *const preferred = CODES("PT-BR");
+    CHECK_EQ_STR(GameStringLang_MatchPreferred(available, preferred), "pt-br");
+    Vector_Free(available);
+    Vector_Free(preferred);
+}
+
+TEST(a_system_that_says_nothing_leaves_the_choice_alone)
+{
+    VECTOR *const available = CODES("en", "de");
+    VECTOR *const preferred = Vector_Create(sizeof(char *));
+    CHECK_NULL(GameStringLang_MatchPreferred(available, preferred));
+    Vector_Free(available);
+    Vector_Free(preferred);
+}

--- a/src/trx/game/game_strings/lang_match.c
+++ b/src/trx/game/game_strings/lang_match.c
@@ -1,0 +1,70 @@
+#include <trx/game/game_strings/lang_match.h>
+
+#include <trx/core/strings.h>
+
+#include <ctype.h>
+#include <string.h>
+
+typedef enum {
+    M_EXACT,
+    M_BASE,
+    M_SIBLING,
+} M_PASS;
+
+static size_t M_GetBaseLength(const char *const code)
+{
+    const char *const sep = strchr(code, '-');
+    return sep != nullptr ? (size_t)(sep - code) : strlen(code);
+}
+
+static bool M_HasSameBase(const char *const a, const char *const b)
+{
+    const size_t len = M_GetBaseLength(a);
+    if (len != M_GetBaseLength(b)) {
+        return false;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (tolower((unsigned char)a[i]) != tolower((unsigned char)b[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool M_Accepts(
+    const M_PASS pass, const char *const available, const char *const wanted)
+{
+    switch (pass) {
+    case M_EXACT:
+        return String_Equivalent(available, wanted);
+    case M_BASE:
+        return M_GetBaseLength(available) == strlen(available)
+            && M_HasSameBase(available, wanted);
+    case M_SIBLING:
+        return M_HasSameBase(available, wanted);
+    }
+    return false;
+}
+
+const char *GameStringLang_MatchPreferred(
+    const VECTOR *const available, const VECTOR *const preferred)
+{
+    if (available == nullptr || preferred == nullptr) {
+        return nullptr;
+    }
+    for (M_PASS pass = M_EXACT; pass <= M_SIBLING; pass++) {
+        for (int32_t i = 0; i < preferred->count; i++) {
+            const char *const wanted = *(char **)Vector_Get(preferred, i);
+            if (wanted == nullptr || *wanted == '\0') {
+                continue;
+            }
+            for (int32_t j = 0; j < available->count; j++) {
+                const char *const code = *(char **)Vector_Get(available, j);
+                if (code != nullptr && M_Accepts(pass, code, wanted)) {
+                    return code;
+                }
+            }
+        }
+    }
+    return nullptr;
+}

--- a/src/trx/game/game_strings/lang_match.h
+++ b/src/trx/game/game_strings/lang_match.h
@@ -1,0 +1,15 @@
+// Choosing which of the shipped languages fits the one the player's system is
+// set to.
+#pragma once
+
+#include <trx/core/vector.h>
+
+// The code from `available` that best fits `preferred`, or nullptr where none
+// of them does. Both are vectors of char *: `available` holds the codes the
+// strings files were discovered under, `preferred` the player's locales from
+// most wanted to least. A region is honoured before it is discarded, so pt-br
+// is answered with pt-br where that ships, with pt where it does not, and with
+// another Portuguese only as a last resort.
+// The returned pointer belongs to `available`.
+const char *GameStringLang_MatchPreferred(
+    const VECTOR *available, const VECTOR *preferred);

--- a/src/trx/game/game_strings/manager.c
+++ b/src/trx/game/game_strings/manager.c
@@ -10,8 +10,11 @@
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/common.h>
+#include <trx/game/game_strings/lang_match.h>
 #include <trx/game/game_strings/table.h>
+#include <trx/game/replay/test_replay.h>
 #include <trx/game/shell.h>
+#include <trx/game/shell/platform.h>
 
 #include <string.h>
 
@@ -305,6 +308,37 @@ static void M_DiscoverLanguages(void)
     M_ReorderLanguages();
 }
 
+static void M_FreeCodes(VECTOR *const codes)
+{
+    for (int32_t i = 0; i < codes->count; i++) {
+        Memory_Free(*(char **)Vector_Get(codes, i));
+    }
+    Vector_Free(codes);
+}
+
+// A player who has never launched the game has never said what language they
+// want, so the one their system is set to stands in for the answer. A replay
+// is left out of it: what it plays back has to read the same on every machine.
+static void M_ApplySystemLanguage(void)
+{
+    if (!Config_IsFirstRun() || TestReplay_IsOpened()) {
+        return;
+    }
+    VECTOR *const available = GameStringManager_GetAvailableLanguages();
+    if (available == nullptr) {
+        return;
+    }
+    VECTOR *const preferred = Shell_GetPreferredLanguages();
+    const char *const match =
+        GameStringLang_MatchPreferred(available, preferred);
+    if (match != nullptr) {
+        LOG_INFO("selecting language '%s' from system preferences", match);
+        CONFIG_SET(g_Config.language, match);
+    }
+    M_FreeCodes(preferred);
+    M_FreeCodes(available);
+}
+
 void GameStringManager_LoadForMod(const SHELL_MOD *const mod)
 {
     M_ClearSourceFiles();
@@ -334,6 +368,7 @@ void GameStringManager_LoadForMod(const SHELL_MOD *const mod)
     Memory_FreePointer(&mod_strings_path);
 
     M_DiscoverLanguages();
+    M_ApplySystemLanguage();
     GameStringManager_ReloadLanguage(g_Config.language);
 }
 

--- a/src/trx/game/shell/platform.c
+++ b/src/trx/game/shell/platform.c
@@ -8,7 +8,12 @@
 
 #endif
 
+#include <trx/core/memory.h>
+#include <trx/core/strings.h>
+
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_locale.h>
+#include <ctype.h>
 #include <libavcodec/version.h>
 #include <libavutil/log.h>
 
@@ -79,6 +84,26 @@ void Shell_SetupHiDPI(void)
     SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
     SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "0");
 #endif
+}
+
+VECTOR *Shell_GetPreferredLanguages(void)
+{
+    VECTOR *const out = Vector_Create(sizeof(char *));
+    SDL_Locale *const locales = SDL_GetPreferredLocales();
+    if (locales == nullptr) {
+        return out;
+    }
+    for (const SDL_Locale *loc = locales; loc->language != nullptr; loc++) {
+        char *const code = loc->country != nullptr
+            ? String_Format("%s-%s", loc->language, loc->country)
+            : Memory_DupStr(loc->language);
+        for (char *c = code; *c != '\0'; c++) {
+            *c = tolower((unsigned char)*c);
+        }
+        Vector_Add(out, &code);
+    }
+    SDL_free(locales);
+    return out;
 }
 
 void Shell_SetupLibAV(void)

--- a/src/trx/game/shell/platform.h
+++ b/src/trx/game/shell/platform.h
@@ -1,9 +1,16 @@
 #pragma once
 
 // Isolated platform-sensitive initialization code
+#include <trx/core/vector.h>
+
 #include <SDL2/SDL_video.h>
 
 void Shell_SetupHiDPI(void);
 void Shell_SetupLibAV(void);
+
+// The languages the player's system is set to, most wanted first, as a vector
+// of char * holding codes like "pl" or "pt-br". Empty where the system does
+// not say. The caller owns the vector and each string in it.
+VECTOR *Shell_GetPreferredLanguages(void);
 
 void Shell_EnableThemeSupport(SDL_Window *window);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fresh installs now default to the operating system's language when supported, falling back from regional variants (e.g. pt-BR → pt) and ultimately to English. This only happens when no settings file exists, preserving replay consistency. TR3 FMV dubbing behavior remains unchanged.

Resolves #4460
