### PR TITLE
cutseq: keep the camera's room while it flies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **TR4**
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level
+- Fixed rooms and their contents sometimes disappearing while an in-game cutscene plays
 
 ## [1.10](https://github.com/LostArtefacts/TRX/compare/trx-1.9.3...trx-1.10) - 2026-08-12
 Showcase: https://youtu.be/DKpqz_Yum6o

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -589,10 +589,10 @@ void CutSeq_UpdateCamera(void)
         .y = info->origin.y + 2 * m_State.camera_nodes[1].y_run,
         .z = info->origin.z + 2 * m_State.camera_nodes[1].z_run,
     };
-    const int16_t room_num = Room_GetIndexFromPos(g_Camera.pos.pos);
-    if (room_num != NO_ROOM) {
-        g_Camera.pos.room_num = room_num;
-    }
+
+    int16_t room_num = g_Camera.pos.room_num;
+    Room_GetSector(g_Camera.pos.pos, &room_num);
+    g_Camera.pos.room_num = room_num;
     g_Camera.roll = 0;
     g_Camera.shift = 0;
     Viewport_AlterFOV(m_State.fov, FOV_MODE_CUTSCENE);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The original engine walks portals from the room the camera was in towards the point, which lands on the room nearest to it.