### PR TITLE
pathing: cross TR4's jump and monkey overlaps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 **Lua**
 - Added `trx.cutscenes.actor_count`, `trx.cutscenes.set_actor_visible()`, `trx.cutscenes.set_node_mesh()` and `trx.cutscenes.clear_node_mesh()`, for hiding an actor in the scene on screen or putting another object's mesh on one
+- Fixed creatures taking wrong routes where crossing to the next square needs a jump or a monkey swing
 
 ## [1.10](https://github.com/LostArtefacts/TRX/compare/trx-1.9.3...trx-1.10) - 2026-08-12
 Showcase: https://youtu.be/DKpqz_Yum6o

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -672,6 +672,9 @@ void Creature_ApplyMood(
         Box_TargetBox(lot, item->box_num);
     }
     Box_CalculateTarget(&creature->target, item, lot);
+
+    creature->monkey_ahead =
+        g_TRVersion >= 4 && Box_IsMonkeyAhead(lot, item->box_num);
 }
 
 int16_t Creature_Turn(ITEM *const item, int16_t max_turn)
@@ -962,9 +965,10 @@ bool Creature_Animate(
     const int32_t box_height =
         item->box_num == NO_BOX ? height : Box_GetBox(item->box_num)->height;
     if (sector->box == NO_BOX
-        || (fly_check && zone[item->box_num] != zone[sector->box])
-        || box_height - height > lot->setup.step
-        || box_height - height < lot->setup.drop) {
+        || (!lot->is_jumping
+            && ((fly_check && zone[item->box_num] != zone[sector->box])
+                || box_height - height > lot->setup.step
+                || box_height - height < lot->setup.drop))) {
         const int32_t pos_x = item->pos.x >> WALL_SHIFT;
         const int32_t pos_z = g_TRVersion < 3
             ? pos_x
@@ -1194,6 +1198,23 @@ bool Creature_Animate(
             item->rot.x += DEG_1;
         } else {
             item->rot.x = item_angle;
+        }
+    } else if (lot->is_jumping) {
+        // A jumper is off the boxes until it lands, so its height comes from
+        // the room rather than from the box it is over. Monkey swinging hangs
+        // it off the ceiling the same way.
+        sector = Room_GetSector(item->pos, &room_num);
+        item->floor = Room_GetHeight(sector, item->pos);
+        if (lot->is_monkeying) {
+            item->pos.y = Room_GetCeiling(
+                              sector, (XYZ_32) { item->pos.x, y, item->pos.z })
+                - bounds->min.y;
+        } else if (item->pos.y > item->floor) {
+            if (item->pos.y > item->floor + STEP_L) {
+                item->pos = old;
+            } else {
+                item->pos.y = item->floor;
+            }
         }
     } else {
         sector = Room_GetSector(item->pos, &room_num);

--- a/src/trx/game/creature/types.h
+++ b/src/trx/game/creature/types.h
@@ -22,6 +22,8 @@ typedef struct CREATURE {
     bool head_left;
     bool head_right;
     bool reached_goal;
+    // Set while the path ahead is monkey bars, which TR4's guides swing along.
+    bool monkey_ahead;
     bool hurt_by_lara;
     int32_t damage_from_lara;
     bool patrol_2;

--- a/src/trx/game/pathing/box.c
+++ b/src/trx/game/pathing/box.c
@@ -13,6 +13,12 @@
 #define BOX_END_BIT 0x8000
 #define BOX_NUMBER_BITS 0x7FFF // = ~BOX_END_BIT
 
+// TR4 spends the room above the box number on what it takes to cross the
+// overlap, which leaves it eleven bits to number a box with.
+#define BOX_NUMBER_BITS_TR4 0x07FF
+#define BOX_OVERLAP_JUMP 0x0800
+#define BOX_OVERLAP_MONKEY 0x2000
+
 #define BOX_MAX_EXPANSION 5
 #define BOX_BIFF (WALL_L / 2) // = 0x200 = 512
 #define BOX_CLIP_LEFT 1
@@ -29,6 +35,11 @@ static int32_t m_OverlapCount = 0;
 static int16_t *m_Overlaps = nullptr;
 static int16_t *m_FlyZone[2] = {};
 static int16_t *m_GroundZone[MAX_ZONES][2] = {};
+
+static int16_t M_GetOverlapBoxNum(const int16_t overlap)
+{
+    return overlap & (g_TRVersion >= 4 ? BOX_NUMBER_BITS_TR4 : BOX_NUMBER_BITS);
+}
 
 static int16_t M_GetOverlap(const int32_t overlap_idx)
 {
@@ -126,8 +137,9 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
 
             if ((box_num & BOX_END_BIT) != 0) {
                 done = true;
-                box_num &= BOX_NUMBER_BITS;
             }
+            const int16_t overlap_flags = box_num;
+            box_num = M_GetOverlapBoxNum(box_num);
 
             const BOX_INFO *const box = Box_GetBox(box_num);
             if (box == nullptr) {
@@ -139,7 +151,15 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
             }
 
             const int32_t change = box->height - head_box->height;
-            if (change > lot->setup.step || change < lot->setup.drop) {
+            if ((change > lot->setup.step || change < lot->setup.drop)
+                && !(
+                    lot->setup.can_monkey
+                    && (overlap_flags & BOX_OVERLAP_MONKEY) != 0)) {
+                continue;
+            }
+
+            if ((overlap_flags & BOX_OVERLAP_JUMP) != 0
+                && !lot->setup.can_jump) {
                 continue;
             }
 
@@ -186,6 +206,31 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
     }
 
     return true;
+}
+
+// How the path leaves the box the creature stands in. TR4 marks the overlaps
+// that take a jump or a swing along the monkey bars to cross.
+bool Box_IsMonkeyAhead(const LOT_INFO *const lot, const int16_t box_num)
+{
+    const BOX_INFO *const box = Box_GetBox(box_num);
+    if (box == nullptr || lot->node[box_num].exit_box == NO_BOX) {
+        return false;
+    }
+
+    const int16_t exit_box = lot->node[box_num].exit_box;
+    int32_t index = box->overlap_index & BOX_OVERLAP_BITS;
+    while (true) {
+        const int16_t overlap = M_GetOverlap(index++);
+        if (overlap == NO_BOX) {
+            return false;
+        }
+        if (M_GetOverlapBoxNum(overlap) == exit_box) {
+            return (overlap & BOX_OVERLAP_MONKEY) != 0;
+        }
+        if ((overlap & BOX_END_BIT) != 0) {
+            return false;
+        }
+    }
 }
 
 bool Box_UpdateLOT(LOT_INFO *const lot, const int32_t expansion)
@@ -484,6 +529,12 @@ bool Box_BadFloor(
         Room_GetSector((XYZ_32) { x, y, z }, &room_num);
     if (sector->box == NO_BOX) {
         return true;
+    }
+
+    // A jumper is crossing a gap the boxes call bad floor, which is what it
+    // was sent over the gap to do.
+    if (lot->is_jumping) {
+        return false;
     }
 
     const BOX_INFO *const box = Box_GetBox(sector->box);

--- a/src/trx/game/pathing/box.h
+++ b/src/trx/game/pathing/box.h
@@ -19,6 +19,9 @@ bool Box_EscapeBox(const ITEM *item, const ITEM *enemy, int16_t box_num);
 bool Box_ValidBox(const ITEM *item, int16_t zone_num, int16_t box_num);
 TARGET_TYPE Box_CalculateTarget(
     XYZ_32 *target, const ITEM *item, LOT_INFO *lot);
+// Checks whether the path out of the given box crosses monkey bars.
+bool Box_IsMonkeyAhead(const LOT_INFO *lot, int16_t box_num);
+
 bool Box_BadFloor(
     int32_t x, int32_t y, int32_t z, int32_t box_height, int32_t next_height,
     int16_t room_num, const LOT_INFO *lot);

--- a/src/trx/game/pathing/lot.c
+++ b/src/trx/game/pathing/lot.c
@@ -54,6 +54,16 @@ LOT_SETUP LOT_Setup(const LOT_SETUP_TYPE type)
             .block_mask = BOX_BLOCKED,
         };
 
+    case LOT_SETUP_ACROBAT:
+        return (LOT_SETUP) {
+            .step = WALL_L,
+            .drop = -WALL_L,
+            .fly = 0,
+            .block_mask = BOX_BLOCKED,
+            .can_jump = true,
+            .can_monkey = true,
+        };
+
     case LOT_SETUP_FLYER:
         return (LOT_SETUP) {
             .step = WALL_L * 20,

--- a/src/trx/game/pathing/types.h
+++ b/src/trx/game/pathing/types.h
@@ -24,6 +24,7 @@ typedef enum {
     LOT_SETUP_QUADRUPED,
     LOT_SETUP_JUMPER,
     LOT_SETUP_CLIMBER,
+    LOT_SETUP_ACROBAT,
     LOT_SETUP_FLYER,
 } LOT_SETUP_TYPE;
 
@@ -32,10 +33,18 @@ typedef struct {
     int16_t drop;
     int16_t fly;
     uint16_t block_mask;
+    // TR4 marks the overlaps that take a jump or the monkey bars to cross,
+    // and only a creature that can do either is pathed over them.
+    bool can_jump;
+    bool can_monkey;
 } LOT_SETUP;
 
 typedef struct {
     LOT_SETUP setup;
+    // TR4's guides leave the floor along their path: they jump the gaps and
+    // swing the monkey bars. Set while that is what they are doing.
+    bool is_jumping;
+    bool is_monkeying;
     BOX_NODE *node;
     int16_t head;
     int16_t tail;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

TR4 numbers a box in eleven bits and spends the rest of the word on what it takes to cross the overlap: a jump, or a swing along the monkey bars. The box search reads those, and a creature that can do neither is not offered them, so its LOT setup says which it can.

A creature crossing one is off the boxes until it lands, so the box it is over stops holding it back and its height comes from the room. Monkey swinging hangs it off the ceiling the same way. Its own control asks whether the way ahead is bars, which nothing answered before.