### PR TITLE
output: keep effect sizes off the raster grid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,11 @@
 - Changed the save crystal behavior to give Lara a crystal when starting a game, if the mode is set to Saving (pickups), in line with the TR3 PS1 version (Gameplay → General → Crystal mode)
 - Fixed the PS1 water color preset showing as unnamed text in The Lost Artefact and Golden Mask (#6265)
 
+**Rendering**
+- Fixed the water particles and the lightning bolts growing as the supersampling factor is raised, and following the resolution besides (regression from 1.10)
+- Fixed the sparks that keep a fixed size, such as ricochets, shrinking as the supersampling factor is raised (regression from 1.10)
+- Fixed the wireframe and debug portal lines thinning as the supersampling factor is raised (regression from 1.10)
+
 **Music and sound**
 - Fixed crystal sound effects not playing if Lara collects one underwater (OG bug)
 

--- a/src/trx/game/fx/fire.c
+++ b/src/trx/game/fx/fire.c
@@ -4,6 +4,7 @@
 #include <trx/game/const.h>
 #include <trx/game/fx/common.h>
 #include <trx/game/matrix.h>
+#include <trx/game/output/const.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/output/state.h>
 #include <trx/game/random.h>
@@ -15,10 +16,6 @@
 #define M_MAX_FIRES 32
 #define M_MAX_DRAW_DIST (20 * WALL_L)
 #define M_FADE_DRAW_DIST (12 * WALL_L)
-// The original's screen-space size clamp at its 640-wide, 80-degree FOV
-// reference (phd_persp); expressed in world space here so the clamp onset
-// does not shift with resolution or FOV.
-#define M_CLAMP_PERSP 381
 
 typedef struct {
     XYZ_32 pos;
@@ -271,7 +268,7 @@ static int32_t M_GetViewDepth(const XYZ_32 pos)
 static int32_t M_ScaleSize(
     const int32_t size, const int32_t shift, const int32_t depth)
 {
-    return MIN(size >> shift, size * depth / M_CLAMP_PERSP);
+    return MIN(size >> shift, size * depth / REF_PERSP);
 }
 
 static void M_DrawFire(const M_FIRE *const fire)

--- a/src/trx/game/fx/water_particles.c
+++ b/src/trx/game/fx/water_particles.c
@@ -9,12 +9,12 @@
 #include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/game/output/const.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/output/state.h>
 #include <trx/game/output/vars.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
-#include <trx/game/viewport.h>
 
 #include <string.h>
 
@@ -26,6 +26,7 @@
 #define M_BASE_Y_OFF (-1024)
 #define M_MIN_SIZE 4.0f
 #define M_MAX_SIZE 16.0f
+#define M_SIZE_DIV 6.0f
 
 typedef struct {
     XYZ_32 pos;
@@ -62,17 +63,6 @@ static int64_t M_GetViewDepth(const XYZ_32 pos)
         g_ViewMatrix._22 * pos.z +
         g_ViewMatrix._23;
     // clang-format on
-}
-
-static float M_GetFixedScale(const float unit)
-{
-    const float base_w = 640.0f;
-    const float base_h = 480.0f;
-    const float game_w = (float)Viewport_GetWidth(VIEWPORT_GAME);
-    const float game_h = (float)Viewport_GetHeight(VIEWPORT_GAME);
-    const float x = game_w > base_w ? (game_w * unit) / base_w : unit;
-    const float y = game_h > base_h ? (game_h * unit) / base_h : unit;
-    return MIN(x, y);
 }
 
 static void M_Spawn(M_WATER_PARTICLE *const particle)
@@ -209,14 +199,17 @@ static void M_Draw(void)
             continue;
         }
 
-        if (zv <= near_z || zv >= far_z || g_PhdPersp <= 0) {
+        if (zv <= near_z || zv >= far_z) {
             continue;
         }
 
-        float size = (float)((g_PhdPersp * (particle->yv >> 3)) / vpos_z);
+        // The original sizes the speck in the screen pixels of its reference
+        // viewport, so the clamp is applied there and the result taken back
+        // into world units - a size in pixels of the rasterized picture would
+        // follow the resolution and the supersampling factor.
+        float size = (float)((REF_PERSP * (particle->yv >> 3)) / vpos_z);
         CLAMP(size, M_MIN_SIZE, M_MAX_SIZE);
-        size /= 3.0f;
-        size = M_GetFixedScale(size) / 2.0f;
+        size = (size * vpos_z) / (REF_PERSP * M_SIZE_DIV);
 
         uint32_t c;
         if ((particle->yv & 7) < 7) {

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -401,11 +401,6 @@ static void M_DrawSnow(void)
             ? (int32_t)LERP(snow->prev_life, snow->life, ratio)
             : (int32_t)snow->life;
 
-        const int32_t game_w = Viewport_GetWidth(VIEWPORT_GAME);
-        const int32_t game_h = Viewport_GetHeight(VIEWPORT_GAME);
-        const int32_t ui_w = Viewport_GetWidth(VIEWPORT_UI);
-        const int32_t ui_h = Viewport_GetHeight(VIEWPORT_UI);
-
         const XYZ_32 world_pos[4] = { center, center, center, center };
         const float s = 8.0f;
         const float disp[4][2] = {

--- a/src/trx/game/objects/traps/lightning_emitter.c
+++ b/src/trx/game/objects/traps/lightning_emitter.c
@@ -6,12 +6,17 @@
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
-#include <trx/game/viewport.h>
 
 #define M_DEFAULT_DAMAGE 400
 #define M_STEPS 8
 #define M_RND 64
 #define M_SHOOTS 2
+
+// The original divides its 640-wide reference viewport by 6 and by 16. The
+// bolts are built in world space here, so the widths are those two figures
+// taken as world units rather than a share of the rasterized picture.
+#define M_MAIN_WIDTH (640 / 6)
+#define M_SHOOT_WIDTH (640 / 16)
 
 typedef struct {
     int32_t damage;
@@ -189,12 +194,12 @@ static void M_DrawBolts(const ITEM *const item)
             Output_DrawLightningSegment((LIGHTNING_SEGMENT) {
                 .from = { x1, y1 + p->wibble[i - 1].y, z1 },
                 .to = { x2, y2, z2 },
-                .thickness = Viewport_GetWidth(VIEWPORT_GAME) / 6 });
+                .thickness = M_MAIN_WIDTH });
         } else {
-            Output_DrawLightningSegment((LIGHTNING_SEGMENT) {
-                .from = { x1, y1, z1 },
-                .to = { x2, y2, z2 },
-                .thickness = Viewport_GetWidth(VIEWPORT_GAME) / 6 });
+            Output_DrawLightningSegment(
+                (LIGHTNING_SEGMENT) { .from = { x1, y1, z1 },
+                                      .to = { x2, y2, z2 },
+                                      .thickness = M_MAIN_WIDTH });
         }
 
         x1 = x2;
@@ -240,12 +245,12 @@ static void M_DrawBolts(const ITEM *const item)
                 Output_DrawLightningSegment((LIGHTNING_SEGMENT) {
                     .from = { x1, y1 + p->shoot[i][k - 1].y, z1 },
                     .to = { x2, y2, z2 },
-                    .thickness = Viewport_GetWidth(VIEWPORT_GAME) / 16 });
+                    .thickness = M_SHOOT_WIDTH });
             } else {
-                Output_DrawLightningSegment((LIGHTNING_SEGMENT) {
-                    .from = { x1, y1, z1 },
-                    .to = { x2, y2, z2 },
-                    .thickness = Viewport_GetWidth(VIEWPORT_GAME) / 16 });
+                Output_DrawLightningSegment(
+                    (LIGHTNING_SEGMENT) { .from = { x1, y1, z1 },
+                                          .to = { x2, y2, z2 },
+                                          .thickness = M_SHOOT_WIDTH });
             }
 
             x1 = x2;

