### PR TITLE
objects/flame: reset TR4 draw routine

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Changed the message shown when there is nothing to play to name each game it passed over and say what is wrong with it, rather than leaving the reason in the log
 - Changed a game named with `--mod` to say why it cannot be played, rather than quietly starting a different one
 - Changed Lara turning to gold on the Midas hand to gild the outfit she has on, rather than swap her for a golden model
+- Fixed flames not being drawn if TR4 is launched and the game is then switched to a different mod (regression from 1.10)
 
 **Lua**
 - Added the full weapon definition to `trx.weapons`, so a script can read and change what a weapon does: its damage, reach and accuracy, its aim limits, its ammunition, the animations it is drawn by, and the flash, glow, smoke and shells it throws

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -528,6 +528,7 @@ static void M_Setup(OBJECT *const obj)
     } else {
         obj->effect_control_func =
             g_TRVersion == 3 ? M_TR3_Control : M_TR12_Control;
+        obj->effect_draw_func = nullptr;
     }
     obj->semi_transparent = true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures TR4's flame draw routine override is reset when switching mods to the other games.

Resolves TRX1090.