### PR TITLE
ui/config_presets: show the confirm choices

### DIFF
--- a/data/trx/ship/cfg/base_strings-de.json5
+++ b/data/trx/ship/cfg/base_strings-de.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "\\{review}Voreinstellung angewendet.",
+            "confirm_apply": "\\{review}Anwenden",
+            "confirm_back": "\\{review}Zurück",
             "confirm_description": "\\{review}Die folgenden Einstellungen werden geändert:",
             "confirm_restart_note": "\\{review}Hinweis: Einige Einstellungen erfordern möglicherweise einen Neustart des Spiels, um wirksam zu werden.",
             "empty": "\\{review}Keine Voreinstellungen gefunden.",

--- a/data/trx/ship/cfg/base_strings-fr.json5
+++ b/data/trx/ship/cfg/base_strings-fr.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "\\{review}Préréglage appliqué.",
+            "confirm_apply": "\\{review}Appliquer",
+            "confirm_back": "\\{review}Retour",
             "confirm_description": "\\{review}Les paramètres suivants seront modifiés :",
             "confirm_restart_note": "\\{review}Remarque : certains paramètres peuvent nécessiter un redémarrage du jeu pour prendre effet.",
             "empty": "\\{review}Aucun préréglage trouvé.",

--- a/data/trx/ship/cfg/base_strings-gd.json5
+++ b/data/trx/ship/cfg/base_strings-gd.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "Ro-shealladh air a chur an sàs.",
+            "confirm_apply": "\\{review}Cuir an sàs",
+            "confirm_back": "\\{review}Air ais",
             "confirm_description": "Bidh na suidheachaidhean a leanas air an atharrachadh:",
             "confirm_restart_note": "Nota: dh’fhaodadh gum feum cuid de shuidheachaidhean ath-thòiseachadh a’ gheama airson buaidh fhaighinn.",
             "empty": "Cha deach ro-shealladh sam bith a lorg.",

--- a/data/trx/ship/cfg/base_strings-it.json5
+++ b/data/trx/ship/cfg/base_strings-it.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "Profilo applicato.",
+            "confirm_apply": "\\{review}Applica",
+            "confirm_back": "\\{review}Indietro",
             "confirm_description": "Verranno modificate le seguenti impostazioni:",
             "confirm_restart_note": "Nota: per avere effetto, alcune impostazioni\n         potrebbero richiedere il riavvio del gioco.",
             "empty": "Nessun profilo trovato.",

--- a/data/trx/ship/cfg/base_strings-pl.json5
+++ b/data/trx/ship/cfg/base_strings-pl.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "Ustawienia zastosowane.",
+            "confirm_apply": "\\{review}Zastosuj",
+            "confirm_back": "\\{review}Wróć",
             "confirm_description": "Następujące ustawienia zostaną zmienione:",
             "confirm_restart_note": "Uwaga: niektóre ustawienia mogą wymagać ponownego uruchomienia gry, aby zaczęły obowiązywać.",
             "empty": "Nie znaleziono żadnych ustawień.",

--- a/data/trx/ship/cfg/base_strings-ru.json5
+++ b/data/trx/ship/cfg/base_strings-ru.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "\\{review}Предустановка применена.",
+            "confirm_apply": "\\{review}Применить",
+            "confirm_back": "\\{review}Назад",
             "confirm_description": "\\{review}Следующие настройки будут изменены:",
             "confirm_restart_note": "\\{review}Примечание: для вступления изменений в силу может потребоваться перезапуск игры.",
             "empty": "\\{review}Пресеты не найдены.",

