### PR TITLE
phase/picture: follow the upscaling settings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,7 @@
 - Fixed a crash when drawing an animating object that has no frame data (#5869)
 - Fixed colored dynamic lights in TR1 and TR2 being drawn at the wrong brightness
 - Fixed FMVs costing frame rate at high resolutions, where every frame was resized twice on its way to the screen (#6152, #262)
+- Fixed loading and legal screens ignoring the upscaling factor and filter
 
 **Music and sound**
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -8,6 +8,7 @@
 #include <trx/game/output/lights.h>
 #include <trx/game/output/lights/priv.h>
 #include <trx/game/output/mesh_batcher/batcher.h>
+#include <trx/game/output/overlay.h>
 #include <trx/game/output/scene_compositor.h>
 #include <trx/game/output/sky.h>
 #include <trx/game/output/sources/lightnings.h>
@@ -121,6 +122,7 @@ void Output_BeginScene(void)
     TRX_GL_Context_Clear();
     TRX_GL_Track_Reset();
     TRX_GL_Context_SetWireframeMode(g_Config.rendering.enable_wireframe);
+    Output_Overlay_BeginFrame();
     SceneCompositor_BeginScene();
     Output_Lights_BeginScene();
 }

--- a/src/trx/game/output/overlay.h
+++ b/src/trx/game/output/overlay.h
@@ -16,6 +16,9 @@ bool Output_Overlay_LoadImage(const char *file_name);
 void Output_Overlay_DrawImage(const char *file_name);
 void Output_Overlay_DrawImageBilinear(const char *file_name);
 void Output_Overlay_DrawImageMono(const char *file_name, float intensity);
+// Marks the start of a new frame, so that a transition captured before it is
+// drawn once no matter how many times the frame is flushed.
+void Output_Overlay_BeginFrame(void);
 void Output_Overlay_CaptureSnapshot(void);
 void Output_Overlay_CaptureGameSnapshot(void);
 void Output_Overlay_DrawSnapshot(float opacity);

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -836,7 +836,7 @@ bool Output_Overlay_LoadImage(const char *const file_name)
 
 void Output_Overlay_DrawImage(const char *const file_name)
 {
-    M_DrawImageImpl(file_name, 0.0f, TEXTURE_FILTER_POINT);
+    M_DrawImageImpl(file_name, 0.0f, g_Config.rendering.upscaling_filter);
 }
 
 void Output_Overlay_DrawImageBilinear(const char *const file_name)
@@ -847,7 +847,7 @@ void Output_Overlay_DrawImageBilinear(const char *const file_name)
 void Output_Overlay_DrawImageMono(
     const char *const file_name, const float intensity)
 {
-    M_DrawImageImpl(file_name, intensity, TEXTURE_FILTER_POINT);
+    M_DrawImageImpl(file_name, intensity, g_Config.rendering.upscaling_filter);
 }
 
 void Output_Overlay_CaptureSnapshot(void)

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -122,6 +122,7 @@ typedef struct {
         OUTPUT_QUAD *renderer;
         M_SNAPSHOT_STATE state;
         bool transition_active;
+        bool transition_drawn;
         FADER transition_fader;
     } snapshot;
     struct {
@@ -763,45 +764,48 @@ static void M_RunQueue(const VECTOR *const queue)
     }
 }
 
