### PR TITLE
Generate the outfit slot tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,15 @@ repos:
     pass_filenames: false
     files: ^data/trx/ship/
 
+  - id: gen-outfit-slots
+    name: Regenerate the outfit slot tables in OUTFITS.md
+    entry: tools/lint/gen/outfit_slots
+    language: python
+    pass_filenames: false
+    files: ^(data/trx/ship/(cfg/outfits\.json5|games/.*/catalog_objects\.csv)|docs/trx/OUTFITS\.md)$
+    additional_dependencies:
+      - pyjson5
+
   - id: gen-water-colors
     name: Regenerate WATER_COLORS.md from water_colors.yml
     entry: tools/lint/gen/water_colors

--- a/docs/trx/OUTFITS.md
+++ b/docs/trx/OUTFITS.md
@@ -51,6 +51,290 @@ This object contains copies of Lara's legs for each outfit, with holster strap
 textures removed. This allows levels such as Home Sweet Home to swap out Lara's
 legs when she has no holsters. It is not an essential object to include.
 
+### Which slot holds which outfit
+
+<!-- gen:outfit-slots -->
+Each game gives these objects a different slot number. Import into
+the slot listed for the game you are building for.
+
+<table>
+  <tr valign='top' align='left'>
+    <th>Outfit</th>
+    <th>Object</th>
+    <th>TR1</th>
+    <th>TR2</th>
+    <th>TR3</th>
+    <th>TR4</th>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr1_gym</code></td>
+    <td><code>O_LARA_SKIN_SWAP_1</code></td>
+    <td>258</td>
+    <td>302</td>
+    <td>393</td>
+    <td>465</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr1_classic</code></td>
+    <td><code>O_LARA_SKIN_SWAP_2</code></td>
+    <td>259</td>
+    <td>303</td>
+    <td>394</td>
+    <td>466</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr1_mauled</code></td>
+    <td><code>O_LARA_SKIN_SWAP_3</code></td>
+    <td>260</td>
+    <td>304</td>
+    <td>395</td>
+    <td>467</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr1_combo</code></td>
+    <td><code>O_LARA_SKIN_SWAP_4</code></td>
+    <td>261</td>
+    <td>305</td>
+    <td>396</td>
+    <td>468</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr1_ngage</code></td>
+    <td><code>O_LARA_SKIN_SWAP_24</code></td>
+    <td>281</td>
+    <td>325</td>
+    <td>416</td>
+    <td>488</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr1_bacon_lara</code></td>
+    <td><code>O_LARA_SKIN_SWAP_6</code></td>
+    <td>263</td>
+    <td>307</td>
+    <td>398</td>
+    <td>470</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_gym</code></td>
+    <td><code>O_LARA_SKIN_SWAP_8</code></td>
+    <td>265</td>
+    <td>309</td>
+    <td>400</td>
+    <td>472</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_classic</code></td>
+    <td><code>O_LARA_SKIN_SWAP_9</code></td>
+    <td>266</td>
+    <td>310</td>
+    <td>401</td>
+    <td>473</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_diving_suit</code></td>
+    <td><code>O_LARA_SKIN_SWAP_10</code></td>
+    <td>267</td>
+    <td>311</td>
+    <td>402</td>
+    <td>474</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_diving_suit_alpha</code></td>
+    <td><code>O_LARA_SKIN_SWAP_23</code></td>
+    <td>280</td>
+    <td>324</td>
+    <td>415</td>
+    <td>487</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_bomber_jacket</code></td>
+    <td><code>O_LARA_SKIN_SWAP_11</code></td>
+    <td>268</td>
+    <td>312</td>
+    <td>403</td>
+    <td>475</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_bomber_jacket_alpha</code></td>
+    <td><code>O_LARA_SKIN_SWAP_26</code></td>
+    <td>283</td>
+    <td>327</td>
+    <td>418</td>
+    <td>490</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_robe</code></td>
+    <td><code>O_LARA_SKIN_SWAP_12</code></td>
+    <td>269</td>
+    <td>313</td>
+    <td>404</td>
+    <td>476</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr2_vegas</code></td>
+    <td><code>O_LARA_SKIN_SWAP_13</code></td>
+    <td>270</td>
+    <td>314</td>
+    <td>405</td>
+    <td>477</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_gym</code></td>
+    <td><code>O_LARA_SKIN_SWAP_15</code></td>
+    <td>272</td>
+    <td>316</td>
+    <td>407</td>
+    <td>479</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_classic</code></td>
+    <td><code>O_LARA_SKIN_SWAP_16</code></td>
+    <td>273</td>
+    <td>317</td>
+    <td>408</td>
+    <td>480</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_south_pacific</code></td>
+    <td><code>O_LARA_SKIN_SWAP_17</code></td>
+    <td>274</td>
+    <td>318</td>
+    <td>409</td>
+    <td>481</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_catsuit</code></td>
+    <td><code>O_LARA_SKIN_SWAP_18</code></td>
+    <td>275</td>
+    <td>319</td>
+    <td>410</td>
+    <td>482</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_nevada</code></td>
+    <td><code>O_LARA_SKIN_SWAP_19</code></td>
+    <td>276</td>
+    <td>320</td>
+    <td>411</td>
+    <td>483</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_antarctica</code></td>
+    <td><code>O_LARA_SKIN_SWAP_20</code></td>
+    <td>277</td>
+    <td>321</td>
+    <td>412</td>
+    <td>484</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr3_antarctica_beta</code></td>
+    <td><code>O_LARA_SKIN_SWAP_25</code></td>
+    <td>282</td>
+    <td>326</td>
+    <td>417</td>
+    <td>489</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>sophia</code></td>
+    <td><code>O_LARA_SKIN_SWAP_21</code></td>
+    <td>278</td>
+    <td>322</td>
+    <td>413</td>
+    <td>485</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr4_young</code></td>
+    <td><code>O_LARA_SKIN_SWAP_27</code></td>
+    <td>284</td>
+    <td>328</td>
+    <td>419</td>
+    <td>491</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr4_classic</code></td>
+    <td><code>O_LARA_SKIN_SWAP_29</code></td>
+    <td>286</td>
+    <td>330</td>
+    <td>421</td>
+    <td>493</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>natla</code></td>
+    <td><code>O_LARA_SKIN_SWAP_31</code></td>
+    <td>288</td>
+    <td>332</td>
+    <td>423</td>
+    <td>495</td>
+  </tr>
+</table>
+
+Only the outfits below have a joints model. The rest need none.
+
+<table>
+  <tr valign='top' align='left'>
+    <th>Outfit</th>
+    <th>Object</th>
+    <th>TR1</th>
+    <th>TR2</th>
+    <th>TR3</th>
+    <th>TR4</th>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr4_young</code> joints</td>
+    <td><code>O_LARA_SKIN_JOINTS_1</code></td>
+    <td>296</td>
+    <td>340</td>
+    <td>433</td>
+    <td>502</td>
+  </tr>
+  <tr valign='top'>
+    <td><code>tr4_classic</code> joints</td>
+    <td><code>O_LARA_SKIN_JOINTS_3</code></td>
+    <td>298</td>
+    <td>342</td>
+    <td>435</td>
+    <td>504</td>
+  </tr>
+</table>
+
+The objects below are used by all outfits.
+
+<table>
+  <tr valign='top' align='left'>
+    <th>Purpose</th>
+    <th>Object</th>
+    <th>TR1</th>
+    <th>TR2</th>
+    <th>TR3</th>
+    <th>TR4</th>
+  </tr>
+  <tr valign='top'>
+    <td>Braids, combat faces and extra animation meshes</td>
+    <td><code>O_LARA_SKIN_SWAP_EXTRA</code></td>
+    <td>290</td>
+    <td>334</td>
+    <td>425</td>
+    <td>497</td>
+  </tr>
+  <tr valign='top'>
+    <td>Holsters and the guns themselves</td>
+    <td><code>O_LARA_SKIN_SWAP_GUNS</code></td>
+    <td>291</td>
+    <td>335</td>
+    <td>426</td>
+    <td>498</td>
+  </tr>
+  <tr valign='top'>
+    <td>Legs without holster straps; optional</td>
+    <td><code>O_LARA_SKIN_SWAP_LEGS</code></td>
+    <td>292</td>
+    <td>336</td>
+    <td>427</td>
+    <td>499</td>
+  </tr>
+</table>
+<!-- /gen:outfit-slots -->
+
 ## JSON setup
 The file `cfg/outfits.json5` sets up the available outfits, and how they should
 behave. The structure of this file is described below.

