### PR TITLE
tools/lint: check comments for dismissive words

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,12 @@ repos:
     language: python
     files: \.h$
 
+  - id: lint-dismissive-words
+    name: No dismissive words
+    entry: tools/lint/checks/dismissive_words
+    language: python
+    files: \.(c|h)$
+
   - id: lint-no-stdbool
     name: No stdbool.h
     entry: tools/lint/checks/no_stdbool
@@ -178,6 +184,12 @@ repos:
 
 - repo: local
   hooks:
+  - id: commit-msg-dismissive-words
+    name: No dismissive words in commit messages
+    entry: tools/lint/checks/dismissive_words
+    language: python
+    stages: [commit-msg]
+
   - id: commit-msg-50-72
     name: Commit message 50/72 rule
     entry: python3 tools/check_commit_msg

--- a/src/tests/fakes/console.c
+++ b/src/tests/fakes/console.c
@@ -1,5 +1,5 @@
 // The console overlay, reduced to the last line written to it, plus the verbose
-// flag - which is the only engine state trx.console.eval actually manipulates.
+// flag - which is the only engine state trx.console.eval manipulates.
 
 #include <fakes/console.h>
 

--- a/src/tests/fakes/weather.c
+++ b/src/tests/fakes/weather.c
@@ -1,6 +1,6 @@
 // The weather as the two variables FX_Weather keeps: what falls, and how
 // heavily. The clamp on the severity is the engine's, so a test sees the range
-// a script really gets.
+// a script gets.
 
 #include <harness/fake_calls.h>
 

--- a/src/tests/lua/api/events.c
+++ b/src/tests/lua/api/events.c
@@ -4,7 +4,7 @@
 // `fake.fire()` calls the same LUA_FireEvent* entrypoints the engine calls,
 // and flip effects go through the same ItemAction interceptor seam that
 // floor_data.c and the animation-command paths fire through. That is the point:
-// it pins the declared callback arguments against what C actually pushes.
+// it pins the declared callback arguments against what C pushes.
 
 #include <harness/fake_calls.h>
 #include <harness/lua_surface.h>

--- a/src/tests/trx/config/common.c
+++ b/src/tests/trx/config/common.c
@@ -68,8 +68,8 @@ static void M_RecordChange(const EVENT *const event, void *const user_data)
     m_LastPersist = ((const CONFIG_CHANGE *)event->data)->persist;
 }
 
