### PR TITLE
Keep the music intact when the audio output is changed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)
 - Fixed the sound stuttering when a piece of music starts playing (#3094)
 - Fixed the game pausing the first time a sound effect is played, which was most noticeable with longer ones (#2286)
+- Fixed the music turning to noise when the system audio output is changed while the game is running (#2489)
 - Fixed music briefly restarting from its beginning when loading a save (#1265)
 
 **Options and menus**

--- a/src/trx/av/audio.c
+++ b/src/trx/av/audio.c
@@ -62,6 +62,14 @@ static void M_StopWorker(void)
 static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
 {
     m_CallbackSeen = true;
+
+    // The length is the device's period rather than the size the device was
+    // opened with, and changes when the system output is switched.
+    if ((size_t)len > m_MixBufferCapacity) {
+        m_MixBuffer = Memory_Realloc(m_MixBuffer, len);
+        m_MixBufferCapacity = len;
+    }
+
     memset(m_MixBuffer, m_Silence, len);
     Audio_Sample_Mix(m_MixBuffer, len);
     Audio_Reverb_Process(m_MixBuffer, len);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The mixer now grows its buffer to match SDL’s requested length, preventing a heap overflow and corrupted audio when switching to a device with a longer WASAPI period. FMVs were unaffected because they use their own audio device and buffer.

Resolves #2489

#### Testing

Before merging, we should ideally reproduce the original issue on develop, and confirm the fix.
Switching to a device whose period differs from the one the game started on is what matters; a Bluetooth or virtual output is likelier to differ than another built-in one.

##### Audio output switching (Windows)
- [x] Music keeps playing cleanly when the output device is changed mid-track with <kbd>Ctrl</kbd>+<kbd>Win</kbd>+<kbd>V</kbd>
- [x] Switching back to the original device leaves the music intact
- [x] Switching several times in a row leaves the music intact
- [x] Sound effects still play correctly after a switch
- [x] An FMV still plays with sound after a switch

##### No regression elsewhere
- [x] Music, sound effects and FMVs play normally with no device switching at all
