### PR TITLE
core/filesystem: use wide paths on Windows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -129,6 +129,7 @@
 - fixed touch controls not turning themselves on the first time the game is launched on a device that has a touchscreen
 - fixed the alternative ammunition pickups, such as the second kind of shotgun ammunition, going into the inventory without loading the weapon
 - fixed Lara being able to pull out flares while crawling after picking up an item, and dropping flares when using the draw input to enter crouch state (regression from 1.3)
+- fixed the game not running when its folder name contains characters outside the system language, such as Chinese (#573)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/core/filesystem.c
+++ b/src/trx/core/filesystem.c
@@ -8,6 +8,7 @@
 
 #include <dirent.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #if defined(_WIN32)
@@ -32,6 +33,11 @@ struct MYFILE {
     #include <string.h>
     #include <windows.h>
 
+typedef struct {
+    _WDIR *handle;
+    char *name;
+} M_DIR;
+
 static wchar_t *M_UTF8ToWide(const char *const utf8_str)
 {
     if (utf8_str == nullptr) {
@@ -44,6 +50,22 @@ static wchar_t *M_UTF8ToWide(const char *const utf8_str)
     MultiByteToWideChar(CP_UTF8, 0, utf8_str, len, wide_str, wide_len);
     wide_str[wide_len] = L'\0';
     return wide_str;
+}
+
+static char *M_WideToUTF8(const wchar_t *const wide_str)
+{
+    if (wide_str == nullptr) {
+        return nullptr;
+    }
+    const int32_t len = WideCharToMultiByte(
+        CP_UTF8, 0, wide_str, -1, nullptr, 0, nullptr, nullptr);
+    if (len <= 0) {
+        return nullptr;
+    }
+    char *const utf8_str = Memory_Alloc(len);
+    WideCharToMultiByte(
+        CP_UTF8, 0, wide_str, -1, utf8_str, len, nullptr, nullptr);
+    return utf8_str;
 }
 
 static FILE *M_UTF8Fopen(const char *path, const char *mode)
@@ -97,12 +119,20 @@ bool File_DirExists(const char *path)
     if (path == nullptr) {
         return false;
     }
+#if defined(_WIN32)
+    wchar_t *const wide_path = M_UTF8ToWide(path);
+    const DWORD attrs = GetFileAttributesW(wide_path);
+    Memory_Free(wide_path);
+    return attrs != INVALID_FILE_ATTRIBUTES
+        && (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+#else
     DIR *dir = opendir(path);
     if (dir != nullptr) {
         closedir(dir);
         return true;
     }
     return false;
+#endif
 }
 
 bool File_Exists(const char *path)
@@ -111,6 +141,27 @@ bool File_Exists(const char *path)
         return false;
     }
     return M_ExistsRaw(path);
+}
+
+char *File_GetCurrentDirectory(void)
+{
+#if defined(_WIN32)
+    wchar_t *const wide_cwd = _wgetcwd(nullptr, 0);
+    if (wide_cwd == nullptr) {
+        return nullptr;
+    }
+    char *const cwd = M_WideToUTF8(wide_cwd);
+    free(wide_cwd);
+    return cwd;
+#else
+    char *const raw_cwd = getcwd(nullptr, 0);
+    if (raw_cwd == nullptr) {
+        return nullptr;
+    }
+    char *const cwd = Memory_DupStr(raw_cwd);
+    free(raw_cwd);
+    return cwd;
+#endif
 }
 
 char *File_GetParentDirectory(const char *path)
@@ -398,9 +449,26 @@ void File_CreateDirectory(const char *path)
         return;
     }
 #if defined(_WIN32)
-    _mkdir(path);
+    wchar_t *const wide_path = M_UTF8ToWide(path);
+    _wmkdir(wide_path);
+    Memory_Free(wide_path);
 #else
     mkdir(path, 0775);
+#endif
+}
+
+bool File_Delete(const char *const path)
+{
+    if (path == nullptr) {
+        return false;
+    }
+#if defined(_WIN32)
+    wchar_t *const wide_path = M_UTF8ToWide(path);
+    const bool result = _wremove(wide_path) == 0;
+    Memory_Free(wide_path);
+    return result;
+#else
+    return remove(path) == 0;
 #endif
 }
 
