### PR TITLE
Fix input glyph combos

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Changed the PS1 poison healthbar to flat yellow, as the PS1 releases had it (#5227)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control
 - Fixed the water color setting staying editable while a PS1 water color preset was picked (#6265)
+- Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter
 
 **Developer console**
 - Added the `/outfit` console command, which shows or changes what Lara is wearing

--- a/src/meson.build
+++ b/src/meson.build
@@ -399,6 +399,7 @@ common_sources = [
   'trx/game/input/backends/touch.c',
   'trx/game/input/combo.c',
   'trx/game/input/common.c',
+  'trx/game/input/names.c',
   'trx/game/input/update.c',
   'trx/game/interpolation.c',
   'trx/game/inventory.c',

--- a/src/tests/fakes/ui.c
+++ b/src/tests/fakes/ui.c
@@ -17,11 +17,14 @@
 #include <trx/game/viewport.h>
 #include <trx/version.h>
 
+#define M_DEFAULT_KEY_NAME "\\{keyboard backspace}"
+
 static FONT_BIN m_Fonts[TR_VERSION_COUNT];
 static FONT_BIN *m_Font = nullptr;
 static OBJECT m_Objects[O_NUMBER_OF];
 static int32_t m_ViewportWidth = 640;
 static int32_t m_ViewportHeight = 480;
+static const char *m_KeyName = M_DEFAULT_KEY_NAME;
 
 void FakeUI_SetGame(const int32_t tr_version)
 {
@@ -61,6 +64,7 @@ void FakeUI_Shutdown(void)
         FontBin_Free(&m_Fonts[i]);
     }
     m_Font = nullptr;
+    m_KeyName = M_DEFAULT_KEY_NAME;
 }
 
 OBJECT *Object_Get(const OBJECT_ID object_id)
@@ -87,12 +91,23 @@ int32_t Viewport_GetHeight(const VIEWPORT_SPACE space)
     return m_ViewportHeight;
 }
 
-// The font resolves "\{input <role>}" through the current binding. Nothing here
-// binds keys, so every role reports the widest keycap in the sheet: a check
-// built on these metrics then holds for any binding a player can make.
+// The font resolves "\{input <role>}" through the current binding. By default
+// every role reports the widest keycap in the sheet, so a check built on these
+// metrics holds for any binding a player can make. A test about the binding
+// itself names the keys it wants instead.
 const char *Input_GetKeyName(
     const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
     const INPUT_ROLE role, const int32_t slot)
 {
-    return "\\{keyboard backspace}";
+    return m_KeyName;
+}
+
+void FakeUI_SetKeyName(const char *const key_name)
+{
+    m_KeyName = key_name;
+}
+
+void FakeUI_ResetKeyName(void)
+{
+    m_KeyName = M_DEFAULT_KEY_NAME;
 }

--- a/src/tests/fakes/ui.h
+++ b/src/tests/fakes/ui.h
@@ -13,4 +13,10 @@ void FakeUI_SetGame(int32_t tr_version);
 
 void FakeUI_SetViewport(int32_t width, int32_t height);
 
+// Name the keys every "\{input <role>}" placeholder stands for; nullptr leaves
+// the roles unbound.
+void FakeUI_SetKeyName(const char *key_name);
+
+void FakeUI_ResetKeyName(void);
+
 void FakeUI_Shutdown(void);

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -849,6 +849,13 @@ unit_tests += {
   'engine': ['game/lua/capi/items.c'],
 }
 
+# The text a binding reads as. It knows nothing of SDL, so no backend comes
+# along.
+unit_tests += {
+  'name': 'trx/game/input/names',
+  'engine': ['game/input/names.c'],
+}
+
 unit_tests += {
   'name': 'trx/game/ui/scrollable',
   'engine': ['game/ui/scrollable.c'],

--- a/src/tests/trx/game/input/names.c
+++ b/src/tests/trx/game/input/names.c
@@ -1,0 +1,63 @@
+// The sign between the keycaps of a combination is a glyph of its own, not a
+// literal plus, so a binding of several keys has to spell out as keycap, sign,
+// keycap.
+
+#include <harness/harness.h>
+
+#include <trx/game/input/names.h>
+
+#include <string.h>
+
+#define M_ALT "\\{keyboard l_alt}"
+#define M_RETURN "\\{keyboard return}"
+
+static void M_CheckJoin(
+    const char *const *const names, const int32_t count,
+    const char *const expected)
+{
+    const char *const got = Input_JoinKeyNames(names, count);
+    if (expected == nullptr) {
+        if (got != nullptr) {
+            TEST_FAIL("%d keys: got \"%s\", expected nothing", count, got);
+        }
+        return;
+    }
+    if (got == nullptr) {
+        TEST_FAIL("%d keys: got nothing, expected \"%s\"", count, expected);
+        return;
+    }
+    if (strcmp(got, expected) != 0) {
+        TEST_FAIL("%d keys: got \"%s\", expected \"%s\"", count, got, expected);
+    }
+}
+
+TEST(input_names_joins_a_combo_with_the_separator)
+{
+    const char *const names[] = { M_ALT, M_RETURN };
+    M_CheckJoin(names, 2, M_ALT INPUT_COMBO_SEPARATOR M_RETURN);
+}
+
+TEST(input_names_leaves_a_single_key_alone)
+{
+    const char *const names[] = { M_RETURN };
+    M_CheckJoin(names, 1, M_RETURN);
+}
+
+TEST(input_names_reports_nothing_for_an_unbound_role)
+{
+    const char *const names[] = { nullptr };
+    M_CheckJoin(names, 0, nullptr);
+    M_CheckJoin(names, 1, nullptr);
+}
+
+TEST(input_names_drops_a_nameless_key)
+{
+    const char *const leading[] = { nullptr, M_RETURN };
+    M_CheckJoin(leading, 2, M_RETURN);
+
+    const char *const trailing[] = { M_ALT, nullptr };
+    M_CheckJoin(trailing, 2, M_ALT);
+
+    const char *const middle[] = { M_ALT, nullptr, M_RETURN };
+    M_CheckJoin(middle, 3, M_ALT INPUT_COMBO_SEPARATOR M_RETURN);
+}

--- a/src/tests/trx/game/ui/text.c
+++ b/src/tests/trx/game/ui/text.c
@@ -77,3 +77,54 @@ TEST(ui_text_wrap_keeps_indent)
     M_CheckWrap("  - an indented bullet holding several words", 4);
     UI_ShutdownText();
 }
+
+static float M_Measure(const char *const text)
+{
+    float width = 0.0f;
+    UI_Text_Measure(
+        text, &width, nullptr, (UI_TEXT_SETTINGS) { .scale = 1.0f });
+    return width;
+}
+
+// A key role stands for the keys the player bound it to, and a binding can name
+// more than one: Alt+Enter spells out as two keycaps and the sign between them,
+// so a placeholder has to measure as wide as all three.
+TEST(ui_text_input_spells_out_a_combo)
+{
+    UI_InitText();
+    M_SetUp();
+
+    const char *const single = "\\{keyboard return}";
+    const char *const combo =
+        "\\{keyboard l_alt}\\{icon plus}\\{keyboard return}";
+    const char *const placeholder = "\\{input toggle_fullscreen}";
+
+    FakeUI_SetKeyName(single);
+    CHECK(M_Measure(placeholder) == M_Measure(single));
+
+    FakeUI_SetKeyName(combo);
+    const float combo_width = M_Measure(combo);
+    CHECK(M_Measure(placeholder) == combo_width);
+    CHECK(combo_width > M_Measure(single));
+
+    FakeUI_ResetKeyName();
+    UI_ShutdownText();
+}
+
+TEST(ui_text_input_falls_back_to_a_question_mark)
+{
+    UI_InitText();
+    M_SetUp();
+
+    const char *const placeholder = "\\{input toggle_fullscreen}";
+    const float unknown = M_Measure("?");
+
+    FakeUI_SetKeyName(nullptr);
+    CHECK(M_Measure(placeholder) == unknown);
+
+    FakeUI_SetKeyName("");
+    CHECK(M_Measure(placeholder) == unknown);
+
+    FakeUI_ResetKeyName();
+    UI_ShutdownText();
+}

--- a/src/trx/game/input/backends/controller.c
+++ b/src/trx/game/input/backends/controller.c
@@ -3,6 +3,7 @@
 #include <trx/core/log.h>
 #include <trx/game/input/backends/internal.h>
 #include <trx/game/input/combo.h>
+#include <trx/game/input/names.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_gamecontroller.h>
@@ -617,26 +618,12 @@ static const char *M_GetMapName(const CONTROLLER_MAP *const map)
 static const char *M_GetName(
     const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    const CONTROLLER_BINDING *bind = M_GetBinding(layout, role, slot);
-    if (bind->key_count == 0) {
-        return nullptr;
-    }
-    if (bind->key_count == 1) {
-        return M_GetMapName(&bind->keys[0]);
-    }
-    // Build composite name for multi-key combo
-    static char buf[256];
-    buf[0] = '\0';
+    const CONTROLLER_BINDING *const bind = M_GetBinding(layout, role, slot);
+    const char *names[INPUT_COMBO_MAX_KEYS];
     for (int32_t k = 0; k < bind->key_count; k++) {
-        if (k > 0) {
-            strcat(buf, INPUT_COMBO_SEPARATOR);
-        }
-        const char *name = M_GetMapName(&bind->keys[k]);
-        if (name != nullptr) {
-            strcat(buf, name);
-        }
+        names[k] = M_GetMapName(&bind->keys[k]);
     }
-    return buf;
+    return Input_JoinKeyNames(names, bind->key_count);
 }
 
 static void M_UnassignRole(

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -3,6 +3,7 @@
 #include <trx/core/utils.h>
 #include <trx/game/input/backends/internal.h>
 #include <trx/game/input/combo.h>
+#include <trx/game/input/names.h>
 #include <trx/version.h>
 
 #include <SDL2/SDL_events.h>
@@ -687,26 +688,13 @@ static const char *M_GetName(
         break;
     }
 
-    const KEYBOARD_BINDING *bind = M_GetBinding(layout, actual_role, slot);
-    if (bind->key_count == 0) {
-        return nullptr;
-    }
-    if (bind->key_count == 1) {
-        return M_GetScancodeName(bind->keys[0]);
-    }
-    // Build composite name for multi-key combo
-    static char buf[256];
-    buf[0] = '\0';
+    const KEYBOARD_BINDING *const bind =
+        M_GetBinding(layout, actual_role, slot);
+    const char *names[INPUT_COMBO_MAX_KEYS];
     for (int32_t k = 0; k < bind->key_count; k++) {
-        if (k > 0) {
-            strcat(buf, INPUT_COMBO_SEPARATOR);
-        }
-        const char *name = M_GetScancodeName(bind->keys[k]);
-        if (name != nullptr) {
-            strcat(buf, name);
-        }
+        names[k] = M_GetScancodeName(bind->keys[k]);
     }
-    return buf;
+    return Input_JoinKeyNames(names, bind->key_count);
 }
 
 static void M_UnassignRole(

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -190,8 +190,8 @@ static const char *M_GetScancodeName(SDL_Scancode scancode)
         case SDL_SCANCODE_RCTRL:              return "\\{keyboard r_ctrl}";
         case SDL_SCANCODE_RSHIFT:             return "\\{keyboard r_shift}";
         case SDL_SCANCODE_LSHIFT:             return "\\{keyboard l_shift}";
-        case SDL_SCANCODE_RALT:               return "\\{keyboard l_alt}";
-        case SDL_SCANCODE_LALT:               return "\\{keyboard r_alt}";
+        case SDL_SCANCODE_LALT:               return "\\{keyboard l_alt}";
+        case SDL_SCANCODE_RALT:               return "\\{keyboard r_alt}";
         case SDL_SCANCODE_LGUI:               return "\\{keyboard l_win}";
         case SDL_SCANCODE_RGUI:               return "\\{keyboard r_win}";
 

--- a/src/trx/game/input/backends/touch.c
+++ b/src/trx/game/input/backends/touch.c
@@ -6,6 +6,7 @@
 #include <trx/game/input/backends/internal.h>
 #include <trx/game/input/combo.h>
 #include <trx/game/input/common.h>
+#include <trx/game/input/names.h>
 #include <trx/game/ui/touch_overlay.h>
 
 #include <SDL2/SDL_events.h>
@@ -416,32 +417,23 @@ static bool M_IsRoleConflicted(const INPUT_LAYOUT layout, const INPUT_ROLE role)
     return m_Conflicts[layout][role];
 }
 
+static const char *M_GetPosGlyph(const int32_t pos)
+{
+    if (pos < 0 || pos >= (int32_t)ARRAY_SIZE(m_PosGlyphs)) {
+        return nullptr;
+    }
+    return m_PosGlyphs[pos];
+}
+
 static const char *M_GetName(
     const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    const M_BINDING *b = M_GetBinding(layout, role, slot);
-    if (b->pos_count == 0) {
-        return nullptr;
-    }
-    if (b->pos_count == 1) {
-        const int32_t p = b->positions[0];
-        if (p >= 0 && p < (int32_t)ARRAY_SIZE(m_PosGlyphs)) {
-            return m_PosGlyphs[p];
-        }
-        return nullptr;
-    }
-    static char buf[256];
-    buf[0] = '\0';
+    const M_BINDING *const b = M_GetBinding(layout, role, slot);
+    const char *names[INPUT_COMBO_MAX_KEYS];
     for (int32_t k = 0; k < b->pos_count; k++) {
-        if (k > 0) {
-            strcat(buf, INPUT_COMBO_SEPARATOR);
-        }
-        const int32_t p = b->positions[k];
-        if (p >= 0 && p < (int32_t)ARRAY_SIZE(m_PosGlyphs)) {
-            strcat(buf, m_PosGlyphs[p]);
-        }
+        names[k] = M_GetPosGlyph(b->positions[k]);
     }
-    return buf;
+    return Input_JoinKeyNames(names, b->pos_count);
 }
 
 static void M_UnassignRole(

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -9,10 +9,6 @@
 #define INPUT_COMBO_MAX_KEYS 3
 #define INPUT_BINDING_SLOTS 2
 
-// Glyph joining the keys of a combination in the name returned by
-// Input_GetKeyName. Unlike the plain "+", it is centered on the key icons.
-#define INPUT_COMBO_SEPARATOR "\\{icon plus}"
-
 #define INPUT_STATE_ANY_WORDS ((INPUT_ROLE_NUMBER_OF + 63) / 64)
 
 typedef union {

--- a/src/trx/game/input/names.c
+++ b/src/trx/game/input/names.c
@@ -1,0 +1,35 @@
+#include <trx/game/input/names.h>
+
+#include <stdio.h>
+
+const char *Input_JoinKeyNames(
+    const char *const *const names, const int32_t count)
+{
+    if (count <= 0) {
+        return nullptr;
+    }
+    if (count == 1) {
+        return names[0];
+    }
+
+    static char buf[256];
+    buf[0] = '\0';
+    size_t len = 0;
+    for (int32_t i = 0; i < count; i++) {
+        if (names[i] == nullptr) {
+            continue;
+        }
+        const int32_t written = snprintf(
+            buf + len, sizeof(buf) - len, "%s%s",
+            len > 0 ? INPUT_COMBO_SEPARATOR : "", names[i]);
+        if (written < 0) {
+            break;
+        }
+        len += written;
+        if (len >= sizeof(buf)) {
+            len = sizeof(buf) - 1;
+            break;
+        }
+    }
+    return buf;
+}

--- a/src/trx/game/input/names.h
+++ b/src/trx/game/input/names.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdint.h>
+
+// Glyph joining the keys of a combination. Unlike a plain "+", it is centered
+// on the key icons.
+#define INPUT_COMBO_SEPARATOR "\\{icon plus}"
+
+// Spell out one binding as the text a UI draws for it. Several keys read as a
+// combination and are joined with INPUT_COMBO_SEPARATOR; a key with no name
+// drops out and takes its separator with it. Returns nullptr for no keys, and
+// the name itself for one. Joined text lives in a static buffer.
+const char *Input_JoinKeyNames(const char *const *names, int32_t count);

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -82,6 +82,9 @@ typedef struct {
     UT_hash_handle hh;
 } M_TEXT_MAP_ENTRY;
 
+typedef void (*M_DRAW_FUNC)(
+    int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, const RGBA_F[4]);
+
 static M_GLYPH_INFO m_Glyphs[] = {
 #define X_GLYPH_DEFINE(text_, role_, mesh_idx_)                                \
     { .text = text_, .role = role_, .mesh_idx = mesh_idx_ },
@@ -257,43 +260,52 @@ static const M_GLYPH_INFO **M_DecomposeWithCache(
     return entry->glyphs;
 }
 
-// Replace input placeholder glyph with the actual keyboard glyph for the
-// current binding
-static const M_GLYPH_INFO *M_GetResolvedGlyph(const M_GLYPH_INFO *glyph)
+// The keys an input placeholder stands for, as the glyphs that spell them out.
+// A combo such as Alt+Enter names several keys at once, so a placeholder can
+// expand to more than one glyph.
+static const M_GLYPH_INFO **M_GetInputGlyphs(
+    const M_GLYPH_INFO *const glyph, size_t *const out_count)
 {
-    if (glyph->role != GLYPH_INPUT) {
-        return glyph;
-    }
     const INPUT_BACKEND backend = g_Config.input.backend;
     const INPUT_LAYOUT layout = g_Config.input.layout[backend];
     const char *const key_name =
         Input_GetKeyName(backend, layout, glyph->input_role, 0);
-    // NOTE: this aliasing approach assumes that Input_GetKeyName returns
-    // text that resolves to a single glyph.
-    M_GLYPH_MAP_ENTRY *entry = nullptr;
-    if (key_name != nullptr) {
-        HASH_FIND_STR(m_GlyphMap, key_name, entry);
+    if (key_name == nullptr) {
+        return M_DecomposeWithCache("?", out_count);
     }
-    if (entry == nullptr) {
-        HASH_FIND_STR(m_GlyphMap, "?", entry);
-    }
-    return entry != nullptr ? entry->glyph : nullptr;
+
+    const M_GLYPH_INFO **const parts =
+        M_DecomposeWithCache(key_name, out_count);
+    return *out_count > 0 ? parts : M_DecomposeWithCache("?", out_count);
 }
 
-// Width the glyph occupies when drawn, matching the resolution and font
+static M_FONT M_GetGlyphFont(const M_GLYPH_INFO *const glyph, const M_FONT font)
+{
+    if (font == M_FONT_SMALL && !M_HasGlyph(font, glyph)) {
+        return M_FONT_DEFAULT;
+    }
+    return font;
+}
+
+// Width the glyph occupies when drawn, matching the expansion and font
 // fallback that M_Process applies.
 static float M_GetLayoutWidth(
     const M_GLYPH_INFO *const glyph, const M_FONT font)
 {
-    const M_GLYPH_INFO *const resolved = M_GetResolvedGlyph(glyph);
-    if (resolved == nullptr) {
-        return 0.0f;
+    if (glyph->role != GLYPH_INPUT) {
+        return glyph->width[M_GetGlyphFont(glyph, font)];
     }
-    M_FONT glyph_font = font;
-    if (glyph_font == M_FONT_SMALL && !M_HasGlyph(glyph_font, resolved)) {
-        glyph_font = M_FONT_DEFAULT;
+
+    size_t count = 0;
+    const M_GLYPH_INFO **const parts = M_GetInputGlyphs(glyph, &count);
+    float width = 0.0f;
+    for (size_t i = 0; i < count; i++) {
+        if (i > 0) {
+            width += M_LETTER_SPACING;
+        }
+        width += parts[i]->width[M_GetGlyphFont(parts[i], font)];
     }
-    return resolved->width[glyph_font];
+    return width;
 }
 
 // How far the continuations of a line are indented, so that a line broken in
@@ -367,10 +379,7 @@ static size_t M_WordWrap(
 
     // Iterate glyphs for wrapping
     for (size_t i = 0; i < glyph_count; i++) {
-        const M_GLYPH_INFO *const glyph = M_GetResolvedGlyph(glyphs[i]);
-        if (glyph == nullptr) {
-            continue;
-        }
+        const M_GLYPH_INFO *const glyph = glyphs[i];
 
         if (cur_width == 0.0f && hanging_indent == 0) {
             hanging_indent = M_DetectHangingIndent(glyphs, glyph_count, i);
@@ -473,6 +482,30 @@ static size_t M_WordWrap(
     return out_len;
 }
 
+// Draws one font glyph and returns how far the cursor moves past it.
+static float M_DrawGlyph(
+    const M_GLYPH_INFO *const glyph, const M_FONT font, const float x,
+    const float y, const int32_t z, const float scale, const bool spaced,
+    const bool visible, const int32_t color_idx, const M_DRAW_FUNC draw_func)
+{
+    const M_FONT glyph_font = M_GetGlyphFont(glyph, font);
+    float spacing = glyph->width[glyph_font];
+    if (spaced) {
+        spacing += M_LETTER_SPACING;
+    }
+
+    // A non-breaking space and its like take up room without drawing anything.
+    const bool renders = glyph->role != GLYPH_TEXT || glyph->mesh_idx >= 0;
+    if (renders && visible && draw_func != nullptr) {
+        const OBJECT *const object = Object_Get(m_FontObjects[glyph_font]);
+        draw_func(
+            x, y, z, scale, scale, object->mesh_idx + glyph->mesh_idx,
+            m_TextColor[color_idx]);
+    }
+
+    return spacing * scale / UI_TEXT_BASE_SCALE;
+}
+
 static void M_Process(
     const char *const text, float *const out_w, float *const out_h,
     const UI_TEXT_SETTINGS settings, const float base_x, const float base_y,
@@ -504,10 +537,7 @@ static void M_Process(
 
     const M_GLYPH_INFO **glyph_ptr = glyphs;
     while (*glyph_ptr != nullptr) {
-        const M_GLYPH_INFO *const glyph = M_GetResolvedGlyph(*glyph_ptr);
-        if (glyph == nullptr) {
-            goto loop_end;
-        }
+        const M_GLYPH_INFO *const glyph = *glyph_ptr;
 
         if (glyph->role == GLYPH_REVIEW_MARKER
             && !g_Config.debug.enable_review_markers) {
@@ -580,31 +610,24 @@ static void M_Process(
             goto loop_end;
         }
 
-        M_FONT glyph_font = current_font;
-        if (glyph_font == M_FONT_SMALL && !M_HasGlyph(glyph_font, glyph)) {
-            glyph_font = M_FONT_DEFAULT;
-        }
+        const bool spaced = glyph_ptr[1] != nullptr
+            && glyph_ptr[1]->role != GLYPH_NEW_LINE
+            && glyph_ptr[1]->role != GLYPH_NEW_PAGE;
 
-        float spacing = glyph->width[glyph_font];
-        if (glyph_ptr[1] != nullptr && glyph_ptr[1]->role != GLYPH_NEW_LINE
-            && glyph_ptr[1]->role != GLYPH_NEW_PAGE) {
-            spacing += M_LETTER_SPACING;
-        }
-
-        if (glyph->role == GLYPH_TEXT && glyph->mesh_idx < 0) {
-            // Non-breaking space or other non-rendered text glyphs.
-            x += spacing * scale / UI_TEXT_BASE_SCALE;
+        if (glyph->role == GLYPH_INPUT) {
+            size_t count = 0;
+            const M_GLYPH_INFO **const parts = M_GetInputGlyphs(glyph, &count);
+            for (size_t i = 0; i < count; i++) {
+                x += M_DrawGlyph(
+                    parts[i], current_font, x, y, z, scale,
+                    i + 1 < count || spaced, visible, color_idx, draw_func);
+            }
             goto loop_end;
         }
 
-        if (visible && draw_func != nullptr) {
-            const OBJECT *object = Object_Get(m_FontObjects[glyph_font]);
-            draw_func(
-                x, y, z, scale, scale, object->mesh_idx + glyph->mesh_idx,
-                m_TextColor[color_idx]);
-        }
-
-        x += spacing * scale / UI_TEXT_BASE_SCALE;
+        x += M_DrawGlyph(
+            glyph, current_font, x, y, z, scale, spaced, visible, color_idx,
+            draw_func);
 
     loop_end:
         max_width = MAX(max_width, x);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

`\{input <role>}` looked the key name up as one glyph, so a role bound to a combination (Alt+Enter, or any such rebind) drew a question mark. It now expands to the glyphs the name decomposes into and measures as their sum. Also unswaps the left/right alt key names, which had reported each other's keycap. (Both carry the same label, so nothing on screen changes.)