### PR TITLE
Fix TRLA and TRGM water color preset interactions

### DIFF
--- a/data/trx/ship/modules/water_color.lua
+++ b/data/trx/ship/modules/water_color.lua
@@ -72,7 +72,7 @@ function water_color.declare(spec)
     local color = spec.modes[mode]
     if type(color) == "table" then
       local level = trx.game.current_level
-      color = level ~= nil and color[level.key] or nil
+      color = level ~= nil and color[level.key] or trx.config.get(COLOR_OPTION)
     end
     hold(color)
   end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed the controls key list jumping after switching to a tab with fewer keys (regression from 1.3)
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control
+- Fixed the water color setting staying editable while a PS1 water color preset was picked (#6265)
 
 **Developer console**
 - Added the `/outfit` console command, which shows or changes what Lara is wearing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 **Saves and settings**
 - Changed the save crystal behavior to give Lara a crystal when starting a game, if the mode is set to Saving (pickups), in line with the TR3 PS1 version (Gameplay → General → Crystal mode)
+- Fixed the PS1 water color preset showing as unnamed text in The Lost Artefact and Golden Mask (#6265)
 
 **Music and sound**
 - Fixed crystal sound effects not playing if Lara collects one underwater (OG bug)

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -381,24 +381,42 @@ static M_DECLARATION M_ReadDeclaration(lua_State *const L)
     return spec;
 }
 
-// Seeds a declared enum's values. Each label is a game string key derived from
-// the option, so a declared value is translated as every other one is.
+// Registers one value the option takes. Each label is a game string key derived
+// from the option, so a declared value is translated as every other one is.
+static void M_AddValue(
+    const CONFIG_OPTION *const option, const char *const value)
+{
+    char *label = String_Format("settings/%s/values/%s", option->name, value);
+    DynamicEnum_AddValue(Config_Option_GetEnumKey(option), value, label);
+    Memory_FreePointer(&label);
+}
+
+// Seeds a declared enum's values.
 static void M_SeedValues(lua_State *const L, const CONFIG_OPTION *const option)
 {
-    const void *const token = Config_Option_GetEnumKey(option);
-    DynamicEnum_ResetValues(token);
+    DynamicEnum_ResetValues(Config_Option_GetEnumKey(option));
     lua_getfield(L, 1, "values");
     const int32_t count = (int32_t)lua_rawlen(L, -1);
     for (int32_t i = 1; i <= count; i++) {
         lua_rawgeti(L, -1, i);
-        const char *const value = lua_tostring(L, -1);
-        char *label =
-            String_Format("settings/%s/values/%s", option->name, value);
-        DynamicEnum_AddValue(token, value, label);
-        Memory_FreePointer(&label);
+        M_AddValue(option, lua_tostring(L, -1));
         lua_pop(L, 1);
     }
     lua_pop(L, 1);
+}
+
+// A saved value this declaration does not list belongs to another game sharing
+// the settings file. Kept and turned off rather than dropped, so that game gets
+// it back.
+static void M_KeepUnlistedValue(
+    const CONFIG_OPTION *const option, const char *const value)
+{
+    if (value == nullptr
+        || DynamicEnum_IsValidValue(Config_Option_GetEnumKey(option), value)) {
+        return;
+    }
+    M_AddValue(option, value);
+    DynamicEnum_SetValueEnabled(Config_Option_GetEnumKey(option), value, false);
 }
 
 // trxc.config.declare(spec)
@@ -415,6 +433,8 @@ static int M_L_ConfigDeclare(lua_State *const L)
     }
     if (option->value.type == TVT_DYNAMIC_ENUM) {
         M_SeedValues(L, option);
+        M_KeepUnlistedValue(option, option->value.as_str);
+        M_KeepUnlistedValue(option, Config_Option_GetBaseValue(option)->as_str);
     }
     return 0;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes PS1 water color settings in TR2/TR3 and The Lost Artefact. The PS1 preset is now preserved in shared settings even where it isn’t available, and the water color option stays correctly locked on the title screen while still using the right color for each level.

Resolves #6265