+static void M_DrawTransitionSnapshot(M_PRIV *const p)
+{
+    if (!p->snapshot.transition_active || p->snapshot.transition_drawn) {
+        return;
+    }
+
+    const float opacity = Fader_GetCurrentValue(&p->snapshot.transition_fader);
+    if (opacity <= 0.0f || !p->snapshot.state.has_content
+        || !p->snapshot.state.texture.initialized) {
+        p->snapshot.transition_active = false;
+        p->snapshot.state.has_content = false;
+        return;
+    }
+
+    M_DrawOp_Snapshot(&(M_DRAW_OP_SNAPSHOT) {
+        .texture_id = p->snapshot.state.texture.id,
+        .width = p->snapshot.state.width,
+        .height = p->snapshot.state.height,
+        .opacity = opacity,
+        .tint = COLOR_RGB_F_WHITE,
+    });
+    p->snapshot.transition_drawn = true;
+
+    if (!Fader_IsActive(&p->snapshot.transition_fader)) {
+        p->snapshot.transition_active = false;
+        p->snapshot.state.has_content = false;
+    }
+}
+
 static void M_RenderBegin(const SCENE_SOURCE *const source)
 {
     M_PRIV *const p = &m_Priv;
     Vector_Clear(p->ops[0]);
     Vector_Clear(p->ops[1]);
     Memory_ArenaReset(&p->alloc);
-
-    if (p->snapshot.transition_active) {
-        const float opacity =
-            Fader_GetCurrentValue(&p->snapshot.transition_fader);
-
-        if (opacity <= 0.0f || !p->snapshot.state.has_content
-            || !p->snapshot.state.texture.initialized) {
-            p->snapshot.transition_active = false;
-            p->snapshot.state.has_content = false;
-            return;
-        }
-
-        M_SCHEDULE_OP(
-            false, M_DrawOp_Snapshot,
-            ((M_DRAW_OP_SNAPSHOT) {
-                .texture_id = p->snapshot.state.texture.id,
-                .width = p->snapshot.state.width,
-                .height = p->snapshot.state.height,
-                .opacity = opacity,
-                .tint = COLOR_RGB_F_WHITE,
-            }));
-
-        if (!Fader_IsActive(&p->snapshot.transition_fader)) {
-            p->snapshot.transition_active = false;
-            p->snapshot.state.has_content = false;
-        }
-    }
 }
 
 static void M_RenderPass(const SCENE_SOURCE *const src, const SCENE_PASS pass)
 {
     M_PRIV *const p = &m_Priv;
     if (pass == SCENE_PASS_OVERLAY_PRE_UI) {
+        M_DrawTransitionSnapshot(p);
         M_RunQueue(p->ops[0]);
     } else if (pass == SCENE_PASS_OVERLAY_POST_UI) {
         M_RunQueue(p->ops[1]);
@@ -812,7 +816,8 @@ static bool M_IsDirty(const SCENE_SOURCE *const src, const SCENE_PASS pass)
 {
     M_PRIV *const p = &m_Priv;
     if (pass == SCENE_PASS_OVERLAY_PRE_UI) {
-        return p->ops[0]->count > 0 || p->snapshot.transition_active;
+        return p->ops[0]->count > 0
+            || (p->snapshot.transition_active && !p->snapshot.transition_drawn);
     } else if (pass == SCENE_PASS_OVERLAY_POST_UI) {
         return p->ops[1]->count > 0;
     }
@@ -941,6 +946,11 @@ void Output_Overlay_DrawPatternOpacity(const bool wave, const float opacity)
         ((M_DRAW_OP_PATTERN) { .wave = wave, .opacity = opacity }));
 }
 
+void Output_Overlay_BeginFrame(void)
+{
+    m_Priv.snapshot.transition_drawn = false;
+}
+
 void Output_Overlay_BeginTransitionFadeOut(
     const float duration, const float start)
 {
@@ -951,6 +961,7 @@ void Output_Overlay_BeginTransitionFadeOut(
     }
 
     p->snapshot.transition_active = true;
+    p->snapshot.transition_drawn = false;
     Fader_InitTo(&p->snapshot.transition_fader, start, 0.0f, duration);
 }
 

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -21,6 +21,7 @@
 #include <trx/game/output/state.h>
 #include <trx/game/output/textures.h>
 #include <trx/game/viewport.h>
+#include <trx/gl/context.h>
 #include <trx/gl/renderer.h>
 #include <trx/gl/texture.h>
 #include <trx/gl/utils.h>
@@ -767,6 +768,13 @@ static void M_RunQueue(const VECTOR *const queue)
 static void M_DrawTransitionSnapshot(M_PRIV *const p)
 {
     if (!p->snapshot.transition_active || p->snapshot.transition_drawn) {
+        return;
+    }
+
+    // A capture holds the frame at the window's resolution, which only the UI
+    // buffer shares. Drawing it into the scene buffer would send it through
+    // the upscaling factor a second time.
+    if (TRX_GL_Context_GetViewport() != VIEWPORT_UI) {
         return;
     }
 

--- a/src/trx/game/phase/phase_pause.c
+++ b/src/trx/game/phase/phase_pause.c
@@ -182,6 +182,7 @@ static void M_Draw(PHASE *const phase)
         : p->fader.args.target;
     Output_Overlay_DrawBackground(
         g_Config.ui.pause_background_style, progress, nullptr);
+    Output_Flush();
 
     if (p->state == STATE_ASK) {
         UI_Pause(&p->ui.state);

--- a/src/trx/game/phase/phase_picture.c
+++ b/src/trx/game/phase/phase_picture.c
@@ -121,6 +121,7 @@ static void M_Draw(PHASE *const phase)
         Output_Overlay_DrawImage(p->args.file_name);
         Output_Overlay_DrawBlackRectangle(progress, false);
     }
+    Output_Flush();
     p->has_drawn = true;
 }
 

--- a/src/trx/game/phase/phase_picture.c
+++ b/src/trx/game/phase/phase_picture.c
@@ -111,17 +111,17 @@ static void M_Draw(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     const float progress = Fader_GetCurrentValue(&p->fader);
+    Output_Overlay_DrawImage(p->args.file_name);
+    Output_Flush();
+
     if (p->args.loading_pic
         && (p->state != STATE_FADE_IN || !p->args.block_cross_fade_in)) {
-        Output_Overlay_DrawImage(p->args.file_name);
         if (p->state == STATE_FADE_IN) {
             Output_Overlay_DrawSnapshot(progress);
         }
     } else {
-        Output_Overlay_DrawImage(p->args.file_name);
         Output_Overlay_DrawBlackRectangle(progress, false);
     }
-    Output_Flush();
     p->has_drawn = true;
 }
 

--- a/src/trx/game/phase/phase_stats.c
+++ b/src/trx/game/phase/phase_stats.c
@@ -195,6 +195,7 @@ static void M_Draw(PHASE *const phase)
     if (top_opacity > 0.0f) {
         Output_Overlay_DrawSnapshot(1.0f);
         Output_Overlay_DrawBlackRectangle(top_opacity, false);
+        Output_Flush();
         return;
     }
 
@@ -203,6 +204,7 @@ static void M_Draw(PHASE *const phase)
         : p->back_fader.args.target;
     Output_Overlay_DrawBackground(
         p->args.background_type, progress, p->args.background_path);
+    Output_Flush();
 
     if (p->ui_active) {
         UI_StatsDialog(p->ui_state);

--- a/src/trx/gl/context.c
+++ b/src/trx/gl/context.c
@@ -72,6 +72,11 @@ void TRX_GL_Context_SwitchToViewport(const VIEWPORT_SPACE space)
     TRX_GL_CheckError();
 }
 
+VIEWPORT_SPACE TRX_GL_Context_GetViewport(void)
+{
+    return m_Context.space;
+}
+
 bool TRX_GL_Context_Attach(void *window_handle)
 {
     const char *shading_ver;

--- a/src/trx/gl/context.h
+++ b/src/trx/gl/context.h
@@ -24,6 +24,7 @@ void TRX_GL_Context_SwapBuffers(void);
 void TRX_GL_Context_SetRendered(void);
 
 void TRX_GL_Context_SwitchToViewport(VIEWPORT_SPACE space);
+VIEWPORT_SPACE TRX_GL_Context_GetViewport(void);
 
 void TRX_GL_Context_ScheduleScreenshot(const char *path);
 const char *TRX_GL_Context_GetScheduledScreenshotPath(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Full-screen pictures, such as the loading and legal screens, now render at the game's resolution, so the upscaling factor and filter apply to them as to the rest of the screen. Before this, they were composited into the UI buffer at the full window size, which left them pixel-sharp whatever the factor was set to.

Resolves TRX963.