### PR TITLE
data: give crystal on game start

### DIFF
--- a/data/trx/ship/games/tr1-ub/scripts/_game.lua
+++ b/data/trx/ship/games/tr1-ub/scripts/_game.lua
@@ -5,3 +5,5 @@ require("common.water_color").declare({
     dos = "99B2FF",
   },
 })
+
+require("common.save_crystal").initialise()

--- a/data/trx/ship/games/tr1/scripts/_game.lua
+++ b/data/trx/ship/games/tr1/scripts/_game.lua
@@ -5,3 +5,5 @@ require("common.water_color").declare({
     dos = "99B2FF",
   },
 })
+
+require("common.save_crystal").initialise()

--- a/data/trx/ship/games/tr2-gm/scripts/_game.lua
+++ b/data/trx/ship/games/tr2-gm/scripts/_game.lua
@@ -1,7 +1,3 @@
-trx.events.on_game_start(function()
-  trx.rules.set("music.supports_delay", true)
-end)
-
 require("common.water_color").declare({
   order = { "pc_hardware", "pc_software", "custom" },
   modes = {
@@ -9,3 +5,5 @@ require("common.water_color").declare({
     pc_software = "AAAAFF",
   },
 })
+
+require("common.save_crystal").initialise()

--- a/data/trx/ship/games/tr2/scripts/_game.lua
+++ b/data/trx/ship/games/tr2/scripts/_game.lua
@@ -1,7 +1,3 @@
-trx.events.on_game_start(function()
-  trx.rules.set("music.supports_delay", true)
-end)
-
 require("common.water_color").declare({
   order = { "pc_hardware", "pc_software", "ps1", "custom" },
   modes = {
@@ -31,3 +27,5 @@ require("common.water_color").declare({
     },
   },
 })
+
+require("common.save_crystal").initialise()

--- a/data/trx/ship/games/tr3-la/scripts/_game.lua
+++ b/data/trx/ship/games/tr3-la/scripts/_game.lua
@@ -4,3 +4,5 @@ require("common.water_color").declare({
     pc = "80E0FF",
   },
 })
+
+require("common.save_crystal").initialise()

--- a/data/trx/ship/games/tr3/scripts/_game.lua
+++ b/data/trx/ship/games/tr3/scripts/_game.lua
@@ -30,3 +30,5 @@ require("common.water_color").declare({
     },
   },
 })
+
+require("common.save_crystal").initialise()

--- a/data/trx/ship/modules/save_crystal.lua
+++ b/data/trx/ship/modules/save_crystal.lua
@@ -1,0 +1,17 @@
+local save_crystal = {}
+
+function save_crystal.initialise()
+  trx.events.on_game_start(function(is_save)
+    -- TR3 PS1 gave Lara a save crystal on starting the game
+    if
+      not is_save
+      and trx.game.current_level.type == trx.game.LevelType.NORMAL
+      and trx.game.current_level.num == 1
+      and trx.config.get("gameplay.save_crystal_mode") == "save_pickup"
+    then
+      trx.inventory.give(trx.catalog.objects.save_crystal_item)
+    end
+  end)
+end
+
+return save_crystal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,9 @@
 - Changed a missing or unknown `lara_outfit` in a level to fall back to the default outfit, rather than stopping the game from starting
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own
 
+**Saves and settings**
+- Changed the save crystal behavior to give Lara a crystal when starting a game, if the mode is set to Saving (pickups), in line with the TR3 PS1 version (Gameplay → General → Crystal mode)
+
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold
 - Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1313,6 +1313,7 @@ If you install everything correctly, your game directory should look more or les
 │       ├── strings-it.json5
 │       └── strings.json5
 ├── modules
+│   ├── save_crystal.lua
 │   └── water_color.lua
 └── TRX.exe</code></pre>
 </details>
@@ -2661,6 +2662,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │       ├── strings-it.json5
     │   │       └── strings.json5
     │   ├── modules
+    │   │   ├── save_crystal.lua
     │   │   └── water_color.lua
     │   └── icon.icns
     ├── _CodeSignature


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This gives Lara a save crystal when starting Jungle if that mode is enabled. Do we want to extend it to the other games? I feel like it's not needed there as it's in the same boat as her starting shotgun, flares etc, so is very game-specific.

Resolves TRX1101.