### PR TITLE
output/draw: keep sprite shadows untinted

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -111,6 +111,7 @@
 - Fixed colored dynamic lights in TR1 and TR2 being drawn at the wrong brightness
 - Fixed FMVs costing frame rate at high resolutions, where every frame was resized twice on its way to the screen (#6152, #262)
 - Fixed loading and legal screens ignoring the upscaling factor and filter
+- Fixed sprite shadows tinting the ground they lie on with the water color whenever the camera is underwater (Graphic Options → Visuals → Shadows shape)
 
 **Music and sound**
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -191,6 +191,15 @@ static bool M_DrawShadow_Sprite(
     const float v_span = v_max - v_min;
     const float denom = (float)(M_SHADOW_LINE_POINTS - 1);
 
+    // The shadow subtracts what it draws, so a colored tint would take an
+    // uneven bite out of the floor and shift its hue rather than darken it.
+    // Only the coverage carries over, which is what an item's fade rides on.
+    RGBA_F tint = Output_GetTint();
+    tint.r = 1.0f;
+    tint.g = 1.0f;
+    tint.b = 1.0f;
+    Output_PushTintOverride(tint);
+
     for (int32_t row = 0; row < M_SHADOW_LINE_POINTS - 1; row++) {
         const float v0 = v_min + v_span * ((float)row / denom);
         const float v1 = v_min + v_span * ((float)(row + 1) / denom);
@@ -221,6 +230,8 @@ static bool M_DrawShadow_Sprite(
                 VERT_NO_LIGHTING | VERT_NO_WIBBLE, DRAW_BLEND_SUB);
         }
     }
+
+    Output_PopTintOverride();
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A sprite shadow now darkens the ground evenly, whatever tint is in force around it. Before this, a submerged camera put the water color on the shadow in every room, dry ones included. The shadow subtracts what it draws, so a colored tint took an uneven bite out of the floor and shifted its hue rather than darkening it.

Only the tint's coverage carries over, so an item that is fading out still takes its shadow with it.

Resolves TRX1016