### PR TITLE
Fix operating TR1-3 flipmaps

### DIFF
--- a/src/trx/game/objects/general/big_bowl.c
+++ b/src/trx/game/objects/general/big_bowl.c
@@ -71,7 +71,7 @@ static void M_FlipMap(const M_PRIV *const p)
     FLIP_SLOT *const slot = Room_GetFlipSlot(p->flip_slot);
     slot->mask = TRIGGER_MASK_ALL;
     slot->is_one_shot = true;
-    Room_FlipMap(p->flip_slot);
+    Room_FlipMap(Room_GetFlipGroup(p->flip_slot));
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/trx/game/objects/general/cabin.c
+++ b/src/trx/game/objects/general/cabin.c
@@ -34,7 +34,7 @@ static void M_FlipMap(const M_PRIV *const p)
     FLIP_SLOT *const slot = Room_GetFlipSlot(p->flip_slot);
     slot->mask = TRIGGER_MASK_ALL;
     slot->is_one_shot = true;
-    Room_FlipMap(p->flip_slot);
+    Room_FlipMap(Room_GetFlipGroup(p->flip_slot));
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -508,6 +508,16 @@ void Room_SetFlipStatus(const bool status)
     m_FlipStatus = status;
 }
 
+int32_t Room_GetFlipGroup(const int32_t flip_slot)
+{
+    for (int32_t i = 0; i < m_RoomCount; i++) {
+        if (m_Rooms[i].alternate_group != 0) {
+            return flip_slot;
+        }
+    }
+    return 0;
+}
+
 int32_t Room_GetFlipEffect(void)
 {
     return m_FlipEffect;

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -36,6 +36,12 @@ bool Room_GetFlipStatus(void);
 // Whether the given group is showing its pairs.
 bool Room_GetFlipGroupStatus(int32_t group);
 
+// The group a flip slot moves. A TR4 trigger names the group in the same
+// number it uses for the slot, where a TR1-3 trigger means the slot alone and
+// moves every pair in the level. A level that puts no room in a group is read
+// the TR1-3 way.
+int32_t Room_GetFlipGroup(int32_t flip_slot);
+
 // Puts back what a savegame recorded, once its groups have been replayed. The
 // groups alone do not say which of them moved last, and that is what the zones
 // and the sound sources read.

--- a/src/trx/game/rooms/triggers/flip.c
+++ b/src/trx/game/rooms/triggers/flip.c
@@ -12,17 +12,18 @@ static void M_HandleFlipMap(
         return;
     }
 
+    const int32_t group = Room_GetFlipGroup(flip_slot);
     const FLIP_TRIGGER flip_trigger = {
         .from_switch = trigger->type == TT_SWITCH,
         .mask = trigger->mask,
         .one_shot = trigger->one_shot,
     };
     if (Room_TriggerFlipSlot(flip_slot, &flip_trigger)) {
-        if (!Room_GetFlipGroupStatus(flip_slot)) {
-            status->flip_group = flip_slot;
+        if (!Room_GetFlipGroupStatus(group)) {
+            status->flip_group = group;
         }
-    } else if (Room_GetFlipGroupStatus(flip_slot)) {
-        status->flip_group = flip_slot;
+    } else if (Room_GetFlipGroupStatus(group)) {
+        status->flip_group = group;
     }
 }
 
@@ -32,10 +33,11 @@ static void M_HandleFlipOn(
 {
     const int16_t flip_slot = (int16_t)(intptr_t)cmd->parameter;
     const FLIP_SLOT *const slot = Room_GetFlipSlot(flip_slot);
+    const int32_t group = Room_GetFlipGroup(flip_slot);
     status->flip_available = true;
 
-    if (slot->mask == TRIGGER_MASK_ALL && !Room_GetFlipGroupStatus(flip_slot)) {
-        status->flip_group = flip_slot;
+    if (slot->mask == TRIGGER_MASK_ALL && !Room_GetFlipGroupStatus(group)) {
+        status->flip_group = group;
     }
 }
 
@@ -45,10 +47,11 @@ static void M_HandleFlipOff(
 {
     const int16_t flip_slot = (int16_t)(intptr_t)cmd->parameter;
     const FLIP_SLOT *const slot = Room_GetFlipSlot(flip_slot);
+    const int32_t group = Room_GetFlipGroup(flip_slot);
     status->flip_available = true;
 
-    if (slot->mask == TRIGGER_MASK_ALL && Room_GetFlipGroupStatus(flip_slot)) {
-        status->flip_group = flip_slot;
+    if (slot->mask == TRIGGER_MASK_ALL && Room_GetFlipGroupStatus(group)) {
+        status->flip_group = group;
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where a lever or a switch in TR1-3 did nothing at all: the levers at the end of Temple Ruins left the current running, and the big bowl and the cabin never swapped their rooms either.

Take two keyholes pointing at flip slot 1, each carrying part of its trigger mask, and a room X with an alternate room Y:

- turn the first key, and slot 1 holds part of its mask, so nothing fires;
- turn the second, the mask is complete, and the flip fires;
- TR1-3 swap every room that has an alternate, so X and Y go, where TR4 swaps the rooms whose alternate group matches the number the trigger carries, so group 1 goes.

Before this, TR1-3 were read the TR4 way: slot 1 completing looked for group 1, and a TR3 room has no alternate group, so nothing was in it and X stayed where it was. The stock TR3 levels use slots 0 to 8, and every level bar six has one.

The number is a group where a level puts a room in one, which a TR4 level does of its own and a TR1-3 level can be injected to do. Anywhere else it is the slot alone.

Resolves #6201
