### PR TITLE
Fix a crash on a level missing an outfit

### DIFF
--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -874,7 +874,7 @@ static bool M_LoadLevel(
         }
         if (tmp != nullptr) {
             if (!ctx->validation_mode
-                && !Lara_Skin_IsOutfitAvailable(
+                && !Lara_Skin_IsOutfitDefined(
                     Lara_Skin_FindOutfitByName(tmp))) {
                 JSON_ReadIO_SetError(
                     io, "invalid 'lara_outfit' value (%s)", tmp);

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -419,6 +419,15 @@ void Lara_Skin_Initialise(void)
         }
         return;
     }
+
+    const int32_t outfit_count = Lara_Skin_GetOutfitCount();
+    for (int32_t i = 0; i < outfit_count; i++) {
+        if (!Lara_Skin_IsOutfitAvailable(i) && Lara_Skin_IsOutfitDefined(i)) {
+            LOG_WARNING(
+                "Outfit '%s' has no meshes in this level",
+                Lara_Skin_GetOutfitName(i));
+        }
+    }
     Lara_Skin_ApplyOutfitFromConfig();
 
     // She wears nothing yet, and the outfit above only dresses her where it

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -383,7 +383,8 @@ static bool M_CanDress(void)
     return GF_GetCurrentLevel() != nullptr && !FMV_IsPlaying()
         && Object_Get(O_LARA)->loaded
         && Object_Get(O_LARA_SKIN_SWAP_EXTRA)->loaded
-        && Object_Get(O_LARA_SKIN_SWAP_GUNS)->loaded;
+        && Object_Get(O_LARA_SKIN_SWAP_GUNS)->loaded
+        && Lara_Skin_IsOutfitAvailable(Lara_Skin_GetDefaultType());
 }
 
 void Lara_Skin_Reset(void)
@@ -418,18 +419,6 @@ void Lara_Skin_Initialise(void)
         }
         return;
     }
-    // What every outfit says it is made of, against what the level loaded.
-    const int32_t outfit_count = Lara_Skin_GetOutfitCount();
-    for (int32_t i = 0; i < outfit_count; i++) {
-        const LARA_SKIN_OUTFIT *const outfit = Lara_Skin_GetOutfit(i);
-        if (!outfit->is_defined) {
-            continue;
-        }
-        const OBJECT *const skin_obj = Object_Get(outfit->mesh_obj_id);
-        ASSERT(skin_obj->loaded);
-        ASSERT(skin_obj->mesh_count == LM_NUMBER_OF);
-    }
-
     Lara_Skin_ApplyOutfitFromConfig();
 
     // She wears nothing yet, and the outfit above only dresses her where it
@@ -483,6 +472,12 @@ void Lara_Skin_CycleOutfit(const int32_t dir)
         return;
     }
 
+    // A level whose meshes dress none of the outfits leaves her undressed,
+    // with nothing to cycle from.
+    if (!Lara_Skin_IsOutfitAvailable(m_SkinType)) {
+        return;
+    }
+
     // Update the config twice to guarantee the change is submitted in cases
     // where Lara_Skin_SetType has been called manually for non-permanent swaps
     // e.g. by Lua in cutscenes.
@@ -497,12 +492,13 @@ void Lara_Skin_CycleOutfit(const int32_t dir)
 
     const int32_t outfit_count = Lara_Skin_GetOutfitCount();
     int32_t type = m_SkinType;
-    do {
-        type += dir;
-        type += outfit_count;
-        type %= outfit_count;
-    } while (!Lara_Skin_IsOutfitAvailable(type)
-             || !Lara_Skin_GetOutfit(type)->is_selectable);
+    for (int32_t i = 0; i < outfit_count; i++) {
+        type = (type + dir + outfit_count) % outfit_count;
+        if (Lara_Skin_IsOutfitAvailable(type)
+            && Lara_Skin_GetOutfit(type)->is_selectable) {
+            break;
+        }
+    }
 
     M_SetConfigOutfit(Lara_Skin_GetOutfitName(type));
     Config_Update();

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -14,6 +14,7 @@
 #include <trx/game/catalog/manager.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/lara.h>
+#include <trx/game/objects/common.h>
 #include <trx/game/shell.h>
 
 #include <string.h>
@@ -531,6 +532,11 @@ LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
 
 LARA_SKIN_TYPE Lara_Skin_GetDefaultType(void)
 {
+    for (int32_t i = 0; i < m_OutfitCount; i++) {
+        if (Lara_Skin_IsOutfitAvailable(i)) {
+            return i;
+        }
+    }
     return m_OutfitCount > 0 ? 0 : LARA_SKIN_TYPE_DEFAULT;
 }
 
@@ -539,10 +545,24 @@ int32_t Lara_Skin_GetOutfitCount(void)
     return m_OutfitCount;
 }
 
-bool Lara_Skin_IsOutfitAvailable(const LARA_SKIN_TYPE skin_type)
+bool Lara_Skin_IsOutfitDefined(const LARA_SKIN_TYPE skin_type)
 {
     return skin_type >= 0 && skin_type < m_OutfitCount
         && m_Outfits[skin_type].outfit.is_defined;
+}
+
+// An outfit the level has no meshes for is not one she can wear. Levels built
+// before an outfit was added carry every slot but that one, and an install can
+// be missing the injection that holds them all.
+bool Lara_Skin_IsOutfitAvailable(const LARA_SKIN_TYPE skin_type)
+{
+    if (!Lara_Skin_IsOutfitDefined(skin_type)) {
+        return false;
+    }
+
+    const OBJECT *const skin_obj =
+        Object_Get(m_Outfits[skin_type].outfit.mesh_obj_id);
+    return skin_obj->loaded && skin_obj->mesh_count == LM_NUMBER_OF;
 }
 
 const LARA_SKIN_OUTFIT *Lara_Skin_GetOutfit(const LARA_SKIN_TYPE skin_type)

--- a/src/trx/game/lara/skin/storage.h
+++ b/src/trx/game/lara/skin/storage.h
@@ -3,6 +3,12 @@
 #include <trx/game/lara/skin/types.h>
 
 int32_t Lara_Skin_GetOutfitCount(void);
+// Whether the outfit is one the game declares, which is what a name read from
+// a game flow is checked against. Say nothing about the level, which is not
+// loaded when a game flow is read.
+bool Lara_Skin_IsOutfitDefined(LARA_SKIN_TYPE skin_type);
+
+// Whether the level carries the meshes to wear it.
 bool Lara_Skin_IsOutfitAvailable(LARA_SKIN_TYPE skin_type);
 const LARA_SKIN_OUTFIT *Lara_Skin_GetOutfit(LARA_SKIN_TYPE skin_type);
 const char *Lara_Skin_GetOutfitName(LARA_SKIN_TYPE skin_type);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes crashes when a level is missing outfit meshes. Unavailable outfits are now skipped, with Lara defaulting to the first available one.
