### PR TITLE
Carry the music along when a cutscene is sped up

### DIFF
--- a/.github/actions/prepare_macos_tooling/action.yml
+++ b/.github/actions/prepare_macos_tooling/action.yml
@@ -83,6 +83,11 @@ runs:
       shell: bash
       run: sudo port -N install uthash +universal
 
+    - name: "Build dependency: rubberband (universal)"
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: sudo port -N install rubberband +universal
+
     - name: "Build dependency: ffmpeg (universal)"
       if: steps.restore-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -107,6 +107,7 @@
 
 **Music and sound**
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)
+- Changed cutscenes played at turbo speed to speed their music up to match, rather than skipping through it
 - Fixed the sound stuttering when a piece of music starts playing (#3094)
 - Fixed the game pausing the first time a sound effect is played, which was most noticeable with longer ones (#2286)
 - Fixed music briefly restarting from its beginning when loading a save (#1265)

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 CWD := `pwd`
 HOST_USER_UID := `id -u`
 HOST_USER_GID := `id -g`
-DOCKER_IMAGE_VERSION := "20260501.dev1"
+DOCKER_IMAGE_VERSION := "20260809.dev1"
 
 default: (trx-build-win "debug")
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -177,6 +177,7 @@ add_project_arguments(build_opts, language: 'c')
 
 null_dep = dependency('', required: false)
 dep_avcodec = dependency('libavcodec', static: staticdeps)
+dep_avfilter = dependency('libavfilter', static: staticdeps)
 dep_avformat = dependency('libavformat', static: staticdeps)
 dep_avutil = dependency('libavutil', static: staticdeps)
 dep_sdl2 = dependency('SDL2', static: staticdeps)
@@ -202,6 +203,7 @@ endif
 
 dependencies = [
   dep_avcodec,
+  dep_avfilter,
   dep_avformat,
   dep_avutil,
   dep_backtrace,

--- a/src/trx/av/audio.h
+++ b/src/trx/av/audio.h
@@ -30,6 +30,10 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *data, size_t size);
 bool Audio_Stream_Close(int32_t sound_id);
 bool Audio_Stream_IsLooped(int32_t sound_id);
 bool Audio_Stream_SetVolume(int32_t sound_id, float volume);
+
+// Play the stream faster or slower, pitching it with the rate the way a tape
+// does. Timestamps stay in the source timeline.
+bool Audio_Stream_SetSpeed(int32_t sound_id, double speed);
 bool Audio_Stream_SetIsLooped(int32_t sound_id, bool is_looped);
 
 // Sync the audio against specific timestamp (seek if the drift is too large).

--- a/src/trx/av/audio_decoder.c
+++ b/src/trx/av/audio_decoder.c
@@ -3,12 +3,16 @@
 #include <trx/av/audio_internal.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 
 #include <errno.h>
 #include <libavcodec/avcodec.h>
 #include <libavcodec/packet.h>
+#include <libavfilter/avfilter.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/avutil.h>
@@ -16,6 +20,7 @@
 #include <libavutil/error.h>
 #include <libavutil/frame.h>
 #include <libavutil/mem.h>
+#include <libavutil/opt.h>
 #include <libavutil/rational.h>
 #include <libavutil/samplefmt.h>
 #include <libswresample/swresample.h>
@@ -44,6 +49,13 @@ struct AUDIO_DECODER {
     AVPacket *packet;
     AVFrame *frame;
     SwrContext *swr_ctx;
+
+    double speed;
+    AVFilterGraph *filter_graph;
+    AVFilterContext *filter_src;
+    AVFilterContext *filter_sink;
+    AVFrame *filter_in;
+    AVFrame *filter_out;
 
     float *buffer;
     int32_t buffer_capacity;
@@ -174,6 +186,105 @@ fail:
     return false;
 }
 
+static void M_FreeFilterGraph(AUDIO_DECODER *const decoder)
+{
+    if (decoder->filter_graph != nullptr) {
+        avfilter_graph_free(&decoder->filter_graph);
+    }
+    if (decoder->filter_in != nullptr) {
+        av_frame_free(&decoder->filter_in);
+    }
+    if (decoder->filter_out != nullptr) {
+        av_frame_free(&decoder->filter_out);
+    }
+    decoder->filter_src = nullptr;
+    decoder->filter_sink = nullptr;
+}
+
+static bool M_BuildFilterGraph(AUDIO_DECODER *const decoder)
+{
+    decoder->filter_graph = avfilter_graph_alloc();
+    decoder->filter_in = av_frame_alloc();
+    decoder->filter_out = av_frame_alloc();
+    if (decoder->filter_graph == nullptr || decoder->filter_in == nullptr
+        || decoder->filter_out == nullptr) {
+        return false;
+    }
+
+    AVChannelLayout layout;
+    av_channel_layout_default(&layout, decoder->channels);
+    char layout_name[64];
+    av_channel_layout_describe(&layout, layout_name, sizeof(layout_name));
+
+    char *const args = String_Format(
+        "time_base=1/%d:sample_rate=%d:sample_fmt=%s:channel_layout=%s",
+        AUDIO_WORKING_RATE, AUDIO_WORKING_RATE,
+        av_get_sample_fmt_name(AV_SAMPLE_FMT_FLT), layout_name);
+    const int32_t error_code = avfilter_graph_create_filter(
+        &decoder->filter_src, avfilter_get_by_name("abuffer"), "in", args,
+        nullptr, decoder->filter_graph);
+    Memory_Free(args);
+    if (error_code < 0) {
+        LOG_ERROR(
+            "Failed to create the filter source: %s", av_err2str(error_code));
+        return false;
+    }
+
+    decoder->filter_sink = avfilter_graph_alloc_filter(
+        decoder->filter_graph, avfilter_get_by_name("abuffersink"), "out");
+    if (decoder->filter_sink == nullptr) {
+        LOG_ERROR("Failed to create the filter sink");
+        return false;
+    }
+
+    // the sink only takes its format before it is initialised
+    static const enum AVSampleFormat sample_fmts[] = {
+        AV_SAMPLE_FMT_FLT,
+        AV_SAMPLE_FMT_NONE,
+    };
+    if (av_opt_set_bin(
+            decoder->filter_sink, "sample_fmts", (const uint8_t *)sample_fmts,
+            sizeof(sample_fmts), AV_OPT_SEARCH_CHILDREN)
+            < 0
+        || avfilter_init_dict(decoder->filter_sink, nullptr) < 0) {
+        LOG_ERROR("Failed to pin the filter output format");
+        return false;
+    }
+
+    char *const tempo_args = String_Format("tempo=%f", decoder->speed);
+    AVFilterContext *stretch = nullptr;
+    const int32_t stretch_result = avfilter_graph_create_filter(
+        &stretch, avfilter_get_by_name("rubberband"), "stretch", tempo_args,
+        nullptr, decoder->filter_graph);
+    Memory_Free(tempo_args);
+    if (stretch_result < 0
+        || avfilter_link(decoder->filter_src, 0, stretch, 0) < 0) {
+        LOG_ERROR("Failed to create the time stretch filter");
+        return false;
+    }
+
+    if (avfilter_link(stretch, 0, decoder->filter_sink, 0) < 0
+        || avfilter_graph_config(decoder->filter_graph, nullptr) < 0) {
+        LOG_ERROR("Failed to configure the filter graph");
+        return false;
+    }
+
+    return true;
+}
+
+// Drops whatever the stretcher holds, which a seek makes stale.
+static void M_RebuildFilterGraph(AUDIO_DECODER *const decoder)
+{
+    if (decoder->filter_graph == nullptr) {
+        return;
+    }
+    M_FreeFilterGraph(decoder);
+    if (!M_BuildFilterGraph(decoder)) {
+        M_FreeFilterGraph(decoder);
+        decoder->speed = 1.0;
+    }
+}
+
 static void M_Append(
     AUDIO_DECODER *const decoder, const float *const data, const int32_t count)
 {
@@ -186,6 +297,45 @@ static void M_Append(
     memcpy(
         decoder->buffer + decoder->buffer_count, data, floats * sizeof(float));
     decoder->buffer_count += floats;
+}
+
+static void M_Filter(
+    AUDIO_DECODER *const decoder, const float *const data, const int32_t count)
+{
+    AVFrame *const in = decoder->filter_in;
+    av_frame_unref(in);
+    in->format = AV_SAMPLE_FMT_FLT;
+    in->sample_rate = AUDIO_WORKING_RATE;
+    in->nb_samples = count;
+    av_channel_layout_default(&in->ch_layout, decoder->channels);
+    if (av_frame_get_buffer(in, 0) < 0) {
+        return;
+    }
+    memcpy(in->data[0], data, count * decoder->channels * sizeof(float));
+    if (av_buffersrc_add_frame(decoder->filter_src, in) < 0) {
+        return;
+    }
+
+    AVFrame *const out = decoder->filter_out;
+    while (av_buffersink_get_frame(decoder->filter_sink, out) >= 0) {
+        M_Append(decoder, (const float *)out->data[0], out->nb_samples);
+        av_frame_unref(out);
+    }
+}
+
+// Pushes whatever the stretcher is still holding through to the sink.
+static void M_FlushFilter(AUDIO_DECODER *const decoder)
+{
+    if (decoder->filter_graph == nullptr) {
+        return;
+    }
+
+    av_buffersrc_add_frame(decoder->filter_src, nullptr);
+    AVFrame *const out = decoder->filter_out;
+    while (av_buffersink_get_frame(decoder->filter_sink, out) >= 0) {
+        M_Append(decoder, (const float *)out->data[0], out->nb_samples);
+        av_frame_unref(out);
+    }
 }
 
 static void M_Convert(AUDIO_DECODER *const decoder, AVFrame *const frame)
@@ -203,7 +353,11 @@ static void M_Convert(AUDIO_DECODER *const decoder, AVFrame *const frame)
         decoder->swr_ctx, &out_buffer, max_samples,
         (const uint8_t **)frame->data, frame->nb_samples);
     if (converted > 0) {
-        M_Append(decoder, scratch, converted);
+        if (decoder->filter_graph != nullptr) {
+            M_Filter(decoder, scratch, converted);
+        } else {
+            M_Append(decoder, scratch, converted);
+        }
     }
     Memory_Free(scratch);
 }
@@ -223,6 +377,7 @@ static AUDIO_DECODER *M_Create(const int32_t channels)
 {
     AUDIO_DECODER *const decoder = Memory_Alloc(sizeof(AUDIO_DECODER));
     decoder->channels = channels;
+    decoder->speed = 1.0;
     return decoder;
 }
 
@@ -301,6 +456,7 @@ void AudioDecoder_Free(AUDIO_DECODER **const decoder_ref)
         return;
     }
 
+    M_FreeFilterGraph(decoder);
     if (decoder->swr_ctx != nullptr) {
         swr_free(&decoder->swr_ctx);
     }
@@ -343,6 +499,28 @@ double AudioDecoder_GetTimestamp(const AUDIO_DECODER *const decoder)
     return decoder->timestamp;
 }
 
