### PR TITLE
lara/state/land: fix wading fast turn

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Lara's movement**
 - Fixed Lara entering the step down animation when walking backwards in a swamp room (OG bug) (#6251)
 - Fixed certain SFX, such as Lara's footsteps, playing in swamp rooms (#6248, regression from 1.0)
+- Fixed Lara being able to turn too quickly in swamp rooms (regression from 1.0)
 
 **UI**
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)
@@ -44,6 +45,7 @@
 - Added crystals to each of the levels in The Lost Artefact, and made the crystal mode option visible (Gameplay → General → Crystal mode)
 - Fixed z-fighting in rooms 21, 67 amd 122 in Jungle, and fixed incorrect lighting in room 87 (OG bugs)
 - Fixed missing alpha blending on the MP5 and M16 gun flare in the gym (regression from 1.7)
+- Fixed Lara being able to turn too quickly when wading (regression from 1.0)
 
 **TR4**
 - Added the ability to skip in-game cutscenes

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -578,16 +578,19 @@ static void M_Turn(ITEM *const item, COLL_INFO *const coll)
         lara->turn_rate += LARA_TURN_RATE;
     }
 
-    if (lara->gun_status == LGS_READY) {
+    const bool can_turn_fast = !Room_Get(item->room_num)->flags.swamp
+        && (g_TRVersion < 3 || lara->water_status != LWS_WADE);
+
+    if (lara->gun_status == LGS_READY && can_turn_fast) {
         item->goal_anim_state = LS(LS_FAST_TURN);
     } else if (left_turn && lara->turn_rate < -LARA_SLOW_TURN) {
-        if (g_Input.slow) {
+        if (g_Input.slow || !can_turn_fast) {
             lara->turn_rate = -LARA_SLOW_TURN;
         } else {
             item->goal_anim_state = LS(LS_FAST_TURN);
         }
     } else if (!left_turn && lara->turn_rate > LARA_SLOW_TURN) {
-        if (g_Input.slow) {
+        if (g_Input.slow || !can_turn_fast) {
             lara->turn_rate = LARA_SLOW_TURN;
         } else {
             item->goal_anim_state = LS(LS_FAST_TURN);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes Lara turning too quickly in swamp rooms and when wading in TR3. TR1/2 retain TR2's logic for water, but inherit slow turn in swamps.

Resolves TRX1129.
