### PR TITLE
Offer only the outfits a level can wear

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 **UI**
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)
 - Changed the tab arrows to no longer vanish once the selection moved into the list below them
+- Changed Lara's outfit setting to offer only the outfits the current level can dress her in
 - Fixed the settings and controls dialog tabs ignoring rebound step left and step right keys
 - Fixed the settings dialogs scrolling their list back to the top when the selection moved up to the tabs
 - Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects

--- a/src/tests/trx/core/dynamic_enum.c
+++ b/src/tests/trx/core/dynamic_enum.c
@@ -74,3 +74,42 @@ TEST(cycling_walks_the_values)
     // An unknown current value cycles to the first entry.
     CHECK_EQ_STR(DynamicEnum_GetNext(&m_TokenA, "missing", 1), "first");
 }
+
+TEST(cycling_passes_over_disabled_values)
+{
+    DynamicEnum_ResetValues(&m_TokenA);
+    DynamicEnum_AddValue(&m_TokenA, "first", nullptr);
+    DynamicEnum_AddValue(&m_TokenA, "second", nullptr);
+    DynamicEnum_AddValue(&m_TokenA, "third", nullptr);
+    DynamicEnum_SetValueEnabled(&m_TokenA, "second", false);
+
+    CHECK(DynamicEnum_IsValueEnabled(&m_TokenA, "first"));
+    CHECK(!DynamicEnum_IsValueEnabled(&m_TokenA, "second"));
+
+    CHECK_EQ_STR(DynamicEnum_GetNext(&m_TokenA, "first", 1), "third");
+    CHECK_EQ_STR(DynamicEnum_GetNext(&m_TokenA, "third", -1), "first");
+
+    // An unknown current value skips to the first one on offer.
+    DynamicEnum_SetValueEnabled(&m_TokenA, "first", false);
+    CHECK_EQ_STR(DynamicEnum_GetNext(&m_TokenA, "missing", 1), "third");
+
+    // Nothing left to cycle to once the run of values holds none.
+    DynamicEnum_SetValueEnabled(&m_TokenA, "third", false);
+    CHECK(!DynamicEnum_CanCycle(&m_TokenA, "first", 1));
+    CHECK(!DynamicEnum_CanCycle(&m_TokenA, "missing", 1));
+    CHECK_NULL(DynamicEnum_GetNext(&m_TokenA, "first", 1));
+}
+
+// A disabled value is still one the caller may hold: it stays valid and keeps
+// its label, so a setting is not taken away from whoever chose it.
+TEST(disabled_values_stay_valid)
+{
+    DynamicEnum_ResetValues(&m_TokenA);
+    DynamicEnum_AddValue(&m_TokenA, "coded", "labels/coded");
+    DynamicEnum_SetValueEnabled(&m_TokenA, "coded", false);
+
+    CHECK(DynamicEnum_IsValidValue(&m_TokenA, "coded"));
+    CHECK_EQ_INT(DynamicEnum_GetValueCount(&m_TokenA), 1);
+    CHECK_EQ_STR(
+        DynamicEnum_GetLabelForValue(&m_TokenA, "coded"), "labels/coded");
+}