+bool AudioDecoder_SetSpeed(AUDIO_DECODER *const decoder, const double speed)
+{
+    ASSERT(decoder != nullptr);
+
+    if (speed <= 0.0 || speed == decoder->speed) {
+        return speed > 0.0;
+    }
+
+    M_FreeFilterGraph(decoder);
+    decoder->speed = speed;
+    if (speed == 1.0) {
+        return true;
+    }
+
+    if (!M_BuildFilterGraph(decoder)) {
+        M_FreeFilterGraph(decoder);
+        decoder->speed = 1.0;
+        return false;
+    }
+    return true;
+}
+
 bool AudioDecoder_Seek(AUDIO_DECODER *const decoder, const double timestamp)
 {
     ASSERT(decoder != nullptr);
@@ -364,6 +542,7 @@ bool AudioDecoder_Seek(AUDIO_DECODER *const decoder, const double timestamp)
     }
 
     avcodec_flush_buffers(decoder->codec_ctx);
+    M_RebuildFilterGraph(decoder);
     decoder->timestamp = timestamp;
     decoder->is_drained = false;
     return true;
@@ -397,6 +576,7 @@ bool AudioDecoder_Rewind(AUDIO_DECODER *const decoder, const double start_at)
     }
 
     avcodec_flush_buffers(decoder->codec_ctx);
