### PR TITLE
Stop an outfit from blocking a level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 **Level and game data**
 - Added Natla as an outfit for Lara, selectable in every game (Graphic Options → Visuals → Lara's outfit)
 - Added injection support for putting a room in a flip group, which only TR4 levels carry themselves (#5336)
+- Changed a missing or unknown `lara_outfit` in a level to fall back to the default outfit, rather than stopping the game from starting
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own
 
 **TR1**

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -337,8 +337,7 @@
       "else": {
         "required": [
           "path",
-          "sequence",
-          "lara_outfit"
+          "sequence"
         ]
       },
       "additionalProperties": false

--- a/docs/trx/game_flow/levels/REGULAR_LEVELS.md
+++ b/docs/trx/game_flow/levels/REGULAR_LEVELS.md
@@ -123,9 +123,11 @@ Following are each of the properties available within a level.
   </tr>
   <tr valign="top">
     <td><code>lara_outfit</code></td>
-    <td>string<strong>*</strong></td>
+    <td>string</td>
     <td colspan="2">
       Defines the outfit to use for Lara, unless overridden by player choice.
+      Optional; a level that names none, or names one the game does not offer,
+      dresses Lara in the default outfit.
       See <a href="../../OUTFITS.md">Outfits</a> for full details.
     </td>
   </tr>

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -864,21 +864,16 @@ static bool M_LoadLevel(
     }
 
     {
-        const bool outfit_optional = level->type == GFL_TITLE
-            || level->type == GFL_DUMMY || level->type == GFL_CURRENT;
         const char *tmp = nullptr;
-        if (outfit_optional) {
-            JSON_OPTIONAL(JSON_READ(io, "lara_outfit", &tmp));
-        } else {
-            JSON_MUST(JSON_READ(io, "lara_outfit", &tmp));
-        }
+        JSON_OPTIONAL(JSON_READ(io, "lara_outfit", &tmp));
         if (tmp != nullptr) {
             if (!ctx->validation_mode
                 && !Lara_Skin_IsOutfitAvailable(
                     Lara_Skin_FindOutfitByName(tmp))) {
-                JSON_ReadIO_SetError(
-                    io, "invalid 'lara_outfit' value (%s)", tmp);
-                JSON_FAIL();
+                LOG_WARNING(
+                    "%s: level '%s' asks for outfit '%s', which this game does "
+                    "not offer; Lara wears the default one",
+                    ctx->script_path, level->path, tmp);
             }
             level->lara_outfit = Memory_DupStr(tmp);
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR makes a level's `lara_outfit` optional, and an outfit the game does not offer fall back to the default one, where either used to stop the game from starting.

- deleting one line from a game flow was enough to make a game unplayable, which is a harsh answer to a field most builders never think about
- the skin system already fell back to the default once a level was running, so the reader was stricter than the engine it feeds
- the schema and the level property docs no longer mark the field as required
