### PR TITLE
Fix the picture breaking up during the first fade after launch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Fixed FMVs costing frame rate at high resolutions, where every frame was resized twice on its way to the screen (#6152, #262)
 - Fixed loading and legal screens ignoring the upscaling factor and filter
 - Fixed sprite shadows tinting the ground they lie on with the water color whenever the camera is underwater (Graphic Options → Visuals → Shadows shape)
+- Fixed the picture breaking up into blocks for the length of the first fade after the game is launched, on some graphics drivers (#5506)
 
 **Music and sound**
 - Added an option to keep the music playing when Lara dies (Sound Options → Misc → Play music after death) (#4221)

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -119,6 +119,10 @@ OUTPUT_UI_SHADER *Output_GetUIShader(void)
 void Output_BeginScene(void)
 {
     Output_ApplyFOV();
+    // The frame that was presented is still in the framebuffers until this
+    // point, so that a snapshot can be composited from it between frames.
+    TRX_GL_Renderer_BindGeometryFbo();
+    TRX_GL_Context_SwitchToViewport(VIEWPORT_GAME);
     TRX_GL_Context_Clear();
     TRX_GL_Track_Reset();
     TRX_GL_Context_SetWireframeMode(g_Config.rendering.enable_wireframe);

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -13,6 +13,7 @@
 #include <trx/game/game.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/objects.h>
+#include <trx/game/output/common.h>
 #include <trx/game/output/const.h>
 #include <trx/game/output/overlay.h>
 #include <trx/game/output/quad.h>
@@ -216,8 +217,7 @@ static bool M_PrepareViewportCopy(
 
 static void M_CopyFboToTexture(
     const VIEWPORT_SPACE viewport, const GLuint src_fbo,
-    const bool src_is_default_fbo, TRX_GL_TEXTURE *const texture,
-    const int32_t width, const int32_t height)
+    TRX_GL_TEXTURE *const texture, const int32_t width, const int32_t height)
 {
     if (texture == nullptr || !texture->initialized || width <= 0
         || height <= 0) {
@@ -234,25 +234,13 @@ static void M_CopyFboToTexture(
 
     GLint prev_read_fbo = 0;
     glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &prev_read_fbo);
-    GLint prev_read_buffer = 0;
-    if (src_is_default_fbo) {
-        glGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
-    }
 
     glBindFramebuffer(GL_READ_FRAMEBUFFER, src_fbo);
-    if (src_is_default_fbo) {
-        // The presented (just-swapped) frame lives in the front buffer.
-        glReadBuffer(GL_FRONT);
-    }
-
     TRX_GL_Texture_Bind(texture);
     glCopyTexSubImage2D(
         GL_TEXTURE_2D, 0, 0, 0, rect.x, rect.y, copy_width, copy_height);
 
     glBindFramebuffer(GL_READ_FRAMEBUFFER, (GLuint)prev_read_fbo);
-    if (src_is_default_fbo) {
-        glReadBuffer(prev_read_buffer);
-    }
     TRX_GL_CheckError();
 }
 
@@ -874,11 +862,13 @@ void Output_Overlay_CaptureSnapshot(void)
         return;
     }
 
-    // The presented frame includes UI/console; this captures everything
-    // that was on screen at the moment of the call.
-    M_CopyFboToTexture(
-        VIEWPORT_TARGET, 0, true, &p->snapshot.state.texture,
-        p->snapshot.state.width, p->snapshot.state.height);
+    // The scene and the UI still hold the frame the player is looking at, so
+    // it is put together a second time rather than read back from the window.
+    // A driver does not have to keep the presented pixels readable, and on
+    // Mesa with Intel graphics it did not.
+    TRX_GL_Renderer_CompositeToTexture(
+        &p->snapshot.state.texture, p->snapshot.state.width,
+        p->snapshot.state.height);
     p->snapshot.state.has_content = true;
 }
 
@@ -898,7 +888,7 @@ void Output_Overlay_CaptureGameSnapshot(void)
     }
 
     Interpolation_Disable();
-    TRX_GL_Renderer_BindGeometryFbo();
+    Output_SwitchViewport(VIEWPORT_GAME);
 
     SceneCompositor_BeginScene();
     Game_Draw(false);
@@ -906,7 +896,7 @@ void Output_Overlay_CaptureGameSnapshot(void)
     Interpolation_Enable();
 
     M_CopyFboToTexture(
-        VIEWPORT_SCENE, TRX_GL_Renderer_ResolveSceneFbo(), false,
+        VIEWPORT_SCENE, TRX_GL_Renderer_ResolveSceneFbo(),
         &p->snapshot.state.texture, p->snapshot.state.width,
         p->snapshot.state.height);
     p->snapshot.state.has_content = true;

--- a/src/trx/gl/fbo.c
+++ b/src/trx/gl/fbo.c
@@ -101,6 +101,12 @@ void TRX_GL_FBO_Init(
         LOG_ERROR("framebuffer is not complete!");
     }
 
+    // A framebuffer can be read from before anything has drawn into it: the
+    // frame a resize lands on is composited from the one before it.
+    const GLfloat black[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    glClearBufferfv(GL_COLOR, 0, black);
+    TRX_GL_CheckError();
+
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 

--- a/src/trx/gl/renderer.c
+++ b/src/trx/gl/renderer.c
@@ -41,6 +41,7 @@ typedef struct {
     TRX_GL_PROGRAM program;
     GLint loc_dither;
     GLint loc_supersample;
+    GLuint composite_fbo;
 } M_CONTEXT;
 
 static void M_Blit(const M_CONTEXT *const p, const TRX_GL_FBO *const fbo)
@@ -140,12 +141,12 @@ static void M_UpdateFBOSizes(TRX_GL_RENDERER *renderer)
     TRX_GL_FBO_ResizeIfNeeded(&p->ui_fbo, rect.width, rect.height, 1);
 }
 
-static void M_Render(TRX_GL_RENDERER *renderer)
+// Draws the scene and the UI over it into the given framebuffer. Resolving the
+// scene binds framebuffers of its own, so the destination is bound here rather
+// than by the caller.
+static void M_Composite(
+    M_CONTEXT *const p, const GLuint dst_fbo, const VIEWPORT_RECT rect)
 {
-    ASSERT(renderer != nullptr);
-    M_CONTEXT *const p = renderer->priv;
-    ASSERT(p != nullptr);
-
     const GLuint filter = p->config->display_filter == TEXTURE_FILTER_BILINEAR
         ? GL_LINEAR
         : GL_NEAREST;
@@ -153,7 +154,7 @@ static void M_Render(TRX_GL_RENDERER *renderer)
     const TRX_GL_FBO *const scene_fbo = M_ResolveScene(p);
 
     M_BindQuadState(p);
-    TRX_GL_FBO_Unbind();
+    glBindFramebuffer(GL_FRAMEBUFFER, dst_fbo);
 
     TRX_GL_Sampler_Parameteri(&p->sampler, GL_TEXTURE_MAG_FILTER, filter);
     TRX_GL_Sampler_Parameteri(&p->sampler, GL_TEXTURE_MIN_FILTER, filter);
@@ -161,7 +162,6 @@ static void M_Render(TRX_GL_RENDERER *renderer)
     TRX_GL_Program_Uniform1i(
         &p->program, p->loc_dither, p->config->enable_dithering);
 
-    VIEWPORT_RECT rect = Viewport_GetRect(VIEWPORT_TARGET);
     glViewport(rect.x, rect.y, rect.width, rect.height);
     TRX_GL_CheckError();
 
@@ -173,6 +173,15 @@ static void M_Render(TRX_GL_RENDERER *renderer)
     glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     M_Blit(p, &p->ui_fbo);
     glDisable(GL_BLEND);
+}
+
+static void M_Render(TRX_GL_RENDERER *renderer)
+{
+    ASSERT(renderer != nullptr);
+    M_CONTEXT *const p = renderer->priv;
+    ASSERT(p != nullptr);
+
+    M_Composite(p, 0, Viewport_GetRect(VIEWPORT_TARGET));
 
     if (TRX_GL_Context_GetScheduledScreenshotPath() != nullptr) {
         TRX_GL_Context_SwitchToViewport(VIEWPORT_TARGET);
@@ -182,20 +191,16 @@ static void M_Render(TRX_GL_RENDERER *renderer)
     }
 }
 
+// The framebuffers keep the frame that was just presented until the next one
+// draws over them, so that frame can be composited a second time for a
+// snapshot. Output_BeginScene is what prepares them for the next frame.
 static void M_SwapBuffers(TRX_GL_RENDERER *const renderer)
 {
-    M_CONTEXT *const p = renderer->priv;
-
     M_Render(renderer);
     SDL_GL_SwapWindow(TRX_GL_Context_GetWindowHandle());
     M_UpdateFBOSizes(renderer);
 
     TRX_GL_Context_SwitchToViewport(VIEWPORT_WINDOW);
-    TRX_GL_Context_Clear();
-
-    // Rebind geometry FBO for the next frame
-    TRX_GL_Renderer_BindGeometryFbo();
-    TRX_GL_Context_SwitchToViewport(VIEWPORT_GAME);
     TRX_GL_Context_Clear();
 }
 
@@ -268,6 +273,10 @@ static void M_Shutdown(TRX_GL_RENDERER *renderer)
     TRX_GL_FBO_Close(&p->geometry_fbo);
     TRX_GL_FBO_Close(&p->ui_fbo);
     TRX_GL_FBO_Close(&p->resolve_fbo);
+    if (p->composite_fbo != 0) {
+        glDeleteFramebuffers(1, &p->composite_fbo);
+        p->composite_fbo = 0;
+    }
     TRX_GL_Program_Close(&p->program);
     TRX_GL_Sampler_Close(&p->sampler);
     TRX_GL_Buffer_Close(&p->buffer);
@@ -300,6 +309,41 @@ void TRX_GL_Renderer_BindUiFbo(void)
 void TRX_GL_Renderer_SyncFboSizes(void)
 {
     M_UpdateFBOSizes(&g_TRX_GL_Renderer);
+}
+
+void TRX_GL_Renderer_CompositeToTexture(
+    const TRX_GL_TEXTURE *const texture, const int32_t width,
+    const int32_t height)
+{
+    M_CONTEXT *const p = (M_CONTEXT *)g_TRX_GL_Renderer.priv;
+    if (texture == nullptr || !texture->initialized || width <= 0
+        || height <= 0) {
+        return;
+    }
+
+    if (p->composite_fbo == 0) {
+        glGenFramebuffers(1, &p->composite_fbo);
+    }
+
+    GLint prev_fbo = 0;
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &prev_fbo);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, p->composite_fbo);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture->id, 0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
+        M_Composite(
+            p, p->composite_fbo,
+            (VIEWPORT_RECT) { .width = width, .height = height });
+    } else {
+        LOG_ERROR("cannot draw into the given texture");
+    }
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prev_fbo);
+    TRX_GL_Context_SwitchToViewport(TRX_GL_Context_GetViewport());
+    TRX_GL_CheckError();
 }
 
 GLuint TRX_GL_Renderer_ResolveSceneFbo(void)

