### PR TITLE
ui/scrollable: keep the scroll with no selection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)
 - Changed the tab arrows to no longer vanish once the selection moved into the list below them
 - Fixed the settings and controls dialog tabs ignoring rebound step left and step right keys
+- Fixed the settings dialogs scrolling their list back to the top when the selection moved up to the tabs
 - Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects
 - Fixed the controls key list jumping after switching to a tab with fewer keys (regression from 1.3)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control

--- a/src/tests/trx/game/ui/scrollable.c
+++ b/src/tests/trx/game/ui/scrollable.c
@@ -94,3 +94,23 @@ TEST(selecting_the_last_item_scrolls_it_into_view)
     CHECK(!UI_Scrollable_IsItemVisible(&s, 5));
     CHECK(UI_Scrollable_IsItemSelected(&s, 9));
 }
+
+TEST(an_item_count_leaves_an_empty_selection_empty)
+{
+    // The settings dialog clears the selection while its focus is on the tab
+    // row, and recounts the rows every frame. Taking the count used to turn
+    // the empty selection into the first row, which scrolled the list to the
+    // top a frame after the tabs were reached.
+    UI_SCROLLABLE s = M_Make(30, 15, 15, -1);
+    UI_Scrollable_SetMaxItems(&s, 30);
+    UI_Scrollable_SetVisibleItems(&s, 15);
+    CHECK_EQ_INT(s.sel_item, -1);
+    CHECK_EQ_INT(s.first_item, 15);
+}
+
+TEST(an_item_count_pulls_the_selection_inside_the_list)
+{
+    UI_SCROLLABLE s = M_Make(30, 15, 15, 29);
+    UI_Scrollable_SetMaxItems(&s, 20);
+    CHECK_EQ_INT(s.sel_item, 19);
+}

--- a/src/trx/game/ui/scrollable.c
+++ b/src/trx/game/ui/scrollable.c
@@ -79,7 +79,9 @@ void UI_Scrollable_SetVisibleItems(
 void UI_Scrollable_SetMaxItems(UI_SCROLLABLE *const s, const int32_t max_items)
 {
     s->max_items = max_items;
-    CLAMP(s->sel_item, 0, s->max_items - 1);
+    if (s->sel_item != -1) {
+        CLAMP(s->sel_item, 0, s->max_items - 1);
+    }
     M_Clamp(s, true);
 }
 

--- a/src/trx/game/ui/scrollable.h
+++ b/src/trx/game/ui/scrollable.h
@@ -4,6 +4,8 @@
 
 typedef struct {
     int32_t first_item;
+    // -1 where nothing is selected, which a dialog uses while its focus sits
+    // outside the list. The scroll position is left alone while it holds.
     int32_t sel_item;
     int32_t max_items;
     int32_t vis_items;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the settings dialogs scrolled their list back to the top a frame after the selection moved up to the tab row. Taking the item count turned the empty selection into the first row, and the list then scrolled to show it.

A selection of -1 now survives the count, which is what the dialogs set while their focus is on the tabs.

Resolves TRX1055