@@ -423,21 +491,50 @@ void File_EnsureParentDirectories(const char *path)
 void *File_OpenDirectory(const char *const path)
 {
     ASSERT(path != nullptr);
+#if defined(_WIN32)
+    wchar_t *const wide_path = M_UTF8ToWide(path);
+    _WDIR *const handle = _wopendir(wide_path);
+    Memory_Free(wide_path);
+    if (handle == nullptr) {
+        return nullptr;
+    }
+    M_DIR *const dir = Memory_Alloc(sizeof(M_DIR));
+    dir->handle = handle;
+    return dir;
+#else
     return opendir(path);
+#endif
 }
 
 const char *File_ReadDirectory(void *const dir)
 {
-    DIR *path_dir = (DIR *)dir;
-    struct dirent *cur_file = readdir(dir);
+#if defined(_WIN32)
+    M_DIR *const win_dir = dir;
+    Memory_FreePointer(&win_dir->name);
+    const struct _wdirent *const cur_file = _wreaddir(win_dir->handle);
+    if (cur_file == nullptr) {
+        return nullptr;
+    }
+    win_dir->name = M_WideToUTF8(cur_file->d_name);
+    return win_dir->name;
+#else
+    const struct dirent *const cur_file = readdir(dir);
     if (cur_file == nullptr) {
         return nullptr;
     }
     return cur_file->d_name;
+#endif
 }
 
 void File_CloseDirectory(void *const dir)
 {
     ASSERT(dir != nullptr);
+#if defined(_WIN32)
+    M_DIR *const win_dir = dir;
+    _wclosedir(win_dir->handle);
+    Memory_FreePointer(&win_dir->name);
+    Memory_Free(win_dir);
+#else
     closedir(dir);
+#endif
 }

--- a/src/trx/core/filesystem.h
+++ b/src/trx/core/filesystem.h
@@ -36,6 +36,9 @@ bool File_IsRelative(const char *path);
 // Return true when path points to an existing file.
 bool File_Exists(const char *path);
 
+// Return the process working directory (owning string), or nullptr.
+char *File_GetCurrentDirectory(void);
+
 // Return parent directory component of path (owning string), or nullptr.
 char *File_GetParentDirectory(const char *path);
 
@@ -111,6 +114,9 @@ void File_WriteU32(MYFILE *file, uint32_t value);
 // Write formatted string to file using a static-format buffer.
 // The formatted text is written via fputs; no trailing newline is added.
 void File_WriteString(MYFILE *file, const char *fmt, ...);
+
+// Delete the file at path. Returns false if it could not be deleted.
+bool File_Delete(const char *path);
 
 // ============================================================================
 // Directory functions

--- a/src/trx/game/savegame/manager.c
+++ b/src/trx/game/savegame/manager.c
@@ -1,5 +1,6 @@
 #include <trx/config.h>
 #include <trx/core/benchmark.h>
+#include <trx/core/filesystem.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/debug.h>
@@ -528,7 +529,7 @@ bool SG_Manager_Delete(const SAVEGAME_SLOT_REF slot)
         return false;
     }
 
-    const bool result = remove(savegame_info->full_path) == 0;
+    const bool result = File_Delete(savegame_info->full_path);
     if (!result) {
         return false;
     }

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -16,12 +16,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_WIN32)
-    #include <direct.h>
-#else
-    #include <unistd.h>
-#endif
-
 #define M_MAX_MOD_CHAIN 8
 
 typedef struct {
@@ -419,21 +413,6 @@ static char *M_ResolveCasePathCached(const char *const path)
 
     Memory_FreePointer(&path_copy);
     return current_path;
-}
-
-static char *M_GetCurrentDirectory(void)
-{
-#if defined(_WIN32)
-    char *const cwd = _getcwd(nullptr, 0);
-#else
-    char *const cwd = getcwd(nullptr, 0);
-#endif
-    if (cwd == nullptr) {
-        return nullptr;
-    }
-    char *const result = Memory_DupStr(cwd);
-    free(cwd);
-    return result;
 }
 
 static char *M_GuessExtensionCached(
@@ -1332,7 +1311,7 @@ const char *TRXPath_PeekResolveUserPath(
         return M_PeekResolvedUserPathCandidate(policy, input_path);
     }
 
-    char *cwd = M_GetCurrentDirectory();
+    char *cwd = File_GetCurrentDirectory();
     if (cwd != nullptr) {
         char *cwd_path = String_Format("%s/%s", cwd, input_path);
         Memory_FreePointer(&cwd);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Directory listings, directory creation and deletion now convert the UTF-8 path to UTF-16 and call the wide CRT, as opening a file already did. Before this they handed UTF-8 bytes to the narrow CRT, which reads them in the system ANSI codepage. Resolving any path walks its segments with a directory listing, so a player whose folder is named in Chinese could not start the game.

Resolves #573

