### PR TITLE
items/draw: fix doors vanishing after a load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Changed a game named with `--mod` to say why it cannot be played, rather than quietly starting a different one
 - Changed Lara turning to gold on the Midas hand to gild the outfit she has on, rather than swap her for a golden model
 - Fixed flames not being drawn if TR4 is launched and the game is then switched to a different mod (regression from 1.10)
+- Fixed doors disappearing when seen from the far side of their doorway after loading a save (regression from 1.9)
 
 **Lua**
 - Added the full weapon definition to `trx.weapons`, so a script can read and change what a weapon does: its damage, reach and accuracy, its aim limits, its ammunition, the animations it is drawn by, and the flash, glow, smoke and shells it throws

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -31,44 +31,10 @@ static int16_t m_NextItemFree = NO_ITEM;
 static uint32_t m_ItemGens[MAX_ITEMS];
 static HANDLE_REGISTRY m_ItemHandles;
 
-static inline bool M_ItemBoundsIntersectsPortal(
-    const ITEM *item, const ROOM *room, const PORTAL *const portal)
-{
-    // Axis-aligned bound intersection; ignores item rotation. The object's
-    // whole-animation box stands in for the frame being drawn, so an item
-    // that only reaches the neighbour partway through its animation is
-    // queued there from the start and the queue never has to be redone.
-    const BOUNDS_16 *const frame_bounds =
-        &Object_Get(item->object_id)->anim_bounds;
-    const BOUNDS_32 bounds = {
-        .min = {
-            item->pos.x + frame_bounds->min.x,
-            item->pos.y + frame_bounds->min.y,
-            item->pos.z + frame_bounds->min.z,
-        },
-        .max = {
-            item->pos.x + frame_bounds->max.x,
-            item->pos.y + frame_bounds->max.y,
-            item->pos.z + frame_bounds->max.z,
-        },
-    };
-
-    if (Bounds32_Intersect(&bounds, &portal->bounds)) {
-        return true;
-    }
-
-    const ROOM *const own_room = Room_Get(item->room_num);
-    if (own_room == nullptr) {
-        return false;
-    }
-    const BOUNDS_32 room_bounds = Room_GetRoomBounds(own_room);
-    return !Bounds32_Intersect(&bounds, &room_bounds);
-}
-
 // Take the item out of a room's draw queues: the room itself and every portal
-// neighbour it may have been queued into. Paired with the chain unlink below;
-// both must run when an item leaves a room. Repeated for flipped rooms as
-// portals may differ if the map has been flipped.
+// neighbour. The exact mirror of M_AddToDrawQueues below, plus the flipped
+// room, whose portals may differ if the map has been flipped. Paired with the
+// chain unlink below; both must run when an item leaves a room.
 static void M_RemoveFromDrawQueues(
     const int16_t item_num, const int16_t room_num)
 {
@@ -86,8 +52,11 @@ static void M_RemoveFromDrawQueues(
 }
 
 // Put the item into a room's draw queues: the room itself and every portal
-// neighbour its box reaches into. Additive, so a queue an object's initialiser
-// arranged for itself - the far side of a door - is left alone.
+// neighbour, unconditionally, so the removal above undoes exactly this and an
+// item drawn from a neighbouring room - a door, seen from the far side of its
+// doorway - is queued there again after every room change. The draw pass
+// dedups per frame and clips per room, so a queue entry the camera cannot
+// reach costs one rejected clip test.
 static void M_AddToDrawQueues(const int16_t item_num, const int16_t room_num)
 {
     if (room_num == NO_ROOM) {
@@ -98,12 +67,8 @@ static void M_AddToDrawQueues(const int16_t item_num, const int16_t room_num)
     if (room == nullptr || room->portals == nullptr) {
         return;
     }
-    const ITEM *const item = &m_Items[item_num];
     for (int32_t i = 0; i < room->portals->count; i++) {
-        const PORTAL *const portal = &room->portals->portal[i];
-        if (M_ItemBoundsIntersectsPortal(item, room, portal)) {
-            Room_AddDrawnItem(portal->room_num, item_num);
-        }
+        Room_AddDrawnItem(room->portals->portal[i].room_num, item_num);
     }
 }
 

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -375,10 +375,6 @@ void Door_Initialise(const int16_t item_num)
 
         M_Shut(&p->d2);
         M_Shut(&p->d2flip);
-
-        const int16_t prev_room = item->room_num;
-        Item_UpdateRoom(item_num, room_num);
-        item->room_num = prev_room;
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where a door stopped being drawn from the far side of its doorway after loading a save.

A door is drawn from the room behind its doorway as well as its own. Since the draw queue rewrite (f6bd91f78, 1.9), a room update rebuilt an item's queues from its position alone and lost that arrangement with no way back. Adding to the queues now mirrors removal, taking in every portal neighbour, so a rebuild keeps a door whole and the initialiser no longer has to plant the extra entry itself.

Resolves TRX1097