### PR TITLE
input: keep a skip key out of the option ring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Changed boxes of ammunition in the inventory to always show what Lara is really carrying, where finishing a level could round them down
 - Fixed Lara being able to light a free/ghost flare by selecting one from the inventory while crawling (Gameplay → Fixes → Fix free flare glitch)
 - Fixed the inventory ring being cut off at the sides when the game window is taller than it is wide (#4278)
+- Fixed the key that skips a cutscene or a flyby sequence also opening the inventory ring behind it
 - Fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - Fixed the inventory hint for using an item showing Enter rather than the key bound to Action (regression from 1.8.1)
 - Fixed Lara being able to collect plinth pickups while ducked (regression from 1.9)

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -389,6 +389,7 @@ GF_COMMAND Cutscene_Control(void)
     Input_Update();
     Shell_ProcessInput();
     if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
+        Input_HoldOffSkip();
         return (GF_COMMAND) { .action = GF_LEVEL_COMPLETE };
     } else if (g_InputDB.pause) {
         const GF_COMMAND gf_cmd = GF_PauseGame();

--- a/src/trx/game/flyby_mode.c
+++ b/src/trx/game/flyby_mode.c
@@ -66,6 +66,7 @@ void FlybyMode_PreControl(void)
     if (g_InputDB.option && g_Config.gameplay.enable_cinematic_skips) {
         if (FlybyMode_Cancel()) {
             g_InputDB.option = false;
+            Input_HoldOffSkip();
         }
         return;
     }

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -30,6 +30,15 @@ extern INPUT_STATE g_OldInputDB;
 
 void Input_Update(void);
 
+// Ignores the given role until the player lets go of it. Whatever acted on the
+// press keeps it: it reads as unpressed everywhere else, and does not debounce
+// again while the key is down.
+void Input_HoldOffRole(INPUT_ROLE role);
+
+// Ignores every role a scene can be skipped with until the player lets go, so
+// the press that ended the scene does not open the ring behind it.
+void Input_HoldOffSkip(void);
+
 // Reconciles the connected devices with the current configuration: enabled
 // backends acquire the hardware that is present, disabled ones release it.
 void Input_Discover(void);

--- a/src/trx/game/input/update.c
+++ b/src/trx/game/input/update.c
@@ -16,6 +16,8 @@
 
 static int32_t m_LookFrames = 0;
 static bool m_IsLookHeld = false;
+static INPUT_STATE m_HoldOff = {};
+static INPUT_STATE m_HoldOffLinger = {};
 
 static void M_UpdateFromBackend(
     INPUT_STATE *const s, const INPUT_BACKEND_IMPL *const backend,
@@ -60,6 +62,18 @@ static void M_UpdateTargetChange(void)
     g_Input.look = m_IsLookHeld;
 }
 
+void Input_HoldOffRole(const INPUT_ROLE role)
+{
+    InputState_SetRole(&m_HoldOff, role, true);
+}
+
+void Input_HoldOffSkip(void)
+{
+    Input_HoldOffRole(INPUT_ROLE_INVENTORY);
+    Input_HoldOffRole(INPUT_ROLE_MENU_BACK);
+    Input_HoldOffRole(INPUT_ROLE_MENU_CONFIRM);
+}
+
 void Input_Update(void)
 {
     InputState_Clear(&g_Input);
@@ -83,6 +97,9 @@ void Input_Update(void)
         Input_GetBackendImpl(backend)->resolve_combos(
             g_Config.input.layout[backend], &g_Input);
     }
+
+    // What the devices say, before the game has its way with it.
+    const INPUT_STATE raw = g_Input;
 
     g_Input.camera_reset |= g_Input.look;
     g_Input.menu_up |= g_Input.forward;
@@ -117,6 +134,16 @@ void Input_Update(void)
     }
 
     M_UpdateTargetChange();
+
+    for (int32_t i = 0; i < INPUT_STATE_ANY_WORDS; i++) {
+        // Read from the device, not from g_Input: a scene suppresses the
+        // option role while it plays. The grace update covers the keyboard
+        // firing a deferred combination key once it comes up.
+        const uint64_t held = m_HoldOff.any[i] & raw.any[i];
+        g_Input.any[i] &= ~(m_HoldOff.any[i] | m_HoldOffLinger.any[i]);
+        m_HoldOffLinger.any[i] = m_HoldOff.any[i] & ~held;
+        m_HoldOff.any[i] = held;
+    }
 
     g_InputDB = Input_GetDebounced(g_Input);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A scene hides the option role from the debounce while it plays, so the press that skipped it opened the ring behind it.
This uses a new API orthogonal to `g_OldInputDB` which I believe is much more readable.