### PR TITLE
lara/col/land: avoid step down animations in swamps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.10...develop) - ××××-××-××
 
+**Lara's movement**
+- Fixed Lara entering the step down animation when walking backwards in a swamp room (OG bug) (#6248)
+
 **UI**
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)
 - Changed the tab arrows to no longer vanish once the selection moved into the list below them

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -339,8 +339,9 @@ static void M_WalkBack(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
+    const ROOM *const room = Room_Get(item->room_num);
     if (coll->side_mid.floor > STEP_L / 2
-        && coll->side_mid.floor < STEPUP_HEIGHT) {
+        && coll->side_mid.floor < STEPUP_HEIGHT && !room->flags.swamp) {
         if (Item_TestFrameRange(
                 item, M_LF_WALK_BACK_R_START, M_LF_WALK_BACK_R_END)) {
             Item_SwitchToAnim(item, LA(LA_WALK_DOWN_BACK_RIGHT), 0);
@@ -353,7 +354,6 @@ static void M_WalkBack(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    const ROOM *const room = Room_Get(item->room_num);
     if (coll->side_mid.floor >= 0 && room->flags.swamp) {
         item->pos.y += 2;
     } else if (lara->water_status == LWS_WADE && coll->side_mid.floor >= 50) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This prevents Lara entering the step down animations in swamp rooms. Her Y position moves so slowly that the coll floor values remain within the testing range and hence she kept getting her animation reset.

Resolves #6251 / TRX1118.
