### PR TITLE
replay: let a recording skip ahead

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -171,6 +171,9 @@
 - Fixed the `/cutscene` and `/demo` console commands playing the one after the number they were given
 - Fixed the `/play` console command starting the playthrough over only on the gym, so the rules and how wet Lara was carried over from the last run
 
+**Recordings**
+- Added `skip start` and `skip end` events to recordings, which stop the drawing while the frames keep running, so a stretch passes as fast as the machine manages
+
 **Installer and mods**
 - Changed the installer to explain when it cannot download the files it needs, and to offer to try again (#6052)
 - Fixed mesh debug spheres not rendering after switching mods (regression from 1.5)

--- a/src/trx/game/clock/common.c
+++ b/src/trx/game/clock/common.c
@@ -63,6 +63,11 @@ void Clock_DisableWait(void)
     m_Disabled = true;
 }
 
+void Clock_EnableWait(void)
+{
+    m_Disabled = false;
+}
+
 void Clock_EnableHeadlessFixedFPS(int32_t fps)
 {
     if (fps <= 0) {

--- a/src/trx/game/clock/common.h
+++ b/src/trx/game/clock/common.h
@@ -6,6 +6,9 @@
 // Disables any kind of waiting in Clock_WaitTick
 void Clock_DisableWait(void);
 
+// Restores the waiting Clock_DisableWait turned off.
+void Clock_EnableWait(void);
+
 // In headless mode, simulate a fixed FPS (seconds per frame = 1/fps)
 void Clock_EnableHeadlessFixedFPS(int32_t fps);
 

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -71,6 +71,7 @@ typedef struct {
     int32_t frame_idx; // Current playback frame index
     int32_t next_frame_idx; // Next frame to process
     bool replay_quiet;
+    bool skipping; // a skip stretch has the drawing off
     struct {
         bool seen;
         bool quiet_applied;
@@ -105,6 +106,8 @@ static bool M_ParseNoopEvent(const char *event_str);
 static bool M_ParseLuaEvent(const char *event_str);
 static bool M_ParseTestCaseEvent(const char *event_str);
 static bool M_ParseExpectEvent(const char *event_str);
+static bool M_ParseSkipStartEvent(const char *event_str);
+static bool M_ParseSkipEndEvent(const char *event_str);
 
 // Header parsers
 static bool M_ParseSeedControl(const char *line, M_PARSE_CTX *ctx);
@@ -123,11 +126,10 @@ static const M_HEADER_HANDLER m_HeaderHandlers[] = {
 };
 
 static const M_EVENT_HANDLER m_EventHandlers[] = {
-    M_ParseQuitEvent,   M_ParseTestCaseEvent,
-    M_ParseExpectEvent, M_ParseKeyDownEvent,
-    M_ParseKeyUpEvent,  M_ParseTextInputEvent,
-    M_ParseNoopEvent,   M_ParseCommandEvent,
-    M_ParseLuaEvent,    nullptr,
+    M_ParseQuitEvent,      M_ParseTestCaseEvent, M_ParseExpectEvent,
+    M_ParseKeyDownEvent,   M_ParseKeyUpEvent,    M_ParseTextInputEvent,
+    M_ParseNoopEvent,      M_ParseCommandEvent,  M_ParseLuaEvent,
+    M_ParseSkipStartEvent, M_ParseSkipEndEvent,  nullptr,
 };
 
 static inline M_PARSE_CTX M_ParseCtxInit(void)
@@ -525,6 +527,39 @@ static bool M_ParseNoopEvent(const char *const event_str)
     if (strncmp(event_str, "noop", 4) != 0) {
         return false;
     }
+    return true;
+}
+
+static void M_StopSkipping(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (!p->skipping) {
+        return;
+    }
+    p->skipping = false;
+    Shell_SetHeadless(false);
+}
+
+static bool M_ParseSkipStartEvent(const char *const event_str)
+{
+    if (strcmp(event_str, "skip start") != 0) {
+        return false;
+    }
+    M_PRIV *const p = &m_Priv;
+    // A run already told to draw nothing must not start drawing at skip end.
+    if (!p->skipping && !Shell_GetArgs()->headless) {
+        p->skipping = true;
+        Shell_SetHeadless(true);
+    }
+    return true;
+}
+
+static bool M_ParseSkipEndEvent(const char *const event_str)
+{
+    if (strcmp(event_str, "skip end") != 0) {
+        return false;
+    }
+    M_StopSkipping();
     return true;
 }
 
@@ -1169,6 +1204,7 @@ void TestReplay_Close(void)
 {
     M_PRIV *const p = &m_Priv;
     M_TestReportSummary();
+    M_StopSkipping();
 
     if (p->test_mode.quiet_applied) {
         Log_SetMinLevel(p->test_mode.log_level_before_quiet);

--- a/src/trx/game/shell/common.h
+++ b/src/trx/game/shell/common.h
@@ -32,6 +32,9 @@ bool Shell_GetPrevHeadless(void);
 bool Shell_GetPrevQuiet(void);
 const SHELL_ARGS *Shell_GetArgs(void);
 
+// Stop or resume drawing the game while it keeps running its logic frames.
+void Shell_SetHeadless(bool headless);
+
 bool Shell_IsFullscreen(void);
 SHELL_SIZE Shell_GetDefaultSize(void);
 SHELL_SIZE Shell_GetWindowSize(void);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -6,6 +6,7 @@
 #include <trx/core/subsystem.h>
 #include <trx/debug.h>
 #include <trx/game/catalog/manager.h>
+#include <trx/game/clock.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_strings/manager.h>
 #include <trx/game/lua.h>
@@ -287,6 +288,24 @@ const SHELL_ARGS *Shell_GetArgs(void)
 {
     ASSERT(m_Session != nullptr);
     return m_Session->args;
+}
+
+void Shell_SetHeadless(const bool headless)
+{
+    ASSERT(m_Session != nullptr);
+    SHELL_ARGS *const args = (SHELL_ARGS *)m_Session->args;
+    if (args->headless == headless) {
+        return;
+    }
+
+    args->headless = headless;
+    // The clock counts frames either way; only the pacing changes here.
+    if (headless) {
+        Clock_DisableWait();
+    } else {
+        Clock_EnableWait();
+        Clock_SyncTick();
+    }
 }
 
 SDL_Window *Shell_GetWindow(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

`skip start` and `skip end` stop the drawing while the frames keep running, so the stretch between them passes as fast as it can.