### PR TITLE
installer: explain a failed start

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -135,6 +135,7 @@
 - fixed Lara being able to pull out flares while crawling after picking up an item, and dropping flares when using the draw input to enter crouch state (regression from 1.3)
 - fixed the game not running when its folder name contains characters outside the system language, such as Chinese (#573)
 - fixed music briefly restarting from its beginning when loading a save (#1265)
+- fixed the installer closing with no window and no message when the .NET runtime it needs is damaged, so it now names what to install (#1088)
 
 **TR1**
 - added pickup aids to the scions in Tomb of Qualopec and Sanctuary of the Scion

--- a/tools/installer/TRX_Installer/Program.cs
+++ b/tools/installer/TRX_Installer/Program.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TRX_Installer;
+
+internal static class Program
+{
+    private const int MB_OK = 0x00000000;
+    private const int MB_ICONERROR = 0x00000010;
+
+    [STAThread]
+    private static int Main()
+    {
+        try
+        {
+            return RunApp();
+        }
+        catch (Exception ex)
+        {
+            ShowMessageBox(0, BuildMessage(ex), "TRX Installer", MB_OK | MB_ICONERROR);
+            return 1;
+        }
+    }
+
+    // The app is started from a separate method so that this assembly's WPF
+    // types are only touched once Main is running and the handler above is in
+    // place. Inlining it would move the type loads back into Main, where a
+    // damaged runtime kills the process before anything can report it.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int RunApp()
+    {
+        App app = new();
+        app.InitializeComponent();
+        return app.Run();
+    }
+
+    private static string BuildMessage(Exception ex)
+    {
+        bool runtimeProblem = ex
+            is FileLoadException
+            or FileNotFoundException
+            or BadImageFormatException
+            or TypeLoadException
+            or MissingMethodException;
+
+        string summary = runtimeProblem
+            ? "The installer could not start because the .NET 8 Desktop Runtime "
+                + "is missing or damaged."
+                + Environment.NewLine
+                + Environment.NewLine
+                + "Install the x64 version from "
+                + "https://dotnet.microsoft.com/download/dotnet/8.0 and run the "
+                + "installer again."
+            : "The installer stopped because of an unexpected error.";
+
+        return summary
+            + Environment.NewLine
+            + Environment.NewLine
+            + ex;
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "MessageBoxW")]
+    private static extern int ShowMessageBox(
+        nint hWnd, string text, string caption, int type);
+}

--- a/tools/installer/TRX_Installer/TRX_Installer.csproj
+++ b/tools/installer/TRX_Installer/TRX_Installer.csproj
@@ -9,6 +9,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AssemblyName>TRX_Installer</AssemblyName>
+    <StartupObject>TRX_Installer.Program</StartupObject>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <PublishSingleFile>true</PublishSingleFile>
@@ -19,6 +20,11 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ApplicationDefinition Remove="App.xaml" />
+    <Page Include="App.xaml" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="DiscUtils.Iso9660" Version="0.16.13" />


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The installer now shows a message box naming the .NET runtime it needs and where to get it, along with the exception it died on. Before this, a damaged .NET install killed it before any window appeared, leaving the reason visible only in the Windows event log.

Catching that needs an entry point of its own, since the generated one touches WPF types directly and so fails before a handler is in place.

This fix was untested, and it'd be great if we could verify it works; if not, I'd push it as-is and reopen the original issue in case the problem persists.

Resolves #1088