-// A hold lives as long as whatever put it there. What lands on one is the
-// game flow's, a script's or a demo's doing, so it is never the file's to keep.
+// A hold lives as long as its owner. What lands on one is the game flow's, a
+// script's or a demo's doing, so it is never the file's to keep.
 TEST(a_write_while_held_is_not_the_players_to_save)
 {
     M_SetUp();

--- a/src/tests/trx/game/lua/field.c
+++ b/src/tests/trx/game/lua/field.c
@@ -303,7 +303,7 @@ TEST(a_value_too_wide_for_the_member_is_rejected_even_with_a_setter)
 
 // Found while writing these tests: Field_Find returns the first match, so a
 // name declared twice silently shadows every later entry - a validating setter
-// declared after a plain FIELD would simply never run.
+// declared after a plain FIELD would never run.
 TEST(duplicate_field_names_are_detected)
 {
     CHECK_NULL(Field_FindDuplicateName(&TYPE_SAMPLE));

--- a/src/tests/trx/game/savegame/resume.c
+++ b/src/tests/trx/game/savegame/resume.c
@@ -331,8 +331,8 @@ TEST(healing_between_levels_spares_the_level_she_is_arriving_in)
     SG_Resume_ApplyRulesToEntry(&m_MainLevels[M_SECOND]);
     CHECK_EQ_INT(entry->lara_hitpoints, 320);
 
-    // The first level is where a new game begins, so it is filled up whatever
-    // the setting says.
+    // The first level is where a new game begins, so it is filled up no matter
+    // what the setting says.
     SG_Resume_ApplyRulesToEntry(&m_MainLevels[M_FIRST]);
     CHECK_EQ_INT(
         SG_Resume_GetEntry(&m_MainLevels[M_FIRST])->lara_hitpoints, 1000);

--- a/src/trx/av/audio_decoder.c
+++ b/src/trx/av/audio_decoder.c
@@ -272,7 +272,7 @@ static bool M_BuildFilterGraph(AUDIO_DECODER *const decoder)
     return true;
 }
 
-// Drops whatever the stretcher holds, which a seek makes stale.
+// Drops the samples the stretcher holds, which a seek makes stale.
 static void M_RebuildFilterGraph(AUDIO_DECODER *const decoder)
 {
     if (decoder->filter_graph == nullptr) {
@@ -323,7 +323,7 @@ static void M_Filter(
     }
 }
 
-// Pushes whatever the stretcher is still holding through to the sink.
+// Pushes the samples the stretcher still holds through to the sink.
 static void M_FlushFilter(AUDIO_DECODER *const decoder)
 {
     if (decoder->filter_graph == nullptr) {
@@ -601,7 +601,7 @@ int32_t AudioDecoder_Read(AUDIO_DECODER *const decoder, const float **const out)
         if (error_code != AVERROR_EOF) {
             LOG_ERROR("Error while reading audio: %s", av_err2str(error_code));
         }
-        // let the codec hand back whatever it was still holding
+        // let the codec hand back the frames it was still holding
         avcodec_send_packet(decoder->codec_ctx, nullptr);
         M_Drain(decoder);
         M_FlushFilter(decoder);

--- a/src/trx/config/common.h
+++ b/src/trx/config/common.h
@@ -46,8 +46,8 @@ bool Config_Change_HasMirror(const CONFIG_CHANGE *change, const void *mirror);
 const char *Config_ResolveOptionName(const char *option_name);
 
 // Writes the setting g_Config keeps at `mirror`, which is the only way to write
-// one: g_Config itself is const. The value is taken in whatever shape the
-// caller's own expression had, and the option says what it means.
+// one: g_Config itself is const. The value is taken in the shape the caller's
+// own expression had, and the option says what it means.
 bool Config_SetValue(const void *mirror, TRX_VALUE value);
 
 // Holds and releases the setting g_Config keeps at `mirror`. The value is taken

--- a/src/trx/config/option.c
+++ b/src/trx/config/option.c
@@ -34,10 +34,10 @@ static void M_CopyValue(TRX_VALUE *const dst, const TRX_VALUE *const src)
     }
 }
 
-// Brings the carrier down to what the option's storage can actually hold, so
-// that a 0.8 read from the file and a 0.8f written in map.def are the same
-// value afterwards. Without it every float option would read as changed from
-// its default the moment the file was read.
+// Brings the carrier down to what the option's storage can hold, so that a 0.8
+// read from the file and a 0.8f written in map.def are the same value
+// afterwards. Without it every float option would read as changed from its
+// default the moment the file was read.
 //
 // False where the storage cannot represent the value at all. The buffer is
 // aligned as the carrier is, since the write goes through the storage type's
@@ -76,9 +76,9 @@ static void M_WriteMirror(const CONFIG_OPTION *const option)
     Value_WritePtr(option->value.type, option->mirror, &option->value);
 }
 
-// Puts a value into the option itself, whatever the reason. Every write lands
-// here, so this is the one place that keeps g_Config in step and the one that
-// says an option moved.
+// Puts a value into the option itself, no matter what asked for it. Every write
+// lands here, so this is the one place that keeps g_Config in step and the one
+// that says an option moved.
 static void M_Apply(
     CONFIG_OPTION *const option, const TRX_VALUE *const value,
     const CONFIG_WRITE_KIND kind)
@@ -164,9 +164,9 @@ void Config_Option_WriteAs(
         M_CopyValue(&copy, value);
         M_FreeValue(&hold->value);
         hold->value = copy;
-        // A hold lives for as long as whatever put it there and no longer, so
-        // what lands on one is never the file's to keep: base_value, which is
-        // what gets written, has not moved.
+        // A hold lives for as long as the game flow, script or demo that put it
+        // there, so what lands on one is never the file's to keep: base_value,
+        // which is what gets written, has not moved.
         M_Apply(
             option, value,
             kind == CONFIG_WRITE_PERSIST ? CONFIG_WRITE_TRANSIENT : kind);

--- a/src/trx/config/option.h
+++ b/src/trx/config/option.h
@@ -112,8 +112,8 @@ typedef struct {
 
 // The key naming which enum an option's values come from: for TVT_ENUM the
 // EnumMap name, and for TVT_DYNAMIC_ENUM the option's own address, which is the
-// token its values are registered under - so whatever seeds those values has to
-// key them on this too. Null for a type that is not an enum.
+// token its values are registered under - so the code that seeds those values
+// has to key them on this too. Null for a type that is not an enum.
 //
 // This is what the value parse, format and JSON calls take alongside the type.
 const void *Config_Option_GetEnumKey(const CONFIG_OPTION *option);
@@ -127,7 +127,7 @@ const void *Config_Option_GetEnumKey(const CONFIG_OPTION *option);
 // written at all is the caller's to decide - see Config_Option_IsHeld.
 //
 // The value is taken by copy - a string is duplicated and the option owns it -
-// so the caller keeps whatever it passed.
+// so the caller keeps the value it passed.
 void Config_Option_Write(CONFIG_OPTION *option, const TRX_VALUE *value);
 
 // Holds the option to the bounds it declared. A value outside them is brought

--- a/src/trx/config/registry.h
+++ b/src/trx/config/registry.h
@@ -4,8 +4,8 @@
 
 #include <trx/config/option.h>
 
-// Adds an option and gives it its starting value: its default, then whatever
-// the settings file held for it, then whatever the game flow enforces or hides,
+// Adds an option and gives it its starting value: its default, then the value
+// the settings file held for it, then the one the game flow enforces or hides,
 // then held to its own bounds.
 //
 // The settings file is kept after the read, so this is the only thing that has
@@ -20,7 +20,7 @@
 CONFIG_OPTION *Config_Register(const CONFIG_OPTION_DESC *desc);
 
 // Registers the options this game's map*.def names, each holding its default,
-// and drops whatever was registered before: a different game is a different set
+// and drops the options registered before: a different game is a different set
 // of settings.
 void Config_RegisterBuiltInOptions(void);
 
@@ -42,8 +42,8 @@ CONFIG_OPTION *Config_FindOptionByMirror(const void *mirror);
 // lifetime at once.
 int32_t Config_GetGeneration(void);
 
-// Drops every hold and the player's value underneath it, leaving whatever the
-// topmost hold last applied as the value in force. Nothing is put back: this is
+// Drops every hold and the player's value underneath it, leaving the value the
+// topmost hold last applied as the one in force. Nothing is put back: this is
 // for a config about to be read, where what the file says is what the option
 // ends up holding.
 //

--- a/src/trx/config/vars.h
+++ b/src/trx/config/vars.h
@@ -7,9 +7,9 @@
 // This is a view of what the option registry holds, kept up to date as each
 // setting is written, so reading a setting stays a plain struct access. It is
 // not where a setting lives, and writing one here would go around the option
-// that owns it - past whatever is holding it, past the bounds it is held to,
-// and past the change that has to be reported. So it reads as const, and a
-// write is a compile error rather than a value that quietly fails to stick.
+// that owns it - past the hold on it, past the bounds it is held to, and past
+// the change that has to be reported. So it reads as const, and a write is a
+// compile error rather than a value that quietly fails to stick.
 //
 // Spelled as a cast rather than a second const object: the object itself is not
 // const, since the config module writes it, and this way `&g_Config.member` is

--- a/src/trx/game/effects/types.h
+++ b/src/trx/game/effects/types.h
@@ -25,7 +25,7 @@ typedef struct {
             XYZ_16 rot;
         } result, prev;
         // Set until the effect has lived through a whole frame, so that it is
-        // not interpolated from whatever the recycled slot last held.
+        // not interpolated from the effect the recycled slot last held.
         bool is_new;
     } interp;
 } EFFECT;

--- a/src/trx/game/game_flow/inventory.c
+++ b/src/trx/game/game_flow/inventory.c
@@ -264,9 +264,9 @@ void GF_InventoryModifier_ApplyToResumeInfo(const GF_LEVEL *const level)
         memset(resume->inv.ammo, 0, sizeof(resume->inv.ammo));
     }
 
