### PR TITLE
Stop music restarting for a moment when a save is loaded

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -134,6 +134,7 @@
 - fixed the alternative ammunition pickups, such as the second kind of shotgun ammunition, going into the inventory without loading the weapon
 - fixed Lara being able to pull out flares while crawling after picking up an item, and dropping flares when using the draw input to enter crouch state (regression from 1.3)
 - fixed the game not running when its folder name contains characters outside the system language, such as Chinese (#573)
+- fixed music briefly restarting from its beginning when loading a save (#1265)
 
 **TR1**
 - added pickup aids to the scions in Tomb of Qualopec and Sanctuary of the Scion

--- a/src/trx/av/audio.h
+++ b/src/trx/av/audio.h
@@ -22,6 +22,9 @@ bool Audio_IsMuted(void);
 bool Audio_Stream_Pause(int32_t sound_id);
 bool Audio_Stream_Unpause(int32_t sound_id);
 bool Audio_Stream_SetPaused(int32_t sound_id, bool is_paused);
+// Create a stream. The stream is paused, so that the caller can seek it and
+// set its volume before anything is heard; call Audio_Stream_Unpause to start
+// it.
 int32_t Audio_Stream_CreateFromFile(const char *path);
 int32_t Audio_Stream_CreateFromMemory(uint8_t *data, size_t size);
 bool Audio_Stream_Close(int32_t sound_id);

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -336,7 +336,7 @@ static bool M_InitialiseFromFormatContext(
 
     stream->is_read_done = false;
     stream->is_used = true;
-    stream->is_playing = true;
+    stream->is_playing = false;
     stream->is_looped = false;
     stream->volume = 1.0f;
     stream->decode_timestamp = 0.0;

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -96,6 +96,13 @@ static int32_t M_OpenAudioStream(const char *const file_name)
     return AUDIO_NO_SOUND;
 }
 
+static float M_GetAudioVolume(void)
+{
+    return Audio_IsMuted()
+        ? 0.0f
+        : g_Config.audio.master_volume * g_Config.audio.fmv_volume;
+}
+
 static void *M_AllocateSurface(
     const int32_t width, const int32_t height, void *const user_data)
 {
@@ -252,6 +259,10 @@ static bool M_Play(const char *const file_name)
     Fader_InitTo(&render_ctx.pause_fader, 0.0f, 0.0f, 0.0f);
     M_SetPauseText(false);
     Video_Start(video);
+
+    Audio_Stream_SetVolume(audio_id, M_GetAudioVolume());
+    Audio_Stream_Unpause(audio_id);
+
     while (video->is_playing) {
         Shell_ProcessEvents();
 
@@ -271,10 +282,7 @@ static bool M_Play(const char *const file_name)
             paused = should_pause;
         }
 
-        const float volume = Audio_IsMuted()
-            ? 0.0f
-            : g_Config.audio.master_volume * g_Config.audio.fmv_volume;
-        Audio_Stream_SetVolume(audio_id, volume);
+        Audio_Stream_SetVolume(audio_id, M_GetAudioVolume());
         const double audio_ts = Audio_Stream_GetTimestamp(audio_id);
         if (audio_ts >= 0.0) {
             Video_SetExternalAudioClock(video, audio_ts);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -276,6 +276,7 @@ static int32_t M_PlayOverlayTrack(const MUSIC_ID track_id)
     Audio_Stream_SetIsLooped(stream_id, false);
     Audio_Stream_SetFinishCallback(
         stream_id, M_StreamFinished, &m_OverlayStreams[slot]);
+    Audio_Stream_Unpause(stream_id);
     return slot + 1;
 }
 
@@ -441,6 +442,7 @@ int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
             Audio_Stream_SetIsLooped(stream_id, is_looped);
             Audio_Stream_SetFinishCallback(
                 stream_id, M_StreamFinished, &m_MainStream);
+            Audio_Stream_Unpause(stream_id);
             played = true;
         }
     }

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -244,7 +244,8 @@ static int32_t M_GetFreeOverlaySlot(void)
 
 // Returns the stream slot the overlay plays in - an overlay is slots 1.. - or
 // -1 when it does not play.
-static int32_t M_PlayOverlayTrack(const MUSIC_ID track_id)
+static int32_t M_PlayOverlayTrack(
+    const MUSIC_ID track_id, const double timestamp)
 {
     if (m_Backend == nullptr) {
         LOG_WARNING(
@@ -276,6 +277,9 @@ static int32_t M_PlayOverlayTrack(const MUSIC_ID track_id)
     Audio_Stream_SetIsLooped(stream_id, false);
     Audio_Stream_SetFinishCallback(
         stream_id, M_StreamFinished, &m_OverlayStreams[slot]);
+    if (timestamp > 0.0) {
+        Audio_Stream_SeekTimestamp(stream_id, timestamp);
+    }
     Audio_Stream_Unpause(stream_id);
     return slot + 1;
 }
@@ -300,6 +304,13 @@ static bool M_GetMainTrackState(MUSIC_STREAM_STATE *const state)
         return true;
     }
     return false;
+}
+
+static void M_SeekMainStream(const double timestamp)
+{
+    if (timestamp > 0.0) {
+        Music_SeekTimestamp(timestamp);
+    }
 }
 
 // Slot 0 is the main stream; slots 1.. are the overlays.
@@ -351,36 +362,11 @@ static void M_ApplyConfig(void)
     Music_SetVolume(g_Config.audio.music_volume);
 }
 
