### PR TITLE
Explain when the graphics driver cannot run the game

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Added a water color preset, offering the underwater tint each release shipped with, per level where the PlayStation ones varied it; picking one holds the water color below it, and Custom gives the player's own back (Graphic Options → Visuals → Water color preset) (#1619)
 - Added a brightness option for background images and patterns, so that brightening the UI leaves them alone (Graphic Options → Rendering → Background brightness) (#6074)
 - Added an option for the PS1 raindrops, which are pale rather than blue (Graphic Options → Visuals → PS1 raindrops) (#5206)
+- Added a message naming the graphics driver when it is too old to run the game, where the game used to close without any explanation (#5655)
 - Changed the brightness options to be given as percentages, as the volume options are
 - Changed reflections UV mapping to be more correct
 - Fixed a crash when drawing an animating object that has no frame data (#5869)

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -36,7 +36,14 @@ static void M_ShowFatalError(
 {
     LOG_ERROR("%s", log_message);
     if (M_IsInteractive()) {
-        SDL_Window *const window = Shell_GetWindow();
+        // The dialog is placed over its parent window. Until the game window
+        // is shown, it is still hidden at whatever position the config named,
+        // so the dialog is better off centered on the screen instead.
+        SDL_Window *window = Shell_GetWindow();
+        if (window != nullptr
+            && (SDL_GetWindowFlags(window) & SDL_WINDOW_SHOWN) == 0) {
+            window = nullptr;
+        }
         SDL_ShowSimpleMessageBox(
             SDL_MESSAGEBOX_ERROR, "Tomb Raider Error", dialog_message, window);
     }

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -2,6 +2,7 @@
 #include <trx/config/registry.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/catalog/manager.h>
@@ -51,6 +52,33 @@ static void M_CreateGameWindow(void)
     Shell_EnableThemeSupport(m_Window);
 }
 
+static void M_ExitUnsupportedGraphics(void)
+{
+    char *driver = TRX_GL_Context_DescribeDriver(m_Window);
+
+#ifdef _WIN32
+    const char *const hint =
+        " Where the card is too old for that, installing "
+        "Mesa3D lets TRX draw the game without it.";
+#else
+    const char *const hint = "";
+#endif
+
+    char *message = String_Format(
+        "TRX needs OpenGL 3.3 to draw the game, and the graphics driver on "
+        "this computer does not offer it.\n"
+        "\n"
+        "Graphics driver: %s\n"
+        "\n"
+        "Installing the latest drivers for the graphics card usually helps.%s",
+        driver != nullptr ? driver : "unknown", hint);
+
+    Shell_ExitSystem(message);
+
+    Memory_FreePointer(&message);
+    Memory_FreePointer(&driver);
+}
+
 static void M_CreateGLContext(void)
 {
     if (TRX_GL_Context_GetWindowHandle() != nullptr) {
@@ -61,7 +89,7 @@ static void M_CreateGLContext(void)
     SDL_GL_SetAttribute(
         SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     if (!TRX_GL_Context_Attach(m_Window)) {
-        Shell_ExitSystem("System Error: cannot attach opengl context");
+        M_ExitUnsupportedGraphics();
     }
 }
 

--- a/src/trx/gl/context.c
+++ b/src/trx/gl/context.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/game/shell.h>
 #include <trx/game/viewport.h>
 #include <trx/gl/renderer.h>
@@ -141,6 +142,31 @@ bool TRX_GL_Context_Attach(void *window_handle)
     }
 
     return true;
+}
+
+char *TRX_GL_Context_DescribeDriver(void *const window_handle)
+{
+    SDL_GL_ResetAttributes();
+    SDL_GLContext context = SDL_GL_CreateContext(window_handle);
+    if (context == nullptr) {
+        LOG_ERROR("Can't create fallback OpenGL context: %s", SDL_GetError());
+        return nullptr;
+    }
+
+    char *result = nullptr;
+    if (SDL_GL_MakeCurrent(window_handle, context) == 0) {
+        const char *const renderer = (const char *)glGetString(GL_RENDERER);
+        const char *const version = (const char *)glGetString(GL_VERSION);
+        if (renderer != nullptr && version != nullptr) {
+            result = String_Format("%s (OpenGL %s)", renderer, version);
+        } else if (version != nullptr) {
+            result = String_Format("OpenGL %s", version);
+        }
+        SDL_GL_MakeCurrent(window_handle, nullptr);
+    }
+
+    SDL_GL_DeleteContext(context);
+    return result;
 }
 
 void TRX_GL_Context_Detach(void)

--- a/src/trx/gl/context.h
+++ b/src/trx/gl/context.h
@@ -9,6 +9,12 @@
 bool TRX_GL_Context_Attach(void *window_handle);
 void TRX_GL_Context_Detach(void);
 
+// Describes the OpenGL driver the system offers, in the shape of
+// "Mesa Intel(R) UHD Graphics (OpenGL 1.1)", by way of a throwaway context
+// asking for no particular version. Returns nullptr when even that context
+// cannot be created. The caller owns the result.
+char *TRX_GL_Context_DescribeDriver(void *window_handle);
+
 void TRX_GL_Context_SetDisplayFilter(TEXTURE_FILTER filter);
 void TRX_GL_Context_SetMultisamplingFactor(int32_t factor);
 void TRX_GL_Context_SetDithering(bool enable);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR improves startup error handling: OpenGL failures now report the detected driver/version with actionable driver or Mesa3D advice, and fatal error dialogs shown before the game window now appear centered on screen.

How it looks on my system (ignore Comic Sans please :D) – Linux, so Mesa3D advice is not shown:
<img width="1237" height="436" alt="20260810_104027_vhy" src="https://github.com/user-attachments/assets/231f1191-b6da-41ad-8b9f-809a9d3b5808" />

How it'd look for Windows users:
<img width="1327" height="359" alt="20260810_104202_jxz" src="https://github.com/user-attachments/assets/154eafc4-2211-412f-a6b4-bff147d64807" />

Resolves #5655 / TRX433.