### PR TITLE
Add a glow to enemy gun flashes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - added the ability for Lara to turn on the spot by pressing walk and roll (Gameplay → Controls → Alternative turns) (#5756)
 - added the ability for Lara to turn on the spot on monkeybars by pressing roll (Gameplay → Controls → Alternative turns)
 - added the language being taken from the operating system on the first launch, where the game ships it (#4460)
+- added the glow around gun flashes to enemies firing, where Lara's weapons alone had it (#6127)
 - improved error messages related to bad command invocations
 - improved state change handling when shimmying is requested while in the slow swing-in state on thin ledges (#5161)
 - changed a multi-key shortcut to answer only to the side of Ctrl, Shift or Alt it was bound to, where a shortcut of a single key still takes either

--- a/src/trx/game/effects/manager.c
+++ b/src/trx/game/effects/manager.c
@@ -121,6 +121,7 @@ int16_t Effect_Create(const int16_t room_num)
     effect->shade = SHADE_NEUTRAL;
     effect->flag1 = 0;
     effect->flag2 = 0;
+    effect->interp.is_new = true;
 
     return effect_num;
 }

--- a/src/trx/game/effects/types.h
+++ b/src/trx/game/effects/types.h
@@ -24,5 +24,8 @@ typedef struct {
             XYZ_32 pos;
             XYZ_16 rot;
         } result, prev;
+        // Set until the effect has lived through a whole frame, so that it is
+        // not interpolated from whatever the recycled slot last held.
+        bool is_new;
     } interp;
 } EFFECT;

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -365,11 +365,22 @@ static void M_RememberEffect(EFFECT *const effect)
     REMEMBER(effect, rot.x);
     REMEMBER(effect, rot.y);
     REMEMBER(effect, rot.z);
+    effect->interp.is_new = false;
 }
 
 static void M_InterpolateEffect(const double ratio, EFFECT *const effect)
 {
     ASSERT(effect != nullptr);
+    if (effect->interp.is_new) {
+        COMMIT(effect, pos.x);
+        COMMIT(effect, pos.y);
+        COMMIT(effect, pos.z);
+        COMMIT(effect, rot.x);
+        COMMIT(effect, rot.y);
+        COMMIT(effect, rot.z);
+        return;
+    }
+
     const XYZ_32 max_delta = M_GetEffectMaxDelta(effect);
     INTERPOLATE(effect, pos.x, ratio, max_delta.x);
     INTERPOLATE(effect, pos.y, ratio, max_delta.y);

--- a/src/trx/game/objects/effects/gun_flash.c
+++ b/src/trx/game/objects/effects/gun_flash.c
@@ -28,9 +28,32 @@ static void M_Control(const int16_t effect_num)
     }
 }
 
+// Returning false leaves the flash mesh itself to the generic effect drawing.
+static bool M_Draw(const EFFECT *const effect)
+{
+    if (g_TRVersion < 3 && !g_Config.visuals.enable_gun_glow) {
+        return false;
+    }
+
+    const OBJECT *const glow_obj = Object_Get(O_GLOW);
+    if (!glow_obj->loaded) {
+        return false;
+    }
+
+    const bool is_tr3 = g_TRVersion >= 3;
+    const RGBA_F tint = is_tr3 ? (RGBA_F) { 1.0f, 0.89f, 0.13f, 1.0f }
+                               : (RGBA_F) { 0.247f, 0.22f, 0.059f, 1.0f };
+    Output_DrawSprite(
+        effect->interp.result.pos.x, effect->interp.result.pos.y,
+        effect->interp.result.pos.z, glow_obj->mesh_idx,
+        is_tr3 ? SHADE_NEUTRAL : 0, tint, DRAW_BLEND_ADD, is_tr3 ? 1.0f : 2.0f);
+    return false;
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     obj->effect_control_func = M_Control;
+    obj->effect_draw_func = M_Draw;
     Gun_ApplyFlashSemiTransparency();
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TR1/TR2 enemy muzzle flashes now use the same optional gun glow as Lara's.

Effects also spawn at their correct position instead of briefly interpolating from a reused slot's previous location. Gun flash positions remain unchanged.

Resolves #6127