### PR TITLE
lara: retain equipment on Midas Touch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold
+- Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand
 - Fixed the Cabin in Natla's Mines remaining visible after dropping to the floor (regression from 1.10)
 
 **TR4**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own
 
 **TR1**
+- Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold
 - Fixed the Cabin in Natla's Mines remaining visible after dropping to the floor (regression from 1.10)
 
 **TR4**

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -350,6 +350,24 @@ static void M_UpdateSunglasses(void)
     Lara_Skin_SetExtraEquipment(LM_HEAD, mesh);
 }
 
+static void M_ReapplyEquipmentEx(
+    const LARA_SKIN_OUTFIT *const outfit, const LARA_MESH mesh)
+{
+    const LARA_SKIN_EQUIPMENT *const equipment = &m_Equipment[mesh];
+    switch (equipment->type) {
+    case EQUIPMENT_TYPE_WEAPON:
+        M_SetGunEquipment(mesh, equipment->data, outfit);
+        break;
+    case EQUIPMENT_TYPE_EXTRA:
+        M_SetEquipment(
+            mesh, EQUIPMENT_TYPE_EXTRA, equipment->data,
+            Lara_Skin_GetExtraMeshOffset(equipment->data), outfit);
+        break;
+    default:
+        break;
+    }
+}
+
 // What Lara carries comes from the outfit's objects too - the gun in her hands
 // and the one on her back among it - so a change of outfit has to read it again
 // from what each slot already holds. A slot holding nothing keeps holding
@@ -360,19 +378,7 @@ static void M_ReapplyEquipment(const LARA_SKIN_OUTFIT *const outfit)
         if (i == LM_THIGH_L || i == LM_THIGH_R) {
             continue;
         }
-        const LARA_SKIN_EQUIPMENT *const equipment = &m_Equipment[i];
-        switch (equipment->type) {
-        case EQUIPMENT_TYPE_WEAPON:
-            M_SetGunEquipment(i, equipment->data, outfit);
-            break;
-        case EQUIPMENT_TYPE_EXTRA:
-            M_SetEquipment(
-                i, EQUIPMENT_TYPE_EXTRA, equipment->data,
-                Lara_Skin_GetExtraMeshOffset(equipment->data), outfit);
-            break;
-        default:
-            break;
-        }
+        M_ReapplyEquipmentEx(outfit, i);
     }
 }
 
@@ -648,12 +654,7 @@ void Lara_Skin_SwapSingleExtra(
 
     M_ApplyMeshIfValid(mesh, outfit);
     Lara_Joints_SwapSingle(mesh, outfit);
-
-    if (mesh == LM_THIGH_L) {
-        M_SetGunEquipment(LM_THIGH_L, m_HolsterType_L, outfit);
-    } else if (mesh == LM_THIGH_R) {
-        M_SetGunEquipment(LM_THIGH_R, m_HolsterType_R, outfit);
-    }
+    M_ReapplyEquipmentEx(outfit, mesh);
 }
 
 const ANIM_BONE *Lara_Skin_GetBoneBase(void)

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -121,15 +121,6 @@ static void M_MidasKill(ITEM *const item, COLL_INFO *const coll)
 
         lara->mesh_effects |= (1 << step->mesh);
         Lara_Skin_SwapSingleExtra(step->mesh, LS_EXTRA_MIDAS_KILL);
-        switch (step->mesh) {
-        case LM_TORSO:
-        case LM_HAND_L:
-        case LM_HAND_R:
-            Lara_Skin_ClearEquipment(step->mesh);
-            break;
-        default:
-            break;
-        }
     }
 
     Twinkle_SparkleItem(item, lara->mesh_effects);

--- a/src/trx/game/objects/traps/midas_touch.c
+++ b/src/trx/game/objects/traps/midas_touch.c
@@ -30,6 +30,9 @@ static void M_KillLara(const ITEM *const item)
 {
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (lara->gun_type == LGT_FLARE) {
+        lara->flare.control = false;
+    }
 
     Lara_SwitchToExtraState(LS_EXTRA_MIDAS_KILL);
     Lara_Kill();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This makes Lara retain all equipment when turning to gold on the Midas Touch, with the equipment itself also turning to gold. It also fixes her arm remaining in the flare pose if she lands on it with one in-hand.

Resolves TRX1073.
