### PR TITLE
Say why a game cannot be played

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 **Miscellaneous**
 - Added an option to cast Lara in gold whatever she is wearing (Graphic Options → Visuals → Golden Lara)
 - Changed the message shown when there is nothing to play to name each game it passed over and say what is wrong with it, rather than leaving the reason in the log
+- Changed a game named with `--mod` to say why it cannot be played, rather than quietly starting a different one
 - Changed Lara turning to gold on the Midas hand to gild the outfit she has on, rather than swap her for a golden model
 
 **Lua**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 **Miscellaneous**
 - Added an option to cast Lara in gold whatever she is wearing (Graphic Options → Visuals → Golden Lara)
+- Changed the message shown when there is nothing to play to name each game it passed over and say what is wrong with it, rather than leaving the reason in the log
 - Changed Lara turning to gold on the Midas hand to gild the outfit she has on, rather than swap her for a golden model
 
 **Lua**

--- a/src/trx/core/json/util/file.c
+++ b/src/trx/core/json/util/file.c
@@ -34,8 +34,21 @@ JSON_VALUE *JSONFile_Read(const char *path)
 
 JSON_VALUE *JSONFile_ReadEx(const char *path, const bool exit_on_error)
 {
+    return JSONFile_ReadWithError(path, exit_on_error, nullptr);
+}
+
+JSON_VALUE *JSONFile_ReadWithError(
+    const char *const path, const bool exit_on_error, char **const error_out)
+{
+    if (error_out != nullptr) {
+        *error_out = nullptr;
+    }
+
     char *file_data = nullptr;
     if (!File_Load(path, &file_data, nullptr)) {
+        if (error_out != nullptr) {
+            *error_out = Memory_DupStr("the file could not be read");
+        }
         return nullptr;
     }
 
@@ -47,13 +60,15 @@ JSON_VALUE *JSONFile_ReadEx(const char *path, const bool exit_on_error)
         JSON_ReadIO_SetErrorAt(
             io, pr.error_line_no, pr.error_row_no, "%s",
             JSON_GetErrorDescription(pr.error));
+        char log_message[1024];
+        JSON_ReadIO_FormatError(io, false, log_message, sizeof(log_message));
         if (exit_on_error) {
             JSONFile_ExitWithReadIOError(io, "JSON parse error");
         } else {
-            char log_message[1024];
-            JSON_ReadIO_FormatError(
-                io, false, log_message, sizeof(log_message));
             LOG_ERROR("%s", log_message);
+        }
+        if (error_out != nullptr) {
+            *error_out = Memory_DupStr(log_message);
         }
         JSON_ReadIO_Destroy(io);
     }

--- a/src/trx/core/json/util/file.h
+++ b/src/trx/core/json/util/file.h
@@ -13,6 +13,13 @@ JSON_VALUE *JSONFile_Read(const char *path);
 // Like JSONFile_Read(), except optionally exits on parse error.
 JSON_VALUE *JSONFile_ReadEx(const char *path, bool exit_on_error);
 
