### PR TITLE
cutseq: let the player skip a cutscene

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added injection support for putting a room in a flip group, which only TR4 levels carry themselves (#5336)
 
 **TR4**
+- Added the ability to skip in-game cutscenes
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level
 
 ## [1.10](https://github.com/LostArtefacts/TRX/compare/trx-1.9.3...trx-1.10) - 2026-08-12

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -11,6 +11,7 @@
 #include <trx/game/fader.h>
 #include <trx/game/flyby_mode.h>
 #include <trx/game/game_flow.h>
+#include <trx/game/input.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -419,6 +420,15 @@ void CutSeq_Request(const int32_t num)
     Fader_InitFromCurrent(&m_State.fader, 1.0f, M_FADE_DURATION);
 }
 
+void CutSeq_Skip(void)
+{
+    if (m_State.phase != M_PHASE_PLAYING) {
+        return;
+    }
+    m_State.phase = M_PHASE_FADE_END;
+    Fader_InitFromCurrent(&m_State.fader, 1.0f, M_END_FADE_DURATION);
+}
+
 void CutSeq_HandleTrigger(const int32_t num)
 {
     // A pad answers every frame Lara stands on it, so the once-only rule comes
@@ -532,6 +542,13 @@ void CutSeq_Reset(void)
 
 void CutSeq_Control(void)
 {
+    // As a cutscene level answers them, and for the same reason: a scene the
+    // player has seen before is a scene to get past.
+    if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
+        CutSeq_Skip();
+        Input_HoldOffSkip();
+    }
+
     switch (m_State.phase) {
     case M_PHASE_FADE_OUT:
         if (!Fader_IsActive(&m_State.fader)) {

--- a/src/trx/game/cutseq/playback.h
+++ b/src/trx/game/cutseq/playback.h
@@ -52,6 +52,12 @@ void CutSeq_SetPlayedMask(uint64_t mask);
 // the original engine does for the scenes that move her.
 void CutSeq_SetLaraReturn(XYZ_32 pos, int16_t rot);
 
+// Ends the running cutscene early, fading out as it would at its own last
+// frames, so the scene finishes rather than being torn away: Lara is put back
+// where she belongs and the end event still fires. Does nothing when no
+// cutscene is playing or one is already ending.
+void CutSeq_Skip(void);
+
 // Handles a TO_CUTSCENE floor trigger: plays the cutscene once, unless a
 // script answers the trigger itself.
 void CutSeq_HandleTrigger(int32_t num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A cutscene the player has seen before is one to get past, and the cutscene levels already answer confirm and back that way.

It ends the scene rather than cutting it away: the fade it would run at its own last frames starts early, so Lara is put back where the scene meant to leave her and a script still hears it end.