### PR TITLE
music: restore explicit version behavior

### DIFF
--- a/data/trx/ship/games/tr3-la/scripts/_game.lua
+++ b/data/trx/ship/games/tr3-la/scripts/_game.lua
@@ -1,9 +1,3 @@
-trx.events.on_game_start(function()
-  local level = trx.game.current_level
-  local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
-  trx.rules.set("music.is_one_shot_default", use_one_shot)
-end)
-
 require("common.water_color").declare({
   order = { "pc", "custom" },
   modes = {

--- a/data/trx/ship/games/tr3/scripts/_game.lua
+++ b/data/trx/ship/games/tr3/scripts/_game.lua
@@ -1,9 +1,3 @@
-trx.events.on_game_start(function()
-  local level = trx.game.current_level
-  local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
-  trx.rules.set("music.is_one_shot_default", use_one_shot)
-end)
-
 require("common.water_color").declare({
   order = { "pc", "ps1", "custom" },
   modes = {

--- a/data/trx/ship/games/tr4/scripts/_game.lua
+++ b/data/trx/ship/games/tr4/scripts/_game.lua
@@ -1,5 +1,0 @@
-trx.events.on_game_start(function()
-  local level = trx.game.current_level
-  local use_one_shot = level ~= nil and level.type ~= trx.game.LevelType.GYM
-  trx.rules.set("music.is_one_shot_default", use_one_shot)
-end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -197,7 +197,6 @@
 - Added `show_pickup_aid`, `rotation` and `glow_color` properties for all pickup types
 - Changed object properties to take effect as soon as they change, rather than only when the item is first set up
 - Changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
-- Changed engine-specific music trigger behavior by defining rules settable in Lua; refer to documentation
 - Changed where an item a defeated enemy carried lands, and which way it faces, by defining rules settable in Lua; refer to documentation (#5883)
 - Changed the gameflow's `main_menu_picture` to be optional: a game that names no picture shows its title level behind the menu, and its title script says what plays there
 - Changed `O_SCION_ITEM_1` handling to use a pickup mode of `PLINTH_SCION`; refer to migration guide

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1267,7 +1267,6 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── lara_outfits.bin
 │   │   │   └── sparks_gfx.bin
 │   │   ├── scripts
-│   │   │   ├── _game.lua
 │   │   │   ├── alexhub2.lua
 │   │   │   ├── alexhub.lua
 │   │   │   ├── ang_race.lua
@@ -2619,7 +2618,6 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── lara_outfits.bin
     │   │   │   │   └── sparks_gfx.bin
     │   │   │   ├── scripts
-    │   │   │   │   ├── _game.lua
     │   │   │   │   ├── alexhub2.lua
     │   │   │   │   ├── alexhub.lua
     │   │   │   │   ├── ang_race.lua

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6048,11 +6048,6 @@
       "callable": false,
       "implicit": true,
       "path": "rules.carrier"
-    },
-    {
-      "callable": false,
-      "implicit": true,
-      "path": "rules.music"
     }
   ],
   "numbers": [
@@ -6453,24 +6448,6 @@
     {
       "description": "Whether an item a defeated enemy carried turns to face the way the enemy\ndid, rather than keeping the rotation the level gave it. This only reaches\ndrops the level data places on the enemy; a drop the gameflow names always\ntakes the enemy's facing.",
       "path": "rules.carrier.inherit_facing",
-      "type": "boolean",
-      "writable": true
-    },
-    {
-      "description": "Whether non-ambient tracks triggered from floor data should react to trigger masks, requiring all bits to be set for the music to play. Current playing music whose mask becomes unset will stop.",
-      "path": "rules.music.accumulate_trigger_masks",
-      "type": "boolean",
-      "writable": true
-    },
-    {
-      "description": "Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.",
-      "path": "rules.music.is_one_shot_default",
-      "type": "boolean",
-      "writable": true
-    },
-    {
-      "description": "Whether timers used for non-ambient tracks triggered from floor data should be interpreted as a delay before playing the track.",
-      "path": "rules.music.supports_delay",
       "type": "boolean",
       "writable": true
     },

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -39,9 +39,6 @@ that wants the defaults back asks for them.
   did, rather than keeping the rotation the level gave it. This only reaches
   drops the level data places on the enemy; a drop the gameflow names always
   takes the enemy's facing.
-- <a id="rules.music.accumulate_trigger_masks" name="rules.music.accumulate_trigger_masks"></a>**`trx.rules.music.accumulate_trigger_masks`** (boolean). Whether non-ambient tracks triggered from floor data should react to trigger masks, requiring all bits to be set for the music to play. Current playing music whose mask becomes unset will stop.
-- <a id="rules.music.is_one_shot_default" name="rules.music.is_one_shot_default"></a>**`trx.rules.music.is_one_shot_default`** (boolean). Whether non-ambient tracks triggered from floor data default to being flagged as one-shot.
-- <a id="rules.music.supports_delay" name="rules.music.supports_delay"></a>**`trx.rules.music.supports_delay`** (boolean). Whether timers used for non-ambient tracks triggered from floor data should be interpreted as a delay before playing the track.
 
 ### Functions
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -86,25 +86,6 @@ rule("carrier.inherit_facing", {
   ]],
 })
 
-rule("music.accumulate_trigger_masks", {
-  type = "boolean",
-  description = "Whether non-ambient tracks triggered from floor data should "
-    .. "react to trigger masks, requiring all bits to be set for the music to "
-    .. "play. Current playing music whose mask becomes unset will stop.",
-})
-
-rule("music.is_one_shot_default", {
-  type = "boolean",
-  description = "Whether non-ambient tracks triggered from floor data default "
-    .. "to being flagged as one-shot.",
-})
-
-rule("music.supports_delay", {
-  type = "boolean",
-  description = "Whether timers used for non-ambient tracks triggered from "
-    .. "floor data should be interpreted as a delay before playing the track.",
-})
-
 api.define("rules.list", {
   description = "Every rule there is, as dotted `group.field` keys, in no particular order. "
     .. "<!--noref: group.field-->",

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -839,11 +839,6 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
         return;
     }
 
-    MUSIC_TRACK_STATE *const track = &m_TrackStates[track_id];
-    if (track->is_one_shot) {
-        return;
-    }
-
     if (M_IsAmbientTrack(track_id)) {
         Music_Play_Direct(track_id, MPM_LOOP);
         return;
@@ -855,7 +850,13 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
         play_mode = MPM_OVERLAY;
     }
 
-    if (g_Rules.music.accumulate_trigger_masks) {
+    MUSIC_TRACK_STATE *const track = &m_TrackStates[track_id];
+
+    if (g_TRVersion == 1) {
+        if (track->is_one_shot) {
+            return;
+        }
+
         if (trigger->kind == MUSIC_TRIGGER_SWITCH) {
             track->mask ^= trigger->mask;
         } else if (trigger->kind == MUSIC_TRIGGER_ANTI) {
@@ -864,36 +865,73 @@ void Music_Trigger(MUSIC_ID track_id, const MUSIC_TRIGGER *const trigger)
             track->mask |= trigger->mask;
         }
 
-        if (track->mask != TRIGGER_MASK_ALL) {
+        if (track->mask == TRIGGER_MASK_ALL) {
+            if (trigger->one_shot) {
+                track->is_one_shot = true;
+            }
+            Music_Play_Direct(track_id, play_mode);
+        } else {
             Music_StopTrack_Direct(track_id);
+        }
+        return;
+    }
+
+    if (g_TRVersion == 2) {
+        if ((track->mask & trigger->mask) != 0) {
             return;
         }
-    } else if ((track->mask & trigger->mask) != 0) {
+
+        if (trigger->one_shot) {
+            track->mask |= trigger->mask;
+        }
+
+        if (trigger->timer == 0) {
+            Music_Play_Direct(track_id, play_mode);
+            return;
+        }
+
+        if (track_id != Music_GetDelayedTrack()) {
+            Music_Play_Direct(track_id, MPM_DELAY);
+            track->delay = LOGIC_FPS * trigger->timer;
+            return;
+        }
+
+        if (track->delay == 0) {
+            return;
+        }
+
+        track->delay--;
+        if (track->delay == 0) {
+            Music_Play_Direct(track_id, play_mode);
+        }
+
         return;
     }
 
-    if (trigger->one_shot || g_Rules.music.is_one_shot_default) {
-        track->mask |= trigger->mask;
-        track->is_one_shot = true;
-    }
+    {
+        if (!Game_IsInGym()) {
+            // TR3+ used one-shot as an extra bit together with the other five
+            // usual trigger bits. This is used to allow triggering the same
+            // track multiple times in a level, but keeping one-shot to mean per
+            // unique trigger setup.
+            uint8_t trigger_mask = trigger->mask;
+            if (trigger->one_shot) {
+                trigger_mask |= 1 << 6;
+            }
 
-    if (trigger->timer == 0 || !g_Rules.music.supports_delay) {
-        Music_Play_Direct(track_id, play_mode);
-        return;
-    }
+            uint8_t track_mask = track->mask;
+            if (track->is_one_shot) {
+                track_mask |= 1 << 6;
+            }
 
-    if (track_id != Music_GetDelayedTrack()) {
-        Music_Play_Direct(track_id, MPM_DELAY);
-        track->delay = LOGIC_FPS * trigger->timer;
-        return;
-    }
+            if ((track_mask & trigger_mask) == trigger_mask) {
+                return;
+            }
 
-    if (track->delay == 0) {
-        return;
-    }
+            track->mask |= trigger->mask;
+            track->is_one_shot |= trigger->one_shot;
+        }
 
-    track->delay--;
-    if (track->delay == 0) {
         Music_Play_Direct(track_id, play_mode);
     }
 }

--- a/src/trx/game/rules.def
+++ b/src/trx/game/rules.def
@@ -33,11 +33,3 @@ X_GROUP_BEGIN(carrier)
 X_RULE(bool, carrier, snap_to_sector, false)
 X_RULE(bool, carrier, inherit_facing, true)
 X_GROUP_END(carrier)
-
-// Determines how music triggered from floor data is played and the
-// interpretation of their state flags.
-X_GROUP_BEGIN(music)
-X_RULE(bool, music, accumulate_trigger_masks, false)
-X_RULE(bool, music, is_one_shot_default, false)
-X_RULE(bool, music, supports_delay, false)
-X_GROUP_END(music)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This reverts the rules introduced in f36ce49 to fix TR3's music trigger system. One-shot there does not mean one-shot in the traditional sense, it's used as an extra bit together with the five regular trigger bits to allow re-using the same track in a level, but keeping the "one-shot-ness" tied to the trigger setup. We can look again at normalising this into rules.

Resolves #6188 / TRX1038.

Test
- [x] Load Temple Ruins, `/tp 171` and go through the underwater gate crossing the trigger for track 25. Fly up into room 176 and cross the different music track there, then return to the dart tunnel - the track should not replay. `/tp 124`, open the gate and cross the trigger for track 25 - it should play. Run `/music 2` to interrupt it, then cross the trigger again - it should not play.
- [x] Restart the level and try the above again, but the other way around, so going to room 124 first.
- [x] Check Area51 room 64 - track 3 should play and if you save/load with `Fix one-shot music triggers` enabled it should not replay
- [x] Try above with `Fix one-shot music triggers` disabled
- [x] Check one-shot tracks in TR1
- [x] Check one-shot tracks in TR2
- [x] Check delayed tracks in TR2 gym
