### PR TITLE
items/manager: remove items from flipped rooms

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Added Natla as an outfit for Lara, selectable in every game (Graphic Options → Visuals → Lara's outfit)
 - Added injection support for putting a room in a flip group, which only TR4 levels carry themselves (#5336)
 
+**TR1**
+- Fixed the Cabin in Natla's Mines remaining visible after dropping to the floor (regression from 1.10)
+
 **TR4**
 - Added the ability to skip in-game cutscenes
 - Added waterfalls, which run and play their loop, and the mist that rises where they land

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -67,7 +67,8 @@ static inline bool M_ItemBoundsIntersectsPortal(
 
 // Take the item out of a room's draw queues: the room itself and every portal
 // neighbour it may have been queued into. Paired with the chain unlink below;
-// both must run when an item leaves a room.
+// both must run when an item leaves a room. Repeated for flipped rooms as
+// portals may differ if the map has been flipped.
 static void M_RemoveFromDrawQueues(
     const int16_t item_num, const int16_t room_num)
 {
@@ -80,6 +81,7 @@ static void M_RemoveFromDrawQueues(
         for (int32_t i = 0; i < room->portals->count; i++) {
             Room_RemoveDrawnItem(room->portals->portal[i].room_num, item_num);
         }
+        M_RemoveFromDrawQueues(item_num, room->flipped_room);
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures items are removed from flipped rooms where they have been added to multiple rooms' draw lists based on their bounds, but the items are later destroyed. Because the flipmap can happen at any time, traversing the portals could yield different results compared with when the item was initialised.

Resolves TRX1072.