+// Like JSONFile_ReadEx(), and hands back why the read failed, for a caller
+// that has to tell the player rather than only write it to the log. The
+// message names the line and column where the file stopped making sense.
+// Caller must free it with Memory_FreePointer().
+JSON_VALUE *JSONFile_ReadWithError(
+    const char *path, bool exit_on_error, char **error_out);
+
 // Format and hard-exit with the JSON read error details.
 void JSONFile_ExitWithReadIOError(
     const JSON_READ_IO *io, const char *fallback_message);

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -1003,7 +1003,7 @@ static bool M_LoadGlobalInjections(const M_CONTEXT *const ctx)
 
 static bool M_LoadGameFlowDoc(
     JSON_VALUE *const doc, const char *const path, const bool exit_on_error,
-    const bool validation_mode)
+    const bool validation_mode, char **const error_out)
 {
     GF_Shutdown();
 
@@ -1031,7 +1031,11 @@ fail:
     if (exit_on_error) {
         M_ExitWithJSONError(&ctx);
     } else {
-        LOG_WARNING("%s", JSON_ReadIO_GetError(ctx.io));
+        const char *const error = JSON_ReadIO_GetError(ctx.io);
+        LOG_WARNING("%s", error);
+        if (error_out != nullptr && error != nullptr) {
+            *error_out = Memory_DupStr(error);
+        }
         JSON_ReadIO_Destroy(ctx.io);
         JSON_ValueFree(doc);
         GF_Shutdown();
@@ -1041,31 +1045,34 @@ fail:
 
 static bool M_LoadGameFlowEx(
     const char *const path, const bool exit_on_error,
-    const bool validation_mode)
+    const bool validation_mode, char **const error_out)
 {
-    JSON_VALUE *const doc = JSONFile_ReadEx(path, exit_on_error);
+    JSON_VALUE *const doc =
+        JSONFile_ReadWithError(path, exit_on_error, error_out);
     if (doc == nullptr) {
         if (exit_on_error) {
             Shell_ExitSystemFmt("Failed to open script file %s", path);
         }
         return false;
     }
-    return M_LoadGameFlowDoc(doc, path, exit_on_error, validation_mode);
+    return M_LoadGameFlowDoc(
+        doc, path, exit_on_error, validation_mode, error_out);
 }
 
 void GF_LoadFromFile(const char *const path)
 {
-    M_LoadGameFlowEx(path, true, false);
+    M_LoadGameFlowEx(path, true, false, nullptr);
 }
 
 bool GF_TryLoadFromFile(const char *const path)
 {
-    return M_LoadGameFlowEx(path, false, false);
+    return M_LoadGameFlowEx(path, false, false, nullptr);
 }
 
-bool GF_ValidateMod(const char *const mod_name, const char *const path)
+bool GF_ValidateMod(
+    const char *const mod_name, const char *const path, char **const error_out)
 {
-    if (!M_LoadGameFlowEx(path, false, true)) {
+    if (!M_LoadGameFlowEx(path, false, true, error_out)) {
         LOG_WARNING("Mod '%s' has invalid gameflow data", mod_name);
         return false;
     }

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -1073,11 +1073,12 @@ bool GF_ValidateMod(const char *const mod_name, const char *const path)
     return true;
 }
 
-bool GF_ReadModMeta(const char *const path, GF_MOD_META *const meta)
+bool GF_ReadModMeta(
+    const char *const path, GF_MOD_META *const meta, char **const error_out)
 {
     ASSERT(meta != nullptr);
 
-    JSON_VALUE *const doc = JSONFile_Read(path);
+    JSON_VALUE *const doc = JSONFile_ReadWithError(path, false, error_out);
     if (doc == nullptr) {
         return false;
     }

--- a/src/trx/game/game_flow/reader.h
+++ b/src/trx/game/game_flow/reader.h
@@ -16,4 +16,8 @@ bool GF_ValidateMod(const char *mod_name, const char *path);
 // Quick-parse a gameflow file to extract only the mod metadata fields
 // ("name", "engine", and "extends"). Returns true on success. Caller must
 // free meta->name and meta->extends with Memory_FreePointer().
-bool GF_ReadModMeta(const char *path, GF_MOD_META *meta);
+//
+// Where error_out is given, a failed read leaves the reason in it, for a
+// caller that has to say why the mod was passed over. Caller must free it
+// with Memory_FreePointer().
+bool GF_ReadModMeta(const char *path, GF_MOD_META *meta, char **error_out);

--- a/src/trx/game/game_flow/reader.h
+++ b/src/trx/game/game_flow/reader.h
@@ -10,8 +10,10 @@ void GF_LoadFromFile(const char *path);
 bool GF_TryLoadFromFile(const char *path);
 
 // Load and validate path-backed gameflow references for a mod.
-// Returns false if parsing fails or any required resolved path is missing.
-bool GF_ValidateMod(const char *mod_name, const char *path);
+// Returns false if parsing fails or any required resolved path is missing,
+// leaving why in error_out where one is given. Caller must free it with
+// Memory_FreePointer().
+bool GF_ValidateMod(const char *mod_name, const char *path, char **error_out);
 
 // Quick-parse a gameflow file to extract only the mod metadata fields
 // ("name", "engine", and "extends"). Returns true on success. Caller must

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -151,12 +151,16 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 
         if (!strcmp(arg, "--demo-pc") || !strcmp(arg, "-demo_pc")) {
             result->startup.mod = Shell_GetModByName("tr1-demo-pc");
+            result->startup.mod_request = "tr1-demo-pc";
+            result->startup.mod_explicit = true;
         }
         if (!strcmp(arg, "--mod") && next_arg != nullptr) {
             const SHELL_MOD *const mod = Shell_GetModByName(next_arg);
             if (mod != nullptr) {
                 result->startup.mod = mod;
             }
+            result->startup.mod_request = next_arg;
+            result->startup.mod_explicit = true;
             i++;
         }
 
@@ -169,6 +173,8 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                     && result->startup.engine_version > 0) {
                     result->startup.mod = Shell_GetModByType(
                         MOD_BASE_GAME, result->startup.engine_version);
+                    result->startup.mod_request = "the base game";
+                    result->startup.mod_explicit = true;
                 }
             } else {
                 char **const level_arg = Vector_Get(args, i + 1);
@@ -244,7 +250,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
     }
 
-    if (result->startup.mod == nullptr) {
+    if (result->startup.mod == nullptr && !result->startup.mod_explicit) {
         result->startup.mod =
             Shell_SelectStartupMod(result->startup.engine_version);
     }
@@ -259,6 +265,8 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                    : 0);
         const SHELL_MOD *const gold_mod =
             Shell_GetModByType(MOD_EXPANSION_PACK, engine_version);
+        result->startup.mod_request = "the gold expansion";
+        result->startup.mod_explicit = true;
         if (gold_mod != nullptr) {
             result->startup.mod = gold_mod;
             result->startup.engine_version = gold_mod->engine_version;

--- a/src/trx/game/shell/args.h
+++ b/src/trx/game/shell/args.h
@@ -8,6 +8,11 @@ typedef struct {
 
     bool dump_lua_api;
     const SHELL_MOD *mod;
+    // The game the player named on the command line, and whether they named
+    // one at all. A named game that cannot be played is an error rather than
+    // something to quietly pick around.
+    const char *mod_request;
+    bool mod_explicit;
     struct {
         int32_t num;
         const char *query;

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -213,6 +213,22 @@ static void M_PrepareSystem(void)
     LOG_INFO(
         "Mod: %s",
         s->args->startup.mod != nullptr ? s->args->startup.mod->name : nullptr);
+    const SHELL_MOD *const requested_mod = s->args->startup.mod;
+    if (s->args->startup.mod_explicit
+        && (requested_mod == nullptr || !requested_mod->is_valid)) {
+        const char *const name = requested_mod != nullptr
+            ? requested_mod->name
+            : s->args->startup.mod_request;
+        const char *const reason = Shell_GetModRejection(name);
+        if (reason != nullptr) {
+            Shell_ExitSystemFmt("Cannot play %s.\n\n%s", name, reason);
+        }
+        if (requested_mod == nullptr) {
+            Shell_ExitSystemFmt("There is no game called %s.", name);
+        }
+        Shell_ExitSystemFmt("Cannot play %s.", name);
+    }
+
     if (s->args->startup.engine_version <= 0
         || s->args->startup.mod == nullptr) {
         const char *const rejections = Shell_GetModRejections();

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -309,8 +309,7 @@ bool Shell_GetPrevQuiet(void)
 
 const SHELL_ARGS *Shell_GetArgs(void)
 {
-    ASSERT(m_Session != nullptr);
-    return m_Session->args;
+    return m_Session != nullptr ? m_Session->args : nullptr;
 }
 
 void Shell_SetHeadless(const bool headless)

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -215,6 +215,13 @@ static void M_PrepareSystem(void)
         s->args->startup.mod != nullptr ? s->args->startup.mod->name : nullptr);
     if (s->args->startup.engine_version <= 0
         || s->args->startup.mod == nullptr) {
+        const char *const rejections = Shell_GetModRejections();
+        if (rejections != nullptr) {
+            Shell_ExitSystemFmt(
+                "No playable mods available.\n\nThe following were passed "
+                "over:\n%s",
+                rejections);
+        }
         Shell_ExitSystem("No playable mods available.");
     }
     if (s->args->startup.mod->mod_type != MOD_DIRECT_LEVEL

--- a/src/trx/game/shell/main.c
+++ b/src/trx/game/shell/main.c
@@ -33,7 +33,10 @@ int main(int argc, char *argv[])
 
     LOG_INFO("Starting %s", g_TRXVersion);
     Shell_ValidateMods();
-    if (args->startup.mod == nullptr || !args->startup.mod->is_valid) {
+    // A game the player named is theirs to hear about, so it stays where it is
+    // for the shell to report. Anything else falls back to what can be played.
+    if (!args->startup.mod_explicit
+        && (args->startup.mod == nullptr || !args->startup.mod->is_valid)) {
         args->startup.mod =
             Shell_SelectStartupMod(args->startup.engine_version);
         if (args->startup.mod != nullptr && args->startup.engine_version == 0) {

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -45,6 +45,20 @@ static const M_KNOWN_MOD m_KnownModSeeds[] = {
 
 static VECTOR *m_Mods = nullptr;
 
+// Why a game directory was passed over, kept so that a startup with nothing
+// left to play can say what went wrong with each one.
+static VECTOR *m_Rejections = nullptr;
+static char *m_RejectionSummary = nullptr;
+
+static void M_Reject(const char *const path, const char *const reason)
+{
+    if (m_Rejections == nullptr) {
+        m_Rejections = Vector_Create(sizeof(char *));
+    }
+    char *const text = String_Format("%s: %s", path, reason);
+    Vector_Add(m_Rejections, &text);
+}
+
 static SHELL_MOD *M_FindMod(const char *const name)
 {
     if (m_Mods == nullptr || name == nullptr) {
@@ -112,15 +126,22 @@ static void M_ScanForCustomMods(void)
             String_FormatStatic("%s/%s/gameflow.json5", games_dir, entry);
 
         GF_MOD_META meta = {};
-        if (!GF_ReadModMeta(gameflow_path, &meta)) {
+        char *error = nullptr;
+        if (!GF_ReadModMeta(gameflow_path, &meta, &error)) {
             LOG_WARNING("Failed to read mod metadata from '%s'", gameflow_path);
+            M_Reject(
+                gameflow_path,
+                error != nullptr ? error : "the gameflow could not be read");
+            Memory_FreePointer(&error);
             continue;
         }
+        Memory_FreePointer(&error);
 
         if (meta.engine <= 0) {
             LOG_WARNING(
                 "Custom mod '%s' has no 'engine' field in gameflow; skipping",
                 entry);
+            M_Reject(gameflow_path, "the gameflow has no 'engine' field");
             Memory_FreePointer(&meta.name);
             Memory_FreePointer(&meta.extends);
             continue;
@@ -149,9 +170,15 @@ static void M_ReadModMetaForKnownMods(void)
         }
 
         GF_MOD_META meta = {};
-        if (!GF_ReadModMeta(gameflow_path, &meta)) {
+        char *error = nullptr;
+        if (!GF_ReadModMeta(gameflow_path, &meta, &error)) {
+            M_Reject(
+                gameflow_path,
+                error != nullptr ? error : "the gameflow could not be read");
+            Memory_FreePointer(&error);
             continue;
         }
+        Memory_FreePointer(&error);
 
         if (meta.name != nullptr) {
             Memory_FreePointer(&mod->title);
@@ -229,8 +256,23 @@ static char *M_GetModStringsPath(const char *const mod_id)
         TRX_PATH_GAMES_DIR, String_FormatStatic("%s/strings.json5", mod_id));
 }
 
+static void M_ClearRejections(void)
+{
+    Memory_FreePointer(&m_RejectionSummary);
+    if (m_Rejections == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < m_Rejections->count; i++) {
+        char **const text = Vector_Get(m_Rejections, i);
+        Memory_FreePointer(text);
+    }
+    Vector_Free(m_Rejections);
+    m_Rejections = nullptr;
+}
+
 __attribute__((destructor)) static void M_Shutdown(void)
 {
+    M_ClearRejections();
     if (m_Mods == nullptr) {
         return;
     }
@@ -263,11 +305,30 @@ static const SHELL_MOD *M_GetFirstAvailableMod(const int32_t engine_version)
     return nullptr;
 }
 
+const char *Shell_GetModRejections(void)
+{
+    if (m_Rejections == nullptr || m_Rejections->count == 0) {
+        return nullptr;
+    }
+
+    Memory_FreePointer(&m_RejectionSummary);
+    m_RejectionSummary = Memory_DupStr("");
+    for (int32_t i = 0; i < m_Rejections->count; i++) {
+        char **const text = Vector_Get(m_Rejections, i);
+        char *const merged = String_Format(
+            "%s%s%s", m_RejectionSummary, i > 0 ? "\n" : "", *text);
+        Memory_FreePointer(&m_RejectionSummary);
+        m_RejectionSummary = merged;
+    }
+    return m_RejectionSummary;
+}
+
 void Shell_ScanAvailableMods(void)
 {
     if (m_Mods != nullptr) {
         M_Shutdown();
     }
+    M_ClearRejections();
     m_Mods = Vector_Create(sizeof(SHELL_MOD));
 
     M_SeedKnownMods();

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -20,6 +20,11 @@ typedef struct {
     SHELL_MOD_TYPE mod_type;
 } M_KNOWN_MOD;
 
+typedef struct {
+    char *mod_name;
+    char *text;
+} M_REJECTION;
+
 static const M_KNOWN_MOD m_KnownModSeeds[] = {
     { .meta = { .name = "tr1", .engine = 1 }, .mod_type = MOD_BASE_GAME },
     { .meta = { .name = "tr1-ub", .engine = 1, .extends = "tr1" },
@@ -45,18 +50,22 @@ static const M_KNOWN_MOD m_KnownModSeeds[] = {
 
 static VECTOR *m_Mods = nullptr;
 
-// Why a game directory was passed over, kept so that a startup with nothing
-// left to play can say what went wrong with each one.
+// Why a game was passed over, kept so that a startup can say what went wrong
+// with the game the player asked for, or with every one of them where there is
+// nothing left to play.
 static VECTOR *m_Rejections = nullptr;
 static char *m_RejectionSummary = nullptr;
 
-static void M_Reject(const char *const path, const char *const reason)
+static void M_Reject(const char *const mod_name, const char *const reason)
 {
     if (m_Rejections == nullptr) {
-        m_Rejections = Vector_Create(sizeof(char *));
+        m_Rejections = Vector_Create(sizeof(M_REJECTION));
     }
-    char *const text = String_Format("%s: %s", path, reason);
-    Vector_Add(m_Rejections, &text);
+    const M_REJECTION rejection = {
+        .mod_name = Memory_DupStr(mod_name),
+        .text = Memory_DupStr(reason),
+    };
+    Vector_Add(m_Rejections, &rejection);
 }
 
 static SHELL_MOD *M_FindMod(const char *const name)
@@ -130,8 +139,10 @@ static void M_ScanForCustomMods(void)
         if (!GF_ReadModMeta(gameflow_path, &meta, &error)) {
             LOG_WARNING("Failed to read mod metadata from '%s'", gameflow_path);
             M_Reject(
-                gameflow_path,
-                error != nullptr ? error : "the gameflow could not be read");
+                entry,
+                error != nullptr ? error
+                                 : String_FormatStatic(
+                                       "%s could not be read", gameflow_path));
             Memory_FreePointer(&error);
             continue;
         }
@@ -141,7 +152,9 @@ static void M_ScanForCustomMods(void)
             LOG_WARNING(
                 "Custom mod '%s' has no 'engine' field in gameflow; skipping",
                 entry);
-            M_Reject(gameflow_path, "the gameflow has no 'engine' field");
+            M_Reject(
+                entry,
+                String_FormatStatic("%s has no 'engine' field", gameflow_path));
             Memory_FreePointer(&meta.name);
             Memory_FreePointer(&meta.extends);
             continue;
@@ -173,8 +186,10 @@ static void M_ReadModMetaForKnownMods(void)
         char *error = nullptr;
         if (!GF_ReadModMeta(gameflow_path, &meta, &error)) {
             M_Reject(
-                gameflow_path,
-                error != nullptr ? error : "the gameflow could not be read");
+                mod->name,
+                error != nullptr ? error
+                                 : String_FormatStatic(
+                                       "%s could not be read", gameflow_path));
             Memory_FreePointer(&error);
             continue;
         }
@@ -263,8 +278,9 @@ static void M_ClearRejections(void)
         return;
     }
     for (int32_t i = 0; i < m_Rejections->count; i++) {
-        char **const text = Vector_Get(m_Rejections, i);
-        Memory_FreePointer(text);
+        M_REJECTION *const rejection = Vector_Get(m_Rejections, i);
+        Memory_FreePointer(&rejection->mod_name);
+        Memory_FreePointer(&rejection->text);
     }
     Vector_Free(m_Rejections);
     m_Rejections = nullptr;
@@ -305,6 +321,20 @@ static const SHELL_MOD *M_GetFirstAvailableMod(const int32_t engine_version)
     return nullptr;
 }
 
+const char *Shell_GetModRejection(const char *const mod_name)
+{
+    if (m_Rejections == nullptr || mod_name == nullptr) {
+        return nullptr;
+    }
+    for (int32_t i = 0; i < m_Rejections->count; i++) {
+        const M_REJECTION *const rejection = Vector_Get(m_Rejections, i);
+        if (strcmp(rejection->mod_name, mod_name) == 0) {
+            return rejection->text;
+        }
+    }
+    return nullptr;
+}
+
 const char *Shell_GetModRejections(void)
 {
     if (m_Rejections == nullptr || m_Rejections->count == 0) {
@@ -314,9 +344,10 @@ const char *Shell_GetModRejections(void)
     Memory_FreePointer(&m_RejectionSummary);
     m_RejectionSummary = Memory_DupStr("");
     for (int32_t i = 0; i < m_Rejections->count; i++) {
-        char **const text = Vector_Get(m_Rejections, i);
+        const M_REJECTION *const rejection = Vector_Get(m_Rejections, i);
         char *const merged = String_Format(
-            "%s%s%s", m_RejectionSummary, i > 0 ? "\n" : "", *text);
+            "%s%s%s: %s", m_RejectionSummary, i > 0 ? "\n" : "",
+            rejection->mod_name, rejection->text);
         Memory_FreePointer(&m_RejectionSummary);
         m_RejectionSummary = merged;
     }
@@ -380,7 +411,17 @@ void Shell_ValidateMods(void)
         g_TRVersion = mod->engine_version;
         TRXPath_Init(&args);
 
-        mod->is_valid = GF_ValidateMod(mod->name, Shell_GetGameFlowPath(mod));
+        const char *const gameflow_path = Shell_GetGameFlowPath(mod);
+        char *error = nullptr;
+        mod->is_valid = GF_ValidateMod(mod->name, gameflow_path, &error);
+        if (!mod->is_valid && Shell_GetModRejection(mod->name) == nullptr) {
+            M_Reject(
+                mod->name,
+                error != nullptr ? error
+                                 : String_FormatStatic(
+                                       "%s could not be read", gameflow_path));
+        }
+        Memory_FreePointer(&error);
     }
 
     g_TRVersion = original_tr_version;

--- a/src/trx/game/shell/mod.h
+++ b/src/trx/game/shell/mod.h
@@ -21,6 +21,11 @@ typedef struct {
 } SHELL_MOD;
 
 void Shell_ScanAvailableMods(void);
+
+// Why the scan passed over the game directories it could not use, one per
+// line, or nullptr where it passed over none. Points at the file and, for a
+// gameflow that would not parse, the line and column it stopped at.
+const char *Shell_GetModRejections(void);
 void Shell_ValidateMods(void);
 int32_t Shell_GetModCount(void);
 const SHELL_MOD *Shell_GetMod(int32_t index);

--- a/src/trx/game/shell/mod.h
+++ b/src/trx/game/shell/mod.h
@@ -26,6 +26,9 @@ void Shell_ScanAvailableMods(void);
 // line, or nullptr where it passed over none. Points at the file and, for a
 // gameflow that would not parse, the line and column it stopped at.
 const char *Shell_GetModRejections(void);
+
+// The same for one game by name, or nullptr where nothing passed it over.
+const char *Shell_GetModRejection(const char *mod_name);
 void Shell_ValidateMods(void);
 int32_t Shell_GetModCount(void);
 const SHELL_MOD *Shell_GetMod(int32_t index);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR makes a broken game flow give an error that says what is wrong with it, instead of the game being skipped and the reason written only to the log. A game asked for with `--mod` either starts or fails, and is no longer replaced by another one.

- the error names the file that is broken, and the line and column where it breaks
- asking for a game that does not exist stops the startup too
- starting without naming a game works as before, picking the last game played or the first one that works
- errors that happen very early in startup are now shown instead of crashing the game

```
Cannot play tr1.

Error parsing '.../games/tr1/gameflow.json5' (line 42, col 21): expected colon
```
