### PR TITLE
Fix clearing the gym's course records

### DIFF
--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -426,6 +426,7 @@ void Gym_TrackManager_ClearStats(const GYM_TRACK_TYPE track)
         return;
     }
     *stats = (GYM_TRACK_STATS) {};
+    Config_SectionChanged();
     Config_Update();
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Clearing the gym's course records now reports the change to the config module, so the settings file is written out. Before this, only the in-memory records were cleared, and the file kept the old times: they came back on the next launch, and the reset looked as if it had never happened.

Resolves TRX1027