### PR TITLE
objects/quad_bike: exit control after drowning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -86,6 +86,7 @@
 - Fixed Lara attempting to climb ladders from inside lifts (#5890)
 - Fixed Lara not getting killed by lifts if standing on top of one and the ceiling space becomes too low
 - Fixed the detonator box returning to its original position after loading a save (OG bug)
+- Fixed the game sometimes crashing when Lara rides a quad bike into deep water or a swamp
 
 **Weather and effects**
 - Added the ability to change how heavily the rain or snow falls, from Lua and with the `/weather` console command (#6080)

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -995,7 +995,7 @@ static int32_t M_SkidooDynamics(ITEM *const item)
     return anim;
 }
 
-static void M_AnimateQuadBike(
+static bool M_AnimateQuadBike(
     ITEM *const item, const int32_t hit_wall, const bool killed)
 {
     int16_t state;
@@ -1145,7 +1145,10 @@ static void M_AnimateQuadBike(
         lara_item->goal_anim_state = M_STATE_FALL_OFF;
         Lara_Kill();
         M_Explode(item);
+        return false;
     }
+
+    return true;
 }
 
 static bool M_UserControl(ITEM *item, int32_t height, int32_t *pitch)
@@ -1485,7 +1488,9 @@ bool QuadBike_Control(void)
 
         lara_item->pos = item->pos;
         lara_item->rot = item->rot;
-        M_AnimateQuadBike(item, hit_wall, killed);
+        if (!M_AnimateQuadBike(item, hit_wall, killed)) {
+            return false;
+        }
         Item_Animate(lara_item);
         Lara_Vehicle_SyncItemAnim();
         g_Camera.target_elevation = -5460;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The control routine now stops as soon as riding into water or swamp explodes the quad. Before this it ran on with the vehicle already destroyed and the vehicle index cleared, so the dismount check read a null vehicle and crashed the game whenever Lara's animation sat on its last frame that tick.

Resolves TRX1042