### PR TITLE
lara/common: dry Lara off for the gym and demos

### DIFF
--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -181,6 +181,12 @@ void Lara_Initialise(const GF_LEVEL *const level)
     lara_info->tr3_smoke_count_r = 0;
     lara_info->mesh_pos_matrices_valid = false;
 
+    // Wetness carries from level to level within a playthrough, but the gym
+    // and the demos start one of their own.
+    if (level->type == GFL_GYM || level->type == GFL_DEMO) {
+        Lara_Dry();
+    }
+
     LOT_InitialiseLOT(&lara_info->lot);
     lara_info->lot.setup.step = WALL_L * 20;
     lara_info->lot.setup.drop = -WALL_L * 20;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The gym and the demos start Lara dry. Before this, her wetness was cleared only when a playthrough was reset, so a demo or a gym run started after a level where she had been swimming still shed droplets, and the wetness carried over even when switching mods.

Resolves TRX1018