### PR TITLE
Move audio decoding off the mixer thread

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,6 +102,7 @@
 
 **Music and sound**
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)
+- Fixed the sound stuttering when a piece of music starts playing (#3094)
 - Fixed music briefly restarting from its beginning when loading a save (#1265)
 
 **Options and menus**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 **Music and sound**
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)
 - Fixed the sound stuttering when a piece of music starts playing (#3094)
+- Fixed the game pausing the first time a sound effect is played, which was most noticeable with longer ones (#2286)
 - Fixed music briefly restarting from its beginning when loading a save (#1265)
 
 **Options and menus**

--- a/src/meson.build
+++ b/src/meson.build
@@ -218,6 +218,7 @@ dependencies = [
 
 common_sources = [
   'trx/av/audio.c',
+  'trx/av/audio_decoder.c',
   'trx/av/audio_reverb.c',
   'trx/av/audio_sample.c',
   'trx/av/audio_stream.c',

--- a/src/trx/av/audio.c
+++ b/src/trx/av/audio.c
@@ -33,6 +33,7 @@ static int32_t M_WorkerThread(void *const user_data)
 {
     while (SDL_AtomicGet(&m_WorkerStop) == 0) {
         Audio_Stream_Pump();
+        Audio_Sample_Pump();
         SDL_Delay(WORKER_TICK_MS);
     }
     return 0;

--- a/src/trx/av/audio.c
+++ b/src/trx/av/audio.c
@@ -4,10 +4,18 @@
 #include <trx/core/memory.h>
 
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_atomic.h>
 #include <SDL2/SDL_error.h>
+#include <SDL2/SDL_mutex.h>
 #include <SDL2/SDL_stdinc.h>
+#include <SDL2/SDL_thread.h>
+#include <SDL2/SDL_timer.h>
 #include <stdint.h>
 #include <string.h>
+
+// Every stream buffers far more audio than this, so the tick only decides how
+// promptly freshly started sounds reach the mixer.
+#define WORKER_TICK_MS 2
 
 SDL_AudioDeviceID g_AudioDeviceID = 0;
 static int32_t m_RefCount = 0;
@@ -17,6 +25,38 @@ static Uint8 m_Silence = 0;
 static bool m_Muted = false;
 static bool m_CallbackSeen = false;
 static bool m_ShouldSkipSDLQuitAudio = false;
+static SDL_mutex *m_WorkerMutex = nullptr;
+static SDL_Thread *m_WorkerThread = nullptr;
+static SDL_atomic_t m_WorkerStop = {};
+
+static int32_t M_WorkerThread(void *const user_data)
+{
+    while (SDL_AtomicGet(&m_WorkerStop) == 0) {
+        Audio_Stream_Pump();
+        SDL_Delay(WORKER_TICK_MS);
+    }
+    return 0;
+}
+
+static void M_StartWorker(void)
+{
+    SDL_AtomicSet(&m_WorkerStop, 0);
+    m_WorkerThread = SDL_CreateThread(M_WorkerThread, "audio decoder", nullptr);
+    if (m_WorkerThread == nullptr) {
+        LOG_ERROR(
+            "Failed to start the audio decoder thread: %s", SDL_GetError());
+    }
+}
+
+static void M_StopWorker(void)
+{
+    if (m_WorkerThread == nullptr) {
+        return;
+    }
+    SDL_AtomicSet(&m_WorkerStop, 1);
+    SDL_WaitThread(m_WorkerThread, nullptr);
+    m_WorkerThread = nullptr;
+}
 
 static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
 {
@@ -69,12 +109,14 @@ bool Audio_Init(void)
         * SDL_AUDIO_BITSIZE(desired.format) / 8;
 
     m_MixBuffer = Memory_Alloc(m_MixBufferCapacity);
+    m_WorkerMutex = SDL_CreateMutex();
 
     SDL_PauseAudioDevice(g_AudioDeviceID, 0);
 
     Audio_Sample_Init();
     Audio_Stream_Init();
     Audio_Reverb_Init(AUDIO_WORKING_RATE, AUDIO_WORKING_CHANNELS);
+    M_StartWorker();
 
     return true;
 }
@@ -85,6 +127,8 @@ bool Audio_Shutdown(void)
     if (m_RefCount > 0) {
         return false;
     }
+
+    M_StopWorker();
 
     if (g_AudioDeviceID) {
         SDL_PauseAudioDevice(g_AudioDeviceID, 1);
@@ -100,6 +144,11 @@ bool Audio_Shutdown(void)
     Audio_Sample_Shutdown();
     Audio_Stream_Shutdown();
     Audio_Reverb_Shutdown();
+
+    if (m_WorkerMutex != nullptr) {
+        SDL_DestroyMutex(m_WorkerMutex);
+        m_WorkerMutex = nullptr;
+    }
 
     if (!m_ShouldSkipSDLQuitAudio) {
         SDL_QuitSubSystem(SDL_INIT_AUDIO);
@@ -141,6 +190,22 @@ void Audio_UnlockDevice(void)
         return;
     }
     SDL_UnlockAudioDevice(g_AudioDeviceID);
+}
+
+void Audio_WorkerLock(void)
+{
+    if (m_WorkerMutex == nullptr) {
+        return;
+    }
+    SDL_LockMutex(m_WorkerMutex);
+}
+
+void Audio_WorkerUnlock(void)
+{
+    if (m_WorkerMutex == nullptr) {
+        return;
+    }
+    SDL_UnlockMutex(m_WorkerMutex);
 }
 
 void Audio_SetReverbType(const uint8_t reverb_type)

--- a/src/trx/av/audio_decoder.c
+++ b/src/trx/av/audio_decoder.c
@@ -1,0 +1,442 @@
+#include <trx/av/audio_decoder.h>
+
+#include <trx/av/audio_internal.h>
+#include <trx/core/log.h>
+#include <trx/core/memory.h>
+#include <trx/core/utils.h>
+#include <trx/debug.h>
+
+#include <errno.h>
+#include <libavcodec/avcodec.h>
+#include <libavcodec/packet.h>
+#include <libavformat/avformat.h>
+#include <libavformat/avio.h>
+#include <libavutil/avutil.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/error.h>
+#include <libavutil/frame.h>
+#include <libavutil/mem.h>
+#include <libavutil/rational.h>
+#include <libavutil/samplefmt.h>
+#include <libswresample/swresample.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define AVIO_BUFFER_SIZE 4096
+
+typedef struct {
+    const uint8_t *data;
+    size_t size;
+    size_t pos;
+} M_MEMORY_SOURCE;
+
+struct AUDIO_DECODER {
+    int32_t channels;
+    double timestamp;
+    bool is_drained;
+
+    M_MEMORY_SOURCE memory;
+    AVIOContext *avio_ctx;
+    AVFormatContext *format_ctx;
+    AVStream *stream;
+    AVCodecContext *codec_ctx;
+    AVPacket *packet;
+    AVFrame *frame;
+    SwrContext *swr_ctx;
+
+    float *buffer;
+    int32_t buffer_capacity;
+    int32_t buffer_count;
+};
+
+static int32_t M_MemoryRead(
+    void *const opaque, uint8_t *const buf, const int32_t buf_size)
+{
+    ASSERT(opaque != nullptr);
+    ASSERT(buf != nullptr);
+
+    if (buf_size <= 0) {
+        return 0;
+    }
+
+    M_MEMORY_SOURCE *const source = opaque;
+    if (source->pos >= source->size) {
+        return AVERROR_EOF;
+    }
+
+    const size_t to_copy = MIN(source->size - source->pos, (size_t)buf_size);
+    memcpy(buf, source->data + source->pos, to_copy);
+    source->pos += to_copy;
+    return (int32_t)to_copy;
+}
+
+static int64_t M_MemorySeek(
+    void *const opaque, const int64_t offset, const int32_t whence)
+{
+    ASSERT(opaque != nullptr);
+
+    M_MEMORY_SOURCE *const source = opaque;
+    if ((whence & AVSEEK_SIZE) != 0) {
+        return (int64_t)source->size;
+    }
+
+    const int32_t base_whence = whence & ~AVSEEK_FORCE;
+    int64_t base;
+    if (base_whence == SEEK_SET) {
+        base = 0;
+    } else if (base_whence == SEEK_CUR) {
+        base = (int64_t)source->pos;
+    } else if (base_whence == SEEK_END) {
+        base = (int64_t)source->size;
+    } else {
+        return AVERROR(EINVAL);
+    }
+
+    int64_t new_pos = base + offset;
+    CLAMP(new_pos, 0, (int64_t)source->size);
+    source->pos = (size_t)new_pos;
+    return new_pos;
+}
+
+static bool M_OpenCodec(AUDIO_DECODER *const decoder)
+{
+    int32_t error_code =
+        avformat_find_stream_info(decoder->format_ctx, nullptr);
+    if (error_code < 0) {
+        goto fail;
+    }
+
+    for (uint32_t i = 0; i < decoder->format_ctx->nb_streams; i++) {
+        AVStream *const stream = decoder->format_ctx->streams[i];
+        if (stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            decoder->stream = stream;
+            break;
+        }
+    }
+    if (decoder->stream == nullptr) {
+        error_code = AVERROR_STREAM_NOT_FOUND;
+        goto fail;
+    }
+
+    const AVCodec *const codec =
+        avcodec_find_decoder(decoder->stream->codecpar->codec_id);
+    if (codec == nullptr) {
+        error_code = AVERROR_DECODER_NOT_FOUND;
+        goto fail;
+    }
+
+    decoder->codec_ctx = avcodec_alloc_context3(codec);
+    if (decoder->codec_ctx == nullptr) {
+        error_code = AVERROR(ENOMEM);
+        goto fail;
+    }
+
+    error_code = avcodec_parameters_to_context(
+        decoder->codec_ctx, decoder->stream->codecpar);
+    if (error_code != 0) {
+        goto fail;
+    }
+
+    error_code = avcodec_open2(decoder->codec_ctx, codec, nullptr);
+    if (error_code < 0) {
+        goto fail;
+    }
+
+    decoder->packet = av_packet_alloc();
+    decoder->frame = av_frame_alloc();
+    if (decoder->packet == nullptr || decoder->frame == nullptr) {
+        error_code = AVERROR(ENOMEM);
+        goto fail;
+    }
+
+    AVChannelLayout dst_layout;
+    av_channel_layout_default(&dst_layout, decoder->channels);
+    swr_alloc_set_opts2(
+        &decoder->swr_ctx, &dst_layout,
+        Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT), AUDIO_WORKING_RATE,
+        &decoder->codec_ctx->ch_layout, decoder->codec_ctx->sample_fmt,
+        decoder->codec_ctx->sample_rate, 0, 0);
+    if (decoder->swr_ctx == nullptr) {
+        error_code = AVERROR(ENOMEM);
+        goto fail;
+    }
+
+    error_code = swr_init(decoder->swr_ctx);
+    if (error_code != 0) {
+        goto fail;
+    }
+
+    return true;
+
+fail:
+    LOG_ERROR("Error while opening audio: %s", av_err2str(error_code));
+    return false;
+}
+
+static void M_Append(
+    AUDIO_DECODER *const decoder, const float *const data, const int32_t count)
+{
+    const int32_t floats = count * decoder->channels;
+    if (decoder->buffer_count + floats > decoder->buffer_capacity) {
+        decoder->buffer_capacity = decoder->buffer_count + floats;
+        decoder->buffer = Memory_Realloc(
+            decoder->buffer, decoder->buffer_capacity * sizeof(float));
+    }
+    memcpy(
+        decoder->buffer + decoder->buffer_count, data, floats * sizeof(float));
+    decoder->buffer_count += floats;
+}
+
+static void M_Convert(AUDIO_DECODER *const decoder, AVFrame *const frame)
+{
+    const int32_t max_samples =
+        swr_get_out_samples(decoder->swr_ctx, frame->nb_samples);
+    if (max_samples <= 0) {
+        return;
+    }
+
+    const int32_t floats = max_samples * decoder->channels;
+    float *const scratch = Memory_Alloc(floats * sizeof(float));
+    uint8_t *out_buffer = (uint8_t *)scratch;
+    const int32_t converted = swr_convert(
+        decoder->swr_ctx, &out_buffer, max_samples,
+        (const uint8_t **)frame->data, frame->nb_samples);
+    if (converted > 0) {
+        M_Append(decoder, scratch, converted);
+    }
+    Memory_Free(scratch);
+}
+
+static void M_Drain(AUDIO_DECODER *const decoder)
+{
+    while (avcodec_receive_frame(decoder->codec_ctx, decoder->frame) >= 0) {
+        M_Convert(decoder, decoder->frame);
+        decoder->timestamp = decoder->frame->best_effort_timestamp
+            * av_q2d(decoder->stream->time_base);
+        av_frame_unref(decoder->frame);
+    }
+    av_frame_unref(decoder->frame);
+}
+
+static AUDIO_DECODER *M_Create(const int32_t channels)
+{
+    AUDIO_DECODER *const decoder = Memory_Alloc(sizeof(AUDIO_DECODER));
+    decoder->channels = channels;
+    return decoder;
+}
+
+AUDIO_DECODER *AudioDecoder_CreateFromPath(
+    const char *const path, const int32_t channels)
+{
+    ASSERT(path != nullptr);
+
+    AUDIO_DECODER *decoder = M_Create(channels);
+    const int32_t error_code =
+        avformat_open_input(&decoder->format_ctx, path, nullptr, nullptr);
+    if (error_code != 0) {
+        LOG_ERROR(
+            "Error while opening audio %s: %s", path, av_err2str(error_code));
+        AudioDecoder_Free(&decoder);
+        return nullptr;
+    }
+
+    if (!M_OpenCodec(decoder)) {
+        AudioDecoder_Free(&decoder);
+        return nullptr;
+    }
+    return decoder;
+}
+
+AUDIO_DECODER *AudioDecoder_CreateFromMemory(
+    const uint8_t *const data, const size_t size, const int32_t channels)
+{
+    ASSERT(data != nullptr);
+    ASSERT(size != 0);
+
+    AUDIO_DECODER *decoder = M_Create(channels);
+    decoder->memory = (M_MEMORY_SOURCE) {
+        .data = data,
+        .size = size,
+        .pos = 0,
+    };
+
+    decoder->avio_ctx = avio_alloc_context(
+        av_malloc(AVIO_BUFFER_SIZE), AVIO_BUFFER_SIZE, 0, &decoder->memory,
+        M_MemoryRead, nullptr, M_MemorySeek);
+    if (decoder->avio_ctx == nullptr) {
+        AudioDecoder_Free(&decoder);
+        return nullptr;
+    }
+
+    decoder->format_ctx = avformat_alloc_context();
+    if (decoder->format_ctx == nullptr) {
+        AudioDecoder_Free(&decoder);
+        return nullptr;
+    }
+    decoder->format_ctx->pb = decoder->avio_ctx;
+    decoder->format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+    const int32_t error_code =
+        avformat_open_input(&decoder->format_ctx, nullptr, nullptr, nullptr);
+    if (error_code != 0) {
+        LOG_ERROR(
+            "Error while opening audio memory stream: %s",
+            av_err2str(error_code));
+        AudioDecoder_Free(&decoder);
+        return nullptr;
+    }
+
+    if (!M_OpenCodec(decoder)) {
+        AudioDecoder_Free(&decoder);
+        return nullptr;
+    }
+    return decoder;
+}
+
+void AudioDecoder_Free(AUDIO_DECODER **const decoder_ref)
+{
+    AUDIO_DECODER *const decoder = *decoder_ref;
+    if (decoder == nullptr) {
+        return;
+    }
+
+    if (decoder->swr_ctx != nullptr) {
+        swr_free(&decoder->swr_ctx);
+    }
+    if (decoder->frame != nullptr) {
+        av_frame_free(&decoder->frame);
+    }
+    if (decoder->packet != nullptr) {
+        av_packet_free(&decoder->packet);
+    }
+    if (decoder->codec_ctx != nullptr) {
+        // XXX: potential libav bug - avcodec_close should free this info
+        if (decoder->codec_ctx->extradata != nullptr) {
+            av_freep(&decoder->codec_ctx->extradata);
+        }
+        avcodec_free_context(&decoder->codec_ctx);
+    }
+    if (decoder->format_ctx != nullptr) {
+        avformat_close_input(&decoder->format_ctx);
+    }
+    if (decoder->avio_ctx != nullptr) {
+        av_freep(&decoder->avio_ctx->buffer);
+        avio_context_free(&decoder->avio_ctx);
+    }
+    Memory_FreePointer(&decoder->buffer);
+    Memory_FreePointer(decoder_ref);
+}
+
+double AudioDecoder_GetDuration(const AUDIO_DECODER *const decoder)
+{
+    ASSERT(decoder != nullptr);
+    if (decoder->format_ctx->duration <= 0) {
+        return -1.0;
+    }
+    return (double)decoder->format_ctx->duration / (double)AV_TIME_BASE;
+}
+
+double AudioDecoder_GetTimestamp(const AUDIO_DECODER *const decoder)
+{
+    ASSERT(decoder != nullptr);
+    return decoder->timestamp;
+}
+
+bool AudioDecoder_Seek(AUDIO_DECODER *const decoder, const double timestamp)
+{
+    ASSERT(decoder != nullptr);
+
+    const double time_base_sec = av_q2d(decoder->stream->time_base);
+    if (time_base_sec <= 0.0) {
+        LOG_ERROR("Invalid time base %f", time_base_sec);
+        return false;
+    }
+
+    const int32_t error_code = av_seek_frame(
+        decoder->format_ctx, decoder->stream->index,
+        (int64_t)(timestamp / time_base_sec), AVSEEK_FLAG_ANY);
+    if (error_code < 0) {
+        LOG_ERROR(
+            "seek failed for timestamp %f: %s", timestamp,
+            av_err2str(error_code));
+        return false;
+    }
+
+    avcodec_flush_buffers(decoder->codec_ctx);
+    decoder->timestamp = timestamp;
+    decoder->is_drained = false;
+    return true;
+}
+
+bool AudioDecoder_Rewind(AUDIO_DECODER *const decoder, const double start_at)
+{
+    ASSERT(decoder != nullptr);
+
+    int32_t error_code;
+    if (start_at <= 0.0) {
+        avio_seek(decoder->format_ctx->pb, 0, SEEK_SET);
+        error_code = avformat_seek_file(
+            decoder->format_ctx, -1, 0, 0, 0, AVSEEK_FLAG_FRAME);
+    } else if (
+        decoder->format_ctx->pb != nullptr
+        && (decoder->format_ctx->pb->seekable & AVIO_SEEKABLE_NORMAL) != 0) {
+        const int64_t ts = (int64_t)(start_at * AV_TIME_BASE);
+        error_code = avformat_seek_file(
+            decoder->format_ctx, decoder->stream->index, INT64_MIN, ts,
+            INT64_MAX, AVSEEK_FLAG_BACKWARD);
+    } else {
+        return AudioDecoder_Seek(decoder, start_at);
+    }
+
+    if (error_code < 0) {
+        LOG_ERROR(
+            "seek failed for timestamp %f: %s", start_at,
+            av_err2str(error_code));
+        return false;
+    }
+
+    avcodec_flush_buffers(decoder->codec_ctx);
+    decoder->timestamp = start_at;
+    decoder->is_drained = false;
+    return true;
+}
+
+int32_t AudioDecoder_Read(AUDIO_DECODER *const decoder, const float **const out)
+{
+    ASSERT(decoder != nullptr);
+    ASSERT(out != nullptr);
+
+    decoder->buffer_count = 0;
+    *out = decoder->buffer;
+
+    if (decoder->is_drained) {
+        return -1;
+    }
+
+    av_packet_unref(decoder->packet);
+    const int32_t error_code =
+        av_read_frame(decoder->format_ctx, decoder->packet);
+    if (error_code < 0) {
+        if (error_code != AVERROR_EOF) {
+            LOG_ERROR("Error while reading audio: %s", av_err2str(error_code));
+        }
+        // let the codec hand back whatever it was still holding
+        avcodec_send_packet(decoder->codec_ctx, nullptr);
+        M_Drain(decoder);
+        decoder->is_drained = true;
+        *out = decoder->buffer;
+        return decoder->buffer_count > 0
+            ? decoder->buffer_count / decoder->channels
+            : -1;
+    }
+
+    if (decoder->packet->stream_index == decoder->stream->index
+        && avcodec_send_packet(decoder->codec_ctx, decoder->packet) >= 0) {
+        M_Drain(decoder);
+    }
+    av_packet_unref(decoder->packet);
+
+    *out = decoder->buffer;
+    return decoder->buffer_count / decoder->channels;
+}

--- a/src/trx/av/audio_decoder.h
+++ b/src/trx/av/audio_decoder.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Turns a compressed audio file into the mixer's working format. The caller
+// keeps the memory a decoder was created over alive for as long as it lives.
+typedef struct AUDIO_DECODER AUDIO_DECODER;
+
+AUDIO_DECODER *AudioDecoder_CreateFromPath(const char *path, int32_t channels);
+AUDIO_DECODER *AudioDecoder_CreateFromMemory(
+    const uint8_t *data, size_t size, int32_t channels);
+void AudioDecoder_Free(AUDIO_DECODER **decoder);
+
+// How long the source is, in seconds, or a negative value where the container
+// does not say.
+double AudioDecoder_GetDuration(const AUDIO_DECODER *decoder);
+
+// Where in the source the last decoded frame came from, in seconds.
+double AudioDecoder_GetTimestamp(const AUDIO_DECODER *decoder);
+
+bool AudioDecoder_Seek(AUDIO_DECODER *decoder, double timestamp);
+bool AudioDecoder_Rewind(AUDIO_DECODER *decoder, double start_at);
+
+// Decodes the next packet and points `out` at the samples it produced. Returns
+// how many samples per channel those are - zero where the packet carried none
+// - or a negative value once the source has run out. The samples stay valid
+// until the next call.
+int32_t AudioDecoder_Read(AUDIO_DECODER *decoder, const float **out);

--- a/src/trx/av/audio_internal.h
+++ b/src/trx/av/audio_internal.h
@@ -29,6 +29,9 @@ void Audio_Sample_Init(void);
 void Audio_Sample_Shutdown(void);
 void Audio_Sample_Mix(float *dst_buffer, size_t len);
 
+// Decode samples that have started playing. Runs on the worker thread.
+void Audio_Sample_Pump(void);
+
 void Audio_Stream_Init(void);
 void Audio_Stream_Shutdown(void);
 void Audio_Stream_Mix(float *dst_buffer, size_t len);

--- a/src/trx/av/audio_internal.h
+++ b/src/trx/av/audio_internal.h
@@ -15,6 +15,12 @@ extern SDL_AudioDeviceID g_AudioDeviceID;
 void Audio_LockDevice(void);
 void Audio_UnlockDevice(void);
 
+// Guards every decoder-side structure: libav contexts, resamplers, and the
+// buffers the mixer reads from. The audio callback must never take it, as it
+// is held across decoding.
+void Audio_WorkerLock(void);
+void Audio_WorkerUnlock(void);
+
 int32_t Audio_GetAVChannelLayout(int32_t sample_fmt);
 int32_t Audio_GetAVAudioFormat(int32_t sample_fmt);
 int32_t Audio_GetSDLAudioFormat(enum AVSampleFormat sample_fmt);
@@ -26,6 +32,9 @@ void Audio_Sample_Mix(float *dst_buffer, size_t len);
 void Audio_Stream_Init(void);
 void Audio_Stream_Shutdown(void);
 void Audio_Stream_Mix(float *dst_buffer, size_t len);
+
+// Decode ahead of the mixer. Runs on the worker thread.
+void Audio_Stream_Pump(void);
 
 void Audio_Reverb_Init(int32_t sample_rate, int32_t channels);
 void Audio_Reverb_Shutdown(void);

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -1,11 +1,12 @@
 #include <trx/av/audio_internal.h>
 
-#include <trx/core/benchmark.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/version.h>
 
+#include <SDL2/SDL_atomic.h>
 #include <SDL2/SDL_audio.h>
 #include <errno.h>
 #include <libavcodec/avcodec.h>
@@ -14,8 +15,10 @@
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/avutil.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/error.h>
 #include <libavutil/frame.h>
+#include <libavutil/mathematics.h>
 #include <libavutil/mem.h>
 #include <libavutil/samplefmt.h>
 #include <libswresample/swresample.h>
@@ -24,23 +27,60 @@
 #include <stdio.h>
 #include <string.h>
 
+#define AVIO_BUFFER_SIZE 8192
+
+// Samples are mixed in mono: the game does its own 3D panning.
+#define SAMPLE_CHANNELS 1
+
+// How much new audio a single sample may produce per sweep, so a long sample
+// never holds up the streams sharing the worker.
+#define SAMPLE_CHUNK_SAMPLES (AUDIO_WORKING_RATE / 4)
+
+// Decoding writes a few samples more than the container duration suggests, as
+// the resampler rounds up. Room for a second of it costs nothing.
+#define SAMPLE_LENGTH_SLACK AUDIO_WORKING_RATE
+
 typedef struct {
-    struct {
-        int32_t format;
-        AVChannelLayout ch_layout;
-        int32_t sample_rate;
-    } src, dst;
-    SwrContext *ctx;
-    size_t working_buffer_size;
-    uint8_t *working_buffer;
-} M_SWR_CONTEXT;
+    const uint8_t *data;
+    const uint8_t *ptr;
+    int32_t size;
+    int32_t remaining;
+} AUDIO_AV_BUFFER;
+
+typedef struct {
+    AUDIO_AV_BUFFER buffer;
+    AVIOContext *avio_ctx;
+    AVFormatContext *format_ctx;
+    AVStream *stream;
+    AVCodecContext *codec_ctx;
+    AVPacket *packet;
+    AVFrame *frame;
+    SwrContext *swr_ctx;
+
+    float *pcm;
+    int32_t count;
+    int32_t capacity;
+    // Set when the container did not say how long the sample is. The buffer
+    // then has to grow, so it stays private until the decode finishes.
+    bool can_grow;
+
+    float *convert_buffer;
+    int32_t convert_capacity;
+} AUDIO_SAMPLE_DECODER;
 
 typedef struct {
     char *original_data;
     size_t original_size;
-    float *sample_data;
     int32_t channels;
-    int32_t num_samples;
+
+    // Owned by the decoder until it publishes it. The mixer reads
+    // `sample_data` only up to `ready_samples`, which the worker raises as it
+    // decodes, so the buffer is never reallocated underneath the mixer.
+    float *sample_data;
+    SDL_atomic_t ready_samples;
+    bool is_decoded;
+    bool is_queued;
+    AUDIO_SAMPLE_DECODER *decoder;
 } AUDIO_SAMPLE;
 
 typedef struct {
@@ -76,16 +116,11 @@ typedef struct {
     AUDIO_SAMPLE *sample;
 } AUDIO_SAMPLE_SOUND;
 
-typedef struct {
-    const uint8_t *data;
-    const uint8_t *ptr;
-    int32_t size;
-    int32_t remaining;
-} AUDIO_AV_BUFFER;
-
 static int32_t m_LoadedSamplesCount = 0;
 static AUDIO_SAMPLE m_LoadedSamples[AUDIO_MAX_SAMPLES] = {};
 static AUDIO_SAMPLE_SOUND m_Samples[AUDIO_MAX_ACTIVE_SAMPLES] = {};
+static int32_t m_DecodeQueue[AUDIO_MAX_SAMPLES] = {};
+static int32_t m_DecodeQueueCount = 0;
 
 static double M_DecibelToMultiplier(double db_gain)
 {
@@ -162,324 +197,317 @@ static int64_t M_SeekAVBuffer(void *opaque, int64_t offset, int32_t whence)
     return src->ptr - src->data;
 }
 
-static int32_t M_OutputAudioFrame(
-    M_SWR_CONTEXT *const swr, AVFrame *const frame)
+// Hands the decoder's own buffer over, or frees it when the sample never got
+// it. Everything else the decode needed goes with it.
+static void M_DecoderFree(AUDIO_SAMPLE *const sample)
 {
-    // Determine the maximum number of output samples this call can produce,
-    // based on the current delay already inside the resampler plus the new
-    // input. Using av_rescale_rnd() keeps everything in integer domain and
-    // avoids cumulative rounding errors.
-    const int64_t delay = swr_get_delay(swr->ctx, swr->src.sample_rate);
-    const int32_t out_samples = (int32_t)av_rescale_rnd(
-        delay + frame->nb_samples, swr->dst.sample_rate, swr->src.sample_rate,
-        AV_ROUND_UP);
-    if (out_samples <= 0) {
-        return 0; // nothing to do
+    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
+    if (decoder == nullptr) {
+        return;
     }
 
-    uint8_t *out_buffer = nullptr;
-    if (av_samples_alloc(
-            &out_buffer, nullptr, swr->dst.ch_layout.nb_channels, out_samples,
-            swr->dst.format, 1)
-        < 0) {
-        return AVERROR(ENOMEM);
+    if (decoder->pcm != sample->sample_data) {
+        Memory_Free(decoder->pcm);
+    }
+    Memory_FreePointer(&decoder->convert_buffer);
+
+    if (decoder->swr_ctx != nullptr) {
+        swr_free(&decoder->swr_ctx);
+    }
+    if (decoder->frame != nullptr) {
+        av_frame_free(&decoder->frame);
+    }
+    if (decoder->packet != nullptr) {
+        av_packet_free(&decoder->packet);
+    }
+    if (decoder->codec_ctx != nullptr) {
+        avcodec_free_context(&decoder->codec_ctx);
+    }
+    if (decoder->format_ctx != nullptr) {
+        avformat_close_input(&decoder->format_ctx);
+    }
+    if (decoder->avio_ctx != nullptr) {
+        av_freep(&decoder->avio_ctx->buffer);
+        avio_context_free(&decoder->avio_ctx);
     }
 
-    // Convert – we do *not* drain the resampler here.
-    const int32_t converted = swr_convert(
-        swr->ctx, &out_buffer, out_samples, (const uint8_t **)frame->data,
-        frame->nb_samples);
-
-    if (converted < 0) {
-        av_freep(&out_buffer);
-        return converted; // propagate error
-    }
-
-    if (converted > 0) {
-        const int32_t out_buffer_size = av_samples_get_buffer_size(
-            nullptr, swr->dst.ch_layout.nb_channels, converted, swr->dst.format,
-            1);
-        if (out_buffer_size > 0) {
-            swr->working_buffer = Memory_Realloc(
-                swr->working_buffer,
-                swr->working_buffer_size + out_buffer_size);
-            memcpy(
-                swr->working_buffer + swr->working_buffer_size, out_buffer,
-                out_buffer_size);
-            swr->working_buffer_size += out_buffer_size;
-        }
-    }
-
-    av_freep(&out_buffer);
-    return 0;
+    Memory_FreePointer(&sample->decoder);
 }
 
-static int32_t M_DecodePacket(
-    AVCodecContext *const dec, const AVPacket *const pkt, AVFrame *frame,
-    M_SWR_CONTEXT *const swr)
+static bool M_DecoderOpen(AUDIO_SAMPLE *const sample)
 {
-    // Submit the packet to the decoder
-    int32_t ret = avcodec_send_packet(dec, pkt);
-    if (ret < 0) {
-        LOG_ERROR(
-            "Error submitting a packet for decoding (%s)\n", av_err2str(ret));
-        return ret;
-    }
+    ASSERT(sample->decoder == nullptr);
 
-    // Get all the available frames from the decoder
-    while (ret >= 0) {
-        ret = avcodec_receive_frame(dec, frame);
-        if (ret < 0) {
-            // those two return values are special and mean there is no output
-            // frame available, but there were no errors during decoding
-            if (ret == AVERROR_EOF || ret == AVERROR(EAGAIN)) {
-                return 0;
-            }
-            LOG_ERROR(
-                "Error receiving a frame for decoding (%s)\n", av_err2str(ret));
-            return ret;
-        }
+    AUDIO_SAMPLE_DECODER *const decoder =
+        Memory_Alloc(sizeof(AUDIO_SAMPLE_DECODER));
+    sample->decoder = decoder;
 
-        ret = M_OutputAudioFrame(swr, frame);
-        av_frame_unref(frame);
-    }
-
-    return ret;
-}
-
-static bool M_ConvertRawData(
-    const uint8_t *const original_data, const int32_t original_size,
-    const int32_t dst_sample_rate, const int32_t dst_format,
-    const int32_t dst_channel_count, uint8_t **const out_sample_data,
-    size_t *const out_size, size_t *const out_sample_count)
-{
-    bool result = false;
-
-    struct {
-        size_t read_buffer_size;
-        AVIOContext *avio_context;
-        AVStream *stream;
-        AVFormatContext *format_ctx;
-        const AVCodec *codec;
-        AVCodecContext *codec_ctx;
-        AVPacket *packet;
-        AVFrame *frame;
-    } av = {
-        .read_buffer_size = 8192,
-        .avio_context = nullptr,
-        .stream = nullptr,
-        .format_ctx = nullptr,
-        .codec = nullptr,
-        .codec_ctx = nullptr,
-        .packet = nullptr,
-        .frame = nullptr,
+    decoder->buffer = (AUDIO_AV_BUFFER) {
+        .data = (const uint8_t *)sample->original_data,
+        .ptr = (const uint8_t *)sample->original_data,
+        .size = sample->original_size,
+        .remaining = sample->original_size,
     };
 
-    M_SWR_CONTEXT swr = {};
-    int32_t error_code;
-
-    uint8_t *const read_buffer = av_malloc(av.read_buffer_size);
-    if (read_buffer == nullptr) {
+    int32_t error_code = 0;
+    decoder->avio_ctx = avio_alloc_context(
+        av_malloc(AVIO_BUFFER_SIZE), AVIO_BUFFER_SIZE, 0, &decoder->buffer,
+        M_ReadAVBuffer, nullptr, M_SeekAVBuffer);
+    if (decoder->avio_ctx == nullptr) {
         error_code = AVERROR(ENOMEM);
-        goto cleanup;
+        goto fail;
     }
 
-    AUDIO_AV_BUFFER av_buf = {
-        .data = original_data,
-        .ptr = original_data,
-        .size = original_size,
-        .remaining = original_size,
-    };
-
-    av.avio_context = avio_alloc_context(
-        read_buffer, av.read_buffer_size, 0, &av_buf, M_ReadAVBuffer, nullptr,
-        M_SeekAVBuffer);
-
-    av.format_ctx = avformat_alloc_context();
-    av.format_ctx->pb = av.avio_context;
-    error_code = avformat_open_input(&av.format_ctx, "mem:", nullptr, nullptr);
-    if (error_code != 0) {
-        goto cleanup;
-    }
-
-    error_code = avformat_find_stream_info(av.format_ctx, nullptr);
-    if (error_code < 0) {
-        goto cleanup;
-    }
-
-    av.stream = nullptr;
-    for (uint32_t i = 0; i < av.format_ctx->nb_streams; i++) {
-        AVStream *current_stream = av.format_ctx->streams[i];
-        if (current_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-            av.stream = current_stream;
-            break;
-        }
-    }
-    if (av.stream == nullptr) {
-        error_code = AVERROR_STREAM_NOT_FOUND;
-        goto cleanup;
-    }
-
-    av.codec = avcodec_find_decoder(av.stream->codecpar->codec_id);
-    if (av.codec == nullptr) {
-        error_code = AVERROR_DEMUXER_NOT_FOUND;
-        goto cleanup;
-    }
-
-    av.codec_ctx = avcodec_alloc_context3(av.codec);
-    if (av.codec_ctx == nullptr) {
+    decoder->format_ctx = avformat_alloc_context();
+    if (decoder->format_ctx == nullptr) {
         error_code = AVERROR(ENOMEM);
-        goto cleanup;
+        goto fail;
     }
+    decoder->format_ctx->pb = decoder->avio_ctx;
 
     error_code =
-        avcodec_parameters_to_context(av.codec_ctx, av.stream->codecpar);
-    if (error_code) {
-        goto cleanup;
-    }
-
-    error_code = avcodec_open2(av.codec_ctx, av.codec, nullptr);
-    if (error_code < 0) {
-        goto cleanup;
-    }
-
-    av.packet = av_packet_alloc();
-    if (av.packet == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    av.frame = av_frame_alloc();
-    if (av.frame == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    swr.src.sample_rate = av.codec_ctx->sample_rate;
-    swr.src.ch_layout = av.codec_ctx->ch_layout;
-    swr.src.format = av.codec_ctx->sample_fmt;
-    swr.dst.sample_rate = AUDIO_WORKING_RATE;
-    av_channel_layout_default(&swr.dst.ch_layout, dst_channel_count);
-    swr.dst.format = Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT);
-    swr_alloc_set_opts2(
-        &swr.ctx, &swr.dst.ch_layout, swr.dst.format, swr.dst.sample_rate,
-        &swr.src.ch_layout, swr.src.format, swr.src.sample_rate, 0, 0);
-    if (swr.ctx == nullptr) {
-        av_packet_unref(av.packet);
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    error_code = swr_init(swr.ctx);
+        avformat_open_input(&decoder->format_ctx, "mem:", nullptr, nullptr);
     if (error_code != 0) {
-        av_packet_unref(av.packet);
-        goto cleanup;
+        goto fail;
     }
 
-    while ((error_code = av_read_frame(av.format_ctx, av.packet)) >= 0) {
-        M_DecodePacket(av.codec_ctx, av.packet, av.frame, &swr);
-        av_packet_unref(av.packet);
-        if (error_code < 0) {
+    error_code = avformat_find_stream_info(decoder->format_ctx, nullptr);
+    if (error_code < 0) {
+        goto fail;
+    }
+
+    for (uint32_t i = 0; i < decoder->format_ctx->nb_streams; i++) {
+        AVStream *const stream = decoder->format_ctx->streams[i];
+        if (stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            decoder->stream = stream;
             break;
         }
     }
-
-    if (av.codec_ctx != nullptr) {
-        M_DecodePacket(av.codec_ctx, nullptr, av.frame, &swr);
+    if (decoder->stream == nullptr) {
+        error_code = AVERROR_STREAM_NOT_FOUND;
+        goto fail;
     }
 
-    if (error_code == AVERROR_EOF) {
-        error_code = 0;
-    } else if (error_code < 0) {
-        goto cleanup;
+    const AVCodec *const codec =
+        avcodec_find_decoder(decoder->stream->codecpar->codec_id);
+    if (codec == nullptr) {
+        error_code = AVERROR_DEMUXER_NOT_FOUND;
+        goto fail;
     }
 
-    if (out_size != nullptr) {
-        *out_size = swr.working_buffer_size;
+    decoder->codec_ctx = avcodec_alloc_context3(codec);
+    if (decoder->codec_ctx == nullptr) {
+        error_code = AVERROR(ENOMEM);
+        goto fail;
     }
-    if (out_sample_count != nullptr) {
-        *out_sample_count = (int32_t)swr.working_buffer_size
-            / av_get_bytes_per_sample(swr.dst.format)
-            / swr.dst.ch_layout.nb_channels;
-    }
-    if (out_sample_data != nullptr) {
-        *out_sample_data = swr.working_buffer;
-    } else {
-        Memory_FreePointer(&swr.working_buffer);
-    }
-    result = true;
 
-cleanup:
+    error_code = avcodec_parameters_to_context(
+        decoder->codec_ctx, decoder->stream->codecpar);
     if (error_code != 0) {
-        LOG_ERROR("Error while decoding sample: %s", av_err2str(error_code));
+        goto fail;
     }
 
-    if (!result) {
-        if (out_size != nullptr) {
-            *out_size = 0;
-        }
-        if (out_sample_count != nullptr) {
-            *out_sample_count = 0;
-        }
-        if (out_sample_data != nullptr) {
-            *out_sample_data = nullptr;
-        }
-        Memory_FreePointer(&swr.working_buffer);
+    error_code = avcodec_open2(decoder->codec_ctx, codec, nullptr);
+    if (error_code < 0) {
+        goto fail;
     }
 
-    if (swr.ctx) {
-        swr_free(&swr.ctx);
+    decoder->packet = av_packet_alloc();
+    decoder->frame = av_frame_alloc();
+    if (decoder->packet == nullptr || decoder->frame == nullptr) {
+        error_code = AVERROR(ENOMEM);
+        goto fail;
     }
-    if (av.frame) {
-        av_frame_free(&av.frame);
+
+    AVChannelLayout dst_layout;
+    av_channel_layout_default(&dst_layout, SAMPLE_CHANNELS);
+    swr_alloc_set_opts2(
+        &decoder->swr_ctx, &dst_layout,
+        Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT), AUDIO_WORKING_RATE,
+        &decoder->codec_ctx->ch_layout, decoder->codec_ctx->sample_fmt,
+        decoder->codec_ctx->sample_rate, 0, 0);
+    if (decoder->swr_ctx == nullptr) {
+        error_code = AVERROR(ENOMEM);
+        goto fail;
     }
-    if (av.packet) {
-        av_packet_free(&av.packet);
+    error_code = swr_init(decoder->swr_ctx);
+    if (error_code != 0) {
+        goto fail;
     }
-    av.codec = nullptr;
-    if (av.codec_ctx) {
-        avcodec_free_context(&av.codec_ctx);
+
+    const int64_t duration = decoder->format_ctx->duration;
+    decoder->can_grow = duration <= 0;
+    decoder->capacity = decoder->can_grow
+        ? AUDIO_WORKING_RATE
+        : av_rescale_rnd(
+              duration, AUDIO_WORKING_RATE, AV_TIME_BASE, AV_ROUND_UP)
+            + SAMPLE_LENGTH_SLACK;
+    decoder->pcm = Memory_Alloc(decoder->capacity * sizeof(float));
+
+    sample->channels = SAMPLE_CHANNELS;
+    if (!decoder->can_grow) {
+        sample->sample_data = decoder->pcm;
     }
-    if (av.format_ctx) {
-        avformat_close_input(&av.format_ctx);
-    }
-    if (av.avio_context) {
-        av_freep(&av.avio_context->buffer);
-        avio_context_free(&av.avio_context);
-    }
-    return result;
+    return true;
+
+fail:
+    LOG_ERROR("Error while decoding sample: %s", av_err2str(error_code));
+    M_DecoderFree(sample);
+    return false;
 }
 
-static bool M_ConvertSample(const int32_t sample_id)
+static void M_DecoderAppend(
+    AUDIO_SAMPLE *const sample, const float *const data, const int32_t count)
 {
-    ASSERT(sample_id >= 0 && sample_id < m_LoadedSamplesCount);
+    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
+
+    if (decoder->count + count > decoder->capacity) {
+        if (!decoder->can_grow) {
+            LOG_ERROR("Sample runs past the length its container declares");
+            return;
+        }
+        decoder->capacity = MAX(decoder->capacity * 2, decoder->count + count);
+        decoder->pcm =
+            Memory_Realloc(decoder->pcm, decoder->capacity * sizeof(float));
+    }
+
+    memcpy(decoder->pcm + decoder->count, data, count * sizeof(float));
+    decoder->count += count;
+
+    if (!decoder->can_grow) {
+        SDL_AtomicSet(&sample->ready_samples, decoder->count);
+    }
+}
+
+static void M_DecoderConvert(AUDIO_SAMPLE *const sample, AVFrame *const frame)
+{
+    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
+
+    const int32_t max_samples =
+        swr_get_out_samples(decoder->swr_ctx, frame->nb_samples);
+    if (max_samples <= 0) {
+        return;
+    }
+
+    if (max_samples > decoder->convert_capacity) {
+        decoder->convert_capacity = max_samples;
+        decoder->convert_buffer = Memory_Realloc(
+            decoder->convert_buffer, max_samples * sizeof(float));
+    }
+
+    uint8_t *out_buffer = (uint8_t *)decoder->convert_buffer;
+    const int32_t converted = swr_convert(
+        decoder->swr_ctx, &out_buffer, max_samples,
+        (const uint8_t **)frame->data, frame->nb_samples);
+    if (converted > 0) {
+        M_DecoderAppend(sample, decoder->convert_buffer, converted);
+    }
+}
+
+static void M_DecoderDrain(AUDIO_SAMPLE *const sample)
+{
+    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
+
+    while (avcodec_receive_frame(decoder->codec_ctx, decoder->frame) >= 0) {
+        M_DecoderConvert(sample, decoder->frame);
+        av_frame_unref(decoder->frame);
+    }
+    av_frame_unref(decoder->frame);
+}
+
+static bool M_DecoderStep(AUDIO_SAMPLE *const sample)
+{
+    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
+
+    if (av_read_frame(decoder->format_ctx, decoder->packet) < 0) {
+        avcodec_send_packet(decoder->codec_ctx, nullptr);
+        M_DecoderDrain(sample);
+        return false;
+    }
+
+    if (decoder->packet->stream_index == decoder->stream->index
+        && avcodec_send_packet(decoder->codec_ctx, decoder->packet) >= 0) {
+        M_DecoderDrain(sample);
+    }
+    av_packet_unref(decoder->packet);
+    return true;
+}
+
+static void M_DecoderClose(AUDIO_SAMPLE *const sample)
+{
+    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
+
+    if (decoder->can_grow) {
+        Audio_LockDevice();
+        sample->sample_data = decoder->pcm;
+        SDL_AtomicSet(&sample->ready_samples, decoder->count);
+        Audio_UnlockDevice();
+    }
+
+    sample->is_decoded = true;
+    M_DecoderFree(sample);
+}
+
+static void M_DequeueDecode(const int32_t queue_idx)
+{
+    m_LoadedSamples[m_DecodeQueue[queue_idx]].is_queued = false;
+    m_DecodeQueue[queue_idx] = m_DecodeQueue[--m_DecodeQueueCount];
+}
+
+static void M_QueueDecode(const int32_t sample_id)
+{
     AUDIO_SAMPLE *const sample = &m_LoadedSamples[sample_id];
-    if (sample->sample_data != nullptr) {
-        return true;
+    if (sample->is_decoded || sample->is_queued) {
+        return;
     }
-
-    size_t num_samples;
-    BENCHMARK benchmark = Benchmark_Start();
-
-    const bool result = M_ConvertRawData(
-        (uint8_t *)sample->original_data, sample->original_size,
-        AUDIO_WORKING_RATE, Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT), 1,
-        (uint8_t **)&sample->sample_data, nullptr, &num_samples);
-
-    char buffer[80];
-    sprintf(buffer, "sample %d decoded", sample_id);
-    Benchmark_End(&benchmark, buffer);
-
-    sample->channels = 1;
-    sample->num_samples = num_samples;
-    return result;
+    sample->is_queued = true;
+    m_DecodeQueue[m_DecodeQueueCount++] = sample_id;
 }
 
-static bool M_IsOriginalDataDefined(const int32_t sample_id)
+static void M_CancelDecode(AUDIO_SAMPLE *const sample)
 {
-    ASSERT(sample_id >= 0 && sample_id < m_LoadedSamplesCount);
-    const AUDIO_SAMPLE *const sample = &m_LoadedSamples[sample_id];
-    return sample->original_data != nullptr;
+    for (int32_t i = 0; i < m_DecodeQueueCount; i++) {
+        if (&m_LoadedSamples[m_DecodeQueue[i]] == sample) {
+            M_DequeueDecode(i);
+            break;
+        }
+    }
+    M_DecoderFree(sample);
+}
+
+// Drops every sound playing the given sample, so its buffer can be freed. The
+// device lock must be held.
+static void M_DropSoundsOfSample(const AUDIO_SAMPLE *const sample)
+{
+    for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
+         sound_id++) {
+        AUDIO_SAMPLE_SOUND *const sound = &m_Samples[sound_id];
+        if (sound->sample == sample) {
+            sound->is_used = false;
+            sound->is_playing = false;
+            sound->sample = nullptr;
+        }
+    }
+}
+
+static void M_UnloadSample(AUDIO_SAMPLE *const sample)
+{
+    if (sample->original_data == nullptr && sample->sample_data == nullptr) {
+        return;
+    }
+
+    M_CancelDecode(sample);
+
+    Audio_LockDevice();
+    M_DropSoundsOfSample(sample);
+    Memory_FreePointer(&sample->sample_data);
+    SDL_AtomicSet(&sample->ready_samples, 0);
+    Audio_UnlockDevice();
+
+    Memory_FreePointer(&sample->original_data);
+    sample->original_size = 0;
+    sample->channels = 0;
+    sample->is_decoded = false;
 }
 
 void Audio_Sample_Init(void)
@@ -503,6 +531,29 @@ void Audio_Sample_Shutdown(void)
     Audio_Sample_UnloadAll();
 }
 
+void Audio_Sample_Pump(void)
+{
+    Audio_WorkerLock();
+    for (int32_t i = 0; i < m_DecodeQueueCount; i++) {
+        AUDIO_SAMPLE *const sample = &m_LoadedSamples[m_DecodeQueue[i]];
+
+        if (sample->decoder == nullptr && !M_DecoderOpen(sample)) {
+            M_DequeueDecode(i--);
+            continue;
+        }
+
+        const int32_t target = sample->decoder->count + SAMPLE_CHUNK_SAMPLES;
+        while (sample->decoder->count < target) {
+            if (!M_DecoderStep(sample)) {
+                M_DecoderClose(sample);
+                M_DequeueDecode(i--);
+                break;
+            }
+        }
+    }
+    Audio_WorkerUnlock();
+}
+
 bool Audio_Sample_Unload(const int32_t sample_id)
 {
     if (sample_id < 0 || sample_id >= AUDIO_MAX_SAMPLES) {
@@ -510,26 +561,27 @@ bool Audio_Sample_Unload(const int32_t sample_id)
         return false;
     }
 
-    bool result = false;
     AUDIO_SAMPLE *const sample = &m_LoadedSamples[sample_id];
-    if (sample->sample_data == nullptr) {
+    if (sample->original_data == nullptr) {
         LOG_ERROR("Sample %d is already unloaded", sample_id);
         return false;
     }
-    Memory_FreePointer(&sample->sample_data);
-    Memory_FreePointer(&sample->original_data);
+
+    Audio_WorkerLock();
+    M_UnloadSample(sample);
+    Audio_WorkerUnlock();
     m_LoadedSamplesCount--;
     return true;
 }
 
 bool Audio_Sample_UnloadAll(void)
 {
+    Audio_WorkerLock();
     m_LoadedSamplesCount = 0;
     for (int32_t i = 0; i < AUDIO_MAX_SAMPLES; i++) {
-        AUDIO_SAMPLE *const sample = &m_LoadedSamples[i];
-        Memory_FreePointer(&sample->sample_data);
-        Memory_FreePointer(&sample->original_data);
+        M_UnloadSample(&m_LoadedSamples[i]);
     }
+    Audio_WorkerUnlock();
     return true;
 }
 
@@ -579,11 +631,14 @@ int32_t Audio_Sample_Play(
         return AUDIO_NO_SOUND;
     }
 
-    if (!M_IsOriginalDataDefined(sample_id)) {
+    if (m_LoadedSamples[sample_id].original_data == nullptr) {
         return AUDIO_NO_SOUND;
     }
 
     int32_t result = AUDIO_NO_SOUND;
+
+    Audio_WorkerLock();
+    M_QueueDecode(sample_id);
 
     Audio_LockDevice();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
@@ -592,8 +647,6 @@ int32_t Audio_Sample_Play(
         if (sound->is_used) {
             continue;
         }
-
-        M_ConvertSample(sample_id);
 
         sound->is_used = true;
         sound->is_playing = true;
@@ -610,6 +663,7 @@ int32_t Audio_Sample_Play(
         break;
     }
     Audio_UnlockDevice();
+    Audio_WorkerUnlock();
 
     if (result == AUDIO_NO_SOUND) {
         LOG_ERROR("All sample buffers are used!");
@@ -775,39 +829,45 @@ void Audio_Sample_Mix(float *dst_buffer, size_t len)
             continue;
         }
 
+        AUDIO_SAMPLE *const sample = sound->sample;
+        const int32_t ready = SDL_AtomicGet(&sample->ready_samples);
+        if (ready <= 0) {
+            continue;
+        }
+
         int32_t samples_requested =
             len / sizeof(AUDIO_WORKING_FORMAT) / AUDIO_WORKING_CHANNELS;
         float src_sample_idx = sound->current_sample;
-        const float *src_buffer = sound->sample->sample_data;
+        const float *src_buffer = sample->sample_data;
         float *dst_ptr = dst_buffer;
 
         while ((dst_ptr - dst_buffer) / AUDIO_WORKING_CHANNELS
                < samples_requested) {
 
+            if ((int32_t)src_sample_idx >= ready) {
+                // the decoder has not caught up yet, or the sample ended
+                if (!sample->is_decoded || !sound->is_looped) {
+                    break;
+                }
+                src_sample_idx = 0.0f;
+            }
+
             // because we handle 3d sound ourselves, downmix to mono
             float src_sample = 0.0f;
-            for (int32_t i = 0; i < sound->sample->channels; i++) {
-                src_sample += src_buffer
-                    [(int32_t)src_sample_idx * sound->sample->channels + i];
+            for (int32_t i = 0; i < sample->channels; i++) {
+                src_sample +=
+                    src_buffer[(int32_t)src_sample_idx * sample->channels + i];
             }
-            src_sample /= (float)sound->sample->channels;
+            src_sample /= (float)sample->channels;
 
             *dst_ptr++ += src_sample * sound->volume_l;
             *dst_ptr++ += src_sample * sound->volume_r;
             src_sample_idx += sound->pitch;
-
-            if ((int32_t)src_sample_idx >= sound->sample->num_samples) {
-                if (sound->is_looped) {
-                    src_sample_idx = 0.0f;
-                } else {
-                    break;
-                }
-            }
         }
 
         sound->current_sample = src_sample_idx;
-        if (sound->current_sample >= sound->sample->num_samples
-            && !sound->is_looped) {
+        if (sample->is_decoded && !sound->is_looped
+            && (int32_t)src_sample_idx >= ready) {
             Audio_Sample_Close(sound_id);
         }
     }

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -1,5 +1,6 @@
 #include <trx/av/audio_internal.h>
 
+#include <trx/av/audio_decoder.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
@@ -8,26 +9,9 @@
 
 #include <SDL2/SDL_atomic.h>
 #include <SDL2/SDL_audio.h>
-#include <errno.h>
-#include <libavcodec/avcodec.h>
-#include <libavcodec/codec.h>
-#include <libavcodec/packet.h>
-#include <libavformat/avformat.h>
-#include <libavformat/avio.h>
-#include <libavutil/avutil.h>
-#include <libavutil/channel_layout.h>
-#include <libavutil/error.h>
-#include <libavutil/frame.h>
-#include <libavutil/mathematics.h>
-#include <libavutil/mem.h>
-#include <libavutil/samplefmt.h>
-#include <libswresample/swresample.h>
 #include <math.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
-
-#define AVIO_BUFFER_SIZE 8192
 
 // Samples are mixed in mono: the game does its own 3D panning.
 #define SAMPLE_CHANNELS 1
@@ -41,21 +25,7 @@
 #define SAMPLE_LENGTH_SLACK AUDIO_WORKING_RATE
 
 typedef struct {
-    const uint8_t *data;
-    const uint8_t *ptr;
-    int32_t size;
-    int32_t remaining;
-} AUDIO_AV_BUFFER;
-
-typedef struct {
-    AUDIO_AV_BUFFER buffer;
-    AVIOContext *avio_ctx;
-    AVFormatContext *format_ctx;
-    AVStream *stream;
-    AVCodecContext *codec_ctx;
-    AVPacket *packet;
-    AVFrame *frame;
-    SwrContext *swr_ctx;
+    AUDIO_DECODER *decoder;
 
     float *pcm;
     int32_t count;
@@ -63,9 +33,6 @@ typedef struct {
     // Set when the container did not say how long the sample is. The buffer
     // then has to grow, so it stays private until the decode finishes.
     bool can_grow;
-
-    float *convert_buffer;
-    int32_t convert_capacity;
 } AUDIO_SAMPLE_DECODER;
 
 typedef struct {
@@ -149,54 +116,6 @@ static bool M_RecalculateChannelVolumes(int32_t sound_id)
     return true;
 }
 
-static int32_t M_ReadAVBuffer(void *opaque, uint8_t *dst, int32_t dst_size)
-{
-    ASSERT(opaque != nullptr);
-    ASSERT(dst != nullptr);
-    AUDIO_AV_BUFFER *src = opaque;
-    int32_t read = dst_size >= src->remaining ? src->remaining : dst_size;
-    if (!read) {
-        return AVERROR_EOF;
-    }
-    memcpy(dst, src->ptr, read);
-    src->ptr += read;
-    src->remaining -= read;
-    return read;
-}
-
-static int64_t M_SeekAVBuffer(void *opaque, int64_t offset, int32_t whence)
-{
-    ASSERT(opaque != nullptr);
-    AUDIO_AV_BUFFER *src = opaque;
-    if (whence & AVSEEK_SIZE) {
-        return src->size;
-    }
-    switch (whence) {
-    case SEEK_SET:
-        if (src->size - offset < 0) {
-            return AVERROR_EOF;
-        }
-        src->ptr = src->data + offset;
-        src->remaining = src->size - offset;
-        break;
-    case SEEK_CUR:
-        if (src->remaining - offset < 0) {
-            return AVERROR_EOF;
-        }
-        src->ptr += offset;
-        src->remaining -= offset;
-        break;
-    case SEEK_END:
-        if (src->size + offset < 0) {
-            return AVERROR_EOF;
-        }
-        src->ptr = src->data - offset;
-        src->remaining = src->size + offset;
-        break;
-    }
-    return src->ptr - src->data;
-}
-
 // Hands the decoder's own buffer over, or frees it when the sample never got
 // it. Everything else the decode needed goes with it.
 static void M_DecoderFree(AUDIO_SAMPLE *const sample)
@@ -209,28 +128,7 @@ static void M_DecoderFree(AUDIO_SAMPLE *const sample)
     if (decoder->pcm != sample->sample_data) {
         Memory_Free(decoder->pcm);
     }
-    Memory_FreePointer(&decoder->convert_buffer);
-
-    if (decoder->swr_ctx != nullptr) {
-        swr_free(&decoder->swr_ctx);
-    }
-    if (decoder->frame != nullptr) {
-        av_frame_free(&decoder->frame);
-    }
-    if (decoder->packet != nullptr) {
-        av_packet_free(&decoder->packet);
-    }
-    if (decoder->codec_ctx != nullptr) {
-        avcodec_free_context(&decoder->codec_ctx);
-    }
-    if (decoder->format_ctx != nullptr) {
-        avformat_close_input(&decoder->format_ctx);
-    }
-    if (decoder->avio_ctx != nullptr) {
-        av_freep(&decoder->avio_ctx->buffer);
-        avio_context_free(&decoder->avio_ctx);
-    }
-
+    AudioDecoder_Free(&decoder->decoder);
     Memory_FreePointer(&sample->decoder);
 }
 
@@ -238,110 +136,23 @@ static bool M_DecoderOpen(AUDIO_SAMPLE *const sample)
 {
     ASSERT(sample->decoder == nullptr);
 
+    AUDIO_DECODER *const source = AudioDecoder_CreateFromMemory(
+        (const uint8_t *)sample->original_data, sample->original_size,
+        SAMPLE_CHANNELS);
+    if (source == nullptr) {
+        return false;
+    }
+
     AUDIO_SAMPLE_DECODER *const decoder =
         Memory_Alloc(sizeof(AUDIO_SAMPLE_DECODER));
     sample->decoder = decoder;
+    decoder->decoder = source;
 
-    decoder->buffer = (AUDIO_AV_BUFFER) {
-        .data = (const uint8_t *)sample->original_data,
-        .ptr = (const uint8_t *)sample->original_data,
-        .size = sample->original_size,
-        .remaining = sample->original_size,
-    };
-
-    int32_t error_code = 0;
-    decoder->avio_ctx = avio_alloc_context(
-        av_malloc(AVIO_BUFFER_SIZE), AVIO_BUFFER_SIZE, 0, &decoder->buffer,
-        M_ReadAVBuffer, nullptr, M_SeekAVBuffer);
-    if (decoder->avio_ctx == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto fail;
-    }
-
-    decoder->format_ctx = avformat_alloc_context();
-    if (decoder->format_ctx == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto fail;
-    }
-    decoder->format_ctx->pb = decoder->avio_ctx;
-
-    error_code =
-        avformat_open_input(&decoder->format_ctx, "mem:", nullptr, nullptr);
-    if (error_code != 0) {
-        goto fail;
-    }
-
-    error_code = avformat_find_stream_info(decoder->format_ctx, nullptr);
-    if (error_code < 0) {
-        goto fail;
-    }
-
-    for (uint32_t i = 0; i < decoder->format_ctx->nb_streams; i++) {
-        AVStream *const stream = decoder->format_ctx->streams[i];
-        if (stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-            decoder->stream = stream;
-            break;
-        }
-    }
-    if (decoder->stream == nullptr) {
-        error_code = AVERROR_STREAM_NOT_FOUND;
-        goto fail;
-    }
-
-    const AVCodec *const codec =
-        avcodec_find_decoder(decoder->stream->codecpar->codec_id);
-    if (codec == nullptr) {
-        error_code = AVERROR_DEMUXER_NOT_FOUND;
-        goto fail;
-    }
-
-    decoder->codec_ctx = avcodec_alloc_context3(codec);
-    if (decoder->codec_ctx == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto fail;
-    }
-
-    error_code = avcodec_parameters_to_context(
-        decoder->codec_ctx, decoder->stream->codecpar);
-    if (error_code != 0) {
-        goto fail;
-    }
-
-    error_code = avcodec_open2(decoder->codec_ctx, codec, nullptr);
-    if (error_code < 0) {
-        goto fail;
-    }
-
-    decoder->packet = av_packet_alloc();
-    decoder->frame = av_frame_alloc();
-    if (decoder->packet == nullptr || decoder->frame == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto fail;
-    }
-
-    AVChannelLayout dst_layout;
-    av_channel_layout_default(&dst_layout, SAMPLE_CHANNELS);
-    swr_alloc_set_opts2(
-        &decoder->swr_ctx, &dst_layout,
-        Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT), AUDIO_WORKING_RATE,
-        &decoder->codec_ctx->ch_layout, decoder->codec_ctx->sample_fmt,
-        decoder->codec_ctx->sample_rate, 0, 0);
-    if (decoder->swr_ctx == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto fail;
-    }
-    error_code = swr_init(decoder->swr_ctx);
-    if (error_code != 0) {
-        goto fail;
-    }
-
-    const int64_t duration = decoder->format_ctx->duration;
-    decoder->can_grow = duration <= 0;
+    const double duration = AudioDecoder_GetDuration(source);
+    decoder->can_grow = duration <= 0.0;
     decoder->capacity = decoder->can_grow
         ? AUDIO_WORKING_RATE
-        : av_rescale_rnd(
-              duration, AUDIO_WORKING_RATE, AV_TIME_BASE, AV_ROUND_UP)
-            + SAMPLE_LENGTH_SLACK;
+        : (int32_t)(duration * AUDIO_WORKING_RATE) + SAMPLE_LENGTH_SLACK;
     decoder->pcm = Memory_Alloc(decoder->capacity * sizeof(float));
 
     sample->channels = SAMPLE_CHANNELS;
@@ -349,11 +160,6 @@ static bool M_DecoderOpen(AUDIO_SAMPLE *const sample)
         sample->sample_data = decoder->pcm;
     }
     return true;
-
-fail:
-    LOG_ERROR("Error while decoding sample: %s", av_err2str(error_code));
-    M_DecoderFree(sample);
-    return false;
 }
 
 static void M_DecoderAppend(
@@ -379,57 +185,16 @@ static void M_DecoderAppend(
     }
 }
 
-static void M_DecoderConvert(AUDIO_SAMPLE *const sample, AVFrame *const frame)
-{
-    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
-
-    const int32_t max_samples =
-        swr_get_out_samples(decoder->swr_ctx, frame->nb_samples);
-    if (max_samples <= 0) {
-        return;
-    }
-
-    if (max_samples > decoder->convert_capacity) {
-        decoder->convert_capacity = max_samples;
-        decoder->convert_buffer = Memory_Realloc(
-            decoder->convert_buffer, max_samples * sizeof(float));
-    }
-
-    uint8_t *out_buffer = (uint8_t *)decoder->convert_buffer;
-    const int32_t converted = swr_convert(
-        decoder->swr_ctx, &out_buffer, max_samples,
-        (const uint8_t **)frame->data, frame->nb_samples);
-    if (converted > 0) {
-        M_DecoderAppend(sample, decoder->convert_buffer, converted);
-    }
-}
-
-static void M_DecoderDrain(AUDIO_SAMPLE *const sample)
-{
-    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
-
-    while (avcodec_receive_frame(decoder->codec_ctx, decoder->frame) >= 0) {
-        M_DecoderConvert(sample, decoder->frame);
-        av_frame_unref(decoder->frame);
-    }
-    av_frame_unref(decoder->frame);
-}
-
 static bool M_DecoderStep(AUDIO_SAMPLE *const sample)
 {
-    AUDIO_SAMPLE_DECODER *const decoder = sample->decoder;
-
-    if (av_read_frame(decoder->format_ctx, decoder->packet) < 0) {
-        avcodec_send_packet(decoder->codec_ctx, nullptr);
-        M_DecoderDrain(sample);
+    const float *samples = nullptr;
+    const int32_t count = AudioDecoder_Read(sample->decoder->decoder, &samples);
+    if (count < 0) {
         return false;
     }
-
-    if (decoder->packet->stream_index == decoder->stream->index
-        && avcodec_send_packet(decoder->codec_ctx, decoder->packet) >= 0) {
-        M_DecoderDrain(sample);
+    if (count > 0) {
+        M_DecoderAppend(sample, samples, count);
     }
-    av_packet_unref(decoder->packet);
     return true;
 }
 

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -1,47 +1,20 @@
 #include <trx/av/audio_internal.h>
 
+#include <trx/av/audio_decoder.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 
 #include <SDL2/SDL_atomic.h>
-#include <errno.h>
-#include <libavcodec/avcodec.h>
-#include <libavcodec/codec.h>
-#include <libavcodec/packet.h>
-#include <libavformat/avformat.h>
-#include <libavformat/avio.h>
-#include <libavutil/avutil.h>
-#include <libavutil/channel_layout.h>
-#include <libavutil/error.h>
-#include <libavutil/frame.h>
-#include <libavutil/mem.h>
-#include <libavutil/rational.h>
-#include <libavutil/samplefmt.h>
-#include <libswresample/swresample.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
-
-#define AVIO_BUFFER_SIZE 4096
 
 // The mixer must never wait for the decoder, and a seek must never discard
 // audible audio. 0.37 s of stereo sits comfortably between the two.
 #define RING_FLOATS (1 << 15)
 #define RING_MASK (RING_FLOATS - 1)
 #define RING_REFILL_FLOATS (RING_FLOATS / 2)
-
-typedef enum {
-    M_STREAM_SRC_NONE,
-    M_STREAM_SRC_MEMORY,
-} M_STREAM_SOURCE_TYPE;
-
-typedef struct {
-    uint8_t *data;
-    size_t size;
-    size_t pos;
-} M_MEM_SOURCE;
 
 // Written by the worker thread, read by the audio callback, and by nobody
 // else. Reset only while the device is locked.
@@ -72,33 +45,16 @@ typedef struct {
     void (*finish_callback)(int32_t sound_id, void *user_data);
     void *finish_callback_user_data;
 
-    M_STREAM_SOURCE_TYPE src_type;
-    void *src;
-    uint8_t *avio_ctx_buffer;
-    AVIOContext *avio_ctx;
-
-    struct {
-        AVStream *stream;
-        AVFormatContext *format_ctx;
-        const AVCodec *codec;
-        AVCodecContext *codec_ctx;
-        AVPacket *packet;
-        AVFrame *frame;
-    } av;
-
-    struct {
-        struct {
-            int32_t format;
-            AVChannelLayout ch_layout;
-            int32_t sample_rate;
-        } src, dst;
-        SwrContext *ctx;
-    } swr;
+    AUDIO_DECODER *decoder;
+    // what the last read produced but the ring had no room for; it stays
+    // valid until the decoder is read again
+    const float *pending;
+    uint32_t pending_count;
+    // the memory a stream was created over, which it then owns
+    uint8_t *memory;
 
     M_RING ring;
     SDL_atomic_t is_finished;
-    float *convert_buffer;
-    size_t convert_capacity;
 } AUDIO_STREAM_SOUND;
 
 extern SDL_AudioDeviceID g_AudioDeviceID;
@@ -116,10 +72,11 @@ static uint32_t M_RingSpace(M_RING *const ring)
     return RING_FLOATS - M_RingUsed(ring);
 }
 
-static void M_RingWrite(
+// Writes what there is room for and reports it, so that the caller decides
+// what to do with a block the ring cannot take in one go.
+static uint32_t M_RingWrite(
     M_RING *const ring, const float *const src, uint32_t count)
 {
-    ASSERT(count <= M_RingSpace(ring));
     count = MIN(count, M_RingSpace(ring));
 
     const uint32_t write_pos = (uint32_t)SDL_AtomicGet(&ring->write_pos);
@@ -130,6 +87,7 @@ static void M_RingWrite(
 
     SDL_MemoryBarrierRelease();
     SDL_AtomicSet(&ring->write_pos, (int32_t)(write_pos + count));
+    return count;
 }
 
 static uint32_t M_RingMix(
@@ -167,64 +125,6 @@ static bool M_IsValidID(const int32_t sound_id)
         && sound_id < AUDIO_MAX_ACTIVE_STREAMS;
 }
 
-static int32_t M_MemoryRead(
-    void *const opaque, uint8_t *const buf, const int32_t buf_size)
-{
-    ASSERT(opaque != nullptr);
-    ASSERT(buf != nullptr);
-
-    if (buf_size <= 0) {
-        return 0;
-    }
-
-    M_MEM_SOURCE *const s = opaque;
-    if (s->pos >= s->size) {
-        return AVERROR_EOF;
-    }
-
-    size_t to_copy = s->size - s->pos;
-    if (to_copy > (size_t)buf_size) {
-        to_copy = (size_t)buf_size;
-    }
-
-    memcpy(buf, s->data + s->pos, to_copy);
-    s->pos += to_copy;
-    return (int32_t)to_copy;
-}
-
-static int64_t M_MemorySeek(
-    void *const opaque, const int64_t offset, const int32_t whence)
-{
-    ASSERT(opaque != nullptr);
-
-    M_MEM_SOURCE *const s = opaque;
-    if ((whence & AVSEEK_SIZE) != 0) {
-        return (int64_t)s->size;
-    }
-
-    const int32_t base_whence = whence & ~AVSEEK_FORCE;
-    int64_t base;
-    if (base_whence == SEEK_SET) {
-        base = 0;
-    } else if (base_whence == SEEK_CUR) {
-        base = (int64_t)s->pos;
-    } else if (base_whence == SEEK_END) {
-        base = (int64_t)s->size;
-    } else {
-        return AVERROR(EINVAL);
-    }
-
-    int64_t new_pos = base + offset;
-    if (new_pos < 0) {
-        new_pos = 0;
-    }
-    if (new_pos > (int64_t)s->size) {
-        new_pos = (int64_t)s->size;
-    }
-    s->pos = (size_t)new_pos;
-    return new_pos;
-}
-
 static void M_ResetPlaybackState(
     AUDIO_STREAM_SOUND *const stream, const double relative_timestamp)
 {
@@ -236,190 +136,65 @@ static void M_ResetPlaybackState(
     Audio_UnlockDevice();
 }
 
-static void M_SeekToStart(AUDIO_STREAM_SOUND *const stream)
+static bool M_Rewind(AUDIO_STREAM_SOUND *const stream)
 {
     ASSERT(stream != nullptr);
 
-    stream->decode_timestamp = stream->start_at;
+    if (!stream->is_looped
+        || !AudioDecoder_Rewind(stream->decoder, stream->start_at)) {
+        return false;
+    }
+
+    stream->decode_timestamp = MAX(stream->start_at, 0.0);
     M_ResetPlaybackState(stream, 0.0);
-    int32_t error_code;
-    if (stream->start_at <= 0.0) {
-        // reset to start of file
-        avio_seek(stream->av.format_ctx->pb, 0, SEEK_SET);
-        error_code = avformat_seek_file(
-            stream->av.format_ctx, -1, 0, 0, 0, AVSEEK_FLAG_FRAME);
-    } else {
-        // seek to specific timestamp
-        AVFormatContext *const fmt = stream->av.format_ctx;
-        if (fmt->pb != nullptr && (fmt->pb->seekable & AVIO_SEEKABLE_NORMAL)) {
-            const int64_t ts = (int64_t)(stream->start_at * AV_TIME_BASE);
-            error_code = avformat_seek_file(
-                fmt, stream->av.stream->index, INT64_MIN, ts, INT64_MAX,
-                AVSEEK_FLAG_BACKWARD);
-        } else {
-            // fallback to stream-based seek
-            const double time_base_sec = av_q2d(stream->av.stream->time_base);
-            error_code = av_seek_frame(
-                fmt, stream->av.stream->index,
-                (int64_t)(stream->start_at / time_base_sec), AVSEEK_FLAG_ANY);
-        }
-    }
-    if (error_code < 0) {
-        LOG_ERROR(
-            "seek failed for timestamp %f: %s", stream->decode_timestamp,
-            av_err2str(error_code));
-    } else {
-        avcodec_flush_buffers(stream->av.codec_ctx);
-        stream->is_read_done = false;
-    }
-}
-
-static bool M_DecodeFrame(AUDIO_STREAM_SOUND *const stream)
-{
-    ASSERT(stream != nullptr);
-
-    if (stream->stop_at > 0.0 && stream->decode_timestamp >= stream->stop_at) {
-        if (stream->is_looped) {
-            M_SeekToStart(stream);
-            return M_DecodeFrame(stream);
-        } else {
-            return false;
-        }
-    }
-
-    // av_read_frame() overwrites the packet; always unref any previous content.
-    av_packet_unref(stream->av.packet);
-    int32_t error_code =
-        av_read_frame(stream->av.format_ctx, stream->av.packet);
-
-    if (error_code == AVERROR_EOF && stream->is_looped) {
-        M_SeekToStart(stream);
-        return M_DecodeFrame(stream);
-    }
-
-    if (error_code == AVERROR_EOF) {
-        return false;
-    }
-
-    if (error_code < 0) {
-        LOG_ERROR(
-            "error while decoding audio stream: %d (%s)", error_code,
-            av_err2str(error_code));
-        return false;
-    }
-
-    if (stream->av.packet->stream_index != stream->av.stream->index) {
-        return true;
-    }
-
-    error_code = avcodec_send_packet(stream->av.codec_ctx, stream->av.packet);
-    if (error_code < 0) {
-        av_packet_unref(stream->av.packet);
-        LOG_ERROR(
-            "Got an error when decoding frame: %s", av_err2str(error_code));
-        return false;
-    }
-
     return true;
-}
-
-static bool M_InitialiseResampler(AUDIO_STREAM_SOUND *const stream)
-{
-    ASSERT(stream != nullptr);
-
-    stream->swr.src.sample_rate = stream->av.codec_ctx->sample_rate;
-    stream->swr.src.ch_layout = stream->av.codec_ctx->ch_layout;
-    stream->swr.src.format = stream->av.codec_ctx->sample_fmt;
-    stream->swr.dst.sample_rate = AUDIO_WORKING_RATE;
-    av_channel_layout_default(
-        &stream->swr.dst.ch_layout, AUDIO_WORKING_CHANNELS);
-    stream->swr.dst.format = Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT);
-
-    swr_alloc_set_opts2(
-        &stream->swr.ctx, &stream->swr.dst.ch_layout, stream->swr.dst.format,
-        stream->swr.dst.sample_rate, &stream->swr.src.ch_layout,
-        stream->swr.src.format, stream->swr.src.sample_rate, 0, 0);
-    if (stream->swr.ctx == nullptr) {
-        LOG_ERROR("Failed to allocate the resampler");
-        return false;
-    }
-
-    const int32_t error_code = swr_init(stream->swr.ctx);
-    if (error_code != 0) {
-        LOG_ERROR(
-            "Failed to initialise the resampler: %s", av_err2str(error_code));
-        swr_free(&stream->swr.ctx);
-        return false;
-    }
-
-    return true;
-}
-
-static float *M_ReserveConvertBuffer(
-    AUDIO_STREAM_SOUND *const stream, const int32_t count)
-{
-    ASSERT(stream != nullptr);
-
-    if ((size_t)count > stream->convert_capacity) {
-        stream->convert_capacity = count;
-        stream->convert_buffer =
-            Memory_Realloc(stream->convert_buffer, count * sizeof(float));
-    }
-    return stream->convert_buffer;
-}
-
-static void M_EnqueueFrame(AUDIO_STREAM_SOUND *const stream)
-{
-    ASSERT(stream != nullptr);
-
-    if (stream->swr.ctx == nullptr && !M_InitialiseResampler(stream)) {
-        av_packet_unref(stream->av.packet);
-        return;
-    }
-
-    while (true) {
-        AVFrame *const frame = stream->av.frame;
-        if (avcodec_receive_frame(stream->av.codec_ctx, frame) < 0) {
-            av_frame_unref(frame);
-            break;
-        }
-
-        const int32_t max_samples =
-            swr_get_out_samples(stream->swr.ctx, frame->nb_samples);
-        uint8_t *out_buffer = (uint8_t *)M_ReserveConvertBuffer(
-            stream, max_samples * AUDIO_WORKING_CHANNELS);
-        const int32_t converted = swr_convert(
-            stream->swr.ctx, &out_buffer, max_samples,
-            (const uint8_t **)frame->data, frame->nb_samples);
-        const uint32_t produced = converted * AUDIO_WORKING_CHANNELS;
-        if (converted > 0 && produced > M_RingSpace(&stream->ring)) {
-            LOG_ERROR("Frame of %d samples does not fit the buffer", converted);
-            av_frame_unref(frame);
-            break;
-        }
-        if (converted > 0) {
-            M_RingWrite(&stream->ring, stream->convert_buffer, produced);
-        }
-
-        const double time_base_sec = av_q2d(stream->av.stream->time_base);
-        stream->decode_timestamp = frame->best_effort_timestamp * time_base_sec;
-        av_frame_unref(frame);
-    }
-
-    av_packet_unref(stream->av.packet);
 }
 
 static void M_Refill(AUDIO_STREAM_SOUND *const stream)
 {
     ASSERT(stream != nullptr);
 
-    while (!stream->is_read_done
-           && M_RingSpace(&stream->ring) >= RING_REFILL_FLOATS) {
-        if (M_DecodeFrame(stream)) {
-            M_EnqueueFrame(stream);
-        } else {
-            stream->is_read_done = true;
+    bool has_rewound = false;
+    while (!stream->is_read_done) {
+        if (stream->pending_count > 0) {
+            const uint32_t written = M_RingWrite(
+                &stream->ring, stream->pending, stream->pending_count);
+            stream->pending += written;
+            stream->pending_count -= written;
+            if (stream->pending_count > 0) {
+                // the rest waits for the mixer to make room
+                break;
+            }
+            continue;
         }
+
+        if (M_RingSpace(&stream->ring) < RING_REFILL_FLOATS) {
+            break;
+        }
+
+        const bool is_past_stop = stream->stop_at > 0.0
+            && stream->decode_timestamp >= stream->stop_at;
+
+        const float *samples = nullptr;
+        const int32_t count =
+            is_past_stop ? -1 : AudioDecoder_Read(stream->decoder, &samples);
+
+        if (count < 0) {
+            // a loop that hands back nothing twice over has nothing to play
+            if (has_rewound || !M_Rewind(stream)) {
+                stream->is_read_done = true;
+                break;
+            }
+            has_rewound = true;
+            continue;
+        }
+
+        if (count > 0) {
+            stream->pending = samples;
+            stream->pending_count = count * AUDIO_WORKING_CHANNELS;
+            has_rewound = false;
+        }
+        stream->decode_timestamp = AudioDecoder_GetTimestamp(stream->decoder);
     }
 }
 
@@ -452,16 +227,13 @@ static void M_Clear(AUDIO_STREAM_SOUND *const stream)
     stream->finish_callback = nullptr;
     stream->finish_callback_user_data = nullptr;
 
-    stream->src_type = M_STREAM_SRC_NONE;
-    stream->src = nullptr;
-    stream->avio_ctx_buffer = nullptr;
-    stream->avio_ctx = nullptr;
-
+    stream->decoder = nullptr;
+    stream->memory = nullptr;
+    stream->pending = nullptr;
+    stream->pending_count = 0;
     stream->ring.data = nullptr;
     M_RingReset(&stream->ring);
     SDL_AtomicSet(&stream->is_finished, 0);
-    stream->convert_buffer = nullptr;
-    stream->convert_capacity = 0;
 }
 
 // Tears a stream down. The worker lock must be held; the device lock is taken
@@ -475,117 +247,24 @@ static void M_Close(AUDIO_STREAM_SOUND *const stream)
     stream->is_playing = false;
     Audio_UnlockDevice();
 
-    if (stream->av.codec_ctx != nullptr) {
-        // XXX: potential libav bug - avcodec_close should free this info
-        if (stream->av.codec_ctx->extradata != nullptr) {
-            av_freep(&stream->av.codec_ctx->extradata);
-        }
-        avcodec_free_context(&stream->av.codec_ctx);
-    }
-
-    if (stream->av.format_ctx != nullptr) {
-        avformat_close_input(&stream->av.format_ctx);
-    }
-
-    if (stream->avio_ctx != nullptr) {
-        av_freep(&stream->avio_ctx->buffer);
-        avio_context_free(&stream->avio_ctx);
-    } else if (stream->avio_ctx_buffer != nullptr) {
-        av_freep(&stream->avio_ctx_buffer);
-    }
-
-    if (stream->src_type == M_STREAM_SRC_MEMORY && stream->src != nullptr) {
-        M_MEM_SOURCE *const src = stream->src;
-        Memory_FreePointer(&src->data);
-        Memory_FreePointer(&stream->src);
-    }
-
-    if (stream->swr.ctx != nullptr) {
-        swr_free(&stream->swr.ctx);
-    }
-
-    if (stream->av.frame != nullptr) {
-        av_frame_free(&stream->av.frame);
-    }
-
-    if (stream->av.packet != nullptr) {
-        av_packet_free(&stream->av.packet);
-    }
-
-    stream->av.stream = nullptr;
-    stream->av.codec = nullptr;
-
+    AudioDecoder_Free(&stream->decoder);
+    Memory_FreePointer(&stream->memory);
     Memory_FreePointer(&stream->ring.data);
-    Memory_FreePointer(&stream->convert_buffer);
 
     M_Clear(stream);
 }
 
-static bool M_InitialiseFromFormatContext(
-    const int32_t sound_id, AVFormatContext *const fmt_ctx)
+// Takes over the decoder, and the memory it reads, either way it turns out.
+static bool M_Initialise(
+    const int32_t sound_id, AUDIO_DECODER *const decoder, uint8_t *const memory)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
-    bool ret = false;
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    int32_t error_code = 0;
+    stream->decoder = decoder;
+    stream->memory = memory;
 
-    stream->av.format_ctx = fmt_ctx;
-
-    error_code = avformat_find_stream_info(stream->av.format_ctx, nullptr);
-    if (error_code < 0) {
-        goto cleanup;
-    }
-
-    stream->av.stream = nullptr;
-    for (uint32_t i = 0; i < stream->av.format_ctx->nb_streams; i++) {
-        AVStream *current_stream = stream->av.format_ctx->streams[i];
-        if (current_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-            stream->av.stream = current_stream;
-            break;
-        }
-    }
-    if (stream->av.stream == nullptr) {
-        error_code = AVERROR_STREAM_NOT_FOUND;
-        goto cleanup;
-    }
-
-    stream->av.codec =
-        avcodec_find_decoder(stream->av.stream->codecpar->codec_id);
-    if (stream->av.codec == nullptr) {
-        error_code = AVERROR_DEMUXER_NOT_FOUND;
-        goto cleanup;
-    }
-
-    stream->av.codec_ctx = avcodec_alloc_context3(stream->av.codec);
-    if (stream->av.codec_ctx == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    error_code = avcodec_parameters_to_context(
-        stream->av.codec_ctx, stream->av.stream->codecpar);
-    if (error_code != 0) {
-        goto cleanup;
-    }
-
-    error_code = avcodec_open2(stream->av.codec_ctx, stream->av.codec, nullptr);
-    if (error_code < 0) {
-        goto cleanup;
-    }
-
-    stream->av.packet = av_packet_alloc();
-    if (stream->av.packet == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    stream->av.frame = av_frame_alloc();
-    if (stream->av.frame == nullptr) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
+    if (decoder == nullptr) {
+        M_Close(stream);
+        return false;
     }
 
     stream->ring.data = Memory_Alloc(RING_FLOATS * sizeof(float));
@@ -599,8 +278,7 @@ static bool M_InitialiseFromFormatContext(
     stream->played_samples = 0;
     stream->finish_callback = nullptr;
     stream->finish_callback_user_data = nullptr;
-    stream->duration =
-        (double)stream->av.format_ctx->duration / (double)AV_TIME_BASE;
+    stream->duration = AudioDecoder_GetDuration(decoder);
     stream->start_at = -1.0; // negative value means unset
     stream->stop_at = -1.0; // negative value means unset
 
@@ -609,42 +287,9 @@ static bool M_InitialiseFromFormatContext(
     stream->is_playing = false;
     Audio_UnlockDevice();
 
-    ret = true;
-
-cleanup:
-    if (error_code != 0) {
-        LOG_ERROR(
-            "Error while opening audio stream: %s", av_err2str(error_code));
-    }
-
-    if (!ret) {
-        M_Close(stream);
-    }
-
-    return ret;
+    return true;
 }
 
-static bool M_InitialiseFromPath(
-    const int32_t sound_id, const char *const file_path)
-{
-    ASSERT(file_path != nullptr);
-
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
-    AVFormatContext *fmt_ctx = nullptr;
-    const int32_t error_code =
-        avformat_open_input(&fmt_ctx, file_path, nullptr, nullptr);
-    if (error_code != 0) {
-        LOG_ERROR(
-            "Error while opening audio %s: %s", file_path,
-            av_err2str(error_code));
-        return false;
-    }
-
-    return M_InitialiseFromFormatContext(sound_id, fmt_ctx);
-}
 void Audio_Stream_Init(void)
 {
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
@@ -758,7 +403,9 @@ int32_t Audio_Stream_CreateFromFile(const char *const file_path)
         if (m_Streams[sound_id].is_used) {
             continue;
         }
-        if (M_InitialiseFromPath(sound_id, file_path)) {
+        AUDIO_DECODER *const decoder =
+            AudioDecoder_CreateFromPath(file_path, AUDIO_WORKING_CHANNELS);
+        if (M_Initialise(sound_id, decoder, nullptr)) {
             result = sound_id;
         }
         break;
@@ -781,54 +428,12 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
     Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
-        AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-        if (stream->is_used) {
+        if (m_Streams[sound_id].is_used) {
             continue;
         }
-
-        M_MEM_SOURCE *const src = Memory_Alloc(sizeof(M_MEM_SOURCE));
-        *src = (M_MEM_SOURCE) {
-            .data = data,
-            .size = size,
-            .pos = 0,
-        };
-
-        stream->src_type = M_STREAM_SRC_MEMORY;
-        stream->src = src;
-
-        stream->avio_ctx_buffer = av_malloc(AVIO_BUFFER_SIZE);
-        if (stream->avio_ctx_buffer == nullptr) {
-            M_Close(stream);
-            break;
-        }
-
-        stream->avio_ctx = avio_alloc_context(
-            stream->avio_ctx_buffer, AVIO_BUFFER_SIZE, 0, src, M_MemoryRead,
-            nullptr, M_MemorySeek);
-        if (stream->avio_ctx == nullptr) {
-            M_Close(stream);
-            break;
-        }
-
-        stream->av.format_ctx = avformat_alloc_context();
-        if (stream->av.format_ctx == nullptr) {
-            M_Close(stream);
-            break;
-        }
-        stream->av.format_ctx->pb = stream->avio_ctx;
-        stream->av.format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
-
-        const int32_t error_code = avformat_open_input(
-            &stream->av.format_ctx, nullptr, nullptr, nullptr);
-        if (error_code != 0) {
-            LOG_ERROR(
-                "Error while opening audio memory stream: %s",
-                av_err2str(error_code));
-            M_Close(stream);
-            break;
-        }
-
-        if (M_InitialiseFromFormatContext(sound_id, stream->av.format_ctx)) {
+        AUDIO_DECODER *const decoder =
+            AudioDecoder_CreateFromMemory(data, size, AUDIO_WORKING_CHANNELS);
+        if (M_Initialise(sound_id, decoder, data)) {
             result = sound_id;
         }
         break;
@@ -966,44 +571,25 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
 
     Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    if (!stream->is_used) {
-        Audio_WorkerUnlock();
-        return false;
+    bool result = false;
+    if (stream->is_used) {
+        const double target = MAX(stream->start_at, 0.0) + timestamp;
+        result = AudioDecoder_Seek(stream->decoder, target);
     }
 
-    const double time_base_sec = av_q2d(stream->av.stream->time_base);
-    if (time_base_sec <= 0.0) {
-        LOG_ERROR(
-            "Audio_Stream_SeekTimestamp: invalid time_base %f", time_base_sec);
-        Audio_WorkerUnlock();
-        return false;
+    if (result) {
+        Audio_LockDevice();
+        M_RingReset(&stream->ring);
+        Audio_UnlockDevice();
+
+        stream->pending_count = 0;
+        stream->decode_timestamp = timestamp + MAX(stream->start_at, 0.0);
+        M_ResetPlaybackState(stream, timestamp);
+        stream->is_read_done = false;
     }
-
-    const int32_t stream_index = stream->av.stream->index;
-    const int64_t seek_target =
-        (int64_t)((MAX(0.0f, stream->start_at) + timestamp) / time_base_sec);
-    const int32_t error_code = av_seek_frame(
-        stream->av.format_ctx, stream_index, seek_target, AVSEEK_FLAG_ANY);
-    if (error_code < 0) {
-        LOG_ERROR(
-            "seek failed for timestamp %f: %s", timestamp,
-            av_err2str(error_code));
-        Audio_WorkerUnlock();
-        return false;
-    }
-
-    avcodec_flush_buffers(stream->av.codec_ctx);
-
-    Audio_LockDevice();
-    M_RingReset(&stream->ring);
-    Audio_UnlockDevice();
-
-    stream->decode_timestamp = timestamp + MAX(stream->start_at, 0.0f);
-    M_ResetPlaybackState(stream, timestamp);
-    stream->is_read_done = false;
     Audio_WorkerUnlock();
 
-    return true;
+    return result;
 }
 
 bool Audio_Stream_SetStartTimestamp(

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -1,13 +1,11 @@
 #include <trx/av/audio_internal.h>
 
-#include <trx/core/filesystem.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 
-#include <SDL2/SDL_audio.h>
-#include <SDL2/SDL_error.h>
+#include <SDL2/SDL_atomic.h>
 #include <errno.h>
 #include <libavcodec/avcodec.h>
 #include <libavcodec/codec.h>
@@ -15,6 +13,7 @@
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/avutil.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/error.h>
 #include <libavutil/frame.h>
 #include <libavutil/mem.h>
@@ -25,8 +24,13 @@
 #include <stdio.h>
 #include <string.h>
 
-#define READ_BUFFER_SIZE                                                       \
-    (AUDIO_SAMPLES * AUDIO_WORKING_CHANNELS * sizeof(AUDIO_WORKING_FORMAT))
+#define AVIO_BUFFER_SIZE 4096
+
+// The mixer must never wait for the decoder, and a seek must never discard
+// audible audio. 0.37 s of stereo sits comfortably between the two.
+#define RING_FLOATS (1 << 15)
+#define RING_MASK (RING_FLOATS - 1)
+#define RING_REFILL_FLOATS (RING_FLOATS / 2)
 
 typedef enum {
     M_STREAM_SRC_NONE,
@@ -38,6 +42,19 @@ typedef struct {
     size_t size;
     size_t pos;
 } M_MEM_SOURCE;
+
+// Written by the worker thread, read by the audio callback, and by nobody
+// else. Reset only while the device is locked.
+typedef struct {
+    float *data;
+    SDL_atomic_t read_pos;
+    SDL_atomic_t write_pos;
+} M_RING;
+
+typedef struct {
+    void (*func)(int32_t sound_id, void *user_data);
+    void *user_data;
+} M_FINISH_NOTIFICATION;
 
 typedef struct {
     bool is_used;
@@ -78,17 +95,77 @@ typedef struct {
         SwrContext *ctx;
     } swr;
 
-    struct {
-        SDL_AudioStream *stream;
-    } sdl;
+    M_RING ring;
+    SDL_atomic_t is_finished;
+    float *convert_buffer;
+    size_t convert_capacity;
 } AUDIO_STREAM_SOUND;
 
 extern SDL_AudioDeviceID g_AudioDeviceID;
 
 static AUDIO_STREAM_SOUND m_Streams[AUDIO_MAX_ACTIVE_STREAMS] = {};
-static float m_MixBuffer[AUDIO_SAMPLES * AUDIO_WORKING_CHANNELS] = {};
-static size_t m_DecodeBufferCapacity = 0;
-static float *m_DecodeBuffer = nullptr;
+
+static uint32_t M_RingUsed(M_RING *const ring)
+{
+    return (uint32_t)SDL_AtomicGet(&ring->write_pos)
+        - (uint32_t)SDL_AtomicGet(&ring->read_pos);
+}
+
+static uint32_t M_RingSpace(M_RING *const ring)
+{
+    return RING_FLOATS - M_RingUsed(ring);
+}
+
+static void M_RingWrite(
+    M_RING *const ring, const float *const src, uint32_t count)
+{
+    ASSERT(count <= M_RingSpace(ring));
+    count = MIN(count, M_RingSpace(ring));
+
+    const uint32_t write_pos = (uint32_t)SDL_AtomicGet(&ring->write_pos);
+    const uint32_t offset = write_pos & RING_MASK;
+    const uint32_t head = MIN(count, RING_FLOATS - offset);
+    memcpy(ring->data + offset, src, head * sizeof(float));
+    memcpy(ring->data, src + head, (count - head) * sizeof(float));
+
+    SDL_MemoryBarrierRelease();
+    SDL_AtomicSet(&ring->write_pos, (int32_t)(write_pos + count));
+}
+
+static uint32_t M_RingMix(
+    M_RING *const ring, float *dst, uint32_t count, const float gain)
+{
+    count = MIN(count, M_RingUsed(ring));
+    SDL_MemoryBarrierAcquire();
+
+    const uint32_t read_pos = (uint32_t)SDL_AtomicGet(&ring->read_pos);
+    const uint32_t offset = read_pos & RING_MASK;
+    const uint32_t head = MIN(count, RING_FLOATS - offset);
+
+    const float *src = ring->data + offset;
+    for (uint32_t i = 0; i < head; i++) {
+        *dst++ += *src++ * gain;
+    }
+    src = ring->data;
+    for (uint32_t i = head; i < count; i++) {
+        *dst++ += *src++ * gain;
+    }
+
+    SDL_AtomicSet(&ring->read_pos, (int32_t)(read_pos + count));
+    return count;
+}
+
+static void M_RingReset(M_RING *const ring)
+{
+    SDL_AtomicSet(&ring->read_pos, 0);
+    SDL_AtomicSet(&ring->write_pos, 0);
+}
+
+static bool M_IsValidID(const int32_t sound_id)
+{
+    return g_AudioDeviceID != 0 && sound_id >= 0
+        && sound_id < AUDIO_MAX_ACTIVE_STREAMS;
+}
 
 static int32_t M_MemoryRead(
     void *const opaque, uint8_t *const buf, const int32_t buf_size)
@@ -154,25 +231,12 @@ static void M_ResetPlaybackState(
     ASSERT(stream != nullptr);
 
     const double clamped = MAX(0.0, relative_timestamp);
+    Audio_LockDevice();
     stream->played_samples = (int64_t)(clamped * (double)AUDIO_WORKING_RATE);
+    Audio_UnlockDevice();
 }
 
-static void M_DiscardSDLStreamData(AUDIO_STREAM_SOUND *const stream)
-{
-    ASSERT(stream != nullptr);
-
-    if (stream->sdl.stream != nullptr) {
-        while (SDL_AudioStreamAvailable(stream->sdl.stream) > 0) {
-            const int32_t bytes_gotten = SDL_AudioStreamGet(
-                stream->sdl.stream, m_MixBuffer, READ_BUFFER_SIZE);
-            if (bytes_gotten <= 0) {
-                break;
-            }
-        }
-    }
-}
-
-static void M_SeekToStart(AUDIO_STREAM_SOUND *stream)
+static void M_SeekToStart(AUDIO_STREAM_SOUND *const stream)
 {
     ASSERT(stream != nullptr);
 
@@ -206,12 +270,11 @@ static void M_SeekToStart(AUDIO_STREAM_SOUND *stream)
             av_err2str(error_code));
     } else {
         avcodec_flush_buffers(stream->av.codec_ctx);
-        M_DiscardSDLStreamData(stream);
         stream->is_read_done = false;
     }
 }
 
-static bool M_DecodeFrame(AUDIO_STREAM_SOUND *stream)
+static bool M_DecodeFrame(AUDIO_STREAM_SOUND *const stream)
 {
     ASSERT(stream != nullptr);
 
@@ -260,18 +323,213 @@ static bool M_DecodeFrame(AUDIO_STREAM_SOUND *stream)
     return true;
 }
 
-static bool M_InitialiseFromFormatContext(
-    int32_t sound_id, AVFormatContext *const fmt_ctx)
+static bool M_InitialiseResampler(AUDIO_STREAM_SOUND *const stream)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    ASSERT(stream != nullptr);
+
+    stream->swr.src.sample_rate = stream->av.codec_ctx->sample_rate;
+    stream->swr.src.ch_layout = stream->av.codec_ctx->ch_layout;
+    stream->swr.src.format = stream->av.codec_ctx->sample_fmt;
+    stream->swr.dst.sample_rate = AUDIO_WORKING_RATE;
+    av_channel_layout_default(
+        &stream->swr.dst.ch_layout, AUDIO_WORKING_CHANNELS);
+    stream->swr.dst.format = Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT);
+
+    swr_alloc_set_opts2(
+        &stream->swr.ctx, &stream->swr.dst.ch_layout, stream->swr.dst.format,
+        stream->swr.dst.sample_rate, &stream->swr.src.ch_layout,
+        stream->swr.src.format, stream->swr.src.sample_rate, 0, 0);
+    if (stream->swr.ctx == nullptr) {
+        LOG_ERROR("Failed to allocate the resampler");
+        return false;
+    }
+
+    const int32_t error_code = swr_init(stream->swr.ctx);
+    if (error_code != 0) {
+        LOG_ERROR(
+            "Failed to initialise the resampler: %s", av_err2str(error_code));
+        swr_free(&stream->swr.ctx);
+        return false;
+    }
+
+    return true;
+}
+
+static float *M_ReserveConvertBuffer(
+    AUDIO_STREAM_SOUND *const stream, const int32_t count)
+{
+    ASSERT(stream != nullptr);
+
+    if ((size_t)count > stream->convert_capacity) {
+        stream->convert_capacity = count;
+        stream->convert_buffer =
+            Memory_Realloc(stream->convert_buffer, count * sizeof(float));
+    }
+    return stream->convert_buffer;
+}
+
+static void M_EnqueueFrame(AUDIO_STREAM_SOUND *const stream)
+{
+    ASSERT(stream != nullptr);
+
+    if (stream->swr.ctx == nullptr && !M_InitialiseResampler(stream)) {
+        av_packet_unref(stream->av.packet);
+        return;
+    }
+
+    while (true) {
+        AVFrame *const frame = stream->av.frame;
+        if (avcodec_receive_frame(stream->av.codec_ctx, frame) < 0) {
+            av_frame_unref(frame);
+            break;
+        }
+
+        const int32_t max_samples =
+            swr_get_out_samples(stream->swr.ctx, frame->nb_samples);
+        uint8_t *out_buffer = (uint8_t *)M_ReserveConvertBuffer(
+            stream, max_samples * AUDIO_WORKING_CHANNELS);
+        const int32_t converted = swr_convert(
+            stream->swr.ctx, &out_buffer, max_samples,
+            (const uint8_t **)frame->data, frame->nb_samples);
+        const uint32_t produced = converted * AUDIO_WORKING_CHANNELS;
+        if (converted > 0 && produced > M_RingSpace(&stream->ring)) {
+            LOG_ERROR("Frame of %d samples does not fit the buffer", converted);
+            av_frame_unref(frame);
+            break;
+        }
+        if (converted > 0) {
+            M_RingWrite(&stream->ring, stream->convert_buffer, produced);
+        }
+
+        const double time_base_sec = av_q2d(stream->av.stream->time_base);
+        stream->decode_timestamp = frame->best_effort_timestamp * time_base_sec;
+        av_frame_unref(frame);
+    }
+
+    av_packet_unref(stream->av.packet);
+}
+
+static void M_Refill(AUDIO_STREAM_SOUND *const stream)
+{
+    ASSERT(stream != nullptr);
+
+    while (!stream->is_read_done
+           && M_RingSpace(&stream->ring) >= RING_REFILL_FLOATS) {
+        if (M_DecodeFrame(stream)) {
+            M_EnqueueFrame(stream);
+        } else {
+            stream->is_read_done = true;
+        }
+    }
+}
+
+static M_FINISH_NOTIFICATION M_TakeFinishNotification(
+    AUDIO_STREAM_SOUND *const stream)
+{
+    ASSERT(stream != nullptr);
+
+    const M_FINISH_NOTIFICATION notification = {
+        .func = stream->finish_callback,
+        .user_data = stream->finish_callback_user_data,
+    };
+    stream->finish_callback = nullptr;
+    stream->finish_callback_user_data = nullptr;
+    return notification;
+}
+
+static void M_Clear(AUDIO_STREAM_SOUND *const stream)
+{
+    ASSERT(stream != nullptr);
+
+    stream->is_used = false;
+    stream->is_playing = false;
+    stream->is_read_done = true;
+    stream->is_looped = false;
+    stream->volume = 0.0f;
+    stream->duration = 0.0;
+    stream->decode_timestamp = 0.0;
+    stream->played_samples = 0;
+    stream->finish_callback = nullptr;
+    stream->finish_callback_user_data = nullptr;
+
+    stream->src_type = M_STREAM_SRC_NONE;
+    stream->src = nullptr;
+    stream->avio_ctx_buffer = nullptr;
+    stream->avio_ctx = nullptr;
+
+    stream->ring.data = nullptr;
+    M_RingReset(&stream->ring);
+    SDL_AtomicSet(&stream->is_finished, 0);
+    stream->convert_buffer = nullptr;
+    stream->convert_capacity = 0;
+}
+
+// Tears a stream down. The worker lock must be held; the device lock is taken
+// to hide the stream from the mixer before anything it reads is freed.
+static void M_Close(AUDIO_STREAM_SOUND *const stream)
+{
+    ASSERT(stream != nullptr);
+
+    Audio_LockDevice();
+    stream->is_used = false;
+    stream->is_playing = false;
+    Audio_UnlockDevice();
+
+    if (stream->av.codec_ctx != nullptr) {
+        // XXX: potential libav bug - avcodec_close should free this info
+        if (stream->av.codec_ctx->extradata != nullptr) {
+            av_freep(&stream->av.codec_ctx->extradata);
+        }
+        avcodec_free_context(&stream->av.codec_ctx);
+    }
+
+    if (stream->av.format_ctx != nullptr) {
+        avformat_close_input(&stream->av.format_ctx);
+    }
+
+    if (stream->avio_ctx != nullptr) {
+        av_freep(&stream->avio_ctx->buffer);
+        avio_context_free(&stream->avio_ctx);
+    } else if (stream->avio_ctx_buffer != nullptr) {
+        av_freep(&stream->avio_ctx_buffer);
+    }
+
+    if (stream->src_type == M_STREAM_SRC_MEMORY && stream->src != nullptr) {
+        M_MEM_SOURCE *const src = stream->src;
+        Memory_FreePointer(&src->data);
+        Memory_FreePointer(&stream->src);
+    }
+
+    if (stream->swr.ctx != nullptr) {
+        swr_free(&stream->swr.ctx);
+    }
+
+    if (stream->av.frame != nullptr) {
+        av_frame_free(&stream->av.frame);
+    }
+
+    if (stream->av.packet != nullptr) {
+        av_packet_free(&stream->av.packet);
+    }
+
+    stream->av.stream = nullptr;
+    stream->av.codec = nullptr;
+
+    Memory_FreePointer(&stream->ring.data);
+    Memory_FreePointer(&stream->convert_buffer);
+
+    M_Clear(stream);
+}
+
+static bool M_InitialiseFromFormatContext(
+    const int32_t sound_id, AVFormatContext *const fmt_ctx)
+{
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
     bool ret = false;
-    Audio_LockDevice();
-
-    AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     int32_t error_code = 0;
 
     stream->av.format_ctx = fmt_ctx;
@@ -289,20 +547,20 @@ static bool M_InitialiseFromFormatContext(
             break;
         }
     }
-    if (!stream->av.stream) {
+    if (stream->av.stream == nullptr) {
         error_code = AVERROR_STREAM_NOT_FOUND;
         goto cleanup;
     }
 
     stream->av.codec =
         avcodec_find_decoder(stream->av.stream->codecpar->codec_id);
-    if (!stream->av.codec) {
+    if (stream->av.codec == nullptr) {
         error_code = AVERROR_DEMUXER_NOT_FOUND;
         goto cleanup;
     }
 
     stream->av.codec_ctx = avcodec_alloc_context3(stream->av.codec);
-    if (!stream->av.codec_ctx) {
+    if (stream->av.codec_ctx == nullptr) {
         error_code = AVERROR(ENOMEM);
         goto cleanup;
     }
@@ -319,24 +577,22 @@ static bool M_InitialiseFromFormatContext(
     }
 
     stream->av.packet = av_packet_alloc();
-    if (!stream->av.packet) {
+    if (stream->av.packet == nullptr) {
         error_code = AVERROR(ENOMEM);
         goto cleanup;
     }
 
     stream->av.frame = av_frame_alloc();
-    if (!stream->av.frame) {
+    if (stream->av.frame == nullptr) {
         error_code = AVERROR(ENOMEM);
         goto cleanup;
     }
 
-    M_DecodeFrame(stream);
-
-    const int32_t sdl_channels = stream->av.codec_ctx->ch_layout.nb_channels;
+    stream->ring.data = Memory_Alloc(RING_FLOATS * sizeof(float));
+    M_RingReset(&stream->ring);
+    SDL_AtomicSet(&stream->is_finished, 0);
 
     stream->is_read_done = false;
-    stream->is_used = true;
-    stream->is_playing = false;
     stream->is_looped = false;
     stream->volume = 1.0f;
     stream->decode_timestamp = 0.0;
@@ -348,13 +604,10 @@ static bool M_InitialiseFromFormatContext(
     stream->start_at = -1.0; // negative value means unset
     stream->stop_at = -1.0; // negative value means unset
 
-    stream->sdl.stream = SDL_NewAudioStream(
-        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE,
-        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE);
-    if (!stream->sdl.stream) {
-        LOG_ERROR("Failed to create SDL stream: %s", SDL_GetError());
-        goto cleanup;
-    }
+    Audio_LockDevice();
+    stream->is_used = true;
+    stream->is_playing = false;
+    Audio_UnlockDevice();
 
     ret = true;
 
@@ -365,132 +618,24 @@ cleanup:
     }
 
     if (!ret) {
-        Audio_Stream_Close(sound_id);
+        M_Close(stream);
     }
 
-    Audio_UnlockDevice();
     return ret;
 }
 
-static bool M_EnqueueFrame(AUDIO_STREAM_SOUND *stream)
-{
-    ASSERT(stream != nullptr);
-
-    int32_t error_code;
-
-    if (!stream->swr.ctx) {
-        stream->swr.src.sample_rate = stream->av.codec_ctx->sample_rate;
-        stream->swr.src.ch_layout = stream->av.codec_ctx->ch_layout;
-        stream->swr.src.format = stream->av.codec_ctx->sample_fmt;
-        stream->swr.dst.sample_rate = AUDIO_WORKING_RATE;
-        av_channel_layout_default(
-            &stream->swr.dst.ch_layout, AUDIO_WORKING_CHANNELS);
-        stream->swr.dst.format = Audio_GetAVAudioFormat(AUDIO_WORKING_FORMAT);
-        swr_alloc_set_opts2(
-            &stream->swr.ctx, &stream->swr.dst.ch_layout,
-            stream->swr.dst.format, stream->swr.dst.sample_rate,
-            &stream->swr.src.ch_layout, stream->swr.src.format,
-            stream->swr.src.sample_rate, 0, 0);
-        if (!stream->swr.ctx) {
-            av_packet_unref(stream->av.packet);
-            error_code = AVERROR(ENOMEM);
-            goto cleanup;
-        }
-
-        error_code = swr_init(stream->swr.ctx);
-        if (error_code != 0) {
-            av_packet_unref(stream->av.packet);
-            goto cleanup;
-        }
-    }
-
-    while (1) {
-        error_code =
-            avcodec_receive_frame(stream->av.codec_ctx, stream->av.frame);
-        if (error_code == AVERROR(EAGAIN)) {
-            av_frame_unref(stream->av.frame);
-            error_code = 0;
-            break;
-        }
-
-        if (error_code < 0) {
-            av_frame_unref(stream->av.frame);
-            break;
-        }
-
-        uint8_t *out_buffer = nullptr;
-        const int32_t out_samples =
-            swr_get_out_samples(stream->swr.ctx, stream->av.frame->nb_samples);
-        av_samples_alloc(
-            &out_buffer, nullptr, stream->swr.dst.ch_layout.nb_channels,
-            out_samples, stream->swr.dst.format, 1);
-        int32_t resampled_size = swr_convert(
-            stream->swr.ctx, &out_buffer, out_samples,
-            (const uint8_t **)stream->av.frame->data,
-            stream->av.frame->nb_samples);
-
-        size_t out_pos = 0;
-        while (resampled_size > 0) {
-            const size_t out_buffer_size = av_samples_get_buffer_size(
-                nullptr, stream->swr.dst.ch_layout.nb_channels, resampled_size,
-                stream->swr.dst.format, 1);
-
-            if (out_pos + out_buffer_size > m_DecodeBufferCapacity) {
-                m_DecodeBufferCapacity = out_pos + out_buffer_size;
-                m_DecodeBuffer =
-                    Memory_Realloc(m_DecodeBuffer, m_DecodeBufferCapacity);
-            }
-            if (m_DecodeBuffer != nullptr && out_buffer != nullptr) {
-                memcpy(
-                    (uint8_t *)m_DecodeBuffer + out_pos, out_buffer,
-                    out_buffer_size);
-            }
-            out_pos += out_buffer_size;
-
-            resampled_size = swr_convert(
-                stream->swr.ctx, &out_buffer, out_samples, nullptr, 0);
-        }
-
-        if (SDL_AudioStreamPut(stream->sdl.stream, m_DecodeBuffer, out_pos)) {
-            LOG_ERROR("Got an error when decoding frame: %s", SDL_GetError());
-            av_frame_unref(stream->av.frame);
-            break;
-        }
-
-        ASSERT(stream->av.format_ctx != nullptr);
-        ASSERT(stream->av.codec_ctx != nullptr);
-        ASSERT(stream->av.stream != nullptr);
-        double time_base_sec = av_q2d(stream->av.stream->time_base);
-        stream->decode_timestamp =
-            stream->av.frame->best_effort_timestamp * time_base_sec;
-        av_freep(&out_buffer);
-        av_frame_unref(stream->av.frame);
-    }
-
-    av_packet_unref(stream->av.packet);
-
-cleanup:
-    if (error_code > 0) {
-        LOG_ERROR(
-            "Got an error when decoding frame: %d, %s", error_code,
-            av_err2str(error_code));
-    }
-
-    return true;
-}
-
-static bool M_InitialiseFromPath(int32_t sound_id, const char *file_path)
+static bool M_InitialiseFromPath(
+    const int32_t sound_id, const char *const file_path)
 {
     ASSERT(file_path != nullptr);
 
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
-    int32_t error_code = 0;
     AVFormatContext *fmt_ctx = nullptr;
-    error_code = avformat_open_input(&fmt_ctx, file_path, nullptr, nullptr);
+    const int32_t error_code =
+        avformat_open_input(&fmt_ctx, file_path, nullptr, nullptr);
     if (error_code != 0) {
         LOG_ERROR(
             "Error while opening audio %s: %s", file_path,
@@ -500,29 +645,6 @@ static bool M_InitialiseFromPath(int32_t sound_id, const char *file_path)
 
     return M_InitialiseFromFormatContext(sound_id, fmt_ctx);
 }
-
-static void M_Clear(AUDIO_STREAM_SOUND *stream)
-{
-    ASSERT(stream != nullptr);
-
-    stream->is_used = false;
-    stream->is_playing = false;
-    stream->is_read_done = true;
-    stream->is_looped = false;
-    stream->volume = 0.0f;
-    stream->duration = 0.0;
-    stream->decode_timestamp = 0.0;
-    stream->played_samples = 0;
-    stream->sdl.stream = nullptr;
-    stream->finish_callback = nullptr;
-    stream->finish_callback_user_data = nullptr;
-
-    stream->src_type = M_STREAM_SRC_NONE;
-    stream->src = nullptr;
-    stream->avio_ctx_buffer = nullptr;
-    stream->avio_ctx = nullptr;
-}
-
 void Audio_Stream_Init(void)
 {
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
@@ -533,28 +655,44 @@ void Audio_Stream_Init(void)
 
 void Audio_Stream_Shutdown(void)
 {
-    Memory_FreePointer(&m_DecodeBuffer);
-    m_DecodeBufferCapacity = 0;
-    if (!g_AudioDeviceID) {
-        return;
-    }
-
+    Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
-        if (m_Streams[sound_id].is_used) {
-            Audio_Stream_Close(sound_id);
+        M_Close(&m_Streams[sound_id]);
+    }
+    Audio_WorkerUnlock();
+}
+
+void Audio_Stream_Pump(void)
+{
+    for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
+         sound_id++) {
+        M_FINISH_NOTIFICATION notification = {};
+
+        Audio_WorkerLock();
+        AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+        if (stream->is_used) {
+            if (SDL_AtomicGet(&stream->is_finished) != 0) {
+                notification = M_TakeFinishNotification(stream);
+                M_Close(stream);
+            } else {
+                M_Refill(stream);
+            }
+        }
+        Audio_WorkerUnlock();
+
+        if (notification.func != nullptr) {
+            notification.func(sound_id, notification.user_data);
         }
     }
 }
 
 bool Audio_Stream_SyncTimestamp(const int32_t sound_id, const double timestamp)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
-    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     double drift = Audio_Stream_GetTimestamp(sound_id) - timestamp;
     if (drift < 0) {
         drift = -drift;
@@ -567,10 +705,9 @@ bool Audio_Stream_SyncTimestamp(const int32_t sound_id, const double timestamp)
     return false;
 }
 
-bool Audio_Stream_Pause(int32_t sound_id)
+bool Audio_Stream_Pause(const int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
@@ -584,10 +721,9 @@ bool Audio_Stream_Pause(int32_t sound_id)
     return true;
 }
 
-bool Audio_Stream_Unpause(int32_t sound_id)
+bool Audio_Stream_Unpause(const int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
@@ -607,43 +743,45 @@ bool Audio_Stream_SetPaused(const int32_t sound_id, const bool is_paused)
                      : Audio_Stream_Unpause(sound_id);
 }
 
-int32_t Audio_Stream_CreateFromFile(const char *file_path)
+int32_t Audio_Stream_CreateFromFile(const char *const file_path)
 {
-    if (!g_AudioDeviceID) {
+    if (g_AudioDeviceID == 0) {
         return AUDIO_NO_SOUND;
     }
 
     ASSERT(file_path != nullptr);
 
+    int32_t result = AUDIO_NO_SOUND;
+    Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
-        AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
-        if (stream->is_used) {
+        if (m_Streams[sound_id].is_used) {
             continue;
         }
-
-        if (!M_InitialiseFromPath(sound_id, file_path)) {
-            return AUDIO_NO_SOUND;
+        if (M_InitialiseFromPath(sound_id, file_path)) {
+            result = sound_id;
         }
-
-        return sound_id;
+        break;
     }
+    Audio_WorkerUnlock();
 
-    return AUDIO_NO_SOUND;
+    return result;
 }
 
 int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
 {
-    if (!g_AudioDeviceID) {
+    if (g_AudioDeviceID == 0) {
         return AUDIO_NO_SOUND;
     }
 
     ASSERT(data != nullptr);
     ASSERT(size != 0);
 
+    int32_t result = AUDIO_NO_SOUND;
+    Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
-        AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
+        AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
         if (stream->is_used) {
             continue;
         }
@@ -658,130 +796,70 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
         stream->src_type = M_STREAM_SRC_MEMORY;
         stream->src = src;
 
-        stream->avio_ctx_buffer = av_malloc(4096);
+        stream->avio_ctx_buffer = av_malloc(AVIO_BUFFER_SIZE);
         if (stream->avio_ctx_buffer == nullptr) {
-            Audio_Stream_Close(sound_id);
-            return AUDIO_NO_SOUND;
+            M_Close(stream);
+            break;
         }
 
         stream->avio_ctx = avio_alloc_context(
-            stream->avio_ctx_buffer, 4096, 0, src, M_MemoryRead, nullptr,
-            M_MemorySeek);
+            stream->avio_ctx_buffer, AVIO_BUFFER_SIZE, 0, src, M_MemoryRead,
+            nullptr, M_MemorySeek);
         if (stream->avio_ctx == nullptr) {
-            Audio_Stream_Close(sound_id);
-            return AUDIO_NO_SOUND;
+            M_Close(stream);
+            break;
         }
 
         stream->av.format_ctx = avformat_alloc_context();
         if (stream->av.format_ctx == nullptr) {
-            Audio_Stream_Close(sound_id);
-            return AUDIO_NO_SOUND;
+            M_Close(stream);
+            break;
         }
         stream->av.format_ctx->pb = stream->avio_ctx;
         stream->av.format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
 
-        int32_t error_code = avformat_open_input(
+        const int32_t error_code = avformat_open_input(
             &stream->av.format_ctx, nullptr, nullptr, nullptr);
         if (error_code != 0) {
             LOG_ERROR(
                 "Error while opening audio memory stream: %s",
                 av_err2str(error_code));
-            Audio_Stream_Close(sound_id);
-            return AUDIO_NO_SOUND;
+            M_Close(stream);
+            break;
         }
 
-        if (!M_InitialiseFromFormatContext(sound_id, stream->av.format_ctx)) {
-            Audio_Stream_Close(sound_id);
-            return AUDIO_NO_SOUND;
+        if (M_InitialiseFromFormatContext(sound_id, stream->av.format_ctx)) {
+            result = sound_id;
         }
-
-        return sound_id;
+        break;
     }
+    Audio_WorkerUnlock();
 
-    return AUDIO_NO_SOUND;
+    return result;
 }
 
-bool Audio_Stream_Close(int32_t sound_id)
+bool Audio_Stream_Close(const int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
-    Audio_LockDevice();
+    Audio_WorkerLock();
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+    const M_FINISH_NOTIFICATION notification = M_TakeFinishNotification(stream);
+    M_Close(stream);
+    Audio_WorkerUnlock();
 
-    AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
-
-    if (stream->av.codec_ctx) {
-        // XXX: potential libav bug - avcodec_close should free this info
-        if (stream->av.codec_ctx->extradata != nullptr) {
-            av_freep(&stream->av.codec_ctx->extradata);
-        }
-
-        avcodec_free_context(&stream->av.codec_ctx);
-        stream->av.codec_ctx = nullptr;
-    }
-
-    if (stream->av.format_ctx) {
-        avformat_close_input(&stream->av.format_ctx);
-        stream->av.format_ctx = nullptr;
-    }
-
-    if (stream->avio_ctx != nullptr) {
-        av_freep(&stream->avio_ctx->buffer);
-        avio_context_free(&stream->avio_ctx);
-        stream->avio_ctx = nullptr;
-    } else if (stream->avio_ctx_buffer != nullptr) {
-        av_freep(&stream->avio_ctx_buffer);
-    }
-    stream->avio_ctx_buffer = nullptr;
-
-    if (stream->src_type == M_STREAM_SRC_MEMORY && stream->src != nullptr) {
-        M_MEM_SOURCE *const src = stream->src;
-        Memory_FreePointer(&src->data);
-        Memory_FreePointer(&stream->src);
-    }
-
-    if (stream->swr.ctx) {
-        swr_free(&stream->swr.ctx);
-    }
-
-    if (stream->av.frame) {
-        av_frame_free(&stream->av.frame);
-        stream->av.frame = nullptr;
-    }
-
-    if (stream->av.packet) {
-        av_packet_free(&stream->av.packet);
-        stream->av.packet = nullptr;
-    }
-
-    stream->av.stream = nullptr;
-    stream->av.codec = nullptr;
-
-    if (stream->sdl.stream) {
-        SDL_FreeAudioStream(stream->sdl.stream);
-        stream->sdl.stream = nullptr;
-    }
-
-    void (*finish_callback)(int32_t, void *) = stream->finish_callback;
-    void *finish_callback_user_data = stream->finish_callback_user_data;
-
-    M_Clear(stream);
-
-    Audio_UnlockDevice();
-
-    if (finish_callback) {
-        finish_callback(sound_id, finish_callback_user_data);
+    if (notification.func != nullptr) {
+        notification.func(sound_id, notification.user_data);
     }
 
     return true;
 }
 
-bool Audio_Stream_SetVolume(int32_t sound_id, float volume)
+bool Audio_Stream_SetVolume(const int32_t sound_id, const float volume)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
@@ -790,20 +868,18 @@ bool Audio_Stream_SetVolume(int32_t sound_id, float volume)
     return true;
 }
 
-bool Audio_Stream_IsLooped(int32_t sound_id)
+bool Audio_Stream_IsLooped(const int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
     return m_Streams[sound_id].is_looped;
 }
 
-bool Audio_Stream_SetIsLooped(int32_t sound_id, bool is_looped)
+bool Audio_Stream_SetIsLooped(const int32_t sound_id, const bool is_looped)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
@@ -813,82 +889,53 @@ bool Audio_Stream_SetIsLooped(int32_t sound_id, bool is_looped)
 }
 
 bool Audio_Stream_SetFinishCallback(
-    int32_t sound_id, void (*callback)(int32_t sound_id, void *user_data),
-    void *user_data)
+    const int32_t sound_id,
+    void (*const callback)(int32_t sound_id, void *user_data),
+    void *const user_data)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
+    Audio_WorkerLock();
     m_Streams[sound_id].finish_callback = callback;
     m_Streams[sound_id].finish_callback_user_data = user_data;
+    Audio_WorkerUnlock();
 
     return true;
 }
 
-void Audio_Stream_Mix(float *dst_buffer, size_t len)
+void Audio_Stream_Mix(float *const dst_buffer, const size_t len)
 {
+    const uint32_t requested = len / sizeof(float);
+
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
         AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-        if (!stream->is_playing) {
+        if (!stream->is_used || !stream->is_playing) {
             continue;
         }
 
-        while ((SDL_AudioStreamAvailable(stream->sdl.stream) < (int32_t)len)
-               && !stream->is_read_done) {
-            if (M_DecodeFrame(stream)) {
-                M_EnqueueFrame(stream);
-            } else {
-                stream->is_read_done = true;
-            }
-        }
+        const uint32_t mixed =
+            M_RingMix(&stream->ring, dst_buffer, requested, stream->volume);
+        stream->played_samples += mixed / AUDIO_WORKING_CHANNELS;
 
-        memset(m_MixBuffer, 0, READ_BUFFER_SIZE);
-        int32_t bytes_gotten = SDL_AudioStreamGet(
-            stream->sdl.stream, m_MixBuffer, READ_BUFFER_SIZE);
-        if (bytes_gotten < 0) {
-            LOG_ERROR("Error reading from sdl.stream: %s", SDL_GetError());
-            stream->is_playing = false;
-            stream->is_used = false;
-            stream->is_read_done = true;
-        } else if (bytes_gotten == 0) {
-            // legit end of stream. looping is handled in
-            // M_DecodeFrame
-            stream->is_playing = false;
-            stream->is_used = false;
-            stream->is_read_done = true;
-        } else {
-            int32_t samples_gotten = bytes_gotten
-                / (AUDIO_WORKING_CHANNELS * sizeof(AUDIO_WORKING_FORMAT));
-            stream->played_samples += (int64_t)samples_gotten;
-
-            const float *src_ptr = &m_MixBuffer[0];
-            float *dst_ptr = dst_buffer;
-
-            for (int32_t s = 0; s < samples_gotten; s++) {
-                for (int32_t c = 0; c < AUDIO_WORKING_CHANNELS; c++) {
-                    *dst_ptr++ += *src_ptr++ * stream->volume;
-                }
-            }
-        }
-
-        if (!stream->is_used) {
-            Audio_Stream_Close(sound_id);
+        // Looping is handled by the worker, so a dry ring on a stream that has
+        // read everything is a legitimate end of playback.
+        if (mixed < requested && stream->is_read_done) {
+            SDL_AtomicSet(&stream->is_finished, 1);
         }
     }
 }
 
-double Audio_Stream_GetTimestamp(int32_t sound_id)
+double Audio_Stream_GetTimestamp(const int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return -1.0;
     }
 
     double timestamp = -1.0;
-    AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
 
     if (stream->duration > 0.0) {
         Audio_LockDevice();
@@ -899,38 +946,36 @@ double Audio_Stream_GetTimestamp(int32_t sound_id)
     return timestamp;
 }
 
-double Audio_Stream_GetDuration(int32_t sound_id)
+double Audio_Stream_GetDuration(const int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return -1.0;
     }
 
     Audio_LockDevice();
-    AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
-    double duration = stream->duration;
+    const double duration = m_Streams[sound_id].duration;
     Audio_UnlockDevice();
     return duration;
 }
 
 bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
+    Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     if (!stream->is_used) {
+        Audio_WorkerUnlock();
         return false;
     }
 
-    Audio_LockDevice();
     const double time_base_sec = av_q2d(stream->av.stream->time_base);
     if (time_base_sec <= 0.0) {
         LOG_ERROR(
             "Audio_Stream_SeekTimestamp: invalid time_base %f", time_base_sec);
-        Audio_UnlockDevice();
+        Audio_WorkerUnlock();
         return false;
     }
 
@@ -943,27 +988,28 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
         LOG_ERROR(
             "seek failed for timestamp %f: %s", timestamp,
             av_err2str(error_code));
-        Audio_UnlockDevice();
+        Audio_WorkerUnlock();
         return false;
     }
 
     avcodec_flush_buffers(stream->av.codec_ctx);
-    if (stream->sdl.stream != nullptr) {
-        M_DiscardSDLStreamData(stream);
-    }
+
+    Audio_LockDevice();
+    M_RingReset(&stream->ring);
+    Audio_UnlockDevice();
 
     stream->decode_timestamp = timestamp + MAX(stream->start_at, 0.0f);
     M_ResetPlaybackState(stream, timestamp);
     stream->is_read_done = false;
+    Audio_WorkerUnlock();
 
-    Audio_UnlockDevice();
     return true;
 }
 
-bool Audio_Stream_SetStartTimestamp(int32_t sound_id, double timestamp)
+bool Audio_Stream_SetStartTimestamp(
+    const int32_t sound_id, const double timestamp)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 
@@ -971,10 +1017,10 @@ bool Audio_Stream_SetStartTimestamp(int32_t sound_id, double timestamp)
     return true;
 }
 
-bool Audio_Stream_SetStopTimestamp(int32_t sound_id, double timestamp)
+bool Audio_Stream_SetStopTimestamp(
+    const int32_t sound_id, const double timestamp)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+    if (!M_IsValidID(sound_id)) {
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Audio decoding now runs on a dedicated worker thread instead of inside SDL's time-critical audio callback. Streams use lock-free buffering and progressive decoding, eliminating stutters when music or sound effects start, loop, seek, or close.

Both audio backends now share a unified `AUDIO_DECODER`, with no Lua/API changes. Stream position timing changes slightly around loops.

Resolves #3094, resolves #2286
