### PR TITLE
Keep TR3 flying enemies below ceilings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -89,6 +89,7 @@
 - fixed Lara being able to light a free/ghost flare by selecting one from the inventory while crawling (Gameplay → Fixes → Fix free flare glitch)
 - fixed Lara leaving ripples on ceilings that lie below the waterline (regression from 1.1)
 - fixed shoals of fish and piranhas jumping back to their starting spot when loading a save
+- fixed flying enemies chasing Lara up into ceilings and back out of solid rock, most visible with the wasps in Lost City of Tinnos (#5563, OG bug)
 - fixed rain and snow starting over when a save is loaded (#5901)
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from
 - fixed Bacon Lara remaining targetable after death

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -263,6 +263,15 @@ static bool M_SameZone(const CREATURE *const creature, ITEM *const target_item)
     return zone[item->box_num] == zone[target_item->box_num];
 }
 
+static bool M_TestWaterBelow(const ITEM *const item, const int32_t y)
+{
+    int16_t room_num = item->room_num;
+    Room_GetSector(
+        (XYZ_32) { item->pos.x, y + STEP_L, item->pos.z }, &room_num);
+    const ROOM *const room = Room_Get(room_num);
+    return room->flags.underwater || room->flags.swamp;
+}
+
 static const ITEM *M_GetBaddieOverlap(const int16_t item_num)
 {
     const ITEM *item = Item_Get(item_num);
@@ -1137,8 +1146,12 @@ bool Creature_Animate(
                 item->pos.x = old.x;
                 item->pos.z = old.z;
             }
-        } else if (
-            fly_check || Object_IsType(item->object_id, g_WaterObjects)) {
+        } else {
+            if (!fly_check && !Object_IsType(item->object_id, g_WaterObjects)
+                && M_TestWaterBelow(item, y)) {
+                dy = -lot->setup.fly;
+            }
+
             const int32_t ceiling = Room_GetCeiling(
                 sector, (XYZ_32) { item->pos.x, y, item->pos.z });
             int32_t min_y = bounds->min.y;
@@ -1162,13 +1175,6 @@ bool Creature_Animate(
                 } else {
                     dy = 0;
                 }
-            }
-        } else {
-            sample_pos = (XYZ_32) { item->pos.x, y + STEP_L, item->pos.z };
-            Room_GetSector(sample_pos, &room_num);
-            const ROOM *const room = Room_Get(room_num);
-            if (room->flags.underwater || room->flags.swamp) {
-                dy = -lot->setup.fly;
             }
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Flying enemies now test the ceiling before rising, so a creature chasing Lara into a lower room stays in the open space rather than climbing into the rock above it. Before this, only water creatures made that test: a wasp in Lost City of Tinnos crossed into the room below at the height it started from, spent a few seconds inside solid geometry, and then sank out of the ceiling in front of Lara.

The original game has the same omission, so this diverges from it for bats and the TR4 flyers as well.

Resolves #5563
