### PR TITLE
items/anim: avoid land/water SFX in swamp rooms

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.10...develop) - ××××-××-××
 
 **Lara's movement**
-- Fixed Lara entering the step down animation when walking backwards in a swamp room (OG bug) (#6248)
+- Fixed Lara entering the step down animation when walking backwards in a swamp room (OG bug) (#6251)
+- Fixed certain SFX, such as Lara's footsteps, playing in swamp rooms (#6248, regression from 1.0)
 
 **UI**
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -356,6 +356,9 @@ void Item_PlayAnimSFX(
     const ANIM_COMMAND_ENVIRONMENT mode = data->environment;
 
     if (mode != ACE_ALL && item->room_num != NO_ROOM) {
+        if (Room_Get(item->room_num)->flags.swamp) {
+            return;
+        }
         int32_t height = NO_HEIGHT;
         if (is_lara) {
             height = Lara_GetLaraInfo()->water_surface_dist;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids land and water specific SFX playing in swamp rooms.

I'd appreciate a sanity check in OG TR3 that the only sound she makes is from wading forward (that SFX has mode set to `ACE_ALL`).

Resolves #6248 / TRX1115.
