### PR TITLE
objects/zipline: fix setting Lara state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Fixed flames not being drawn if TR4 is launched and the game is then switched to a different mod (regression from 1.10)
 - Fixed doors disappearing when seen from the far side of their doorway after loading a save (regression from 1.9)
 - Fixed breeze defaulting to being off in fresh installations (regression from 1.10)
+- Fixed Lara having the wrong state while grabbing a zipline (regression from 1.10)
 - Fixed the game closing when a language with a broken strings file is picked
 - Fixed a false warning that the settings could not be saved
 

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -141,7 +141,7 @@ static void M_Grab(
     ITEM *const zip_item, ITEM *const lara_item, LARA_INFO *const lara)
 {
     Item_SwitchToAnim(lara_item, LA(LA_ZIPLINE_GRAB), 0);
-    lara_item->current_anim_state == LS(LS_PULL_UP);
+    lara_item->current_anim_state = LS(LS_PULL_UP);
     lara_item->goal_anim_state = LS(LS_ZIPLINE);
     lara->gun_status = LGS_HANDS_BUSY;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes not setting Lara's state correctly when grabbing a zipline. Regression in 589e05a.

I don't think there would have been any immediately obvious implications, perhaps with different state/col routines running she may have been able to do something she shouldn't. Changelog entry added regardless.