--- a/src/trx/game/output/const.h
+++ b/src/trx/game/output/const.h
@@ -15,6 +15,13 @@
 #define SHADE_SUNSET   0x400
 // clang-format on
 
+// The perspective divisor of the original's 640-wide, 80 degree reference
+// viewport. Sizes the original expressed in screen pixels become world units
+// when divided by it, which keeps them put as the resolution, the upscaling
+// factor and the supersampling factor change - the rasterized picture is
+// magnified back to the same rectangle at every one of those settings.
+#define REF_PERSP 381
+
 #define WIBBLE_SIZE 32
 
 #define LIGHT_MAP_SIZE 32

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -11,6 +11,7 @@
 #include <trx/game/output/textures_gl.h>
 #include <trx/game/output/uniforms.h>
 #include <trx/game/shell.h>
+#include <trx/game/viewport.h>
 #include <trx/gl/context.h>
 #include <trx/gl/utils.h>
 
@@ -108,7 +109,8 @@ static bool M_IsAnySourceDirty(const M_PRIV *const p)
 static void M_PrepareScene(const M_PRIV *const p)
 {
 #ifndef __APPLE__
-    glLineWidth(g_Config.rendering.wireframe_width);
+    glLineWidth(
+        g_Config.rendering.wireframe_width * Viewport_GetSupersamplingFactor());
     TRX_GL_CheckError();
 #endif
 

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -8,6 +8,7 @@
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/output.h>
+#include <trx/game/output/const.h>
 #include <trx/game/output/lights/priv.h>
 #include <trx/game/output/scene_compositor.h>
 #include <trx/game/output/shaders/mesh.h>
@@ -828,12 +829,16 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
     const bool use_sprite = (spark->flags & SPARK_F_SPRITE) != 0U;
     if ((spark->flags & SPARK_F_SCALE) != 0U) {
         const int32_t scalar = spark->scalar;
-        sw = (int32_t)(((((int64_t)sw * g_PhdPersp) << scalar) / vpos_z));
-        sh = (int32_t)(((((int64_t)sh * g_PhdPersp) << scalar) / vpos_z));
+        sw = (int32_t)(((((int64_t)sw * REF_PERSP) << scalar) / vpos_z));
+        sh = (int32_t)(((((int64_t)sh * REF_PERSP) << scalar) / vpos_z));
     }
 
-    const float w = ((sw / 2.0f) * (float)vpos_z) / (float)g_PhdPersp;
-    const float h = ((sh / 2.0f) * (float)vpos_z) / (float)g_PhdPersp;
+    // A spark that does not scale keeps the size the original gave it in the
+    // screen pixels of its reference viewport, so the size is taken back into
+    // world units against the same reference - the pixels of the rasterized
+    // picture would shrink it as the supersampling factor goes up.
+    const float w = ((sw / 2.0f) * (float)vpos_z) / (float)REF_PERSP;
+    const float h = ((sh / 2.0f) * (float)vpos_z) / (float)REF_PERSP;
     float disp[4][2] = {
         { -w, -h },
         { -w, h },

--- a/src/trx/game/viewport.c
+++ b/src/trx/game/viewport.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/core/log.h>
+#include <trx/core/utils.h>
 #include <trx/game/const.h>
 #include <trx/game/output/vars.h>
 #include <trx/game/shell.h>
@@ -138,6 +139,15 @@ int32_t Viewport_GetWidth(const VIEWPORT_SPACE space)
 int32_t Viewport_GetHeight(const VIEWPORT_SPACE space)
 {
     return m_Rects[space].height;
+}
+
+int32_t Viewport_GetSupersamplingFactor(void)
+{
+    const int32_t scene_w = m_Rects[VIEWPORT_SCENE].width;
+    if (scene_w <= 0) {
+        return 1;
+    }
+    return MAX(1, m_Rects[VIEWPORT_GAME].width / scene_w);
 }
 
 VIEWPORT_RECT Viewport_GetRect(const VIEWPORT_SPACE space)

--- a/src/trx/game/viewport.h
+++ b/src/trx/game/viewport.h
@@ -55,6 +55,12 @@ int32_t Viewport_GetCenterX(VIEWPORT_SPACE space);
 int32_t Viewport_GetCenterY(VIEWPORT_SPACE space);
 VIEWPORT_RECT Viewport_GetRect(VIEWPORT_SPACE space);
 
+// Returns how many rasterized pixels the scene draws per pixel the player
+// sees, along one axis. Anything sized in the pixels the driver rasterizes
+// with, such as the line width, has to be multiplied by it to keep the width
+// it had before supersampling.
+int32_t Viewport_GetSupersamplingFactor(void);
+
 // Return the current FOV as overriden by the game mechanics, such as special
 // cameras or cutscenes. If the FOV is not overriden, returns -1.
 int16_t Viewport_GetSystemFOV(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Water particles, lightning bolts and the sparks that hold a fixed size took their size from the viewport the scene is rasterized on, which the supersampling factor multiplies. A billboard displacement is a world space offset, so the specks and the bolts grew with the factor while the sparks shrank. They now convert from the screen pixels of the original's 640-wide, 80 degree reference viewport, which also stops them from following the resolution and the upscaling factor. `fx/fire.c` already kept that reference privately and now shares it.

This means that the lightnings will become thinner, and water particles will become larger on bigger desktop resolutions. Please LMK if this is acceptable - if not, we'll have to tweak by feel I'm afraid.

The wireframe and the debug portal lines are drawn in the pixels the driver rasterizes with, and thinned rather than grew, so they take the factor instead.

Resolves TRX1106.