-    // Pistols the game flow hands over come loaded, whatever else the level
-    // took away. An endless supply needs no such rounds: the count follows the
-    // gun, and Inv_State_SetCount has already written it.
+    // Pistols the game flow hands over come loaded, even where the level took
+    // the rest away. An endless supply needs no such rounds: the count follows
+    // the gun, and Inv_State_SetCount has already written it.
     if (pistols_given && !Gun_HasInfiniteAmmo(LGT_PISTOLS)) {
         Inv_State_AddAmmo(
             &resume->inv, LGT_PISTOLS, Gun_GetInitialRounds(LGT_PISTOLS));

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -318,7 +318,7 @@ static void M_LoadAssaultSection(const JSON_OBJECT *const obj)
 static void M_SaveAssaultSection(JSON_OBJECT *const obj)
 {
     // A game with no assault course has nothing to say here, and saying it
-    // would drop whatever the game that does have one left behind.
+    // would drop the records the game that does have one left behind.
     if (Gym_TrackManager_HasStats(GYM_TRACK_ASSAULT)) {
         M_SaveStats(obj, &m_AssaultStats);
     }

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -377,8 +377,8 @@ static void M_FloorDataEdits(
         const uint16_t z = VFile_ReadU16(injection->fp);
         const int32_t fd_edit_count = VFile_ReadS32(injection->fp);
 
-        // Verify that the given room and coordinates are accurate.
-        // Individual FD functions must check that sector is actually set.
+        // Verify that the given room and coordinates are accurate. Individual
+        // FD functions must check that sector is set.
         const ROOM *room = nullptr;
         SECTOR *sector = nullptr;
         if (room_num < 0 || room_num >= Room_GetCount()) {

--- a/src/trx/game/input/backends/controller.c
+++ b/src/trx/game/input/backends/controller.c
@@ -503,7 +503,7 @@ static void M_Init(void)
                 (CONTROLLER_BINDING) { .key_count = 0 };
         }
     }
-    // then load actually defined default bindings into slot 0
+    // then load the defined default bindings into slot 0
     for (int32_t i = 0; m_BuiltinLayout[i].role != (INPUT_ROLE)-1; i++) {
         const BUILTIN_CONTROLLER_LAYOUT *const builtin = &m_BuiltinLayout[i];
         m_Layout[INPUT_LAYOUT_DEFAULT][builtin->role].slots[0] =

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -532,7 +532,7 @@ static void M_Init(void)
     }
     // allow specific engines to re-assign default bindings
     M_HandleBuiltInDefaults();
-    // then load actually defined default bindings into slot 0
+    // then load the defined default bindings into slot 0
     for (int32_t i = 0; m_BuiltinLayout[i].role != (INPUT_ROLE)-1; i++) {
         const BUILTIN_KEYBOARD_LAYOUT *const builtin = &m_BuiltinLayout[i];
         m_Layout[INPUT_LAYOUT_DEFAULT][builtin->role].slots[0] = builtin->bind;

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -30,9 +30,9 @@ extern INPUT_STATE g_OldInputDB;
 
 void Input_Update(void);
 
-// Ignores the given role until the player lets go of it. Whatever acted on the
-// press keeps it: it reads as unpressed everywhere else, and does not debounce
-// again while the key is down.
+// Ignores the given role until the player lets go of it. The caller that acted
+// on the press keeps it: it reads as unpressed everywhere else, and does not
+// debounce again while the key is down.
 void Input_HoldOffRole(INPUT_ROLE role);
 
 // Ignores every role a scene can be skipped with until the player lets go, so

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -619,8 +619,8 @@ void Item_Deactivate(const int16_t item_num)
         LOT_DisableBaddieAI(item_num);
     }
 
-    // Only when it was actually running, so an antitrigger on an idle item is
-    // not reported as a stop. on_leave_sim has already fired for it.
+    // Only when it was running, so an antitrigger on an idle item is not
+    // reported as a stop. on_leave_sim has already fired for it.
     if (was_simulated && !Game_IsSettingUpItems()) {
         LUA_FireEventInt32(LUA_EVENT_DEACTIVATE, item_num);
     }

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -307,9 +307,9 @@ static bool M_IsValidHangPos(ITEM *const item, COLL_INFO *const coll)
 
     // A laterally sloping ledge cannot be grabbed, matching an ordinary hang
     // grab (Lara_Col_HangTest rejects side_left2/side_right2 tilt). A side that
-    // simply drops away - e.g. the open half of an inner corner - is fine, so
-    // only the case where both ledge ends stay at grab height yet tilt across
-    // is rejected.
+    // drops away - e.g. the open half of an inner corner - is fine, so only the
+    // case where both ledge ends stay at grab height yet tilt across is
+    // rejected.
     const bool left_level =
         ABS(coll->side_front.floor - coll->side_left2.floor) < SLOPE_DIF;
     if (left_level
@@ -463,8 +463,8 @@ static int32_t M_TestHangCorner(
                     }
                 }
             } else if (ABS(front - coll->side_front.floor) <= SLOPE_DIF) {
-                // Only allow the outer turn when Lara hangs on the half
-                // of the sector that actually meets the corner.
+                // Only allow the outer turn when Lara hangs on the half of the
+                // sector that meets the corner.
                 const int32_t side_pos =
                     (dir == DIR_NORTH || dir == DIR_SOUTH ? old_pos.x
                                                           : old_pos.z)

--- a/src/trx/game/lara/col/monkey.c
+++ b/src/trx/game/lara/col/monkey.c
@@ -187,7 +187,7 @@ static void M_MonkeyIdle(ITEM *const item, COLL_INFO *const coll)
     }
 
     // Monkey idle state can be the result of swinging on a thin ledge as well
-    // as actually being on monkeybars. LA_SWING_IN_SLOW links to this state.
+    // as being on monkeybars. LA_SWING_IN_SLOW links to this state.
     Lara_Col_HangTest(item, coll);
     if (item->goal_anim_state != LS(LS_MONKEY_IDLE)) {
         return;

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -599,13 +599,13 @@ static float M_RingRoll(
     return atan2f(cross, dot);
 }
 
-// Chooses the rotation of the lower pairing that lines up with the two
-// anchors' relative roll. The comparison is made in the ring's plane with the
-// upper ring's roll factored out, so the bridge's own frame drops out of the
-// choice; and the previous rotation is kept unless the winner is clearly
-// better - without that margin the idle sway flicks the ring back and forth
-// across the switching point. Only rotations are tried, never reflections, so
-// the ring's winding holds.
+// Chooses the rotation of the lower pairing that lines up with the two anchors'
+// relative roll. The comparison is made in the ring's plane with the upper
+// ring's roll factored out, so the bridge's own frame drops out of the choice;
+// and the previous rotation is kept unless the winner is better by a margin -
+// without it the idle sway flicks the ring back and forth across the switching
+// point. Only rotations are tried, never reflections, so the ring's winding
+// holds.
 static int32_t M_PickShift(
     const M_SEGMENT_SEAM *const seam, const OBJECT_MESH *const mesh,
     const XYZ_F *const targets, const float upper_roll,

--- a/src/trx/game/lara/hair.h
+++ b/src/trx/game/lara/hair.h
@@ -18,7 +18,7 @@ typedef struct {
 void Lara_Hair_Initialise(void);
 // Detects the ring adjacent braid segments share and enables welding it shut at
 // draw time. A no-op unless the outfit opts into joints and the segment meshes
-// actually share a ring; call whenever the outfit changes.
+// share a ring; call whenever the outfit changes.
 void Lara_Hair_InitJoints(const LARA_SKIN_OUTFIT *outfit);
 bool Lara_Hair_IsActive(void);
 void Lara_Hair_Control(bool in_cutscene);

--- a/src/trx/game/lara/skin/common.h
+++ b/src/trx/game/lara/skin/common.h
@@ -12,7 +12,7 @@ bool Lara_Skin_IsDefaultType(void);
 void Lara_Skin_SetType(LARA_SKIN_TYPE skin_type);
 void Lara_Skin_ApplyOutfit(void);
 
-// Put another mesh on one of Lara's own, in place of whatever her outfit gives
+// Put another mesh on one of Lara's own, in place of the one her outfit gives
 // her there. It outlives an outfit change, because applying an outfit reads it,
 // which is what lets a level dress her from its own geometry - TR4's Angkor Wat
 // carries the torso young Lara wears before she picks up her backpack. nullptr

--- a/src/trx/game/level/finalize/render_assets.c
+++ b/src/trx/game/level/finalize/render_assets.c
@@ -24,9 +24,8 @@ static void M_FixTrapezoidRatios(FACE *const face, const XYZ_16 vertices[4])
     // rendered using affine interpolation of texture coordinates, causing
     // visible warping when a four-sided polygon is split internally.
     // The original approach (coded by XProger) handled only rectangular UV
-    // maps by simply scaling the edges; this updated version takes into
-    // account the actual UV trapezoid to achieve a more uniform texture
-    // projection.
+    // maps by scaling the edges; this updated version takes into account the
+    // actual UV trapezoid to achieve a more uniform texture projection.
 
     // 1) Gather the coordinate and texture information
     const OBJECT_TEXTURE *const tex =

--- a/src/trx/game/level/sections/meshes.c
+++ b/src/trx/game/level/sections/meshes.c
@@ -174,7 +174,7 @@ void Level_Section_AppendObjectMeshes(
 
     // Savegames identify meshes by their file pointer values divided by 2.
     // (Historically, meshes were stored in int16_t[] arrays, so the so-called
-    // "pointers" are really just array indices into that layout.)
+    // "pointers" are array indices into that layout.)
     //
     // Original level meshes work fine under this scheme, but injected meshes
     // are different, as they come from separate VFiles and bring their own

--- a/src/trx/game/lua/capi/assault.c
+++ b/src/trx/game/lua/capi/assault.c
@@ -153,7 +153,7 @@ static int M_L_AssaultFinish(lua_State *const L)
 // trxc.assault.is_running([track]) -> bool
 //
 // No availability check: asking whether a timer runs is a fair question outside
-// a gym level, and the answer there is simply false.
+// a gym level, and the answer there is false.
 static int M_L_AssaultIsRunning(lua_State *const L)
 {
     lua_pushboolean(L, Gym_TrackManager_IsTimerActive(M_GetTrack(L)));

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -555,8 +555,8 @@ static void M_Create(lua_State *const L)
 }
 
 // A ref names a slot in the registry of the state that is going, and the next
-// state numbers its own from scratch. Kept, it would name whatever landed
-// there.
+// state numbers its own from scratch. Kept, it would name the slot's next
+// occupant.
 static void M_Shutdown(void)
 {
     for (int32_t i = 0; m_Watchers != nullptr && i < m_Watchers->count; i++) {

--- a/src/trx/game/lua/capi/cutscenes.c
+++ b/src/trx/game/lua/capi/cutscenes.c
@@ -8,8 +8,8 @@
 #define M_NO_CUTSCENE (-1)
 #define M_NO_FRAME (-1)
 
-// A cutscene a script asks to play has to be one this game can actually play,
-// or the call would do nothing and say nothing about why.
+// A cutscene a script asks to play has to be one this game can play, or the
+// call would do nothing and say nothing about why.
 static int32_t M_CheckPlayableNum(lua_State *const L, const int32_t arg)
 {
     const lua_Integer num = luaL_checkinteger(L, arg);

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -13,7 +13,7 @@
 
 // clang-format off
 static const FIELD_DESC m_Fields[] = {
-    // what the level actually has
+    // what the level holds
     FIELD_RO(OBJECT, loaded),
     FIELD_RO(OBJECT, intelligent),
     FIELD_RO(OBJECT, mesh_count),

--- a/src/trx/game/lua/field.c
+++ b/src/trx/game/lua/field.c
@@ -62,9 +62,9 @@ void Field_ValidateType(const TYPE_DESC *const type)
 
     for (int32_t i = 0; i < type->field_count; i++) {
         const FIELD_DESC *const field = &type->fields[i];
-        // Only fields that actually address memory carry a backing member to
-        // check: Field_Get uses the offset when there is no getter, and
-        // Field_Set uses it when there is no setter and the field is writable.
+        // Only fields that address memory carry a backing member to check:
+        // Field_Get uses the offset when there is no getter, and Field_Set uses
+        // it when there is no setter and the field is writable.
         const bool reads_member = field->get == nullptr;
         const bool writes_member =
             field->set == nullptr && !(field->flags & FF_READONLY);

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -192,10 +192,10 @@ static void M_MarkDragonDead(ITEM *const dragon_back_item)
     }
 
     // Allow drops to occur at the beginning of the cinematic camera for a
-    // better window to avoid seeing the items spawn. Carrier_TestItemDrops
-    // only drops for a finished item, so force that phase and restore it.
-    // A raw write, not Item_SetFinished: the value never actually changes
-    // across the call, so nothing should observe the momentary flip.
+    // better window to avoid seeing the items spawn. Carrier_TestItemDrops only
+    // drops for a finished item, so force that phase and restore it. A raw
+    // write, not Item_SetFinished: the value never changes across the call, so
+    // nothing should observe the momentary flip.
     const bool was_finished = dragon_back_item->is_finished;
     dragon_back_item->is_finished = true;
     Carrier_TestItemDrops(Item_GetIndex(dragon_back_item));

--- a/src/trx/game/output/func.c
+++ b/src/trx/game/output/func.c
@@ -82,9 +82,9 @@ CLIP Output_CheckBoundsClip(const BOUNDS_16 *const bounds)
     y_max += vp.h / 2;
 
     // The corners left out above are the ones that would have widened the
-    // rectangle, so what remains is smaller than the box really covers and
-    // cannot be rejected on. It can sit off to one side while the box still
-    // crosses the view.
+    // rectangle, so what remains is smaller than the box covers and cannot be
+    // rejected on. It can sit off to one side while the box still crosses the
+    // view.
     if (num_z < 8) {
         return CLIP_PARTIALLY_VISIBLE;
     }

--- a/src/trx/game/output/lights/common.c
+++ b/src/trx/game/output/lights/common.c
@@ -461,8 +461,8 @@ void Output_TriggerFXFogBulb(
     const XYZ_32 pos, const int32_t fx_rad, const int32_t density,
     const RGB_888 color)
 {
-    // The OG triggers these for underwater flares and the like, which no
-    // other game has.
+    // The OG triggers these for underwater flares and shimmer, which no other
+    // game has.
     if (g_TRVersion != 4) {
         return;
     }

--- a/src/trx/game/output/lights/tr4.c
+++ b/src/trx/game/output/lights/tr4.c
@@ -569,12 +569,12 @@ static void M_StageDynamicLights(
     }
 }
 
-// An item outside the pool - a cutscene actor is posed from a track rather
-// than living in a room - has no slot of its own, and the scratch it would
-// otherwise fall to is shared with every effect and static drawn that frame.
-// This state fades between frames, so sharing it makes an actor's light jump
-// with whatever else was drawn. The original engine keeps it on the item, so
-// one is handed out per item here instead.
+// An item outside the pool - a cutscene actor is posed from a track rather than
+// living in a room - has no slot of its own, and the scratch it would otherwise
+// fall to is shared with every effect and static drawn that frame. This state
+// fades between frames, so sharing it makes an actor's light jump with the
+// effects and statics drawn beside it. The original engine keeps it on the
+// item, so one is handed out per item here instead.
 static M_ITEM_LIGHT *M_GetLooseItemLight(const ITEM *const item)
 {
     for (int32_t i = 0; i < M_MAX_LOOSE_LIGHTS; i++) {

--- a/src/trx/game/output/utils.h
+++ b/src/trx/game/output/utils.h
@@ -29,7 +29,7 @@
     // into huge values, so the whole mesh explodes. NVIDIA, Intel and all
     // post-GCN AMD GPUs fixed the bug.
     //
-    // To deal with this, we simply pack our data to increments of 4.
+    // To deal with this, we pack our data to increments of 4.
     #define OUTPUT_USHORT uint32_t
     #define OUTPUT_USHORT_GL GL_UNSIGNED_INT
     #define OUTPUT_SHORT int32_t

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -581,7 +581,7 @@ bool Room_IsOnWalkable(
                 obj->floor_height_func(item, pos, height);
             // If the floor height changed, try to climb the walkable stack.
             if (test_height != height) {
-                // Check if height changed aka actually on a walkable.
+                // Check if height changed, i.e. standing on a walkable.
                 height = test_height;
                 object_found = true;
             }

--- a/src/trx/game/savegame/common.h
+++ b/src/trx/game/savegame/common.h
@@ -7,7 +7,7 @@
 // data is stored in a special buffer. Then the engine continues to execute the
 // normal game flow and loads the specified level. Second phase occurs after
 // everything finishes loading, e.g. items, creatures, triggers etc., and is
-// what actually sets Lara's health, creatures status, triggers, inventory etc.
+// what sets Lara's health, creatures status, triggers, inventory etc.
 
 void Savegame_Init(void);
 

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -36,9 +36,9 @@ static void M_ShowFatalError(
 {
     LOG_ERROR("%s", log_message);
     if (M_IsInteractive()) {
-        // The dialog is placed over its parent window. Until the game window
-        // is shown, it is still hidden at whatever position the config named,
-        // so the dialog is better off centered on the screen instead.
+        // The dialog is placed over its parent window. Until the game window is
+        // shown, it is still hidden at the position the config named, so the
+        // dialog is better off centered on the screen instead.
         SDL_Window *window = Shell_GetWindow();
         if (window != nullptr
             && (SDL_GetWindowFlags(window) & SDL_WINDOW_SHOWN) == 0) {

--- a/src/trx/game/shell/events.c
+++ b/src/trx/game/shell/events.c
@@ -22,9 +22,9 @@ static void M_HandleQuit(void)
 
 static void M_HandleKeyDown(const SDL_Event *const event)
 {
-    // NOTE: Opening the console normally would get handled by Input_Update,
-    // but by the time Input_Update gets ran, we may already have lost some
-    // keypresses if the player types really fast, so we need to react sooner.
+    // NOTE: Opening the console normally would get handled by Input_Update, but
+    // by the time Input_Update gets ran, we may already have lost some
+    // keypresses if the player types fast, so we need to react sooner.
     if (g_Config.gameplay.enable_console && !Console_IsOpened()
         && !Input_IsInListenMode()
         && Input_IsPressedEx(

--- a/src/trx/game/types.h
+++ b/src/trx/game/types.h
@@ -39,8 +39,8 @@ typedef struct {
     };
     uint16_t vertices[4];
 
-    // trapezoid ratios for textured quads
-    // that cannot be really shared between vertices
+    // trapezoid ratios for textured quads that cannot be shared between
+    // vertices
     TEXTURE_ZW_F texture_zw[4];
 
     uint16_t effects;

--- a/src/trx/game/ui/dialogs/config_presets.c
+++ b/src/trx/game/ui/dialogs/config_presets.c
@@ -164,8 +164,8 @@ static void M_WrappedLabel(const char *const text, const float max_width)
 
 // The width the dialog's text may occupy, in the units the layout sizes in. The
 // modal's padding and the window's chrome come off what the screen allows, and
-// what the phase actually shows sets the width below that, so a narrow list of
-// changes keeps the dialog narrow rather than stretching it.
+// what the phase shows sets the width below that, so a narrow list of changes
+// keeps the dialog narrow rather than stretching it.
 static float M_GetConfirmContentWidth(UI_CONFIG_PRESETS_STATE *const s)
 {
     const float scale = UI_Scaler_GetTextScale();

--- a/src/trx/game/ui/dialogs/setting_helpers/handlers_language.c
+++ b/src/trx/game/ui/dialogs/setting_helpers/handlers_language.c
@@ -59,8 +59,8 @@ static bool M_Language_CanChangeValue(
     const VECTOR *const langs = M_Language_GetLanguages();
     const int32_t idx = M_Language_FindIndex(option);
     if (idx < 0) {
-        // If the language from the user config somehow is no longer on the list
-        // (the file was deleted), let the player return to the default language
+        // If the language from the user config is no longer on the list (the
+        // file was deleted), let the player return to the default language
         return true;
     }
     if (langs->count < 2) {
@@ -81,8 +81,8 @@ static bool M_Language_RequestChangeValue(
     if (idx != -1) {
         new_lang = *(char **)Vector_Get(langs, idx + dir);
     } else {
-        // If the language from the user config somehow is no longer on the list
-        // (the file was deleted), default to the first entry, which is English
+        // If the language from the user config is no longer on the list (the
+        // file was deleted), default to the first entry, which is English
         new_lang = *(char **)Vector_Get(langs, 0);
     }
     Config_Option_SetFromString(option, new_lang, false);

--- a/src/trx/game/ui/elements/modal.h
+++ b/src/trx/game/ui/elements/modal.h
@@ -8,8 +8,8 @@
 void UI_BeginModal(float x, float y);
 
 // A modal that keeps the given height clear at the top and the bottom of the
-// canvas, so that what it places lands within what is left rather than over
-// whatever else is drawn at the screen edges.
+// canvas, so that what it places lands within what is left rather than over the
+// text drawn at the screen edges.
 void UI_BeginModalEx(float x, float y, float inset_v);
 
 void UI_EndModal(void);

--- a/src/trx/game/ui/elements/stack.c
+++ b/src/trx/game/ui/elements/stack.c
@@ -155,7 +155,7 @@ static void M_Layout(
         }
     }
 
-    // Now we actually lay out the children
+    // Now lay the children out
     float cx = x;
     float cy = y;
     child = node->first_child;

--- a/tools/lint/checks/dismissive_words
+++ b/tools/lint/checks/dismissive_words
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harness import LintWarning, file_check
+
+# The words this check rules out, in three kinds, so that a warning can say
+# what is wrong with the one it found: a word that stands in for a thing
+# without naming it, a word the sentence reads the same without, and a word
+# that tells the reader what to think of a thing rather than describing it.
+
+# Stands in for a thing without naming it.
+VAGUE = (
+    "whatever",
+    "whatsoever",
+    "for some reason",
+    "in some way",
+    "one way or another",
+    "and so on",
+    "and so forth",
+    "etcetera",
+    "and the like",
+    "or something",
+    "or whatever",
+    "things like that",
+    "stuff like that",
+    "somehow",
+    "more or less",
+    "for all intents and purposes",
+)
+
+# Says nothing the sentence does not say without it.
+FILLER = (
+    "simply",
+    "basically",
+    "actually",
+    "really",
+    "essentially",
+    "fundamentally",
+    "ultimately",
+    "virtually",
+    "inherently",
+    "naturally",
+)
+
+# Tells the reader what to think of the thing rather than describing it.
+VERDICT = (
+    "obviously",
+    "clearly",
+    "of course",
+    "needless to say",
+    "it goes without saying",
+    "as everyone knows",
+    "as we all know",
+    "everyone knows",
+    "self-evidently",
+    "evidently",
+    "apparently",
+    "undoubtedly",
+    "certainly",
+    "surely",
+    "no doubt",
+    "without a doubt",
+    "trivially",
+)
+
+MESSAGES = {
+    "vague": "`{word}` does not say which thing is meant. Name the thing.",
+    "filler": "`{word}` adds nothing. Write the sentence without it.",
+    "verdict": (
+        "`{word}` tells the reader what to think. State the fact and leave"
+        " the judgement out."
+    ),
+}
+
+KINDS = (("vague", VAGUE), ("filler", FILLER), ("verdict", VERDICT))
+
+
+def _pattern(words):
+    return re.compile(
+        r"\b(?:" + "|".join(w.replace(" ", r"\s+") for w in words) + r")\b",
+        re.IGNORECASE,
+    )
+
+
+PATTERNS = [(kind, _pattern(words)) for kind, words in KINDS]
+COMMENT_RE = re.compile(r"//(.*)$")
+
+
+def _fragments(path, text):
+    # A commit message is prose throughout, bar the lines git writes itself.
+    # A source file is prose only inside its comments, so a string that holds
+    # one of these words is left alone.
+    is_source = path.suffix in {".c", ".h"}
+    for number, line in enumerate(text.splitlines(), start=1):
+        if is_source:
+            match = COMMENT_RE.search(line)
+            if match is not None:
+                yield number, match.group(1)
+            continue
+        # `git commit -v` puts the diff below a scissors line, which is code
+        # rather than prose. Spotted the way tools/check_commit_msg spots it,
+        # since the dashes around it vary.
+        if ">8" in line and line[:1] == "#":
+            return
+        if not line.startswith("#"):
+            yield number, line
+
+
+def check(path, text):
+    for number, fragment in _fragments(path, text):
+        for kind, pattern in PATTERNS:
+            for match in pattern.finditer(fragment):
+                yield LintWarning(
+                    path,
+                    MESSAGES[kind].format(word=match.group(0).lower()),
+                    line=number,
+                )
+
+
+file_check(check)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

LLMs kept slipping dismissive wording in despite system prompts asking them not to. It bothered me enough that certain words are now hard-rejected at commit time, so they can't sneak back in. I also updated the existing instances to match.