--- a/src/trx/gl/renderer.h
+++ b/src/trx/gl/renderer.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <trx/gl/config.h>
+#include <trx/gl/texture.h>
 
 #include <GL/glew.h>
+#include <stdint.h>
 
 typedef struct TRX_GL_Renderer {
     void (*init)(struct TRX_GL_Renderer *renderer, const TRX_GL_CONFIG *config);
@@ -31,3 +33,10 @@ void TRX_GL_Renderer_SyncFboSizes(void);
 // with neither of them on, the geometry framebuffer already is that result and
 // is returned as is. Resolving twice in a frame costs nothing.
 GLuint TRX_GL_Renderer_ResolveSceneFbo(void);
+
+// Draw the scene and the UI over it into the given texture, the same way the
+// frame is put together for the window. Called between frames, before anything
+// has drawn over the framebuffers, this reproduces the frame the player is
+// looking at; the texture is written in full, at its own size.
+void TRX_GL_Renderer_CompositeToTexture(
+    const TRX_GL_TEXTURE *texture, int32_t width, int32_t height);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fade snapshots are now composed by drawing the scene and the UI a second time into the snapshot texture, instead of reading back the window’s front buffer. The latter is not guaranteed to remain readable after presentation and caused corruption on the first fade with Mesa on Intel. The framebuffers are cleared at the start of the next frame rather than right after the swap, which is what leaves the presented frame in them to compose from.

Resolves #5506 / TRX304