### PR TITLE
Fit the passport slot list to the screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -129,6 +129,7 @@
 - Changed a setting a script is holding to be greyed out, where the row carried only the star saying who took it
 - Fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - Fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
+- Fixed the load and save game dialogs covering the rest of the screen at larger text scales, where the list now shows as many slots as there is room for (#6175)
 
 **Saves and settings**
 - Changed the save crystals option to a mode: crystals can save on the spot, be collected to save from the inventory as on PS1 TR3, heal, or be collectibles (Gameplay → General → Crystal mode) (#5939, #5940)

--- a/src/trx/game/ui/dialogs/base_passport.c
+++ b/src/trx/game/ui/dialogs/base_passport.c
@@ -1,52 +1,72 @@
 #include <trx/game/ui/dialogs/base_passport.h>
 
+#include <trx/core/utils.h>
 #include <trx/game/inventory.h>
 #include <trx/game/inventory_ring/vars.h>
 #include <trx/game/ui/elements/modal.h>
 #include <trx/game/ui/elements/requester.h>
 #include <trx/game/ui/elements/resize.h>
+#include <trx/game/ui/hud/overlay.h>
 #include <trx/game/ui/scaler.h>
-#include <trx/game/viewport.h>
 #include <trx/version.h>
 
-static int32_t M_GetVisibleRows(void)
+// A list shorter than this is awkward to browse, so a dialog that cannot fit
+// this many rows is drawn smaller instead of losing further rows.
+#define M_MIN_VISIBLE_ROWS 5
+
+// As many rows as the originals show, however much room a large screen leaves.
+#define M_MAX_VISIBLE_ROWS 10
+
+static float M_GetAvailableHeight(void)
 {
-    if (g_TRVersion >= 2) {
-        return 10;
-    } else {
-        const int32_t res_h = UI_Scaler_CalcInverse(
-            Viewport_GetHeight(VIEWPORT_UI), UI_SCALER_TARGET_TEXT);
-        if (res_h <= 240) {
-            return 5;
-        } else if (res_h <= 384) {
-            return 7;
-        } else if (res_h <= 480) {
-            return 10;
-        } else {
-            return 12;
-        }
+    // The ring writes its heading above the dialog and the name of the page
+    // below it, and the dialog belongs between the two.
+    return UI_GetCanvasHeight() / UI_Scaler_GetTextScale()
+        - 2.0f * UI_Overlay_GetTextInset();
+}
+
+static int32_t M_GetVisibleRows(const UI_REQUESTER_STATE *const req)
+{
+    int32_t rows = UI_Requester_GetRowsForHeight(
+        req, M_GetAvailableHeight() - req->footer_height);
+    CLAMP(rows, M_MIN_VISIBLE_ROWS, M_MAX_VISIBLE_ROWS);
+    return rows;
+}
+
+static float M_GetFitScale(const UI_REQUESTER_STATE *const req)
+{
+    const float natural_height =
+        UI_Requester_GetHeight(req, req->scroll.vis_items) + req->footer_height;
+    const float available = M_GetAvailableHeight();
+    if (natural_height <= available || natural_height <= 0.0f) {
+        return 1.0f;
     }
+    return available / natural_height;
 }
 
 void UI_BasePassportDialog_Init(
-    UI_REQUESTER_STATE *const req, const size_t max_rows)
+    UI_REQUESTER_STATE *const req, const size_t max_rows,
+    const float footer_height)
 {
-    UI_Requester_Init(req, M_GetVisibleRows(), max_rows, true);
+    UI_Requester_Init(req, 0, max_rows, true);
     req->row_pad = 4.0f;
     req->row_spacing = g_TRVersion == 1 ? 2.0f : 3.0f;
     req->show_arrows = g_TRVersion == 1;
     req->reserve_space = true;
+    req->footer_height = footer_height;
+    UI_BasePassportDialog_Control(req);
 }
 
 void UI_BasePassportDialog_Control(UI_REQUESTER_STATE *const req)
 {
-    UI_Requester_SetVisibleRows(req, M_GetVisibleRows());
+    UI_Requester_SetVisibleRows(req, M_GetVisibleRows(req));
 }
 
-void UI_BeginBasePassportDialog(void)
+void UI_BeginBasePassportDialog(const UI_REQUESTER_STATE *const req)
 {
     const float modal_y = g_InvRing_Mode == INV_TITLE_MODE ? 0.81f : 0.62f;
-    UI_BeginModal(0.5f, modal_y);
+    UI_BeginModalEx(0.5f, modal_y, UI_Overlay_GetTextInset());
+    UI_Scaler_PushTextScale(M_GetFitScale(req));
     UI_BeginResizeEx((UI_RESIZE_SETTINGS) {
         .w = 300.0f,
         .h = -1.0f,
@@ -57,5 +77,6 @@ void UI_BeginBasePassportDialog(void)
 void UI_EndBasePassportDialog(void)
 {
     UI_EndResize();
+    UI_Scaler_PopTextScale();
     UI_EndModal();
 }

--- a/src/trx/game/ui/dialogs/base_passport.h
+++ b/src/trx/game/ui/dialogs/base_passport.h
@@ -8,9 +8,14 @@
 #include <trx/game/ui/elements/requester.h>
 
 // state functions
-void UI_BasePassportDialog_Init(UI_REQUESTER_STATE *req, size_t max_rows);
+
+// Sets the requester up for the passport, sizing its list to the room the
+// screen leaves. footer_height is what the dialog draws under the list, if
+// anything, so that the rows make way for it.
+void UI_BasePassportDialog_Init(
+    UI_REQUESTER_STATE *req, size_t max_rows, float footer_height);
 void UI_BasePassportDialog_Control(UI_REQUESTER_STATE *req);
 
 // draw functions
-void UI_BeginBasePassportDialog(void);
+void UI_BeginBasePassportDialog(const UI_REQUESTER_STATE *req);
 void UI_EndBasePassportDialog(void);

--- a/src/trx/game/ui/dialogs/play_any_level.c
+++ b/src/trx/game/ui/dialogs/play_any_level.c
@@ -40,7 +40,7 @@ UI_PLAY_ANY_LEVEL_DIALOG_STATE *UI_PlayAnyLevelDialog_Init(void)
         }
     }
 
-    UI_BasePassportDialog_Init(&s->req, s->rows->count);
+    UI_BasePassportDialog_Init(&s->req, s->rows->count, 0.0f);
     return s;
 }
 
@@ -67,7 +67,7 @@ int32_t UI_PlayAnyLevelDialog_Control(UI_PLAY_ANY_LEVEL_DIALOG_STATE *const s)
 
 void UI_PlayAnyLevelDialog(UI_PLAY_ANY_LEVEL_DIALOG_STATE *const s)
 {
-    UI_BeginBasePassportDialog();
+    UI_BeginBasePassportDialog(&s->req);
     UI_BeginRequester(&s->req, GS("general/passport/select_level"));
 
     for (int32_t i = 0; i < s->rows->count; i++) {

--- a/src/trx/game/ui/dialogs/save_slot.c
+++ b/src/trx/game/ui/dialogs/save_slot.c
@@ -27,6 +27,7 @@
 #include <trx/version.h>
 
 #define M_IMMEDIATE (g_TRVersion >= 2)
+#define M_FOOTER_SPACING 3.0f
 
 typedef enum {
     M_PHASE_BROWSE,
@@ -49,6 +50,12 @@ static const GAME_STRING_ID m_DeleteConfirmOptions[2] = {
     GS_ID("general/passport/delete_save_yes"),
     GS_ID("general/passport/delete_save_no"),
 };
+
+// The delete button under the list, and the gap above it.
+static float M_GetFooterHeight(void)
+{
+    return M_FOOTER_SPACING + UI_ProgressButton_GetHeight();
+}
 
 static void M_NonEmptySlot(
     const UI_SAVE_SLOT_DIALOG_STATE *const s, const SAVEGAME_SLOT_REF slot,
@@ -176,7 +183,7 @@ static void M_RebuildRows(
     UI_Requester_Free(&s->req);
     Memory_FreePointer(&s->rows);
     M_BuildRows(s);
-    UI_BasePassportDialog_Init(&s->req, s->row_count);
+    UI_BasePassportDialog_Init(&s->req, s->row_count, M_GetFooterHeight());
     CLAMP(selected_row, 0, s->row_count - 1);
     UI_Requester_SelectRow(&s->req, selected_row);
 }
@@ -236,7 +243,7 @@ UI_SAVE_SLOT_DIALOG_STATE *UI_SaveSlotDialog_Init(
             }
         }
     }
-    UI_BasePassportDialog_Init(&s->req, s->row_count);
+    UI_BasePassportDialog_Init(&s->req, s->row_count, M_GetFooterHeight());
     UI_Requester_SelectRow(&s->req, initial_row);
     s->last_selected_row = initial_row;
     M_ResetDeleteButton(s);
@@ -339,7 +346,7 @@ void UI_SaveSlotDialog(const UI_SAVE_SLOT_DIALOG_STATE *const s)
         M_MapRowToSlot(s, UI_Requester_GetCurrentRow(&s->req));
     const bool can_delete = M_IsSlotDeletable(selected_slot);
 
-    UI_BeginBasePassportDialog();
+    UI_BeginBasePassportDialog(&s->req);
     const char *title = nullptr;
     switch (s->type) {
     case UI_SAVE_SLOT_DIALOG_SAVE_GAME:
@@ -356,7 +363,7 @@ void UI_SaveSlotDialog(const UI_SAVE_SLOT_DIALOG_STATE *const s)
     UI_BeginStackEx((UI_STACK_SETTINGS) {
         .orientation = UI_STACK_VERTICAL,
         .align = { .h = UI_STACK_H_ALIGN_SPAN },
-        .spacing = { .v = 3.0f },
+        .spacing = { .v = M_FOOTER_SPACING },
     });
     UI_BeginRequester(&s->req, title);
 

--- a/src/trx/game/ui/dialogs/select_level.c
+++ b/src/trx/game/ui/dialogs/select_level.c
@@ -56,7 +56,7 @@ UI_SELECT_LEVEL_DIALOG_STATE *UI_SelectLevelDialog_Init(
         }
     }
 
-    UI_BasePassportDialog_Init(&s->req, s->rows->count);
+    UI_BasePassportDialog_Init(&s->req, s->rows->count, 0.0f);
     return s;
 }
 
@@ -80,7 +80,7 @@ int32_t UI_SelectLevelDialog_Control(UI_SELECT_LEVEL_DIALOG_STATE *const s)
 
 void UI_SelectLevelDialog(UI_SELECT_LEVEL_DIALOG_STATE *const s)
 {
-    UI_BeginBasePassportDialog();
+    UI_BeginBasePassportDialog(&s->req);
     UI_BeginRequester(&s->req, GS("general/passport/select_level"));
 
     const SAVEGAME_INFO *info = SG_Manager_GetSavegameInfo(s->save_slot);

--- a/src/trx/game/ui/dialogs/switch_mod.c
+++ b/src/trx/game/ui/dialogs/switch_mod.c
@@ -40,7 +40,7 @@ UI_SWITCH_MOD_DIALOG_STATE *UI_SwitchModDialog_Init(void)
             s->rows, &(M_ROW) { .name = mod->name, .title = mod->title });
     }
 
-    UI_BasePassportDialog_Init(&s->req, s->rows->count);
+    UI_BasePassportDialog_Init(&s->req, s->rows->count, 0.0f);
     UI_Requester_SelectRow(&s->req, current_row);
     return s;
 }
@@ -70,7 +70,7 @@ const char *UI_SwitchModDialog_GetSelectedMod(
 
 void UI_SwitchModDialog(UI_SWITCH_MOD_DIALOG_STATE *const s)
 {
-    UI_BeginBasePassportDialog();
+    UI_BeginBasePassportDialog(&s->req);
     UI_BeginRequester(&s->req, GS("general/passport/select_mod"));
 
     for (int32_t i = 0; i < s->rows->count; i++) {

--- a/src/trx/game/ui/elements/modal.c
+++ b/src/trx/game/ui/elements/modal.c
@@ -2,6 +2,7 @@
 
 #include <trx/game/ui/draw.h>
 #include <trx/game/ui/elements/anchor.h>
+#include <trx/game/ui/elements/pad.h>
 #include <trx/game/ui/helpers.h>
 
 static void M_Measure(UI_NODE *const node)
@@ -17,6 +18,11 @@ static void M_Draw(const UI_NODE *const node)
 
 void UI_BeginModal(const float x, const float y)
 {
+    UI_BeginModalEx(x, y, 0.0f);
+}
+
+void UI_BeginModalEx(const float x, const float y, const float inset_v)
+{
     UI_NODE *const node = UI_AllocNode(
         &(UI_WIDGET_OPS) {
             .measure = M_Measure,
@@ -26,11 +32,13 @@ void UI_BeginModal(const float x, const float y)
         0);
     UI_AddChild(node);
     UI_PushCurrent(node);
+    UI_BeginPad(0.0f, inset_v);
     UI_BeginAnchor(x, y);
 }
 
 void UI_EndModal(void)
 {
     UI_EndAnchor();
+    UI_EndPad();
     UI_PopCurrent();
 }

--- a/src/trx/game/ui/elements/modal.h
+++ b/src/trx/game/ui/elements/modal.h
@@ -6,4 +6,10 @@
 // and places it at a specific proportional spot.
 
 void UI_BeginModal(float x, float y);
+
+// A modal that keeps the given height clear at the top and the bottom of the
+// canvas, so that what it places lands within what is left rather than over
+// whatever else is drawn at the screen edges.
+void UI_BeginModalEx(float x, float y, float inset_v);
+
 void UI_EndModal(void);

--- a/src/trx/game/ui/elements/progress_button.c
+++ b/src/trx/game/ui/elements/progress_button.c
@@ -9,6 +9,10 @@
 #include <trx/game/ui/elements/sleek_bar.h>
 #include <trx/game/ui/elements/stack.h>
 
+#define M_TEXT_SCALE 0.85f
+#define M_PAD_X 6.0f
+#define M_PAD_Y 3.0f
+#define M_SPACING 2.0f
 #define M_HOLD_TIMER_DEBUFF (LOGIC_FPS / 3)
 #define M_HOLD_TIMER_MAX LOGIC_FPS
 
@@ -58,7 +62,6 @@ void UI_ProgressButton_Free(UI_PROGRESS_BUTTON_STATE *s)
 
 void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
 {
-    const float scale = 0.85f;
     const char *const key_name =
         Input_GetKeyName(s->backend, INPUT_LAYOUT_DEFAULT, s->role, 0);
     if (key_name == nullptr) {
@@ -69,12 +72,10 @@ void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
     const char *const text =
         String_FormatStatic("%s: %s", GameString_Get(s->text), value_label);
 
-    const float pad[2] = { 6.0f, 3.0f };
-    const float spacing = 2.0f;
     const float progress =
         (s->hold_timer - M_HOLD_TIMER_DEBUFF) / (float)M_HOLD_TIMER_MAX;
 
-    UI_BeginPad(pad[0], pad[1]);
+    UI_BeginPad(M_PAD_X, M_PAD_Y);
     UI_BeginStackEx((UI_STACK_SETTINGS) {
         .orientation = UI_STACK_VERTICAL,
         .align = {
@@ -83,13 +84,19 @@ void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
         },
         .spacing = {
             .h = 0.0f,
-            .v = spacing,
+            .v = M_SPACING,
         },
     });
-    UI_LabelEx(text, (UI_LABEL_SETTINGS) { .scale = scale });
+    UI_LabelEx(text, (UI_LABEL_SETTINGS) { .scale = M_TEXT_SCALE });
     UI_BeginHide(progress < 0.0f);
     UI_SleekBar(progress);
     UI_EndHide();
     UI_EndStack();
     UI_EndPad();
+}
+
+float UI_ProgressButton_GetHeight(void)
+{
+    return 2.0f * M_PAD_Y + M_TEXT_SCALE * UI_TEXT_HEIGHT + M_SPACING
+        + UI_SLEEK_BAR_HEIGHT;
 }

--- a/src/trx/game/ui/elements/progress_button.h
+++ b/src/trx/game/ui/elements/progress_button.h
@@ -15,3 +15,7 @@ void UI_ProgressButton_Control(UI_PROGRESS_BUTTON_STATE *s);
 void UI_ProgressButton_Free(UI_PROGRESS_BUTTON_STATE *s);
 
 void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *s);
+
+// The height the button takes, so that a dialog placing one under its content
+// can leave room for it.
+float UI_ProgressButton_GetHeight(void);

--- a/src/trx/game/ui/elements/requester.c
+++ b/src/trx/game/ui/elements/requester.c
@@ -6,6 +6,26 @@
 #include <trx/game/ui.h>
 #include <trx/version.h>
 
+static UI_WINDOW_SETTINGS M_GetWindowSettings(
+    const UI_REQUESTER_STATE *const s, const char *const title)
+{
+    const bool show_scroll_hints =
+        s->show_arrows && s->scroll.vis_items < s->scroll.max_items;
+    return (UI_WINDOW_SETTINGS) {
+        .title = title,
+        .scrollable = show_scroll_hints ? &s->scroll : nullptr,
+        .title_spacing = -1.0f,
+    };
+}
+
+static float M_GetChromeHeight(const UI_REQUESTER_STATE *const s)
+{
+    // A window's height follows whether it has a title, not what the title
+    // says, so any non-empty one measures the same.
+    const UI_WINDOW_SETTINGS settings = M_GetWindowSettings(s, "");
+    return UI_Window_GetChromeHeight(&settings);
+}
+
 void UI_Requester_Init(
     UI_REQUESTER_STATE *const s, const int32_t vis_rows, const int32_t max_rows,
     const bool is_selectable)
@@ -97,16 +117,25 @@ void UI_Requester_SelectRow(UI_REQUESTER_STATE *const s, const int32_t i)
     UI_Scrollable_SelectItem(&s->scroll, i);
 }
 
+float UI_Requester_GetHeight(
+    const UI_REQUESTER_STATE *const s, const int32_t rows)
+{
+    return M_GetChromeHeight(s) + rows * UI_TEXT_HEIGHT
+        + (rows - 1) * s->row_spacing;
+}
+
+int32_t UI_Requester_GetRowsForHeight(
+    const UI_REQUESTER_STATE *const s, const float height)
+{
+    const float rows_height = height - M_GetChromeHeight(s) + s->row_spacing;
+    const int32_t rows = rows_height / (UI_TEXT_HEIGHT + s->row_spacing);
+    return MAX(rows, 1);
+}
+
 void UI_BeginRequester(
     const UI_REQUESTER_STATE *const s, const char *const title)
 {
-    const bool show_scroll_hints =
-        s->show_arrows && s->scroll.vis_items < s->scroll.max_items;
-    UI_BeginWindow((UI_WINDOW_SETTINGS) {
-        .title = title,
-        .scrollable = show_scroll_hints ? &s->scroll : nullptr,
-        .title_spacing = -1.0f,
-    });
+    UI_BeginWindow(M_GetWindowSettings(s, title));
     if (s->reserve_space) {
         UI_BeginResize(
             -1.0f,

--- a/src/trx/game/ui/elements/requester.h
+++ b/src/trx/game/ui/elements/requester.h
@@ -17,6 +17,9 @@ typedef struct {
     float row_spacing;
     bool show_arrows;
     bool reserve_space;
+    // Height the dialog around the requester keeps for itself, such as a
+    // button under the list.
+    float footer_height;
 } UI_REQUESTER_STATE;
 
 // state functions
@@ -33,6 +36,14 @@ int32_t UI_Requester_GetLastRow(const UI_REQUESTER_STATE *s);
 int32_t UI_Requester_GetCurrentRow(const UI_REQUESTER_STATE *s);
 bool UI_Requester_IsRowVisible(const UI_REQUESTER_STATE *s, int32_t i);
 bool UI_Requester_IsRowSelected(const UI_REQUESTER_STATE *s, int32_t i);
+
+// The height the requester takes with the given number of rows: the rows
+// themselves, the spacing between them, and the window around them.
+float UI_Requester_GetHeight(const UI_REQUESTER_STATE *s, int32_t rows);
+
+// The reverse: how many rows fit in the given height, never fewer than one.
+int32_t UI_Requester_GetRowsForHeight(
+    const UI_REQUESTER_STATE *s, float height);
 
 // draw functions
 void UI_BeginRequester(const UI_REQUESTER_STATE *s, const char *title);

--- a/src/trx/game/ui/elements/sleek_bar.c
+++ b/src/trx/game/ui/elements/sleek_bar.c
@@ -27,7 +27,7 @@ static RGBA_8888 m_FillColors[TR_VERSION_COUNT] = {
 static void M_Measure(UI_NODE *const node)
 {
     node->measure_w = 0.0f;
-    node->measure_h = 4.0f * UI_Scaler_GetTextScale();
+    node->measure_h = UI_SLEEK_BAR_HEIGHT * UI_Scaler_GetTextScale();
 }
 
 static void M_Draw(const UI_NODE *const node)

--- a/src/trx/game/ui/elements/sleek_bar.h
+++ b/src/trx/game/ui/elements/sleek_bar.h
@@ -2,4 +2,6 @@
 
 #include <stdint.h>
 
+#define UI_SLEEK_BAR_HEIGHT 4.0f
+
 void UI_SleekBar(float progress);

--- a/src/trx/game/ui/elements/window.c
+++ b/src/trx/game/ui/elements/window.c
@@ -5,6 +5,8 @@
 #include <trx/game/ui.h>
 #include <trx/version.h>
 
+#define M_SCROLL_HINT_HEIGHT 7.0f
+
 typedef struct {
     UI_WINDOW_SETTINGS settings;
     bool show_scroll_hints;
@@ -37,6 +39,11 @@ static float M_GetBodyPadY(void)
     return 4.0f;
 }
 
+static float M_GetTitlePadY(void)
+{
+    return g_TRVersion >= 2 ? 1.0f : 2.0f;
+}
+
 static float M_GetTitleSpacing(const UI_WINDOW_SETTINGS *const settings)
 {
     if (settings->title_spacing >= 0.0f) {
@@ -49,7 +56,7 @@ static void M_ScrollHintRow(
     const UI_WINDOW_SETTINGS *const settings, const bool show_arrow,
     const bool up)
 {
-    UI_BeginResize(-1.0f, 7.0f);
+    UI_BeginResize(-1.0f, M_SCROLL_HINT_HEIGHT);
     UI_BeginAnchor(0.5f, up ? 1.5f : -1.0f);
     if (show_arrow) {
         UI_LabelEx(
@@ -63,7 +70,7 @@ static void M_ScrollHintRow(
 static void M_Title(const char *const title)
 {
     UI_BeginFrame(UI_FRAME_DIALOG_HEADING);
-    UI_BeginPad(10.0f, g_TRVersion >= 2 ? 1.0f : 2.0f);
+    UI_BeginPad(10.0f, M_GetTitlePadY());
     UI_BeginAnchor(0.5f, 0.5f);
     UI_Label(title);
     UI_EndAnchor();
@@ -74,6 +81,19 @@ static void M_Title(const char *const title)
 float UI_Window_GetChromeWidth(void)
 {
     return 2.0f * (M_GetOuterPad() + M_GetBodyPadX());
+}
+
+float UI_Window_GetChromeHeight(const UI_WINDOW_SETTINGS *const settings)
+{
+    float result = 2.0f * (M_GetOuterPad() + M_GetBodyPadY());
+    if (settings->title != nullptr) {
+        result += UI_TEXT_HEIGHT + 2.0f * M_GetTitlePadY()
+            + M_GetTitleSpacing(settings);
+    }
+    if (M_ShouldShowScrollHints(settings)) {
+        result += 2.0f * M_SCROLL_HINT_HEIGHT;
+    }
+    return result;
 }
 
 void UI_BeginWindow(UI_WINDOW_SETTINGS settings)

--- a/src/trx/game/ui/elements/window.h
+++ b/src/trx/game/ui/elements/window.h
@@ -21,3 +21,8 @@ void UI_EndWindow(void);
 // The horizontal space a window spends on its own frame and padding, in the
 // units a caller sizes its content in.
 float UI_Window_GetChromeWidth(void);
+
+// The vertical space a window spends on its own frame, padding, title and
+// scroll hints. What a header or footer function draws is the caller's, and is
+// not counted here.
+float UI_Window_GetChromeHeight(const UI_WINDOW_SETTINGS *settings);

--- a/src/trx/game/ui/hud/overlay.c
+++ b/src/trx/game/ui/hud/overlay.c
@@ -14,6 +14,9 @@
 #include <trx/game/ui/scaler.h>
 #include <trx/version.h>
 
+#define M_REGION_PAD_X 20.0f
+#define M_REGION_PAD_Y 14.0f
+
 typedef struct UI_OVERLAY_STATE {
     struct {
         bool state;
@@ -464,7 +467,7 @@ void UI_BeginOverlayRegion(const float x, const float y)
         UI_STACK_H_ALIGN_CENTER;
     // clang-format on
     UI_BeginModal(x, y);
-    UI_BeginPad(20.0f, 14.0f);
+    UI_BeginPad(M_REGION_PAD_X, M_REGION_PAD_Y);
     UI_BeginStackEx((UI_STACK_SETTINGS) {
         .orientation = UI_STACK_VERTICAL,
         .align = { .h = h_align },
@@ -477,6 +480,11 @@ void UI_EndOverlayRegion(void)
     UI_EndStack();
     UI_EndPad();
     UI_EndModal();
+}
+
+float UI_Overlay_GetTextInset(void)
+{
+    return M_REGION_PAD_Y + UI_TEXT_HEIGHT;
 }
 
 void UI_Overlay_ShowArrow(

--- a/src/trx/game/ui/hud/overlay.h
+++ b/src/trx/game/ui/hud/overlay.h
@@ -45,6 +45,11 @@ void UI_Overlay(UI_OVERLAY_STATE *s);
 void UI_BeginOverlayRegion(float x, float y);
 void UI_EndOverlayRegion(void);
 
+// How far a region's text reaches into the screen from the edge it sits at:
+// one line of text and the padding above it. A dialog that must not run into
+// the heading or the item name keeps this much clear at the top and bottom.
+float UI_Overlay_GetTextInset(void);
+
 void UI_Overlay_ForceHealthBar(UI_OVERLAY_STATE *s, bool show);
 void UI_Overlay_ShowArrow(
     UI_OVERLAY_STATE *s, UI_OVERLAY_ARROW arrow, bool show);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The passport dialogs now size their list to the room the screen has, keeping clear of the heading and the page name the ring writes at the edges, up to the ten slots the originals show. Before this, the row count came from a table of screen heights that took no account of the dialog's title, scroll hints or delete button, so at 200% the load and save game dialogs grew over the text around them.

The dialog works from a height budget rather than a table:

- `UI_Overlay_GetTextInset` reserves space for edge text.
- `UI_Window_GetChromeHeight` reports frame, padding, title, and scroll-hint height.
- `UI_Requester_GetHeight` / `UI_Requester_GetRowsForHeight` convert between requester height and row count.
- `UI_ProgressButton_GetHeight` reserves space for the delete button.

TR1 now caps at ten rows at every window size instead of showing twelve on taller windows.

Resolves #6175 / TRX1025