--- a/tools/lint/gen/outfit_slots
+++ b/tools/lint/gen/outfit_slots
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from shared.json_utils import load_json5
+from shared.paths import CommonPaths, DATA_DIR, DOCS_DIR
+from shared.vfs import VirtualFilesystem
+
+MD_PATH = DOCS_DIR / "trx" / "OUTFITS.md"
+CONFIG_PATH = CommonPaths.shipped_data_dir / "cfg" / "outfits.json5"
+GAMES = ["tr1", "tr2", "tr3", "tr4"]
+MARKER_START = "<!-- gen:outfit-slots -->"
+MARKER_END = "<!-- /gen:outfit-slots -->"
+
+# The objects every outfit draws on, whether or not it names one of its own.
+SHARED_OBJECTS = [
+    ("O_LARA_SKIN_SWAP_EXTRA", "Braids, combat faces and extra animation meshes"),
+    ("O_LARA_SKIN_SWAP_GUNS", "Holsters and the guns themselves"),
+    ("O_LARA_SKIN_SWAP_LEGS", "Legs without holster straps; optional"),
+]
+
+
+def read_slots(game: str) -> dict[str, int]:
+    path = DATA_DIR / "trx" / "ship" / "games" / game / "catalog_objects.csv"
+    slots: dict[str, int] = {}
+    if not path.exists():
+        return slots
+    for row in csv.reader(path.read_text().splitlines()):
+        if len(row) < 2:
+            continue
+        slot, name = row[0].strip(), row[1].strip()
+        if slot.isdigit():
+            slots[name] = int(slot)
+    return slots
+
+
+def read_outfits() -> list[tuple[str, str, str | None]]:
+    config = load_json5(CONFIG_PATH)
+    outfits = []
+    for name, outfit in config["outfits"].items():
+        outfits.append(
+            (name, outfit["mesh_object"], outfit.get("joints_object"))
+        )
+    return outfits
+
+
+def slot_cell(game: str, slots: dict[str, int], object_name: str) -> str:
+    slot = slots.get(object_name)
+    if slot is None:
+        raise SystemExit(f"outfit_slots: {game} has no slot for {object_name}")
+    return str(slot)
+
+
+def build_table(
+    first_header: str,
+    rows: list[tuple[str, str]],
+    slots_per_game: dict[str, dict[str, int]],
+) -> list[str]:
+    lines = [
+        "<table>",
+        "  <tr valign='top' align='left'>",
+        f"    <th>{first_header}</th>",
+        "    <th>Object</th>",
+    ]
+    lines += [f"    <th>{game.upper()}</th>" for game in GAMES]
+    lines.append("  </tr>")
+
+    for label, object_name in rows:
+        lines.append("  <tr valign='top'>")
+        lines.append(f"    <td>{label}</td>")
+        lines.append(f"    <td><code>{object_name}</code></td>")
+        lines += [
+            f"    <td>{slot_cell(game, slots_per_game[game], object_name)}</td>"
+            for game in GAMES
+        ]
+        lines.append("  </tr>")
+
+    lines.append("</table>")
+    return lines
+
+
+def build_section() -> list[str]:
+    slots_per_game = {game: read_slots(game) for game in GAMES}
+    outfits = read_outfits()
+
+    lines = [
+        "Each game gives these objects a different slot number. Import into",
+        "the slot listed for the game you are building for.",
+        "",
+    ]
+
+    outfit_rows = [
+        (f"<code>{name}</code>", mesh_object)
+        for name, mesh_object, _ in outfits
+    ]
+    lines += build_table("Outfit", outfit_rows, slots_per_game)
+
+    joint_rows = [
+        (f"<code>{name}</code> joints", joints_object)
+        for name, _, joints_object in outfits
+        if joints_object is not None
+    ]
+    if joint_rows:
+        lines += [
+            "",
+            "Only the outfits below have a joints model. The rest need none.",
+            "",
+        ]
+        lines += build_table("Outfit", joint_rows, slots_per_game)
+
+    lines += [
+        "",
+        "The objects below are used by all outfits.",
+        "",
+    ]
+    lines += build_table(
+        "Purpose",
+        [(usage, object_name) for object_name, usage in SHARED_OBJECTS],
+        slots_per_game,
+    )
+    return lines
+
+
+def process_doc(content: str) -> str:
+    lines = content.splitlines()
+    try:
+        start = lines.index(MARKER_START)
+        end = lines.index(MARKER_END)
+    except ValueError:
+        raise SystemExit(
+            f"outfit_slots: {MD_PATH} is missing the "
+            f"{MARKER_START} / {MARKER_END} markers"
+        )
+    section = build_section()
+    return "\n".join(lines[: start + 1] + section + lines[end:]) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update the outfit slot tables in OUTFITS.md."
+    )
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="Perform a dry run: show unified diffs instead of writing files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    vfs = VirtualFilesystem()
+    vfs.put(MD_PATH, process_doc(vfs.get(MD_PATH)))
+    if args.dry_run:
+        vfs.show_diff()
+    else:
+        vfs.commit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR adds tables to the outfits documentation saying which object slot each outfit lives in for each game, generated from `cfg/outfits.json5` and the object catalogs by a new prek hook so they cannot drift from the data.
