### PR TITLE
clock: count frames while recording or replaying

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -177,6 +177,7 @@
 **Recordings**
 - Added `skip start` and `skip end` events to recordings, which stop the drawing while the frames keep running, so a stretch passes as fast as the machine manages
 - Fixed a recording pausing along with the game when the window loses focus, which fires the rest of it into a game that is not running
+- Fixed a recording not playing back the same way twice, where a fade or any other effect measured in seconds lasted however many frames the machine managed to deliver
 
 **Installer and mods**
 - Changed the installer to explain when it cannot download the files it needs, and to offer to try again (#6052)

--- a/src/trx/game/clock/common.c
+++ b/src/trx/game/clock/common.c
@@ -5,6 +5,8 @@
 #include <trx/game/clock/const.h>
 #include <trx/game/clock/timer.h>
 #include <trx/game/clock/turbo.h>
+#include <trx/game/replay/test_recorder.h>
+#include <trx/game/replay/test_replay.h>
 #include <trx/game/shell/common.h>
 
 #include <SDL2/SDL_stdinc.h>
@@ -24,19 +26,34 @@ static struct {
     double sim_speed;
 } m_Priv;
 
-// Fixed‐FPS simulation in headless mode
-static bool m_HeadlessFixedFPS = false;
-static double m_HeadlessFPS_DT = 0.0;
-static double m_HeadlessOffset = 0.0;
-static double m_HeadlessAnchor = 0.0;
+// A clock that counts frames rather than seconds
+static bool m_IsFixedFPS = false;
+static double m_FixedFrameTime = 0.0;
+static double m_FixedOffset = 0.0;
+static double m_FixedAnchor = 0.0;
 
 static double M_GetHighPrecisionCounter(void)
 {
-    if (m_HeadlessFixedFPS) {
-        // Return virtual time = anchor + offset
-        return m_HeadlessAnchor + m_HeadlessOffset;
+    if (m_IsFixedFPS) {
+        return m_FixedAnchor + m_FixedOffset;
     }
     return (SDL_GetPerformanceCounter() - m_InitCounter) / (double)m_Frequency;
+}
+
+// Holds until the next frame is due by the real clock.
+static void M_WaitForFrame(void)
+{
+    const Uint64 now = SDL_GetPerformanceCounter();
+    if (m_LastCounter != 0) {
+        const double frame_ticks =
+            m_Frequency / (Clock_GetCurrentFPS() * Clock_GetSpeedMultiplier());
+        const double elapsed = (double)(now - m_LastCounter);
+        if (elapsed < frame_ticks) {
+            SDL_Delay(
+                (Uint32)(((frame_ticks - elapsed) / m_Frequency) * 1000.0));
+        }
+    }
+    m_LastCounter = SDL_GetPerformanceCounter();
 }
 
 static void M_Init(void)
@@ -49,13 +66,18 @@ static void M_ApplyConfig(void)
 {
     Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
 
-    const SHELL_ARGS *const args = Shell_GetArgs();
-    if (!args->headless) {
+    // Frames rather than seconds, so a fader lasts the same however fast they
+    // come. Asked of the replay, not of the arguments: the session swaps to
+    // the ones the recording carries, which hold no path.
+    if (!TestReplay_IsOpened() && !TestRecorder_IsOpened()) {
         return;
     }
-    Clock_DisableWait();
-    Clock_EnableHeadlessFixedFPS(
+    const SHELL_ARGS *const args = Shell_GetArgs();
+    Clock_EnableFixedFPS(
         args->headless_fps > 0 ? args->headless_fps : Clock_GetCurrentFPS());
+    if (args->headless) {
+        Clock_DisableWait();
+    }
 }
 
 void Clock_DisableWait(void)
@@ -68,18 +90,24 @@ void Clock_EnableWait(void)
     m_Disabled = false;
 }
 
-void Clock_EnableHeadlessFixedFPS(int32_t fps)
+void Clock_EnableFixedFPS(const int32_t fps)
 {
     if (fps <= 0) {
-        m_HeadlessFixedFPS = false;
+        if (m_IsFixedFPS) {
+            // The real counter picks up where the frame count left off, so a
+            // timer spanning the change does not see the clock jump.
+            const double frame_now = m_FixedAnchor + m_FixedOffset;
+            m_InitCounter = SDL_GetPerformanceCounter()
+                - (Uint64)(frame_now * (double)m_Frequency);
+        }
+        m_IsFixedFPS = false;
         return;
     }
 
-    // Anchor to current real time, reset offset
-    m_HeadlessAnchor = M_GetHighPrecisionCounter();
-    m_HeadlessOffset = 0.0;
-    m_HeadlessFPS_DT = 1.0 / (double)fps;
-    m_HeadlessFixedFPS = true;
+    m_FixedAnchor = M_GetHighPrecisionCounter();
+    m_FixedOffset = 0.0;
+    m_FixedFrameTime = 1.0 / (double)fps;
+    m_IsFixedFPS = true;
 }
 
 size_t Clock_GetDateTime(char *const buffer, const size_t size)
@@ -111,9 +139,11 @@ void Clock_SyncTick(void)
 
 int32_t Clock_WaitTick(void)
 {
-    if (m_Disabled && m_HeadlessFixedFPS) {
-        // Advance virtual time by one fixed frame
-        m_HeadlessOffset += m_HeadlessFPS_DT;
+    if (m_IsFixedFPS) {
+        m_FixedOffset += m_FixedFrameTime;
+        if (!m_Disabled) {
+            M_WaitForFrame();
+        }
         return 1;
     }
     if (m_Disabled) {

--- a/src/trx/game/clock/common.h
+++ b/src/trx/game/clock/common.h
@@ -9,8 +9,10 @@ void Clock_DisableWait(void);
 // Restores the waiting Clock_DisableWait turned off.
 void Clock_EnableWait(void);
 
-// In headless mode, simulate a fixed FPS (seconds per frame = 1/fps)
-void Clock_EnableHeadlessFixedFPS(int32_t fps);
+// Counts time in frames: every Clock_WaitTick moves the clock on by 1/fps,
+// whatever the frame really took. Zero goes back to real time, carrying on
+// from where the frame count reached.
+void Clock_EnableFixedFPS(int32_t fps);
 
 void Clock_SyncTick(void);
 int32_t Clock_WaitTick(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A recording is made and played back on a clock that advances by a frame per frame, so it plays the same way at any speed, drawn or not. Before this the clock ran on real time except in headless runs, and anything measured in seconds - a fade, a hold-to-repeat, a scene that ends on a timer - lasted however many frames the machine delivered.