### PR TITLE
replay: keep playing while the window is unfocused

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -171,6 +171,9 @@
 - Fixed the `/cutscene` and `/demo` console commands playing the one after the number they were given
 - Fixed the `/play` console command starting the playthrough over only on the gym, so the rules and how wet Lara was carried over from the last run
 
+**Recordings**
+- Fixed a recording pausing along with the game when the window loses focus, which fires the rest of it into a game that is not running
+
 **Installer and mods**
 - Changed the installer to explain when it cannot download the files it needs, and to offer to try again (#6052)
 - Fixed mesh debug spheres not rendering after switching mods (regression from 1.5)

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -271,8 +271,7 @@ static bool M_Play(const char *const file_name)
     while (video->is_playing) {
         Shell_ProcessEvents();
 
-        const bool focus_paused =
-            g_Config.gameplay.pause_on_focus_lost && !Shell_IsFocused();
+        const bool focus_paused = Shell_ShouldPauseForFocusLoss();
         Input_Update();
         Shell_ProcessInput();
 

--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -32,11 +32,6 @@ static PHASE *m_PhaseStack[M_MAX_PHASES] = {};
 static bool m_PendingFadeToBlack = false;
 static FADER_ARGS m_PendingFadeToBlackArgs;
 
-static bool M_ShouldSuspendForFocusLoss(void)
-{
-    return g_Config.gameplay.pause_on_focus_lost && !Shell_IsFocused();
-}
-
 static GF_COMMAND M_HandleOverride(void)
 {
     const GF_COMMAND gf_override_cmd = GF_GetOverrideCommand();
@@ -156,7 +151,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
         return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
     }
 
-    if (M_ShouldSuspendForFocusLoss()) {
+    if (Shell_ShouldPauseForFocusLoss()) {
         return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
     }
 
@@ -290,7 +285,7 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
             }
         }
 
-        if (!M_ShouldSuspendForFocusLoss() && Interpolation_IsActive()) {
+        if (!Shell_ShouldPauseForFocusLoss() && Interpolation_IsActive()) {
             Interpolation_SetRate(0.5);
             Output_SetTime(m_CurrentFrame - 0.5f);
             M_Draw(phase);

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -3,6 +3,7 @@
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/debug.h>
+#include <trx/game/replay/test_replay.h>
 #include <trx/game/shell.h>
 
 #ifdef _WIN32
@@ -177,4 +178,14 @@ void Shell_SetIsFocused(const bool is_focused)
 bool Shell_IsFocused(void)
 {
     return m_IsFocused;
+}
+
+bool Shell_ShouldPauseForFocusLoss(void)
+{
+    // A recording's events are read before anything asks this, so pausing
+    // would fire them into a game that is not running.
+    if (TestReplay_IsOpened()) {
+        return false;
+    }
+    return g_Config.gameplay.pause_on_focus_lost && !Shell_IsFocused();
 }

--- a/src/trx/game/shell/common.h
+++ b/src/trx/game/shell/common.h
@@ -25,6 +25,9 @@ bool Shell_IsExiting(void);
 void Shell_SetIsFocused(bool is_focused);
 bool Shell_IsFocused(void);
 
+// Whether the game holds still because the window is not the one in front.
+bool Shell_ShouldPauseForFocusLoss(void);
+
 void Shell_RequestModSwitch(const char *mod_name);
 const char *Shell_GetPendingMod(void);
 void Shell_ClearPendingMod(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A recording plays to the end regardless of what the window is doing, and the shell answers whether focus loss holds the game still, for the phase executor and the FMV player alike. Before this each worked it out for itself, and a recording paused with the window while its events carried on being read, firing the rest of it into a game that was not running.