### PR TITLE
objects/mini_copter: exit control after destruction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -203,6 +203,7 @@
 - Fixed music triggered from one-shot switches playing more than once (OG bug)
 - Fixed the collapsible tiles in Wreck of the Maria Doria room 68 not triggering if Lara jumps over them, and fixed a missing trigger for barrels item 123
 - Fixed the lever sound playing twice in 40 Fathoms, Wreck of the Maria Doria, Living Quarters, The Deck, Tibetan Foothills and The Cold War (OG bug) (#4371)
+- Fixed the helicopter at the start of The Great Wall and The Cold War remaining visible after stopping (regression from 1.0)
 
 **TR3**
 - Changed the Hand of Rathmore in Reunion to not show pickup aids, in line with the other artefacts

--- a/src/trx/game/objects/general/mini_copter.c
+++ b/src/trx/game/objects/general/mini_copter.c
@@ -19,6 +19,7 @@ static void M_Control(const int16_t item_num)
 
     if (ABS(item->pos.z - lara_item->pos.z) > WALL_L * 30) {
         Item_Destroy(item_num);
+        return;
     }
 
     Item_Animate(item);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids updating the helicopter's room after it has been destroyed, therefore ensuring it doesn't get drawn after stopping.

Resolves TRX1002.