-bool Music_Init(void)
-{
-    m_Initialised = true;
-    if (m_Backend != nullptr) {
-        m_Backend->shutdown(m_Backend);
-        m_Backend = nullptr;
-    }
-    m_Backend = M_FindBackend();
-    if (m_Backend == nullptr) {
-        LOG_ERROR("No music backend is available");
-        goto finish;
-    }
-
-    LOG_INFO("Chosen music backend: %s", m_Backend->describe(m_Backend));
-    Music_SetVolume(g_Config.audio.music_volume);
-
-finish:
-    m_TrackCurrent = MX_INACTIVE;
-    m_TrackLastPlayed = MX_INACTIVE;
-    m_TrackDelayed = MX_INACTIVE;
-    m_TrackLooped = MX_INACTIVE;
-    m_TrackLastLooped = MX_INACTIVE;
-    M_ResetStreamState();
-    return Audio_Init();
-}
-
 // Returns the stream slot the track plays in - the main stream is slot 0, the
 // overlays are slots 1.. - or -1 when the track does not play, which includes a
 // track marked for later (delay) or a deferred ambient.
-int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
+static int32_t M_Play(
+    const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode, const double timestamp)
 {
     if (!m_Initialised) {
         return -1;
@@ -392,11 +378,12 @@ int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
 
     if (mode == MPM_OVERLAY) {
         LOG_INFO("Playing overlay track %d", track_id);
-        return M_PlayOverlayTrack(track_id);
+        return M_PlayOverlayTrack(track_id, timestamp);
     }
 
     // Already on the main stream, so slot 0 carries it.
     if (track_id == m_TrackCurrent) {
+        M_SeekMainStream(timestamp);
         return 0;
     }
 
@@ -406,6 +393,7 @@ int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
 
     const bool is_looped = mode == MPM_LOOP || M_IsAmbientTrack(track_id);
     if (is_looped && track_id == m_TrackLastLooped) {
+        M_SeekMainStream(timestamp);
         return 0;
     }
 
@@ -442,6 +430,9 @@ int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
             Audio_Stream_SetIsLooped(stream_id, is_looped);
             Audio_Stream_SetFinishCallback(
                 stream_id, M_StreamFinished, &m_MainStream);
+            if (timestamp > 0.0) {
+                Audio_Stream_SeekTimestamp(stream_id, timestamp);
+            }
             Audio_Stream_Unpause(stream_id);
             played = true;
         }
@@ -460,6 +451,43 @@ int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
         m_TrackLastPlayed = track_id;
     }
     return played ? 0 : -1;
+}
+
+bool Music_Init(void)
+{
+    m_Initialised = true;
+    if (m_Backend != nullptr) {
+        m_Backend->shutdown(m_Backend);
+        m_Backend = nullptr;
+    }
+    m_Backend = M_FindBackend();
+    if (m_Backend == nullptr) {
+        LOG_ERROR("No music backend is available");
+        goto finish;
+    }
+
+    LOG_INFO("Chosen music backend: %s", m_Backend->describe(m_Backend));
+    Music_SetVolume(g_Config.audio.music_volume);
+
+finish:
+    m_TrackCurrent = MX_INACTIVE;
+    m_TrackLastPlayed = MX_INACTIVE;
+    m_TrackDelayed = MX_INACTIVE;
+    m_TrackLooped = MX_INACTIVE;
+    m_TrackLastLooped = MX_INACTIVE;
+    M_ResetStreamState();
+    return Audio_Init();
+}
+
+int32_t Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
+{
+    return M_Play(track_id, mode, -1.0);
+}
+
+int32_t Music_Play_DirectAt(
+    const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode, const double timestamp)
+{
+    return M_Play(track_id, mode, timestamp);
 }
 
 int32_t Music_Play(const MUSIC_TRX_ID track, const MUSIC_PLAY_MODE mode)

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -35,6 +35,13 @@ bool Music_Init(void);
 // marked for later (delay) or a deferred ambient.
 int32_t Music_Play_Direct(MUSIC_ID track, MUSIC_PLAY_MODE mode);
 
