### PR TITLE
Return a sentinel when an index lookup has nothing to index

### DIFF
--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -203,7 +203,11 @@ ITEM *Item_Get(const int16_t item_num)
 
 int16_t Item_GetIndex(const ITEM *const item)
 {
-    return item - Item_Get(0);
+    if (item == nullptr || m_Items == nullptr || item < m_Items
+        || item >= m_Items + MAX_ITEMS) {
+        return NO_ITEM;
+    }
+    return item - m_Items;
 }
 
 TRX_HANDLE Item_GetHandle(const int16_t item_num)

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -11,6 +11,7 @@ void Item_InitialiseItems(int32_t num_items);
 
 // Resolve a slot index to its item, unchecked. The lookup everything uses.
 ITEM *Item_Get(int16_t num);
+// The item's slot, or NO_ITEM for one the pool does not hold.
 int16_t Item_GetIndex(const ITEM *item);
 
 // A handle to the item currently in the slot, and the item a handle still names

--- a/src/trx/game/output/bind.c
+++ b/src/trx/game/output/bind.c
@@ -29,5 +29,5 @@ void Output_Bind_ResetRooms(void)
 
 OUTPUT_ROOM_BIND *Output_Bind_GetRoom(const ROOM *const room)
 {
-    return &m_RoomBindings[Room_GetNumber(room)];
+    return &m_RoomBindings[Room_GetIndex(room)];
 }

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -257,7 +257,7 @@ void OutputSource_Rooms_ObserveLevelUnload(void)
 void OutputSource_Rooms_ObserveRoomFlip(const ROOM *const room)
 {
     if (room->flip_status == RFS_UNFLIPPED && room->flipped_room != NO_ROOM) {
-        const int16_t room_1 = Room_GetNumber(room);
+        const int16_t room_1 = Room_GetIndex(room);
         const int16_t room_2 = room->flipped_room;
         SWAP(m_Priv.meshes[room_1], m_Priv.meshes[room_2]);
     }
@@ -266,7 +266,7 @@ void OutputSource_Rooms_ObserveRoomFlip(const ROOM *const room)
 void OutputSource_Rooms_StageRoom(const ROOM *const room)
 {
     M_PRIV *const p = &m_Priv;
-    OUTPUT_MESH *const mesh = p->meshes[Room_GetNumber(room)];
+    OUTPUT_MESH *const mesh = p->meshes[Room_GetIndex(room)];
     const OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
     const MESH_INSTANCE inst = {
         .mesh = mesh,

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -233,7 +233,7 @@ static void M_RenderPass(
     for (int32_t i = 0; i < p->scheduled->count; i++) {
         const M_INSTANCE *const instance = Vector_Get(p->scheduled, i);
         const M_ROOM_MESH *const mesh =
-            &p->meshes[Room_GetNumber(instance->room)];
+            &p->meshes[Room_GetIndex(instance->room)];
         Output_MeshShader_UploadModelMatrix(p->shader, &instance->matrix);
         if (g_Config.debug.enable_debug_triggers) {
             glDrawArrays(
@@ -329,7 +329,7 @@ void OutputSource_RoomsDebug_ObserveRoomFlip(const ROOM *const room)
 {
     M_PRIV *const p = &m_Priv;
     if (room->flip_status == RFS_UNFLIPPED && room->flipped_room != NO_ROOM) {
-        const int16_t room_1 = Room_GetNumber(room);
+        const int16_t room_1 = Room_GetIndex(room);
         const int16_t room_2 = room->flipped_room;
         SWAP(p->meshes[room_1], p->meshes[room_2]);
     }

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -414,7 +414,7 @@ int32_t Room_GetOutsideStatus(
     return -2;
 }
 
-int32_t Room_GetNumber(const ROOM *const room)
+int32_t Room_GetIndex(const ROOM *const room)
 {
     if (room == nullptr) {
         return NO_ROOM;

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -416,7 +416,8 @@ int32_t Room_GetOutsideStatus(
 
 int32_t Room_GetIndex(const ROOM *const room)
 {
-    if (room == nullptr) {
+    if (room == nullptr || m_Rooms == nullptr || room < m_Rooms
+        || room >= m_Rooms + m_RoomCount) {
         return NO_ROOM;
     }
     return room - m_Rooms;

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -14,6 +14,7 @@ ROOM *Room_Get(int32_t room_num);
 // the change goes stale rather than naming a different room.
 TRX_HANDLE Room_GetHandle(int32_t room_num);
 ROOM *Room_FromHandle(TRX_HANDLE handle);
+// The room's index, or NO_ROOM for one the level does not hold.
 int32_t Room_GetIndex(const ROOM *room);
 
 void Room_InitialiseFlipStatus(void);

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -14,7 +14,7 @@ ROOM *Room_Get(int32_t room_num);
 // the change goes stale rather than naming a different room.
 TRX_HANDLE Room_GetHandle(int32_t room_num);
 ROOM *Room_FromHandle(TRX_HANDLE handle);
-int32_t Room_GetNumber(const ROOM *room);
+int32_t Room_GetIndex(const ROOM *room);
 
 void Room_InitialiseFlipStatus(void);
 void Room_FlipMap(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Item_GetIndex` and `Room_GetIndex` now verify that their input actually belongs to the pool they index, returning `NO_ITEM` or `NO_ROOM` otherwise. `Room_GetNumber` is renamed to `Room_GetIndex` because it returns the room's table index, not its level-facing room number.

Previously, both functions subtracted the pool's base address without validating the pointer first, so unrelated pointers could produce plausible-looking indices. `Item_GetIndex` made this worse by narrowing the result to `int16_t`, making later range checks depend on memory layout rather than actual pool membership.

Four callers still assume valid pool members. If that assumption breaks, they now hit `[-1]` instead of silently corrupting some random slot. Handling that case properly is out of scope here.
