### PR TITLE
cfg: give the TR1 PS1 preset the TR1 bars

### DIFF
--- a/data/trx/ship/cfg/base_strings-de.json5
+++ b/data/trx/ship/cfg/base_strings-de.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "\\{review}TR2 PC",
                 "tr2_ps1": "\\{review}TR2 PS1",
                 "tr3_pc": "\\{review}TR3 PC",

--- a/data/trx/ship/cfg/base_strings-fr.json5
+++ b/data/trx/ship/cfg/base_strings-fr.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "\\{review}TR2 PC",
                 "tr2_ps1": "\\{review}TR2 PS1",
                 "tr3_pc": "\\{review}TR3 PC",

--- a/data/trx/ship/cfg/base_strings-gd.json5
+++ b/data/trx/ship/cfg/base_strings-gd.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "TR2 PC",
                 "tr2_ps1": "TR2 PS1",
                 "tr3_pc": "TR3 PC",

--- a/data/trx/ship/cfg/base_strings-it.json5
+++ b/data/trx/ship/cfg/base_strings-it.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "TR2 PC",
                 "tr2_ps1": "TR2 PS1",
                 "tr3_pc": "TR3 PC",

--- a/data/trx/ship/cfg/base_strings-pl.json5
+++ b/data/trx/ship/cfg/base_strings-pl.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "TR2 PC",
                 "tr2_ps1": "TR2 PS1",
                 "tr3_pc": "TR3 PC",

--- a/data/trx/ship/cfg/base_strings-ru.json5
+++ b/data/trx/ship/cfg/base_strings-ru.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "TR2 PC",
                 "tr2_ps1": "\\{review}TR2 PS1",
                 "tr3_pc": "TR3 PC",

--- a/data/trx/ship/cfg/base_strings.json5
+++ b/data/trx/ship/cfg/base_strings.json5
@@ -582,7 +582,7 @@
         },
         "enums": {
             "bar_look": {
-                "tr1_pc": "TR1 PC",
+                "tr1_pc": "TR1",
                 "tr2_pc": "TR2 PC",
                 "tr2_ps1": "TR2 PS1",
                 "tr3_pc": "TR3 PC",

--- a/data/trx/ship/cfg/presets/tr1-ps1.json5
+++ b/data/trx/ship/cfg/presets/tr1-ps1.json5
@@ -3,7 +3,7 @@
     "config": {
         "ui.menu_style": "ps1",
         "ui.enable_smooth_bars": false,
-        "ui.bar_look": "tr2_ps1",
+        "ui.bar_look": "tr1_pc",
         "ui.ammo_counter_location": "top-right",
         "audio.enable_ps1_sfx": true,
         "gameplay.restore_ps1_enemies": true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -207,8 +207,10 @@ Showcase: https://youtu.be/DKpqz_Yum6o
 - Changed the Neutral twists option to Alternative turns, which now turns Lara on the spot and on monkeybars as well as twisting her in the air (Gameplay → Controls → Alternative turns)
 - Changed the presets to be listed by name rather than in the order they were found (Gameplay → Presets)
 - Changed a setting a script is holding to be greyed out, where the row carried only the star saying who took it
+- Changed the TR1 PC bars appearance to be named TR1, the bars being the ones both TR1 releases draw (Graphic Options → Bars → Bars appearance)
 - Fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - Fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
+- Fixed the TR1 PS1 preset picking the TR2 PS1 bars, where TR1 draws the same bars on both platforms (#6260)
 - Fixed the load and save game dialogs covering the rest of the screen at larger text scales, where the list now shows as many slots as there is room for (#6175)
 
 **Saves and settings**

--- a/src/trx/game/game_strings/entries.def
+++ b/src/trx/game/game_strings/entries.def
@@ -1,5 +1,5 @@
 // Enum values
-GS_DEFINE(dynamic/enums/bar_look/tr1_pc,                                    "TR1 PC")
+GS_DEFINE(dynamic/enums/bar_look/tr1_pc,                                    "TR1")
 GS_DEFINE(dynamic/enums/bar_look/tr2_pc,                                    "TR2 PC")
 GS_DEFINE(dynamic/enums/bar_look/tr2_ps1,                                   "TR2 PS1")
 GS_DEFINE(dynamic/enums/bar_look/tr3_pc,                                    "TR3 PC")


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes the TR1 PS1 preset to use TR1’s gold bar theme instead of TR2’s red-to-green bars. Also renames the shared "TR1 PC" theme to "TR1", since both TR1 releases use the same bars, while keeping its config key unchanged for compatibility.

Resolves #6260