+// Plays a track from the given timestamp in seconds, as Music_Play_Direct does
+// otherwise. The track is seeked before it becomes audible, so its beginning is
+// never heard. A negative timestamp plays the track from where it would
+// normally start.
+int32_t Music_Play_DirectAt(
+    MUSIC_ID track, MUSIC_PLAY_MODE mode, double timestamp);
+
 // Stops the provided single track and restarts the looped track if applicable.
 void Music_StopTrack_Direct(MUSIC_ID track);
 

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -785,13 +785,18 @@ static bool M_ReadFlare(JSON_READ_IO *const io)
     M_FINISH();
 }
 
-static bool M_ShouldLoadMusicTimestamp(
+// Returns the timestamp to resume the track at, or -1.0 to play it from the
+// start.
+static double M_GetMusicSeekTimestamp(
     const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode,
-    const MUSIC_ID ambient_track)
+    const MUSIC_ID ambient_track, const double timestamp)
 {
     const bool is_ambient = mode == MPM_LOOP && track_id == ambient_track;
-    return !is_ambient
-        || g_Config.audio.music_load_condition == MUSIC_LOAD_CONDITION_ALWAYS;
+    if (is_ambient
+        && g_Config.audio.music_load_condition != MUSIC_LOAD_CONDITION_ALWAYS) {
+        return -1.0;
+    }
+    return timestamp;
 }
 
 static bool M_ReadMusicTracks(JSON_READ_IO *const io)
@@ -826,13 +831,9 @@ static bool M_ReadMusicTracks(JSON_READ_IO *const io)
             if (track_id == MX_INACTIVE) {
                 continue;
             }
-            if (Music_Play_Direct(track_id, mode) < 0) {
-                LOG_WARNING("Could not load stream track %d", track_id);
-                continue;
-            }
-
-            if (M_ShouldLoadMusicTimestamp(track_id, mode, ambient_track)
-                && !Music_SeekTrackTimestamp(track_id, mode, timestamp)) {
+            const double seek_to = M_GetMusicSeekTimestamp(
+                track_id, mode, ambient_track, timestamp);
+            if (Music_Play_DirectAt(track_id, mode, seek_to) < 0) {
                 LOG_WARNING(
                     "Could not load stream track %d at timestamp %lf.",
                     track_id, timestamp);
@@ -845,20 +846,12 @@ static bool M_ReadMusicTracks(JSON_READ_IO *const io)
         M_MUST(JSON_READ(io, "current_track", &current_track));
         M_MUST(JSON_READ(io, "timestamp", &timestamp));
 
-        const bool is_ambient =
-            current_track != MX_INACTIVE && current_track == ambient_track;
-        if (!is_ambient && current_track != MX_INACTIVE
-            && Music_Play_Direct(current_track, MPM_ONCE) < 0) {
-            LOG_WARNING("Could not load current track %d.", current_track);
-        }
-
-        const MUSIC_ID track_to_seek =
-            is_ambient ? ambient_track : current_track;
-        const MUSIC_PLAY_MODE mode_to_seek = is_ambient ? MPM_LOOP : MPM_ONCE;
-        if (M_ShouldLoadMusicTimestamp(
-                track_to_seek, mode_to_seek, ambient_track)
-            && !Music_SeekTrackTimestamp(
-                track_to_seek, mode_to_seek, timestamp)) {
+        const bool is_ambient = current_track == ambient_track;
+        const MUSIC_PLAY_MODE mode = is_ambient ? MPM_LOOP : MPM_ONCE;
+        const double seek_to = M_GetMusicSeekTimestamp(
+            current_track, mode, ambient_track, timestamp);
+        if (current_track != MX_INACTIVE
+            && Music_Play_DirectAt(current_track, mode, seek_to) < 0) {
             LOG_WARNING(
                 "Could not load current track %d at timestamp %lf.",
                 current_track, timestamp);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Loading a save made while music was playing let up to 100 ms of the track's beginning through before playback jumped to the saved position. An audio stream used to become audible the moment it was created, so the mixer emitted from position 0 while the savegame code was still on its way to the seek. Streams are now created paused, and the music module seeks the stream before starting it, so only the saved position is heard.

The same flaw touched two other places, which this fixes as well:

- the CD-audio backend, which opens one large image and seeks to the track it wants, played a fragment of the head of the image first
- FMV sound started before the video did and ignored the FMV volume setting for its first frames

Resolves #1265.