--- a/data/trx/ship/cfg/base_strings.json5
+++ b/data/trx/ship/cfg/base_strings.json5
@@ -13,6 +13,8 @@
         },
         "config_presets": {
             "applied": "Preset applied.",
+            "confirm_apply": "Apply",
+            "confirm_back": "Go back",
             "confirm_description": "The following settings will be changed:",
             "confirm_restart_note": "Note: some settings may require a game restart to take effect.",
             "empty": "No presets found.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed the controls key list jumping after switching to a tab with fewer keys (regression from 1.3)
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10)
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187)
+- Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control
 - Fixed the water color setting staying editable while a PS1 water color preset was picked (#6265)
 

--- a/src/trx/game/game_strings/entries.def
+++ b/src/trx/game/game_strings/entries.def
@@ -877,6 +877,8 @@ GS_DEFINE(general/settings/gameplay/tabs/presets,  "Presets")
 
 GS_DEFINE(general/config_presets/confirm_description,  "The following settings will be changed:")
 GS_DEFINE(general/config_presets/confirm_restart_note, "Note: some settings may require a game restart to take effect.")
+GS_DEFINE(general/config_presets/confirm_apply,        "Apply")
+GS_DEFINE(general/config_presets/confirm_back,         "Go back")
 GS_DEFINE(general/config_presets/applied,              "Preset applied.")
 GS_DEFINE(general/config_presets/no_changes,           "No changes to apply.")
 GS_DEFINE(general/config_presets/title_fmt,            "Apply preset %s?")

--- a/src/trx/game/ui/dialogs/config_presets.c
+++ b/src/trx/game/ui/dialogs/config_presets.c
@@ -28,6 +28,8 @@
 #include <string.h>
 
 #define M_CONFIRM_VISIBLE_ROWS 10
+#define M_CHOICE_SPACING 12.0f
+#define M_CHOICE_PAD 8.0f
 // A narrow list of changes should stay narrow; this is the floor, not the
 // width.
 #define M_CONFIRM_MIN_W 72.0f
@@ -45,12 +47,31 @@ typedef enum {
     M_PHASE_APPLIED,
 } M_PHASE;
 
+typedef enum {
+    M_CHOICE_APPLY,
+    M_CHOICE_BACK,
+    M_CHOICE_COUNT,
+} M_CHOICE;
+
 struct UI_CONFIG_PRESETS_STATE {
     M_PHASE phase;
     UI_REQUESTER_STATE req;
     UI_SCROLLABLE confirm_scroll;
     int32_t selected_idx;
+    M_CHOICE confirm_choice;
 };
+
+static const char *M_GetChoiceLabel(const M_CHOICE choice)
+{
+    switch (choice) {
+    case M_CHOICE_APPLY:
+        return GS("general/config_presets/confirm_apply");
+    case M_CHOICE_BACK:
+        return GS("general/config_presets/confirm_back");
+    default:
+        return "";
+    }
+}
 
 static const char *M_GetPresetKeyLabel(const char *const key)
 {
@@ -185,6 +206,15 @@ static float M_GetConfirmContentWidth(UI_CONFIG_PRESETS_STATE *const s)
         natural = MAX(natural, UI_Label_MeasureW(message));
     }
 
+    if (s->phase == M_PHASE_CONFIRM) {
+        float choices = M_CHOICE_SPACING * scale;
+        for (M_CHOICE i = 0; i < M_CHOICE_COUNT; i++) {
+            choices += UI_Label_MeasureW(M_GetChoiceLabel(i))
+                + 2.0f * M_CHOICE_PAD * scale;
+        }
+        natural = MAX(natural, choices);
+    }
+
     const CONFIG_PRESET *const preset = Config_Presets_Get(s->selected_idx);
     if (s->phase == M_PHASE_CONFIRM && preset != nullptr) {
         for (int32_t i = 0; i < preset->setting_count; i++) {
@@ -237,6 +267,30 @@ static void M_Header(void *const user_data)
     }
 }
 
+static void M_DrawConfirmChoices(const UI_CONFIG_PRESETS_STATE *const s)
+{
+    UI_BeginAnchor(0.5f, 0.5f);
+    UI_BeginStackEx((UI_STACK_SETTINGS) {
+        .orientation = UI_STACK_HORIZONTAL,
+        .align = { .v = UI_STACK_V_ALIGN_CENTER },
+        .spacing = { .h = M_CHOICE_SPACING },
+    });
+    for (M_CHOICE i = 0; i < M_CHOICE_COUNT; i++) {
+        const bool is_selected = s->confirm_choice == i;
+        if (is_selected) {
+            UI_BeginFrame(UI_FRAME_SELECTED_OPTION);
+        }
+        UI_BeginPad(M_CHOICE_PAD, 0.0f);
+        UI_Label(M_GetChoiceLabel(i));
+        UI_EndPad();
+        if (is_selected) {
+            UI_EndFrame();
+        }
+    }
+    UI_EndStack();
+    UI_EndAnchor();
+}
+
 static void M_Footer(void *const user_data)
 {
     UI_CONFIG_PRESETS_STATE *const s = user_data;
@@ -245,6 +299,8 @@ static void M_Footer(void *const user_data)
         M_WrappedLabel(
             GS("general/config_presets/confirm_restart_note"),
             M_GetConfirmContentWidth(s));
+        UI_Spacer(0.0f, UI_TEXT_HEIGHT);
+        M_DrawConfirmChoices(s);
     }
 }
 
@@ -328,12 +384,17 @@ bool UI_ConfigPresets_Control(UI_CONFIG_PRESETS_STATE *const s)
 
     if (s->phase == M_PHASE_CONFIRM) {
         UI_ScrollableStack_Control(&s->confirm_scroll, UI_STACK_VERTICAL);
-        if (g_InputDB.menu_confirm) {
+        if (g_InputDB.menu_left) {
+            s->confirm_choice = M_CHOICE_APPLY;
+        } else if (g_InputDB.menu_right) {
+            s->confirm_choice = M_CHOICE_BACK;
+        }
+        if (g_InputDB.menu_confirm && s->confirm_choice == M_CHOICE_APPLY) {
             Config_Presets_Apply(s->selected_idx);
             s->phase = M_PHASE_APPLIED;
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
-        } else if (g_InputDB.menu_back) {
+        } else if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
             s->phase = M_PHASE_BROWSE;
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
@@ -368,6 +429,7 @@ bool UI_ConfigPresets_Control(UI_CONFIG_PRESETS_STATE *const s)
             // The stack counts its own lines once it has them; wrapping decides
             // how many a row takes.
             s->confirm_scroll.max_items = 0;
+            s->confirm_choice = M_CHOICE_APPLY;
             s->phase = M_PHASE_CONFIRM;
         } else {
             s->phase = M_PHASE_NO_CHANGES;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The confirmation listed the settings a preset would change but said nothing about what to press: Action applied and Escape went back, and neither was on screen. Apply and Go back now sit under the list as two choices, Apply picked to begin with. They take left and right, so up and down still scroll the list of changes.

Resolves #6258.