+    M_RebuildFilterGraph(decoder);
     decoder->timestamp = start_at;
     decoder->is_drained = false;
     return true;
@@ -424,6 +604,7 @@ int32_t AudioDecoder_Read(AUDIO_DECODER *const decoder, const float **const out)
         // let the codec hand back whatever it was still holding
         avcodec_send_packet(decoder->codec_ctx, nullptr);
         M_Drain(decoder);
+        M_FlushFilter(decoder);
         decoder->is_drained = true;
         *out = decoder->buffer;
         return decoder->buffer_count > 0

--- a/src/trx/av/audio_decoder.h
+++ b/src/trx/av/audio_decoder.h
@@ -19,6 +19,9 @@ double AudioDecoder_GetDuration(const AUDIO_DECODER *decoder);
 // Where in the source the last decoded frame came from, in seconds.
 double AudioDecoder_GetTimestamp(const AUDIO_DECODER *decoder);
 
+// Decode faster or slower without moving the pitch.
+bool AudioDecoder_SetSpeed(AUDIO_DECODER *decoder, double speed);
+
 bool AudioDecoder_Seek(AUDIO_DECODER *decoder, double timestamp);
 bool AudioDecoder_Rewind(AUDIO_DECODER *decoder, double start_at);
 

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -35,6 +35,7 @@ typedef struct {
     bool is_read_done;
     bool is_looped;
     float volume;
+    double speed;
     double duration;
     double decode_timestamp;
     int64_t played_samples;
@@ -132,7 +133,8 @@ static void M_ResetPlaybackState(
 
     const double clamped = MAX(0.0, relative_timestamp);
     Audio_LockDevice();
-    stream->played_samples = (int64_t)(clamped * (double)AUDIO_WORKING_RATE);
+    stream->played_samples =
+        (int64_t)(clamped * (double)AUDIO_WORKING_RATE / stream->speed);
     Audio_UnlockDevice();
 }
 
@@ -221,6 +223,7 @@ static void M_Clear(AUDIO_STREAM_SOUND *const stream)
     stream->is_read_done = true;
     stream->is_looped = false;
     stream->volume = 0.0f;
+    stream->speed = 1.0;
     stream->duration = 0.0;
     stream->decode_timestamp = 0.0;
     stream->played_samples = 0;
@@ -274,6 +277,7 @@ static bool M_Initialise(
     stream->is_read_done = false;
     stream->is_looped = false;
     stream->volume = 1.0f;
+    stream->speed = 1.0;
     stream->decode_timestamp = 0.0;
     stream->played_samples = 0;
     stream->finish_callback = nullptr;
@@ -473,6 +477,25 @@ bool Audio_Stream_SetVolume(const int32_t sound_id, const float volume)
     return true;
 }
 
+bool Audio_Stream_SetSpeed(const int32_t sound_id, const double speed)
+{
+    if (!M_IsValidID(sound_id) || speed <= 0.0) {
+        return false;
+    }
+
+    Audio_WorkerLock();
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+    bool result = false;
+    if (stream->is_used) {
+        result = AudioDecoder_SetSpeed(stream->decoder, speed);
+        // a rate the decoder cannot reach leaves it playing at its own
+        stream->speed = result ? speed : 1.0;
+    }
+    Audio_WorkerUnlock();
+
+    return result;
+}
+
 bool Audio_Stream_IsLooped(const int32_t sound_id)
 {
     if (!M_IsValidID(sound_id)) {
@@ -544,7 +567,8 @@ double Audio_Stream_GetTimestamp(const int32_t sound_id)
 
     if (stream->duration > 0.0) {
         Audio_LockDevice();
-        timestamp = (double)stream->played_samples / (double)AUDIO_WORKING_RATE;
+        timestamp = (double)stream->played_samples * stream->speed
+            / (double)AUDIO_WORKING_RATE;
         Audio_UnlockDevice();
     }
 

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -5,6 +5,7 @@
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
+#include <trx/game/clock.h>
 #include <trx/game/collision.h>
 #include <trx/game/const.h>
 #include <trx/game/effects.h>
@@ -382,6 +383,7 @@ void Cutscene_End(void)
 GF_COMMAND Cutscene_Control(void)
 {
     Interpolation_Remember();
+    Music_SetSpeed(Clock_GetSpeedMultiplier());
     Music_SyncTimestamp(Camera_GetCineData()->frame_idx / (double)LOGIC_FPS);
 
     Input_Update();

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -4,6 +4,7 @@
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
+#include <trx/game/clock.h>
 #include <trx/game/const.h>
 #include <trx/game/cutseq/decoder.h>
 #include <trx/game/cutseq/pak.h>
@@ -338,6 +339,7 @@ static void M_Step(void)
 
     if (info->audio_track != -1
         && Music_GetCurrentPlayingTrack() == (MUSIC_ID)info->audio_track) {
+        Music_SetSpeed(Clock_GetSpeedMultiplier());
         Music_SyncTimestamp(m_State.frame / (double)LOGIC_FPS);
     }
 

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -1,5 +1,6 @@
 #include <trx/config.h>
 #include <trx/game/camera.h>
+#include <trx/game/clock.h>
 #include <trx/game/collision.h>
 #include <trx/game/game.h>
 #include <trx/game/interpolation.h>
@@ -281,6 +282,7 @@ static void M_EndHouse(ITEM *const item, COLL_INFO *const coll)
     if (Music_GetCurrentPlayingTrack() == Music_ToGameID(MX_CUTSCENE_BATH)) {
         const int32_t frame_num = Item_GetRelativeFrame(item);
         const double ts = (frame_num - M_LF_SHOWER_START) / (double)LOGIC_FPS;
+        Music_SetSpeed(Clock_GetSpeedMultiplier());
         Music_SyncTimestamp(ts);
     }
 }

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -589,6 +589,14 @@ bool Music_SeekTimestamp(const double timestamp)
     return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 
+bool Music_SetSpeed(const double speed)
+{
+    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
+        return false;
+    }
+    return Audio_Stream_SetSpeed(m_MainStream.audio_stream_id, speed);
+}
+
 bool Music_SyncTimestamp(const double timestamp)
 {
     if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -80,6 +80,10 @@ bool Music_SeekTimestamp(double timestamp);
 // Seeks to the given timestamp if the drift is too big.
 bool Music_SyncTimestamp(double timestamp);
 
+// Play the current track at the given rate, so a sped-up cutscene carries its
+// music with it instead of seeking away from it.
+bool Music_SetSpeed(double speed);
+
 // Returns the number of currently active serializable streams.
 int32_t Music_GetStreamCount(void);
 

--- a/tools/ffmpeg_flags.txt
+++ b/tools/ffmpeg_flags.txt
@@ -1,4 +1,5 @@
 --enable-gpl
+--enable-librubberband
 --enable-decoder=pcx
 --enable-decoder=png
 --enable-decoder=gif

--- a/tools/shared/docker/game-linux/Dockerfile
+++ b/tools/shared/docker/game-linux/Dockerfile
@@ -56,12 +56,49 @@ RUN cd libbacktrace \
 
 
 
+# librubberband
+FROM base AS rubberband
+RUN apt-get install -y \
+    gcc \
+    g++ \
+    pkg-config \
+    python3-pip \
+    && python3 -m pip install --break-system-packages \
+        meson \
+        ninja
+RUN git clone https://github.com/breakfastquay/rubberband --branch v4.0.0
+RUN cd rubberband \
+    && meson setup build \
+        --prefix=/ext/ \
+        --libdir=lib \
+        --default-library=static \
+        -Dfft=builtin \
+        -Dresampler=builtin \
+        -Djni=disabled \
+        -Dladspa=disabled \
+        -Dlv2=disabled \
+        -Dvamp=disabled \
+        -Dcmdline=disabled \
+        -Dtests=disabled \
+    && ninja -C build \
+    && ninja -C build install
+# the generated file names neither the C++ runtime nor libm, which whoever
+# links the static library has to be told about
+RUN sed -i '/^Libs.private:/d' /ext/lib/pkgconfig/rubberband.pc \
+    && echo 'Libs.private: -lstdc++ -lm' >> /ext/lib/pkgconfig/rubberband.pc
+
+
+
 # libav
 FROM base AS libav
 RUN apt-get install -y \
     nasm \
     gcc \
+    g++ \
+    pkg-config \
     zlib1g-dev
+COPY --from=rubberband /ext/ /ext/
+ENV PKG_CONFIG_PATH=/ext/lib/pkgconfig/
 RUN git clone \
     https://github.com/FFmpeg/FFmpeg
 RUN cd FFmpeg && git checkout 066432ebcf
@@ -72,6 +109,9 @@ RUN cd FFmpeg \
         --prefix=/ext/ \
         --enable-static \
         --disable-shared \
+        --pkg-config-flags=--static \
+        --extra-cflags=-I/ext/include \
+        --extra-ldflags=-L/ext/lib \
         $(cat /tmp/ffmpeg_flags.txt) \
     && make -j 4 \
     && make install
@@ -157,7 +197,8 @@ WORKDIR /app
 # package dependencies
 RUN apt-get install -y \
     zlib1g-dev \
-    libgl1-mesa-dev
+    libgl1-mesa-dev \
+    g++
 
 # tooling dependencies
 # configure pkgconfig manually

--- a/tools/shared/docker/game-win/Dockerfile
+++ b/tools/shared/docker/game-win/Dockerfile
@@ -51,10 +51,48 @@ RUN cd zlib \
 
 
 
+# librubberband
+FROM mingw AS rubberband
+RUN apt-get install -y \
+    pkg-config \
+    python3-pip \
+    && python3 -m pip install --break-system-packages \
+        meson \
+        ninja
+RUN git clone https://github.com/breakfastquay/rubberband --branch v4.0.0
+COPY ./tools/shared/docker/game-win/meson_linux_mingw32_deps.txt /tmp/cross.txt
+RUN cd rubberband \
+    && meson setup build \
+        --cross-file /tmp/cross.txt \
+        --prefix=/ext/ \
+        --libdir=lib \
+        --default-library=static \
+        -Dfft=builtin \
+        -Dresampler=builtin \
+        -Djni=disabled \
+        -Dladspa=disabled \
+        -Dlv2=disabled \
+        -Dvamp=disabled \
+        -Dcmdline=disabled \
+        -Dtests=disabled \
+    && ninja -C build \
+    && ninja -C build install
+# the generated file names neither the C++ runtime nor libm, which whoever
+# links the static library has to be told about
+RUN sed -i '/^Libs.private:/d' /ext/lib/pkgconfig/rubberband.pc \
+    && echo 'Libs.private: -lstdc++ -lm' >> /ext/lib/pkgconfig/rubberband.pc
+
+
+
 # libav
 FROM mingw AS libav
 RUN apt-get install -y \
-    nasm
+    nasm \
+    pkg-config \
+    mingw-w64-tools
+COPY --from=rubberband /ext/ /ext/
+ENV PKG_CONFIG_PATH=/ext/lib/pkgconfig/
+ENV PKG_CONFIG_LIBDIR=/ext/lib/pkgconfig/
 RUN git clone \
     https://github.com/FFmpeg/FFmpeg
 RUN cd FFmpeg && git checkout 066432ebcf
@@ -73,6 +111,9 @@ RUN cd FFmpeg \
         --pkg-config=i686-w64-mingw32-pkg-config \
         --enable-static \
         --disable-shared \
+        --pkg-config-flags=--static \
+        --extra-cflags=-I/ext/include \
+        --extra-ldflags=-L/ext/lib \
         $(cat /tmp/ffmpeg_flags.txt) \
     && make -j 4 \
     && make install

--- a/tools/shared/docker/game-win/meson_linux_mingw32_deps.txt
+++ b/tools/shared/docker/game-win/meson_linux_mingw32_deps.txt
@@ -1,0 +1,17 @@
+# Cross file for building dependencies inside the toolchain image, where the
+# ccache and wine wrappers the game build uses are not yet installed.
+[binaries]
+c = '/usr/bin/i686-w64-mingw32-gcc'
+cpp = '/usr/bin/i686-w64-mingw32-g++'
+ar = '/usr/bin/i686-w64-mingw32-ar'
+strip = '/usr/bin/i686-w64-mingw32-strip'
+pkg-config = '/usr/bin/i686-w64-mingw32-pkg-config'
+
+[properties]
+skip_sanity_check = true
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86'
+cpu = 'i686'
+endian = 'little'

--- a/tools/shared/docker/game_entrypoint.py
+++ b/tools/shared/docker/game_entrypoint.py
@@ -110,7 +110,8 @@ def compress_exe(options: BuildOptions, path: Path) -> None:
 
 class BaseCommand:
     name: str = NotImplemented
-    help: str = NotImplemented
+    # argparse reads this as a boolean, which NotImplemented refuses to be
+    help: str | None = None
 
     def decorate_parser(self, parser: argparse.ArgumentParser) -> None:
         pass


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR adds pitch-preserving playback speed control to streams and uses it to keep cutscene music in sync with turbo speed, replacing the frequent corrective seeks that previously chopped up the track.

The implementation uses ffmpeg's rubberband filter, added to both toolchain images and the macOS runner.

The branch also fixes the Docker entrypoint, which broke under Python 3.14 before reaching meson.
