### PR TITLE
inventory_ring: initialise camera in title

### DIFF
--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -77,6 +77,10 @@ void Camera_SetChunky(const bool is_chunky)
 
 void Camera_Initialise(void)
 {
+    if (Lara_GetItem() == nullptr) {
+        return;
+    }
+
     m_IsInitialised = false;
     Camera_Binoculars_Reset();
     g_Camera.fov = Viewport_GetEffectiveFOV();

--- a/src/trx/game/clock/common.h
+++ b/src/trx/game/clock/common.h
@@ -9,9 +9,8 @@ void Clock_DisableWait(void);
 // Restores the waiting Clock_DisableWait turned off.
 void Clock_EnableWait(void);
 
-// Counts time in frames: every Clock_WaitTick moves the clock on by 1/fps,
-// whatever the frame really took. Zero goes back to real time, carrying on
-// from where the frame count reached.
+// Counts time in frames: every Clock_WaitTick moves the clock on by 1/fps. Zero
+// goes back to real time, carrying on from where the frame count reached.
 void Clock_EnableFixedFPS(int32_t fps);
 
 void Clock_SyncTick(void);

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -1080,6 +1080,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     g_InvRing_Mode = mode;
 
     if (mode == INV_TITLE_MODE) {
+        Camera_Initialise();
         LUA_FireEvent(LUA_EVENT_TITLE_START);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures the camera has been initialised in the title to avoid crashes with ones that don't used flybys. If Lara isn't loaded, the initialisation is skipped, so regular title levels are unaffected.