--- a/src/trx/core/dynamic_enum.c
+++ b/src/trx/core/dynamic_enum.c
@@ -11,6 +11,7 @@
 typedef struct {
     char *value;
     char *label;
+    bool enabled;
 } M_DYNAMIC_ENUM_VALUE;
 
 typedef struct M_DYNAMIC_ENUM_REGISTRY_ENTRY {
@@ -94,7 +95,7 @@ static int32_t M_FindValueIndex(
     return -1;
 }
 
-static const M_DYNAMIC_ENUM_VALUE *M_GetValueEntry(
+static M_DYNAMIC_ENUM_VALUE *M_GetValueEntry(
     const void *const token, const int32_t index)
 {
     const M_DYNAMIC_ENUM_REGISTRY_ENTRY *const entry =
@@ -106,6 +107,22 @@ static const M_DYNAMIC_ENUM_VALUE *M_GetValueEntry(
         return nullptr;
     }
     return Vector_Get(entry->values, index);
+}
+
+// The next value in the given direction the caller may be offered, or -1 where
+// the run of values ends without one.
+static int32_t M_FindNextEnabledIndex(
+    const void *const token, const int32_t from_idx, const int32_t dir)
+{
+    const int32_t value_count = DynamicEnum_GetValueCount(token);
+    const int32_t step = dir < 0 ? -1 : 1;
+    for (int32_t idx = from_idx + step; idx >= 0 && idx < value_count;
+         idx += step) {
+        if (M_GetValueEntry(token, idx)->enabled) {
+            return idx;
+        }
+    }
+    return -1;
 }
 
 // Null or whitespace-only. A value with no label at all falls back to its own
@@ -188,6 +205,7 @@ bool DynamicEnum_AddValue(
     M_DYNAMIC_ENUM_VALUE dyn_value = {
         .value = value != nullptr ? Memory_DupStr(value) : nullptr,
         .label = label != nullptr ? Memory_DupStr(label) : nullptr,
+        .enabled = true,
     };
     Vector_Add(entry->values, &dyn_value);
     return true;
@@ -196,6 +214,24 @@ bool DynamicEnum_AddValue(
 bool DynamicEnum_IsValidValue(const void *const token, const char *const value)
 {
     return M_FindValueIndex(token, value) >= 0;
+}
+
+void DynamicEnum_SetValueEnabled(
+    const void *const token, const char *const value, const bool enabled)
+{
+    M_DYNAMIC_ENUM_VALUE *const dyn_value =
+        M_GetValueEntry(token, M_FindValueIndex(token, value));
+    if (dyn_value != nullptr) {
+        dyn_value->enabled = enabled;
+    }
+}
+
+bool DynamicEnum_IsValueEnabled(
+    const void *const token, const char *const value)
+{
+    const M_DYNAMIC_ENUM_VALUE *const dyn_value =
+        M_GetValueEntry(token, M_FindValueIndex(token, value));
+    return dyn_value != nullptr && dyn_value->enabled;
 }
 
 int32_t DynamicEnum_GetValueCount(const void *const token)
@@ -247,12 +283,10 @@ bool DynamicEnum_CanCycle(
 
     const int32_t cur_idx = M_FindValueIndex(token, current);
     if (cur_idx < 0) {
-        return true;
+        return M_FindNextEnabledIndex(token, -1, 1) >= 0;
     }
 
-    const int32_t step = dir < 0 ? -1 : 1;
-    const int32_t next_idx = cur_idx + step;
-    return next_idx >= 0 && next_idx < value_count;
+    return M_FindNextEnabledIndex(token, cur_idx, dir) >= 0;
 }
 
 const char *DynamicEnum_GetNext(
@@ -268,13 +302,10 @@ const char *DynamicEnum_GetNext(
     }
 
     const int32_t cur_idx = M_FindValueIndex(token, current);
-    if (cur_idx < 0) {
-        return DynamicEnum_GetValueAt(token, 0);
-    }
-
-    const int32_t step = dir < 0 ? -1 : 1;
-    const int32_t next_idx = cur_idx + step;
-    if (next_idx < 0 || next_idx >= value_count) {
+    const int32_t next_idx = cur_idx < 0
+        ? M_FindNextEnabledIndex(token, -1, 1)
+        : M_FindNextEnabledIndex(token, cur_idx, dir);
+    if (next_idx < 0) {
         return nullptr;
     }
 

--- a/src/trx/core/dynamic_enum.h
+++ b/src/trx/core/dynamic_enum.h
@@ -9,6 +9,14 @@
 void DynamicEnum_ResetValues(const void *token);
 bool DynamicEnum_AddValue(
     const void *token, const char *value, const char *label);
+
+// Whether a value is one the caller can be offered right now. A value the
+// registry knows but has turned off stays valid to hold and keeps its label -
+// what the caller already chose is not taken away from them - and is passed
+// over when cycling. Values start out on.
+void DynamicEnum_SetValueEnabled(
+    const void *token, const char *value, bool enabled);
+bool DynamicEnum_IsValueEnabled(const void *token, const char *value);
 bool DynamicEnum_IsValidValue(const void *token, const char *value);
 int32_t DynamicEnum_GetValueCount(const void *token);
 const char *DynamicEnum_GetValueAt(const void *token, int32_t index);

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/config/registry.h>
+#include <trx/core/dynamic_enum.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
@@ -375,6 +376,25 @@ static void M_ReapplyEquipment(const LARA_SKIN_OUTFIT *const outfit)
     }
 }
 
+// Offer the player the outfits the level just loaded can dress her in. What it
+// cannot is left in the setting, so an outfit chosen on one level is not lost
+// on the next, but it is passed over as the setting is cycled.
+static void M_RefreshOutfitChoices(void)
+{
+    const CONFIG_OPTION *const option =
+        Config_FindOptionByMirror(&g_Config.visuals.lara_outfit);
+    if (option == nullptr) {
+        return;
+    }
+
+    const void *const token = Config_Option_GetEnumKey(option);
+    const int32_t outfit_count = Lara_Skin_GetOutfitCount();
+    for (int32_t i = 0; i < outfit_count; i++) {
+        DynamicEnum_SetValueEnabled(
+            token, Lara_Skin_GetOutfitName(i), Lara_Skin_IsOutfitAvailable(i));
+    }
+}
+
 // Whether an outfit has this level's meshes to bind to. A title level running
 // behind the menu is dressed like any other, so this asks what is loaded
 // rather than whether a game is under way.
@@ -408,6 +428,8 @@ void Lara_Skin_Initialise(void)
         m_MeshOverrides[i] = nullptr;
         Lara_Skin_ClearEquipment(i);
     }
+
+    M_RefreshOutfitChoices();
 
     // A level need not carry the swap objects: a title that never shows her
     // has no use for them. No outfit is applied then, and she keeps the meshes

--- a/src/trx/game/ui/dialogs/settings_editor.c
+++ b/src/trx/game/ui/dialogs/settings_editor.c
@@ -542,19 +542,27 @@ static float M_GetMaxValueWidth(const UI_SETTINGS_EDITOR_STATE *const s)
     return result;
 }
 
+static bool M_IsValueOnOffer(const UI_SETTINGS_ROW *const row)
+{
+    if (row == nullptr || row->option->value.type != TVT_DYNAMIC_ENUM) {
+        return true;
+    }
+    return DynamicEnum_IsValueEnabled(
+        Config_Option_GetEnumKey(row->option), row->option->value.as_str);
+}
+
 static void M_OptionLabel(
     const UI_SETTINGS_ROW *const row, const char *const text,
-    const bool star_if_enforced)
+    const bool is_title)
 {
     const UI_SETTING_HANDLER *const handler =
         row != nullptr ? row->handler : nullptr;
     const bool is_held = M_IsOptionHeld(row);
-    // A held row is not the player's to move, so it reads as one they cannot
-    // move rather than only carrying the star that says who took it.
     const bool is_available = !is_held
         && (handler == nullptr || handler->is_available == nullptr
-            || handler->is_available(row->option, handler->user_data));
-    const bool is_enforced = star_if_enforced && is_held;
+            || handler->is_available(row->option, handler->user_data))
+        && (is_title || M_IsValueOnOffer(row));
+    const bool is_enforced = is_title && is_held;
     const char *const suffix = is_enforced ? "*" : "";
 
     if (!is_available) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Lara's outfit setting now offers only what the level can dress her in, and greys out a choice it is not honoring. The choice is kept, so an outfit picked on one level comes back on the next that carries it.

A setting can now mark a value as one it cannot offer at the moment. The setting skips past it, but still accepts it, so nothing a player picked is thrown away behind their back.

```c
DynamicEnum_SetValueEnabled(token, "natla", false);
DynamicEnum_IsValueEnabled(token, "natla");
```

This builds on #6224 and should land after it.
