### PR TITLE
lara/col/land: fix controlled drop floor test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -136,6 +136,7 @@
 - fixed the game not running when its folder name contains characters outside the system language, such as Chinese (#573)
 - fixed music briefly restarting from its beginning when loading a save (#1265)
 - fixed the installer closing with no window and no message when the .NET runtime it needs is damaged, so it now names what to install (#1088)
+- fixed Lara incorrectly performing a controlled drop when attempting to grab a perpendicular ledge or when running off a diagonal ledge (regression from TR1X 4.14 / TR2X 1.4)
 
 **TR1**
 - added pickup aids to the scions in Tomb of Qualopec and Sanctuary of the Scion

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -105,15 +105,20 @@ static bool M_CanControlDrop(
 
     COLL_INFO old_coll = {
         .facing = lara->move_angle,
-        .bad_pos = STEPUP_HEIGHT,
+        .bad_pos = NO_BAD_POS,
         .bad_neg = -STEPUP_HEIGHT,
         .slopes_are_pits = 1,
         .slopes_are_walls = 1,
+        .radius = LARA_RADIUS,
     };
     Collide_GetCollisionInfo(
         &old_coll, coll->old_pos, item->room_num, LARA_HEIGHT);
 
     if (old_coll.side_mid.floor != 0) {
+        return false;
+    }
+
+    if (old_coll.side_left2.floor == 0 || old_coll.side_right2.floor == 0) {
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara incorrectly performing a controlled drop when attempting to grab a perpendicular ledge or when running off a diagonal ledge. The old collision test was not determining the geometry around her correctly.

Resolves TRX986.
