### PR TITLE
ui/scrollable: fit the view to a shorter list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.10...develop) - ××××-××-××
 
+**UI**
+- Fixed the controls key list jumping after switching to a tab with fewer keys (regression from 1.3)
+
 **Developer console**
 - Changed the `/flip` console command to take a flip group, so `/flip 3` moves that group alone while `/flip` on its own moves them all
 

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -820,6 +820,11 @@ unit_tests += {
   'engine': ['game/lua/capi/items.c'],
 }
 
+unit_tests += {
+  'name': 'trx/game/ui/scrollable',
+  'engine': ['game/ui/scrollable.c'],
+}
+
 # Word wrapping, over the shipped font.bin of a single game: what the wrapper
 # decides rests on glyph widths, so a stub font would agree with anything.
 unit_tests += {

--- a/src/tests/trx/game/ui/scrollable.c
+++ b/src/tests/trx/game/ui/scrollable.c
@@ -1,0 +1,96 @@
+#include <harness/harness.h>
+
+#include <trx/game/ui/scrollable.h>
+
+static UI_SCROLLABLE M_Make(
+    const int32_t max_items, const int32_t vis_items, const int32_t first_item,
+    const int32_t sel_item)
+{
+    return (UI_SCROLLABLE) {
+        .first_item = first_item,
+        .sel_item = sel_item,
+        .max_items = max_items,
+        .vis_items = vis_items,
+    };
+}
+
+TEST(moving_down_past_the_last_visible_item_scrolls)
+{
+    UI_SCROLLABLE s = M_Make(10, 4, 0, 3);
+    CHECK(UI_Scrollable_SelectNext(&s, false));
+    CHECK_EQ_INT(s.sel_item, 4);
+    CHECK_EQ_INT(s.first_item, 1);
+}
+
+TEST(moving_down_off_the_end_stays_put_without_wraparound)
+{
+    UI_SCROLLABLE s = M_Make(10, 4, 6, 9);
+    CHECK(!UI_Scrollable_SelectNext(&s, false));
+    CHECK_EQ_INT(s.sel_item, 9);
+    CHECK_EQ_INT(s.first_item, 6);
+}
+
+TEST(wrapping_down_scrolls_back_to_the_top)
+{
+    UI_SCROLLABLE s = M_Make(10, 4, 6, 9);
+    CHECK(UI_Scrollable_SelectNext(&s, true));
+    CHECK_EQ_INT(s.sel_item, 0);
+    CHECK_EQ_INT(s.first_item, 0);
+}
+
+TEST(wrapping_up_scrolls_to_the_bottom)
+{
+    UI_SCROLLABLE s = M_Make(10, 4, 0, 0);
+    CHECK(UI_Scrollable_SelectPrev(&s, true));
+    CHECK_EQ_INT(s.sel_item, 9);
+    CHECK_EQ_INT(s.first_item, 6);
+}
+
+TEST(a_shorter_list_pulls_the_view_back_to_its_end)
+{
+    // The controls editor keeps one scroll state across its tabs. Switching
+    // from a long tab, scrolled to its end, to a shorter one used to leave the
+    // view scrolled past the new end, and the next keypress snapped it back.
+    UI_SCROLLABLE s = M_Make(19, 13, 6, 18);
+    UI_Scrollable_SetMaxItems(&s, 15);
+    CHECK_EQ_INT(s.sel_item, 14);
+    CHECK_EQ_INT(s.first_item, 2);
+    CHECK(UI_Scrollable_IsItemVisible(&s, s.sel_item));
+
+    CHECK(UI_Scrollable_SelectPrev(&s, false));
+    CHECK_EQ_INT(s.first_item, 2);
+}
+
+TEST(a_list_shorter_than_the_view_starts_at_its_first_item)
+{
+    UI_SCROLLABLE s = M_Make(19, 13, 6, 18);
+    UI_Scrollable_SetMaxItems(&s, 5);
+    CHECK_EQ_INT(s.sel_item, 4);
+    CHECK_EQ_INT(s.first_item, 0);
+}
+
+TEST(a_longer_list_leaves_the_view_where_it_was)
+{
+    UI_SCROLLABLE s = M_Make(15, 13, 2, 14);
+    UI_Scrollable_SetMaxItems(&s, 19);
+    CHECK_EQ_INT(s.sel_item, 14);
+    CHECK_EQ_INT(s.first_item, 2);
+}
+
+TEST(a_taller_view_shows_more_of_the_list)
+{
+    UI_SCROLLABLE s = M_Make(10, 4, 6, 9);
+    UI_Scrollable_SetVisibleItems(&s, 8);
+    CHECK_EQ_INT(s.first_item, 2);
+    CHECK_EQ_INT(UI_Scrollable_GetLastVisibleItem(&s), 9);
+}
+
+TEST(selecting_the_last_item_scrolls_it_into_view)
+{
+    UI_SCROLLABLE s = M_Make(10, 4, 0, 0);
+    UI_Scrollable_SelectLastItem(&s);
+    CHECK_EQ_INT(s.sel_item, 9);
+    CHECK(UI_Scrollable_IsItemVisible(&s, 9));
+    CHECK(!UI_Scrollable_IsItemVisible(&s, 5));
+    CHECK(UI_Scrollable_IsItemSelected(&s, 9));
+}

--- a/src/trx/game/ui/scrollable.c
+++ b/src/trx/game/ui/scrollable.c
@@ -80,6 +80,7 @@ void UI_Scrollable_SetMaxItems(UI_SCROLLABLE *const s, const int32_t max_items)
 {
     s->max_items = max_items;
     CLAMP(s->sel_item, 0, s->max_items - 1);
+    M_Clamp(s, true);
 }
 
 void UI_Scrollable_SelectItem(UI_SCROLLABLE *const s, const int32_t row)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Setting a scrollable's item count now pulls the view back inside the list. Before this, only the selected item was clamped, so the view could stay scrolled past the end until the next keypress snapped it back.

In the controls dialog this showed when stepping from a tab with many keys, scrolled to its bottom, to a tab with fewer: the list opened part way down with blank rows below it, and the next press of up jumped it several rows at once.

Resolves TRX1054