### PR TITLE
docs: drop the readme item from the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@
 
 - [ ] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
 - [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
-- [ ] I have added a readme entry about my new feature or OG bug fix, or it is a different change
 
 #### Description
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The checklist now asks for the coding conventions and a changelog entry. Before this, it also asked for a readme entry about a new feature or OG bug fix, which the README no longer carries: it points at docs/CHANGELOG.md instead.