### PR TITLE
lara/common: improve pickup embed fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added the ability for Lara to shimmy more quickly (Gameplay → Controls → Fast shimmying) (#5638)
 - Added the ability for Lara to pull up from ledges more quickly (Gameplay → Controls → Fast pull up) (#4857)
 - Improved state change handling when shimmying is requested while in the slow swing-in state on thin ledges (#5161)
+- Improved the pickup embed fix to prevent Lara becoming clamped when picking up items placed on sloped floors with low ceilings (Gameplay → Fixes → Fix pickup embed glitch) (OG bug)
 - Fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
 - Fixed Lara being teleported into the ceiling if a door shuts on the ledge she is climbing onto (Gameplay → Fixes → Wall glitch mode) (#6047)
 - Fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -794,8 +794,10 @@ void Lara_AlignPosition(const ITEM *const item, const XYZ_32 *const vec)
         const int32_t height = Room_GetHeight(sector, new_pos);
         const int32_t ceiling = Room_GetCeiling(sector, new_pos);
 
+        const int32_t lara_height =
+            Lara_GetLaraInfo()->is_crouched ? LARA_HEIGHT_CROUCH : LARA_HEIGHT;
         if (ABS(height - lara->pos.y) > STEP_L
-            || ABS(ceiling - lara->pos.y) < LARA_HEIGHT) {
+            || ABS(ceiling - height) < lara_height) {
             return;
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This improves the position alignment test for Lara to check the overall destination space rather than comparing with her current Y position, as otherwise sloped floors are not taken into account.

`/tp i97` in the [mentioned level](https://trcustoms.org/levels/3912).

Resolves TRX1013.