### PR TITLE
music: come up in a headless run

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -178,6 +178,7 @@
 - Added `skip start` and `skip end` events to recordings, which stop the drawing while the frames keep running, so a stretch passes as fast as the machine manages
 - Fixed a recording pausing along with the game when the window loses focus, which fires the rest of it into a game that is not running
 - Fixed a recording not playing back the same way twice, where a fade or any other effect measured in seconds lasted however many frames the machine managed to deliver
+- Fixed a headless run having no music at all, so anything waiting on a track behaved differently there than in a run that draws
 
 **Installer and mods**
 - Changed the installer to explain when it cannot download the files it needs, and to offer to try again (#6052)

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -253,6 +253,10 @@ static int32_t M_GetFreeOverlaySlot(void)
 static int32_t M_PlayOverlayTrack(
     const MUSIC_ID track_id, const double timestamp)
 {
+    if (Shell_GetArgs()->headless) {
+        LOG_INFO("Not playing overlay track %d out loud", track_id);
+        return -1;
+    }
     if (m_Backend == nullptr) {
         LOG_WARNING(
             "Not playing overlay track %d because no backend is available",
@@ -362,9 +366,6 @@ static void M_Shutdown(void)
 
 static void M_ApplyConfig(void)
 {
-    if (Shell_GetArgs()->headless) {
-        return;
-    }
     Music_Init();
     Music_SetVolume(g_Config.audio.music_volume);
 }
@@ -420,7 +421,9 @@ static int32_t M_Play(
 
     bool played = false;
     M_StopMainStream();
-    if (m_Backend == nullptr) {
+    if (Shell_GetArgs()->headless) {
+        LOG_INFO("Not playing track %d out loud", track_id);
+    } else if (m_Backend == nullptr) {
         LOG_WARNING(
             "Not playing track %d because no backend is available", track_id);
     } else {
@@ -484,6 +487,12 @@ finish:
     m_TrackLooped = MX_INACTIVE;
     m_TrackLastLooped = MX_INACTIVE;
     M_ResetStreamState();
+    // A run that draws nothing comes up with a backend all the same, so the
+    // game still knows which track is playing and what a track resolves to.
+    // What such a run has no use for is the audio device.
+    if (Shell_GetArgs()->headless) {
+        return true;
+    }
     return Audio_Init();
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The module starts in a run that draws nothing, so the game still knows which track is playing and what a track resolves to. Nothing is heard: the audio device stays shut and no stream is created. Before this such a run had no music at all, and a scene waiting for a track to finish waited for one that never started.