### PR TITLE
cfg/presets: name the corner the bars sit in

### DIFF
--- a/data/trx/ship/cfg/presets/tr1-pc.json5
+++ b/data/trx/ship/cfg/presets/tr1-pc.json5
@@ -5,6 +5,8 @@
         "ui.enable_smooth_bars": true,
         "ui.bar_look": "tr1_pc",
         "ui.ammo_counter_location": "top-right",
+        "ui.healthbar_location": "top-left",
+        "ui.airbar_location": "top-right",
         "audio.enable_ps1_sfx": false,
         "gameplay.restore_ps1_enemies": false,
         "visuals.enable_gun_glow": false,

--- a/data/trx/ship/cfg/presets/tr1-ps1.json5
+++ b/data/trx/ship/cfg/presets/tr1-ps1.json5
@@ -5,6 +5,8 @@
         "ui.enable_smooth_bars": false,
         "ui.bar_look": "tr1_pc",
         "ui.ammo_counter_location": "top-right",
+        "ui.healthbar_location": "top-right",
+        "ui.airbar_location": "top-right",
         "audio.enable_ps1_sfx": true,
         "gameplay.restore_ps1_enemies": true,
         "visuals.enable_gun_glow": true,

--- a/data/trx/ship/cfg/presets/tr2-pc.json5
+++ b/data/trx/ship/cfg/presets/tr2-pc.json5
@@ -5,6 +5,8 @@
         "ui.enable_smooth_bars": false,
         "ui.bar_look": "tr2_pc",
         "ui.ammo_counter_location": "top-right",
+        "ui.healthbar_location": "top-left",
+        "ui.airbar_location": "top-right",
         "audio.enable_ps1_sfx": false,
         "gameplay.restore_ps1_enemies": false,
         "visuals.enable_gun_glow": false,

--- a/data/trx/ship/cfg/presets/tr2-ps1.json5
+++ b/data/trx/ship/cfg/presets/tr2-ps1.json5
@@ -5,6 +5,8 @@
         "ui.enable_smooth_bars": false,
         "ui.bar_look": "tr2_ps1",
         "ui.ammo_counter_location": "top-right",
+        "ui.healthbar_location": "top-right",
+        "ui.airbar_location": "top-right",
         "audio.enable_ps1_sfx": true,
         "gameplay.restore_ps1_enemies": true,
         "visuals.enable_gun_glow": true,

--- a/data/trx/ship/cfg/presets/tr3-pc.json5
+++ b/data/trx/ship/cfg/presets/tr3-pc.json5
@@ -5,6 +5,8 @@
         "ui.enable_smooth_bars": false,
         "ui.bar_look": "tr3_pc",
         "ui.ammo_counter_location": "top-right",
+        "ui.healthbar_location": "top-left",
+        "ui.airbar_location": "top-right",
         "audio.enable_ps1_sfx": false,
         "gameplay.restore_ps1_enemies": false,
         "gameplay.save_crystal_mode": "heal",

--- a/data/trx/ship/cfg/presets/tr3-ps1.json5
+++ b/data/trx/ship/cfg/presets/tr3-ps1.json5
@@ -5,6 +5,8 @@
         "ui.enable_smooth_bars": false,
         "ui.bar_look": "tr3_ps1",
         "ui.ammo_counter_location": "bottom-right",
+        "ui.healthbar_location": "top-right",
+        "ui.airbar_location": "top-right",
         "audio.enable_ps1_sfx": true,
         "gameplay.restore_ps1_enemies": true,
         "gameplay.save_crystal_mode": "save_pickup",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -208,7 +208,9 @@ Showcase: https://youtu.be/DKpqz_Yum6o
 - Changed the Neutral twists option to Alternative turns, which now turns Lara on the spot and on monkeybars as well as twisting her in the air (Gameplay → Controls → Alternative turns)
 - Changed the presets to be listed by name rather than in the order they were found (Gameplay → Presets)
 - Changed a setting a script is holding to be greyed out, where the row carried only the star saying who took it
-- Changed the TR1 PC bars appearance to be named TR1, the bars being the ones both TR1 releases draw (Graphic Options → Bars → Bars appearance)
+- Changed the TR1 PC bars appearance to be named TR1, the bars being the ones both TR1 releases draw (Graphic Options → Bars → Bars appearance) (#6260)
+- Changed the PlayStation presets to place the health and air bars on the right, where the PlayStation releases put them (#6261)
+- Changed the PC presets to name the corners the health and air bars sit in, which they had been taking from the defaults
 - Fixed settings text running off both sides of the screen in the longer languages, most visibly at 4:3 (#6000)
 - Fixed the list of settings a preset would change spilling outside its dialog, and its text now wraps (#6000)
 - Fixed the TR1 PS1 preset picking the TR2 PS1 bars, where TR1 draws the same bars on both platforms (#6260)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Presets now explicitly set health/air bar positions: PlayStation uses top-right for both, while PC keeps health top-left and air top-right. This fixes inaccurate PlayStation layouts and removes reliance on defaults.

Resolves #6262.