### PR TITLE
Fix the Lua error when starting TR1

### DIFF
--- a/data/trx/ship/games/tr1-ub/scripts/_game.lua
+++ b/data/trx/ship/games/tr1-ub/scripts/_game.lua
@@ -1,7 +1,3 @@
-trx.events.on_game_start(function()
-  trx.rules.set("music.accumulate_trigger_masks", true)
-end)
-
 require("common.water_color").declare({
   order = { "tombati", "dos", "custom" },
   modes = {

--- a/data/trx/ship/games/tr1/scripts/_game.lua
+++ b/data/trx/ship/games/tr1/scripts/_game.lua
@@ -1,7 +1,3 @@
-trx.events.on_game_start(function()
-  trx.rules.set("music.accumulate_trigger_masks", true)
-end)
-
 require("common.water_color").declare({
   order = { "tombati", "dos", "custom" },
   modes = {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where starting TR1 or Unfinished Business logged a Lua error. Their scripts still set a music rule that the engine stopped offering when the one-shot trigger behavior was restored, and setting a rule nothing knows about is an error.
