### PR TITLE
Add XYZ_32 helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed Lara's outfit setting to offer only the outfits the current level can dress her in
 - Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10)
+- Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187)
 - Added a flat yellow color to the PS1 bar palettes (Graphic Options → UI → Bars) (#5227)
 - Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -186,6 +186,17 @@ unit_tests += {
 }
 
 unit_tests += {
+  'name': 'trx/core/math/geom',
+  'engine': [
+    'core/math/func.c',
+    'core/math/geom.c',
+    'core/math/trig.c',
+    'game/matrix.c',
+  ],
+  'deps': [dep_mathlibrary],
+}
+
+unit_tests += {
   'name': 'trx/game/matrix',
   'engine': [
     'game/matrix.c',

--- a/src/tests/trx/core/math/geom.c
+++ b/src/tests/trx/core/math/geom.c
@@ -1,0 +1,149 @@
+#include <harness/harness.h>
+
+#include <trx/core/math/const.h>
+#include <trx/core/math/geom.h>
+#include <trx/core/utils.h>
+#include <trx/game/matrix.h>
+
+// The rotation helpers stand in for roughly a hundred hand-rolled
+// Math_Sin/Math_Cos pairs, so the thing worth pinning is that they agree with
+// the matrix the renderer builds from the same angles - a sign slip reads as a
+// vehicle drifting sideways and nothing else.
+
+// Fixed point at 14 bits, taken three axes deep, drifts a unit or two.
+#define M_TOLERANCE 3
+
+static const XYZ_16 m_Rotations[] = {
+    { .x = 0, .y = 0, .z = 0 },
+    { .x = 0, .y = DEG_90, .z = 0 },
+    { .x = 0, .y = -DEG_45, .z = 0 },
+    { .x = DEG_45, .y = 0, .z = 0 },
+    { .x = 0, .y = 0, .z = DEG_90 },
+    { .x = DEG_45, .y = DEG_90, .z = -DEG_45 },
+    { .x = -DEG_90, .y = -DEG_180, .z = DEG_45 },
+    { .x = 4000, .y = -12000, .z = 7000 },
+};
+
+static void M_CheckNear(const XYZ_32 actual, const XYZ_32 expected)
+{
+    const XYZ_32 delta = XYZ_32_Subtract(actual, expected);
+    if (ABS(delta.x) > M_TOLERANCE || ABS(delta.y) > M_TOLERANCE
+        || ABS(delta.z) > M_TOLERANCE) {
+        TEST_FAIL(
+            "expected (%d, %d, %d), got (%d, %d, %d)", expected.x, expected.y,
+            expected.z, actual.x, actual.y, actual.z);
+    }
+}
+
+// What the renderer does with the same angles, for the helpers to match.
+static XYZ_32 M_ByMatrix(const XYZ_32 vec, const XYZ_16 rot)
+{
+    MATRIX m = g_IDMatrix;
+    Matrix_RotY_M(&m, rot.y);
+    Matrix_RotX_M(&m, rot.x);
+    Matrix_RotZ_M(&m, rot.z);
+    return Matrix_MulVec32_M(&m, vec);
+}
+
+TEST(rotate_yaw_turns_forward_onto_the_axes)
+{
+    const XYZ_32 forward = { .x = 0, .y = 0, .z = 1024 };
+    M_CheckNear(
+        XYZ_32_RotateYaw(forward, 0), (XYZ_32) { .x = 0, .y = 0, .z = 1024 });
+    M_CheckNear(
+        XYZ_32_RotateYaw(forward, DEG_90),
+        (XYZ_32) { .x = 1024, .y = 0, .z = 0 });
+    M_CheckNear(
+        XYZ_32_RotateYaw(forward, -DEG_180),
+        (XYZ_32) { .x = 0, .y = 0, .z = -1024 });
+    M_CheckNear(
+        XYZ_32_RotateYaw(forward, -DEG_90),
+        (XYZ_32) { .x = -1024, .y = 0, .z = 0 });
+}
+
+TEST(offset_rotated_puts_the_turned_vector_back_on_its_origin)
+{
+    const XYZ_32 origin = { .x = 1000, .y = 100, .z = -2000 };
+    const XYZ_32 offset = { .x = 256, .y = -64, .z = 512 };
+    const XYZ_16 rot = { .x = DEG_45, .y = DEG_90, .z = -DEG_45 };
+    M_CheckNear(
+        XYZ_32_OffsetLocalYaw(origin, offset, rot.y),
+        XYZ_32_Add(origin, XYZ_32_RotateYaw(offset, rot.y)));
+    M_CheckNear(
+        XYZ_32_OffsetLocal(origin, offset, rot),
+        XYZ_32_Add(origin, XYZ_32_Rotate(offset, rot)));
+    // An offset straight ahead is what XYZ_32_OffsetYaw already did.
+    M_CheckNear(
+        XYZ_32_OffsetLocalYaw(origin, (XYZ_32) { .z = 1024 }, 5000),
+        XYZ_32_OffsetYaw(origin, 5000, 1024));
+}
+
+TEST(rotate_yaw_leaves_height_alone)
+{
+    const XYZ_32 vec = { .x = 300, .y = -512, .z = 700 };
+    CHECK_EQ_INT(XYZ_32_RotateYaw(vec, 5000).y, -512);
+}
+
+TEST(rotate_yaw_matches_the_full_rotation_with_no_pitch_or_roll)
+{
+    const XYZ_32 vec = { .x = 256, .y = -128, .z = 1024 };
+    for (int32_t yaw = -DEG_180 / 2; yaw < DEG_180 / 2; yaw += 1024) {
+        M_CheckNear(
+            XYZ_32_RotateYaw(vec, yaw),
+            XYZ_32_Rotate(vec, (XYZ_16) { .x = 0, .y = yaw, .z = 0 }));
+    }
+}
+
+TEST(unrotate_yaw_reads_a_world_vector_along_an_items_axes)
+{
+    // An item turned a quarter to the right faces along world x, so a world
+    // vector 256 along x lies 256 straight ahead of it.
+    const XYZ_32 delta = { .x = 256, .y = 0, .z = -512 };
+    M_CheckNear(
+        XYZ_32_UnrotateYaw(delta, DEG_90),
+        (XYZ_32) { .x = 512, .y = 0, .z = 256 });
+    M_CheckNear(XYZ_32_UnrotateYaw(XYZ_32_RotateYaw(delta, 5000), 5000), delta);
+}
+
+TEST(rotate_matches_the_matrix_the_renderer_builds)
+{
+    const XYZ_32 vec = { .x = 341, .y = -777, .z = 1024 };
+    for (int32_t i = 0; i < (int32_t)(sizeof(m_Rotations) / sizeof(XYZ_16));
+         i++) {
+        M_CheckNear(
+            XYZ_32_Rotate(vec, m_Rotations[i]),
+            M_ByMatrix(vec, m_Rotations[i]));
+    }
+}
+
+TEST(unrotate_undoes_rotate)
+{
+    const XYZ_32 vec = { .x = 341, .y = -777, .z = 1024 };
+    for (int32_t i = 0; i < (int32_t)(sizeof(m_Rotations) / sizeof(XYZ_16));
+         i++) {
+        M_CheckNear(
+            XYZ_32_Unrotate(XYZ_32_Rotate(vec, m_Rotations[i]), m_Rotations[i]),
+            vec);
+    }
+}
+
+TEST(rotate_holds_at_offsets_that_would_overflow_32_bits)
+{
+    // 100000 * 16384 already runs past int32, and every hand-rolled site that
+    // multiplies before shifting is wrong there.
+    const XYZ_32 vec = { .x = 0, .y = 0, .z = 100000 };
+    M_CheckNear(
+        XYZ_32_RotateYaw(vec, DEG_90),
+        (XYZ_32) { .x = 100000, .y = 0, .z = 0 });
+}
+
+TEST(add_and_subtract_are_componentwise)
+{
+    const XYZ_32 a = { .x = 1, .y = 2, .z = 3 };
+    const XYZ_32 b = { .x = 10, .y = -20, .z = 30 };
+    const XYZ_32 sum = XYZ_32_Add(a, b);
+    CHECK_EQ_INT(sum.x, 11);
+    CHECK_EQ_INT(sum.y, -18);
+    CHECK_EQ_INT(sum.z, 33);
+    M_CheckNear(XYZ_32_Subtract(sum, b), a);
+}

--- a/src/tests/trx/game/matrix.c
+++ b/src/tests/trx/game/matrix.c
@@ -1,6 +1,8 @@
 #include <harness/harness.h>
 
 #include <trx/core/math/const.h>
+#include <trx/core/math/geom.h>
+#include <trx/core/utils.h>
 #include <trx/game/matrix.h>
 
 // Rotations reach the renderer as three angles, and the tempting way to meet
@@ -113,4 +115,27 @@ TEST(test_slerp_rot16_reads_back_a_locked_rotation)
     // and cannot be told apart. Any spelling of it has to survive the trip.
     const XYZ_16 rot = { .x = DEG_90, .y = DEG_45, .z = DEG_45 };
     M_CHECK_NEAR(Matrix_SlerpRot16(rot, rot, 0.5), rot, M_TOLERANCE);
+}
+
+TEST(the_view_matrix_undoes_the_rotation_the_camera_stands_at)
+{
+    // A point straight ahead of a camera has to land on the view's own z, and
+    // nowhere else, whichever way the camera is turned.
+    const XYZ_16 rot = { .x = DEG_45, .y = -12000, .z = DEG_1 * 10 };
+    const XYZ_32 eye = { .x = 1000, .y = -2000, .z = 3000 };
+
+    MATRIX facing = g_IDMatrix;
+    Matrix_RotY_M(&facing, rot.y);
+    Matrix_RotX_M(&facing, rot.x);
+    Matrix_RotZ_M(&facing, rot.z);
+    const XYZ_32 ahead =
+        XYZ_32_Add(eye, Matrix_MulVec32_M(&facing, (XYZ_32) { .z = 4096 }));
+
+    Matrix_GenerateW2V(&eye, &rot);
+    const XYZ_32 seen = Matrix_MulVec32_M(&g_ViewMatrix, ahead);
+
+    // A thousandth of the distance, which is what the trig table is worth.
+    CHECK(ABS(seen.x) < 8);
+    CHECK(ABS(seen.y) < 8);
+    CHECK(seen.z > 4096 - 8 && seen.z < 4096 + 8);
 }

--- a/src/trx/core/math/geom.c
+++ b/src/trx/core/math/geom.c
@@ -7,6 +7,18 @@
 
 #include <math.h>
 
+// Turns the (a, b) pair by an angle given as its already-taken sine and
+// cosine, so a caller can hand it a negated sine to turn the other way
+// without having to negate the angle itself.
+static void M_Turn(
+    int32_t *const a, int32_t *const b, const int32_t s, const int32_t c)
+{
+    const int32_t a0 = *a;
+    const int32_t b0 = *b;
+    *a = (int32_t)(((int64_t)a0 * c + (int64_t)b0 * s) >> W2V_SHIFT);
+    *b = (int32_t)(((int64_t)b0 * c - (int64_t)a0 * s) >> W2V_SHIFT);
+}
+
 int16_t XYZ_32_GetYaw(const XYZ_32 pos)
 {
     return Math_Atan(pos.z, pos.x);
@@ -99,6 +111,70 @@ XYZ_32 XYZ_32_From16(const XYZ_16 src)
     return (XYZ_32) { src.x, src.y, src.z };
 }
 
+XYZ_32 XYZ_32_Add(const XYZ_32 a, const XYZ_32 b)
+{
+    return (XYZ_32) {
+        .x = a.x + b.x,
+        .y = a.y + b.y,
+        .z = a.z + b.z,
+    };
+}
+
+XYZ_32 XYZ_32_Subtract(const XYZ_32 a, const XYZ_32 b)
+{
+    return (XYZ_32) {
+        .x = a.x - b.x,
+        .y = a.y - b.y,
+        .z = a.z - b.z,
+    };
+}
+
+XYZ_32 XYZ_32_RotateYaw(XYZ_32 vec, const int16_t yaw)
+{
+    if (yaw != 0) {
+        M_Turn(&vec.x, &vec.z, Math_Sin(yaw), Math_Cos(yaw));
+    }
+    return vec;
+}
+
+XYZ_32 XYZ_32_UnrotateYaw(XYZ_32 vec, const int16_t yaw)
+{
+    if (yaw != 0) {
+        M_Turn(&vec.x, &vec.z, -Math_Sin(yaw), Math_Cos(yaw));
+    }
+    return vec;
+}
+
+XYZ_32 XYZ_32_Rotate(XYZ_32 vec, const XYZ_16 rot)
+{
+    // Matrix_Rot16 composes the turns Y, X, Z, so a vector meets them in the
+    // opposite order.
+    if (rot.z != 0) {
+        M_Turn(&vec.x, &vec.y, -Math_Sin(rot.z), Math_Cos(rot.z));
+    }
+    if (rot.x != 0) {
+        M_Turn(&vec.y, &vec.z, -Math_Sin(rot.x), Math_Cos(rot.x));
+    }
+    if (rot.y != 0) {
+        M_Turn(&vec.x, &vec.z, Math_Sin(rot.y), Math_Cos(rot.y));
+    }
+    return vec;
+}
+
+XYZ_32 XYZ_32_Unrotate(XYZ_32 vec, const XYZ_16 rot)
+{
+    if (rot.y != 0) {
+        M_Turn(&vec.x, &vec.z, -Math_Sin(rot.y), Math_Cos(rot.y));
+    }
+    if (rot.x != 0) {
+        M_Turn(&vec.y, &vec.z, Math_Sin(rot.x), Math_Cos(rot.x));
+    }
+    if (rot.z != 0) {
+        M_Turn(&vec.x, &vec.y, Math_Sin(rot.z), Math_Cos(rot.z));
+    }
+    return vec;
+}
+
 XYZ_32 XYZ_32_OffsetYaw(
     const XYZ_32 src, const int16_t yaw, const int32_t distance)
 {
@@ -123,6 +199,18 @@ XYZ_32 XYZ_32_FromYawPitch(
         .y = -(int32_t)(((int64_t)distance * sx) >> W2V_SHIFT),
         .z = (int32_t)(((int64_t)horz * cy) >> W2V_SHIFT),
     };
+}
+
+XYZ_32 XYZ_32_OffsetLocalYaw(
+    const XYZ_32 src, const XYZ_32 offset, const int16_t yaw)
+{
+    return XYZ_32_Add(src, XYZ_32_RotateYaw(offset, yaw));
+}
+
+XYZ_32 XYZ_32_OffsetLocal(
+    const XYZ_32 src, const XYZ_32 offset, const XYZ_16 rot)
+{
+    return XYZ_32_Add(src, XYZ_32_Rotate(offset, rot));
 }
 
 int64_t XYZ_32_DotProduct_64(const XYZ_32 a, const XYZ_32 b)

--- a/src/trx/core/math/geom.h
+++ b/src/trx/core/math/geom.h
@@ -20,8 +20,45 @@ int64_t XYZ_32_DotProduct_64(XYZ_32 a, XYZ_32 b);
 bool XYZ_32_AreEquivalent(XYZ_32 pos1, XYZ_32 pos2);
 bool XYZ_32_IsNearby(XYZ_32 pos1, XYZ_32 pos2, int32_t distance);
 
+XYZ_32 XYZ_32_Add(XYZ_32 a, XYZ_32 b);
+XYZ_32 XYZ_32_Subtract(XYZ_32 a, XYZ_32 b);
+
+// An offset is nearly always known along the item it belongs to - z the way it
+// faces, x out to its right - while the world it has to land in is not turned
+// that way at all. A gun muzzle sits a fixed step ahead of Lara and a little to
+// one side whichever way she is looking; where that is in the world depends on
+// her yaw.
+//
+//     along the item, S                    the same, in the world
+//
+//         ahead (z)                          world z
+//             ^                                 ^        P
+//             |    P                            |      /
+//             |   /                             |    /
+//             | /                               |  /
+//      -------S------> right (x)                S ----> ahead
+//             |                                 | \ yaw is the turn from
+//             |                                 |  \_ world z to ahead
+//                                               +---------> world x
+//
+// Rotate turns an offset the item gave into the world's axes; Unrotate reads a
+// world delta back along the item's, so its z says how far ahead of the item
+// that delta reaches and its x how far to the side. The Yaw pair only turns
+// about Y, which is all most items need; an item that pitches or rolls - a
+// boat, a vehicle on a slope - needs the XYZ_16 pair to be right.
+XYZ_32 XYZ_32_RotateYaw(XYZ_32 vec, int16_t yaw);
+XYZ_32 XYZ_32_UnrotateYaw(XYZ_32 vec, int16_t yaw);
+XYZ_32 XYZ_32_Rotate(XYZ_32 vec, XYZ_16 rot);
+XYZ_32 XYZ_32_Unrotate(XYZ_32 vec, XYZ_16 rot);
+
 XYZ_32 XYZ_32_FromYawPitch(int16_t yaw, int16_t pitch, int32_t distance);
+
+// P itself rather than the turned offset that reaches it, for the callers that
+// have S to hand. OffsetYaw is the common case of an offset straight ahead:
+// XYZ_32_OffsetYaw(s, yaw, dist) is OffsetLocalYaw(s, { .z = dist }, yaw).
 XYZ_32 XYZ_32_OffsetYaw(XYZ_32 src, int16_t yaw, int32_t distance);
+XYZ_32 XYZ_32_OffsetLocalYaw(XYZ_32 src, XYZ_32 offset, int16_t yaw);
+XYZ_32 XYZ_32_OffsetLocal(XYZ_32 src, XYZ_32 offset, XYZ_16 rot);
 
 bool XYZ_32_ProjectPointOntoAxis(
     XYZ_32 origin, XYZ_32 axis, int64_t axis_len2, XYZ_32 *pos);

--- a/src/trx/game/camera/binoculars.c
+++ b/src/trx/game/camera/binoculars.c
@@ -148,12 +148,9 @@ static void M_EmitTorch(const XYZ_32 start, const XYZ_32 end)
             for (j = 0; j < 5; j++) {
                 XYZ_32 test;
                 if (offs[j] != 0) {
-                    test.x = pos.x
-                        + ((falloff * (Math_Sin(offs[j] + y_rot) / 4)) >> 5);
+                    test = XYZ_32_OffsetYaw(pos, offs[j] + y_rot, falloff << 7);
                     test.y = (offs[j] & 1) != 0 ? pos.y - (falloff << 7)
                                                 : pos.y + (falloff << 7);
-                    test.z = pos.z
-                        + ((falloff * (Math_Cos(offs[j] + y_rot) / 4)) >> 5);
                 } else {
                     test = pos;
                 }
@@ -283,12 +280,8 @@ void Camera_Binoculars_Update(void)
         eye.y += STEP_L / 4;
     }
 
-    const int32_t fwd = (M_TARGET_DIST * Math_Cos(pitch)) >> W2V_SHIFT;
-    const XYZ_32 target = {
-        .x = eye.x + ((Math_Sin(yaw) * fwd) >> W2V_SHIFT),
-        .y = eye.y - ((Math_Sin(pitch) * M_TARGET_DIST) >> W2V_SHIFT),
-        .z = eye.z + ((Math_Cos(yaw) * fwd) >> W2V_SHIFT),
-    };
+    const XYZ_32 target =
+        XYZ_32_Add(eye, XYZ_32_FromYawPitch(yaw, pitch, M_TARGET_DIST));
 
     g_Camera.pos.pos = eye;
     g_Camera.pos.room_num = room_num;

--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -564,12 +564,10 @@ static void M_Chase(const ITEM *const item)
 
     g_Camera.target_square = SQUARE(distance);
 
-    const XYZ_32 offset = {
-        .y = (g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
-            >> W2V_SHIFT,
-        .x = -((distance * Math_Sin(angle)) >> W2V_SHIFT),
-        .z = -((distance * Math_Cos(angle)) >> W2V_SHIFT),
-    };
+    // The camera trails the target, so it steps against the angle.
+    XYZ_32 offset = XYZ_32_RotateYaw((XYZ_32) { .z = -distance }, angle);
+    offset.y = (g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
+        >> W2V_SHIFT;
 
     GAME_VECTOR target = {
         .x = g_Camera.target.x + offset.x,
@@ -607,13 +605,10 @@ static void M_Combat(const ITEM *const item)
     const int32_t distance =
         (M_COMBAT_DISTANCE * Math_Cos(g_Camera.target_elevation)) >> W2V_SHIFT;
 
-    const XYZ_32 offset = {
-        .y =
-            +((g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
-              >> W2V_SHIFT),
-        .x = -((distance * Math_Sin(g_Camera.target_angle)) >> W2V_SHIFT),
-        .z = -((distance * Math_Cos(g_Camera.target_angle)) >> W2V_SHIFT),
-    };
+    XYZ_32 offset =
+        XYZ_32_RotateYaw((XYZ_32) { .z = -distance }, g_Camera.target_angle);
+    offset.y = (g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
+        >> W2V_SHIFT;
 
     GAME_VECTOR target = {
         .x = g_Camera.target.x + offset.x,
@@ -693,8 +688,8 @@ static void M_Look(const ITEM *const item)
 
     g_Camera.shift =
         (-STEP_L * 2 * Math_Sin(g_Camera.target_elevation)) >> W2V_SHIFT;
-    g_Camera.target.z += (g_Camera.shift * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-    g_Camera.target.x += (g_Camera.shift * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+    g_Camera.target.pos =
+        XYZ_32_OffsetYaw(g_Camera.target.pos, item->rot.y, g_Camera.shift);
 
     if (!M_IsGoodPosition(
             g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
@@ -705,13 +700,10 @@ static void M_Look(const ITEM *const item)
 
     g_Camera.target.y += M_ShiftClamp(&g_Camera.target, M_LOOK_CLAMP);
 
-    const XYZ_32 offset = {
-        .y =
-            +((g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
-              >> W2V_SHIFT),
-        .x = -((distance * Math_Sin(g_Camera.target_angle)) >> W2V_SHIFT),
-        .z = -((distance * Math_Cos(g_Camera.target_angle)) >> W2V_SHIFT),
-    };
+    XYZ_32 offset =
+        XYZ_32_RotateYaw((XYZ_32) { .z = -distance }, g_Camera.target_angle);
+    offset.y = (g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
+        >> W2V_SHIFT;
 
     GAME_VECTOR target = {
         .x = g_Camera.target.x + offset.x,
@@ -853,8 +845,8 @@ static void M_Update(
 
         if (g_Camera.flags == CF_FOLLOW_CENTRE) {
             const int32_t shift = (bounds->min.z + bounds->max.z) / 2;
-            g_Camera.target.z += (shift * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-            g_Camera.target.x += (shift * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+            g_Camera.target.pos =
+                XYZ_32_OffsetYaw(g_Camera.target.pos, item->rot.y, shift);
         }
 
         g_Camera.target.room_num = item->room_num;

--- a/src/trx/game/camera/cinematic.c
+++ b/src/trx/game/camera/cinematic.c
@@ -13,26 +13,10 @@ static CINE_DATA m_CineData = {};
 static void M_UpdateCutscene(const XYZ_32 base_pos, const int16_t angle)
 {
     const CINE_FRAME *const frame = Camera_GetCurrentCineFrame();
-    const int32_t c = Math_Cos(angle);
-    const int32_t s = Math_Sin(angle);
-
-#define SHIFT(prop, axis1, op, axis2)                                          \
-    (((frame->prop.shift.axis1 * c) op(frame->prop.shift.axis2 * s))           \
-     >> W2V_SHIFT)
-
-    const XYZ_32 camera_target = {
-        .x = base_pos.x + SHIFT(target, x, +, z),
-        .y = base_pos.y + frame->target.shift.y,
-        .z = base_pos.z + SHIFT(target, z, -, x),
-    };
-
-    const XYZ_32 camera_pos = {
-        .x = base_pos.x + SHIFT(camera, x, +, z),
-        .y = base_pos.y + frame->camera.shift.y,
-        .z = base_pos.z + SHIFT(camera, z, -, x),
-    };
-
-#undef SHIFT
+    const XYZ_32 camera_target = XYZ_32_OffsetLocalYaw(
+        base_pos, XYZ_32_From16(frame->target.shift), angle);
+    const XYZ_32 camera_pos = XYZ_32_OffsetLocalYaw(
+        base_pos, XYZ_32_From16(frame->camera.shift), angle);
 
     const int16_t room_num = Room_GetIndexFromPos(camera_pos);
     if (room_num != NO_ROOM) {

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -159,11 +159,8 @@ void Camera_UpdateMicPosition(void)
         g_Camera.actual_angle = Math_Atan(
             g_Camera.target.z - g_Camera.pos.z,
             g_Camera.target.x - g_Camera.pos.x);
-        g_Camera.mic_pos.pos.x = g_Camera.pos.x
-            + ((g_PhdPersp * Math_Sin(g_Camera.actual_angle)) >> W2V_SHIFT);
-        g_Camera.mic_pos.pos.z = g_Camera.pos.z
-            + ((g_PhdPersp * Math_Cos(g_Camera.actual_angle)) >> W2V_SHIFT);
-        g_Camera.mic_pos.pos.y = g_Camera.pos.y;
+        g_Camera.mic_pos.pos = XYZ_32_OffsetYaw(
+            g_Camera.pos.pos, g_Camera.actual_angle, g_PhdPersp);
         g_Camera.mic_pos.room_num = g_Camera.pos.room_num;
     }
 }

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -368,20 +368,16 @@ static GAME_VECTOR M_GetIdeal(
     GAME_VECTOR temp[2] = {};
     GAME_VECTOR ideals[5] = {};
 
-    for (int32_t i = 0; i < 5; i++) {
-        ideals[i].y =
-            ((Math_Sin(g_Camera.target_elevation) * g_Camera.target_distance)
-             >> W2V_SHIFT)
-            + g_Camera.target.y;
-    }
+    const int32_t rise =
+        (Math_Sin(g_Camera.target_elevation) * g_Camera.target_distance)
+        >> W2V_SHIFT;
 
     for (int32_t i = 0; i < 5; i++) {
         const int16_t angle = i > 0 ? ((i - 1) << W2V_SHIFT)
                                     : (g_Camera.target_angle + target_rot_y);
-        ideals[i].x =
-            g_Camera.target.x - ((distance * Math_Sin(angle)) >> W2V_SHIFT);
-        ideals[i].z =
-            g_Camera.target.z - ((distance * Math_Cos(angle)) >> W2V_SHIFT);
+        ideals[i].pos = XYZ_32_OffsetLocalYaw(
+            g_Camera.target.pos, (XYZ_32) { .z = -distance }, angle);
+        ideals[i].y = g_Camera.target.y + rise;
 
         ideals[i].room_num = g_Camera.target.room_num;
 
@@ -900,8 +896,8 @@ static void M_Update(
 
         if (g_Camera.flags == CF_FOLLOW_CENTRE) {
             const int32_t shift = (bounds->min.z + bounds->max.z) / 2;
-            g_Camera.target.z += (shift * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-            g_Camera.target.x += (shift * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+            g_Camera.target.pos =
+                XYZ_32_OffsetYaw(g_Camera.target.pos, item->rot.y, shift);
         }
 
         g_Camera.target.room_num = item->room_num;

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -17,9 +17,6 @@
 #define PHOTO_MAX_PITCH_ROLL (DEG_90 - DEG_1)
 #define PHOTO_MAX_SPEED 100
 
-#define M_CosMul(a, b) TRIGMULT2(Math_Cos((a)), (b))
-#define M_SinMul(a, b) TRIGMULT2(Math_Sin((a)), (b))
-
 static int32_t m_PhotoSpeed = 0;
 static int32_t m_OriginalFOV;
 static FOV_MODE m_OriginalFOVMode;
@@ -85,36 +82,23 @@ static int32_t M_GetRotSpeed(void)
     return MAX(DEG_1, M_GetShiftSpeed(PHOTO_ROT_SHIFT));
 }
 
+// The step comes in along the camera's own axes, and has to land in the
+// world's.
 static XYZ_32 M_GetShift(const int32_t dx, const int32_t dy, const int32_t dz)
 {
-    const int16_t yaw = g_Camera.target_angle;
-    const int16_t pitch = g_Camera.target_elevation;
-    const int16_t roll = g_Camera.roll;
-
-    const int32_t dx_r = M_CosMul(roll, dx) - M_SinMul(roll, dy);
-    const int32_t dy_r = M_SinMul(roll, dx) + M_CosMul(roll, dy);
-    const int32_t dz_r = dz; // unchanged if roll is around Z
-
-    const int32_t dy_p = M_CosMul(pitch, dy_r) - M_SinMul(pitch, dz_r);
-    const int32_t dz_p = M_SinMul(pitch, dy_r) + M_CosMul(pitch, dz_r);
-    const int32_t dx_p = dx_r; // unchanged if pitch is around X
-
-    const int32_t dx_y = M_CosMul(yaw, dx_p) + M_SinMul(yaw, dz_p);
-    const int32_t dz_y = -M_SinMul(yaw, dx_p) + M_CosMul(yaw, dz_p);
-    const int32_t dy_y = dy_p; // unchanged if yaw is around Y
-
-    return (XYZ_32) { dx_y, dy_y, dz_y };
+    const XYZ_16 rot = {
+        .x = g_Camera.target_elevation,
+        .y = g_Camera.target_angle,
+        .z = g_Camera.roll,
+    };
+    return XYZ_32_Rotate((XYZ_32) { .x = dx, .y = dy, .z = dz }, rot);
 }
 
 static void M_ShiftCamera(int32_t dx, int32_t dy, int32_t dz)
 {
     const XYZ_32 shift = M_GetShift(dx, dy, dz);
-    g_Camera.pos.x += shift.x;
-    g_Camera.pos.y += shift.y;
-    g_Camera.pos.z += shift.z;
-    g_Camera.target.x += shift.x;
-    g_Camera.target.y += shift.y;
-    g_Camera.target.z += shift.z;
+    g_Camera.pos.pos = XYZ_32_Add(g_Camera.pos.pos, shift);
+    g_Camera.target.pos = XYZ_32_Add(g_Camera.target.pos, shift);
 }
 
 static void M_ApplyRotation(
@@ -127,8 +111,10 @@ static void M_ApplyRotation(
 
     // rotate with respect to current upright axis
     if (respect_roll) {
-        yaw += M_CosMul(roll, d_yaw) + M_SinMul(roll, d_pitch);
-        pitch += M_CosMul(roll, d_pitch) - M_SinMul(roll, d_yaw);
+        const XYZ_32 turned =
+            XYZ_32_RotateYaw((XYZ_32) { .x = d_yaw, .z = d_pitch }, roll);
+        yaw += turned.x;
+        pitch += turned.z;
     } else {
         yaw += d_yaw;
         pitch += d_pitch;
@@ -152,9 +138,7 @@ static void M_RotateCamera(
 {
     M_ApplyRotation(d_yaw, d_pitch, d_roll, true);
     const XYZ_32 shift = M_GetShift(0, 0, g_Camera.target_distance);
-    g_Camera.target.x = g_Camera.pos.x + shift.x;
-    g_Camera.target.y = g_Camera.pos.y + shift.y;
-    g_Camera.target.z = g_Camera.pos.z + shift.z;
+    g_Camera.target.pos = XYZ_32_Add(g_Camera.pos.pos, shift);
 }
 
 static void M_RotateTarget(
@@ -162,9 +146,7 @@ static void M_RotateTarget(
 {
     M_ApplyRotation(d_yaw, d_pitch, d_roll, false);
     const XYZ_32 shift = M_GetShift(0, 0, g_Camera.target_distance);
-    g_Camera.pos.x = g_Camera.target.x - shift.x;
-    g_Camera.pos.y = g_Camera.target.y - shift.y;
-    g_Camera.pos.z = g_Camera.target.z - shift.z;
+    g_Camera.pos.pos = XYZ_32_Subtract(g_Camera.target.pos, shift);
 }
 
 static void M_ClampCameraPos(void)

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -752,19 +752,15 @@ bool Collide_TestBoundsCollide(
         return false;
     }
 
-    const int32_t c = Math_Cos(src_item->rot.y);
-    const int32_t s = Math_Sin(src_item->rot.y);
-    const int32_t dx = dst_item->pos.x - src_item->pos.x;
-    const int32_t dz = dst_item->pos.z - src_item->pos.z;
-    const int32_t rx = (c * dx - s * dz) >> W2V_SHIFT;
-    const int32_t rz = (c * dz + s * dx) >> W2V_SHIFT;
+    const XYZ_32 delta = XYZ_32_Subtract(dst_item->pos, src_item->pos);
+    const XYZ_32 local = XYZ_32_UnrotateYaw(delta, src_item->rot.y);
 
     // clang-format off
     return (
-        rx >= src_bounds->min.x - radius &&
-        rx <= src_bounds->max.x + radius &&
-        rz >= src_bounds->min.z - radius &&
-        rz <= src_bounds->max.z + radius);
+        local.x >= src_bounds->min.x - radius &&
+        local.x <= src_bounds->max.x + radius &&
+        local.z >= src_bounds->min.z - radius &&
+        local.z <= src_bounds->max.z + radius);
     // clang-format on
 }
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -394,20 +394,15 @@ void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
     const ITEM *const lara_item = Lara_GetItem();
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
-    const XZ_32 pivot = {
-        .x = (obj->pivot_length * Math_Sin(item->rot.y)) >> W2V_SHIFT,
-        .z = (obj->pivot_length * Math_Cos(item->rot.y)) >> W2V_SHIFT,
-    };
+    const XYZ_32 pivot_offset =
+        XYZ_32_RotateYaw((XYZ_32) { .z = obj->pivot_length }, item->rot.y);
+    const XZ_32 pivot = { .x = pivot_offset.x, .z = pivot_offset.z };
 
-    XZ_32 enemy_pos = {
-        .x = enemy->pos.x,
-        .z = enemy->pos.z,
-    };
+    XYZ_32 enemy_pos = enemy->pos;
     if (g_TRVersion >= 3) {
         const int16_t enemy_angle =
             enemy == lara_item ? lara->move_angle : enemy->rot.y;
-        enemy_pos.x += (14 * enemy->speed * Math_Sin(enemy_angle)) >> W2V_SHIFT;
-        enemy_pos.z += (14 * enemy->speed * Math_Cos(enemy_angle)) >> W2V_SHIFT;
+        enemy_pos = XYZ_32_OffsetYaw(enemy_pos, enemy_angle, 14 * enemy->speed);
     }
 
     int32_t x = enemy_pos.x - pivot.x - item->pos.x;
@@ -891,14 +886,12 @@ void Creature_Collision(
             false);
     } else if (coll->enable_hit && g_TRVersion == 3) {
         const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
-        const int32_t s = Math_Sin(lara_item->rot.y);
-        const int32_t c = Math_Cos(lara_item->rot.y);
-        const int32_t x = (bounds->min.x + bounds->max.x) / 2;
-        const int32_t z = (bounds->max.z - bounds->min.z) / 2;
-        const int32_t rx =
-            (lara_item->pos.x - item->pos.x) - ((c * x + s * z) >> W2V_SHIFT);
-        const int32_t rz =
-            (lara_item->pos.z - item->pos.z) - ((c * z - s * x) >> W2V_SHIFT);
+        const XYZ_32 centre = XYZ_32_RotateYaw(
+            (XYZ_32) { .x = (bounds->min.x + bounds->max.x) / 2,
+                       .z = (bounds->max.z - bounds->min.z) / 2 },
+            lara_item->rot.y);
+        const int32_t rx = lara_item->pos.x - item->pos.x - centre.x;
+        const int32_t rz = lara_item->pos.z - item->pos.z - centre.z;
 
         if (bounds->max.z - bounds->min.z > STEP_L) {
             lara->hit_direction =

--- a/src/trx/game/creature/shooting.c
+++ b/src/trx/game/creature/shooting.c
@@ -33,8 +33,7 @@ static void M_CalcShootVectors(
     });
 
     const int32_t dist = WALL_L * 2;
-    target->x += (dist * Math_Sin(angle)) >> W2V_SHIFT;
-    target->z += (dist * Math_Cos(angle)) >> W2V_SHIFT;
+    *target = XYZ_32_OffsetYaw(*target, angle, dist);
 }
 
 static void M_TriggerTR3GunShell(

--- a/src/trx/game/fx/footprint.c
+++ b/src/trx/game/fx/footprint.c
@@ -54,13 +54,7 @@ static const SAMPLE_TRX_ID m_StepSounds[14] = {
 static void M_GetWorldPoint(
     const M_FOOTPRINT *const print, const XYZ_32 local, XYZ_32 *const out_world)
 {
-    const int32_t s = Math_Sin(print->y_rot);
-    const int32_t c = Math_Cos(print->y_rot);
-    const int32_t dx = TRIGMULT2(local.x, c) + TRIGMULT2(local.z, s);
-    const int32_t dz = TRIGMULT2(local.z, c) - TRIGMULT2(local.x, s);
-    out_world->x = print->pos.x + dx;
-    out_world->y = print->pos.y + local.y;
-    out_world->z = print->pos.z + dz;
+    *out_world = XYZ_32_OffsetLocalYaw(print->pos, local, print->y_rot);
 }
 
 static int32_t M_GetVertexYOffset(

--- a/src/trx/game/fx/ring.c
+++ b/src/trx/game/fx/ring.c
@@ -20,24 +20,6 @@
 static FX_RING m_Rings[FX_RING_TYPE_NUMBER_OF][M_MAX_RINGS] = {};
 static bool m_Active[FX_RING_TYPE_NUMBER_OF] = {};
 
-static void M_RotateZX(
-    XYZ_32 *const out, const XYZ_32 in, const int32_t rot_z,
-    const int32_t rot_x)
-{
-    const int32_t sz = Math_Sin(rot_z);
-    const int32_t cz = Math_Cos(rot_z);
-    const int32_t sx = Math_Sin(rot_x);
-    const int32_t cx = Math_Cos(rot_x);
-
-    const int32_t xz = (in.x * cz - in.y * sz) >> W2V_SHIFT;
-    const int32_t yz = (in.x * sz + in.y * cz) >> W2V_SHIFT;
-    const int32_t zz = in.z;
-
-    out->x = xz;
-    out->y = (yz * cx - zz * sx) >> W2V_SHIFT;
-    out->z = (yz * sx + zz * cx) >> W2V_SHIFT;
-}
-
 static void M_RememberRing(FX_RING *const ring)
 {
     ring->prev_radius = ring->radius;
@@ -64,8 +46,10 @@ static void M_BuildRingCircle(
     int32_t angle = angle_base;
     for (int32_t i = 0; i < 8; i++) {
         FX_RING_VERT *const vtx = &ring->verts[band * 8 + i];
-        vtx->pos.x = (radius * Math_Sin(angle << 4)) >> W2V_SHIFT;
-        vtx->pos.z = (radius * Math_Cos(angle << 4)) >> W2V_SHIFT;
+        const XYZ_32 point =
+            XYZ_32_RotateYaw((XYZ_32) { .z = radius }, angle << 4);
+        vtx->pos.x = point.x;
+        vtx->pos.z = point.z;
         if (clear_inner && band != 0) {
             vtx->color = COLOR_RGB_888_BLACK;
         }
@@ -109,10 +93,9 @@ static void M_DrawTexturedRing(const FX_RING *const ring)
         XYZ_32 p_rot[4] = {};
         XYZ_32 p_world[4] = {};
         for (int32_t c = 0; c < 4; c++) {
-            M_RotateZX(&p_rot[c], p_local[c], rot_z, rot_x);
-            p_world[c].x = ring->pos.x + p_rot[c].x;
-            p_world[c].y = ring->pos.y + p_rot[c].y;
-            p_world[c].z = ring->pos.z + p_rot[c].z;
+            p_rot[c] =
+                XYZ_32_Rotate(p_local[c], (XYZ_16) { .x = rot_x, .z = rot_z });
+            p_world[c] = XYZ_32_Add(ring->pos, p_rot[c]);
         }
 
         const RGBA_8888 color[4] = {
@@ -155,10 +138,9 @@ static void M_DrawFlatRing(const FX_RING *const ring)
         XYZ_32 p_rot[4] = {};
         XYZ_32 p_world[4] = {};
         for (int32_t c = 0; c < 4; c++) {
-            M_RotateZX(&p_rot[c], p_local[c], rot_z, rot_x);
-            p_world[c].x = ring->pos.x + p_rot[c].x;
-            p_world[c].y = ring->pos.y + p_rot[c].y;
-            p_world[c].z = ring->pos.z + p_rot[c].z;
+            p_rot[c] =
+                XYZ_32_Rotate(p_local[c], (XYZ_16) { .x = rot_x, .z = rot_z });
+            p_world[c] = XYZ_32_Add(ring->pos, p_rot[c]);
         }
 
         const XYZ_32 world_pos[4] = {

--- a/src/trx/game/gun/common.c
+++ b/src/trx/game/gun/common.c
@@ -95,13 +95,8 @@ void Gun_AddDynamicLight(void)
     }
 
     const ITEM *const lara_item = Lara_GetItem();
-    const int32_t c = Math_Cos(lara_item->rot.y);
-    const int32_t s = Math_Sin(lara_item->rot.y);
-    const XYZ_32 pos = {
-        .x = lara_item->pos.x + (s >> (W2V_SHIFT - 10)),
-        .y = lara_item->pos.y - WALL_L / 2,
-        .z = lara_item->pos.z + (c >> (W2V_SHIFT - 10)),
-    };
+    XYZ_32 pos = XYZ_32_OffsetYaw(lara_item->pos, lara_item->rot.y, 1024);
+    pos.y -= WALL_L / 2;
     if (g_TRVersion >= 3) {
         Output_AddDynamicLightRGB(pos, 12, (RGB_888) { 192, 144, 0 });
     } else {

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -189,11 +189,9 @@ void Gun_FindTargetPoint(const ITEM *const item, GAME_VECTOR *const target)
     const int32_t x = bounds->min.x + (bounds->max.x - bounds->min.x) / 2;
     const int32_t y = bounds->min.y + (bounds->max.y - bounds->min.y) / 3;
     const int32_t z = bounds->min.z + (bounds->max.z - bounds->min.z) / 2;
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sy = Math_Sin(item->rot.y);
-    target->pos.x = item->pos.x + ((cy * x + sy * z) >> W2V_SHIFT);
+    target->pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x, .z = z }, item->rot.y);
     target->pos.y = item->pos.y + y;
-    target->pos.z = item->pos.z + ((cy * z - sy * x) >> W2V_SHIFT);
     target->room_num = item->room_num;
 }
 

--- a/src/trx/game/items/col.c
+++ b/src/trx/game/items/col.c
@@ -24,11 +24,9 @@ int32_t Item_GetDistance(const ITEM *const item, const XYZ_32 target)
 void Item_Translate(
     ITEM *const item, const int32_t x, const int32_t y, const int32_t z)
 {
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t s = Math_Sin(item->rot.y);
-    item->pos.x += ((c * x + s * z) >> W2V_SHIFT);
+    item->pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x, .z = z }, item->rot.y);
     item->pos.y += y;
-    item->pos.z += ((c * z - s * x) >> W2V_SHIFT);
 }
 
 bool Item_Test3DRange(

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -17,12 +17,10 @@ void Lara_Col_Push(
     const bool big_push)
 {
     ITEM *const target_item = Lara_GetItem();
-    int32_t dx = target_item->pos.x - item->pos.x;
-    int32_t dz = target_item->pos.z - item->pos.z;
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t s = Math_Sin(item->rot.y);
-    int32_t rx = (c * dx - s * dz) >> W2V_SHIFT;
-    int32_t rz = (c * dz + s * dx) >> W2V_SHIFT;
+    const XYZ_32 delta = XYZ_32_Subtract(target_item->pos, item->pos);
+    const XYZ_32 local = XYZ_32_UnrotateYaw(delta, item->rot.y);
+    int32_t rx = local.x;
+    int32_t rz = local.z;
 
     const BOUNDS_16 *const bounds = &item->bounds;
     int32_t min_x = bounds->min.x;
@@ -56,16 +54,20 @@ void Lara_Col_Push(
         rz = min_z;
     }
 
-    target_item->pos.x = item->pos.x + ((rz * s + rx * c) >> W2V_SHIFT);
-    target_item->pos.z = item->pos.z + ((rz * c - rx * s) >> W2V_SHIFT);
+    const XYZ_32 pushed = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = rx, .z = rz }, item->rot.y);
+    target_item->pos.x = pushed.x;
+    target_item->pos.z = pushed.z;
 
-    rz = (bounds->max.z + bounds->min.z) / 2;
-    rx = (bounds->max.x + bounds->min.x) / 2;
-    dx -= (c * rx + s * rz) >> W2V_SHIFT;
-    dz -= (c * rz - s * rx) >> W2V_SHIFT;
+    // How far Lara stands from the middle of the item, rather than from the
+    // point it sits on.
+    const XYZ_32 centre = XYZ_32_RotateYaw(
+        (XYZ_32) { .x = (bounds->max.x + bounds->min.x) / 2,
+                   .z = (bounds->max.z + bounds->min.z) / 2 },
+        item->rot.y);
 
     if (hit_on && bounds->max.y - bounds->min.y > STEP_L) {
-        Lara_TakeHit(target_item, dx, dz);
+        Lara_TakeHit(target_item, delta.x - centre.x, delta.z - centre.z);
     }
 
     const int16_t old_facing = coll->facing;

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -778,11 +778,7 @@ static bool M_TestLedgeJump(const ITEM *const item, const COLL_INFO *const coll)
     }
 
     // Test for a solid surface in front of Lara to push against.
-    const XYZ_32 pos = {
-        .x = item->pos.x + ((Math_Sin(item->rot.y) * STEP_L) >> W2V_SHIFT),
-        .z = item->pos.z + ((Math_Cos(item->rot.y) * STEP_L) >> W2V_SHIFT),
-        .y = item->pos.y,
-    };
+    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, STEP_L);
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     const int32_t height = Room_GetHeight(sector, pos);

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -211,8 +211,8 @@ static void M_SlideEdgeJump(ITEM *const item, COLL_INFO *const coll)
         break;
 
     case COLL_CLAMP:
-        item->pos.z -= (Math_Cos(coll->facing) * 100) >> W2V_SHIFT;
-        item->pos.x -= (Math_Sin(coll->facing) * 100) >> W2V_SHIFT;
+        item->pos = XYZ_32_Subtract(
+            item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = 100 }, coll->facing));
         item->speed = 0;
         coll->side_mid.floor = 0;
         if (item->fall_speed <= 0) {
@@ -680,8 +680,8 @@ void Lara_Col_DeflectEdgeJump(ITEM *const item, COLL_INFO *const coll)
         break;
 
     case COLL_CLAMP:
-        item->pos.z -= (Math_Cos(coll->facing) * 100) >> W2V_SHIFT;
-        item->pos.x -= (Math_Sin(coll->facing) * 100) >> W2V_SHIFT;
+        item->pos = XYZ_32_Subtract(
+            item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = 100 }, coll->facing));
         item->speed = 0;
         coll->side_mid.floor = 0;
         if (item->fall_speed <= 0) {

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -628,8 +628,7 @@ void Lara_Animate(ITEM *const item)
     }
 
     if (!lara->interact_target.is_moving) {
-        item->pos.x += (item->speed * Math_Sin(lara->move_angle)) >> W2V_SHIFT;
-        item->pos.z += (item->speed * Math_Cos(lara->move_angle)) >> W2V_SHIFT;
+        item->pos = XYZ_32_OffsetYaw(item->pos, lara->move_angle, item->speed);
     }
 }
 

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -169,10 +169,11 @@ static void M_WaterCurrent_TR34(COLL_INFO *const coll)
         const int32_t angle =
             -Math_Atan(lara_item->pos.x - sink->x, lara_item->pos.z - sink->z)
             - DEG_90;
-        lara->current.vel.x +=
-            (((speed * Math_Sin(angle)) >> 4) - lara->current.vel.x) >> 4;
-        lara->current.vel.z +=
-            (((speed * Math_Cos(angle)) >> 4) - lara->current.vel.z) >> 4;
+        // A velocity carries ten bits more than a position does.
+        const XYZ_32 vel =
+            XYZ_32_RotateYaw((XYZ_32) { .z = speed << 10 }, angle);
+        lara->current.vel.x += (vel.x - lara->current.vel.x) >> 4;
+        lara->current.vel.z += (vel.z - lara->current.vel.z) >> 4;
         lara_item->pos.y += (sink->y - lara_item->pos.y) >> 4;
     } else {
         int32_t shifter;
@@ -749,16 +750,16 @@ static void M_HandleUnderwater(COLL_INFO *const coll)
     }
 
     Lara_Animate(item);
+    // The step is taken along the heading first and foreshortened by the
+    // pitch after, which is the order the original swims in and the one the
+    // recorded demos are played back against.
+    const XYZ_32 step =
+        XYZ_32_RotateYaw((XYZ_32) { .z = item->fall_speed }, item->rot.y);
+    const int32_t foreshorten = Math_Cos(item->rot.x);
+    item->pos.x += (foreshorten * (step.x >> 2)) >> W2V_SHIFT;
     item->pos.y -=
         (item->fall_speed * Math_Sin(item->rot.x)) >> (W2V_SHIFT + 2);
-    item->pos.x +=
-        (Math_Cos(item->rot.x)
-         * ((item->fall_speed * Math_Sin(item->rot.y)) >> (W2V_SHIFT + 2)))
-        >> W2V_SHIFT;
-    item->pos.z +=
-        (Math_Cos(item->rot.x)
-         * ((item->fall_speed * Math_Cos(item->rot.y)) >> (W2V_SHIFT + 2)))
-        >> W2V_SHIFT;
+    item->pos.z += (foreshorten * (step.z >> 2)) >> W2V_SHIFT;
 
     const SECTOR *const sector = M_GetCurrentSector();
     if (!lara_info->extra_anim) {
@@ -820,10 +821,10 @@ static void M_HandleSurface(COLL_INFO *const coll)
     }
 
     Lara_Animate(item);
-    item->pos.x +=
-        (item->fall_speed * Math_Sin(lara_info->move_angle)) >> (W2V_SHIFT + 2);
-    item->pos.z +=
-        (item->fall_speed * Math_Cos(lara_info->move_angle)) >> (W2V_SHIFT + 2);
+    const XYZ_32 step = XYZ_32_RotateYaw(
+        (XYZ_32) { .z = item->fall_speed }, lara_info->move_angle);
+    item->pos.x += step.x >> 2;
+    item->pos.z += step.z >> 2;
 
     const SECTOR *const sector = M_GetCurrentSector();
 

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -305,10 +305,8 @@ int32_t Lara_CeilingFront(
     const ITEM *const item, const int16_t ang, const int32_t dist,
     const int32_t item_height)
 {
-    const int32_t x = item->pos.x + ((dist * Math_Sin(ang)) >> W2V_SHIFT);
-    const int32_t y = item->pos.y - item_height;
-    const int32_t z = item->pos.z + ((dist * Math_Cos(ang)) >> W2V_SHIFT);
-    const XYZ_32 pos = { x, y, z };
+    XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, ang, dist);
+    pos.y -= item_height;
     // Something reaching down to where Lara's head would be leaves her no more
     // room than a ceiling at her feet does.
     if (Room_IsPathBlocked(

--- a/src/trx/game/lara/rope.c
+++ b/src/trx/game/lara/rope.c
@@ -23,9 +23,10 @@ const ANIM *Lara_Rope_GetSwingAnim(void)
 
 void Lara_Rope_ApplyVelocity(const int16_t angle, const uint16_t vel)
 {
-    const int32_t x_vel = (vel * Math_Sin(angle)) >> 2;
-    const int32_t z_vel = (vel * Math_Cos(angle)) >> 2;
-    Rope_SetPendulumVelocity(x_vel, 0, z_vel);
+    // A rope velocity carries twelve bits more than a position does.
+    const XYZ_32 pendulum =
+        XYZ_32_RotateYaw((XYZ_32) { .z = vel << 12 }, angle);
+    Rope_SetPendulumVelocity(pendulum.x, 0, pendulum.z);
 }
 
 void Lara_Rope_UpdateSwing(ITEM *const item)

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -21,8 +21,6 @@ static inline BOUNDS_32 M_GetStaticBounds(const STATIC_MESH *const mesh)
     // its Y rotation (see M_DrawSingleRoom). A box taken without that turn
     // sits askew of the mesh it stands for, and one at an angle the axes do
     // not share misses the portal it leans through.
-    const int32_t cos_y = Math_Cos(mesh->rot.y);
-    const int32_t sin_y = Math_Sin(mesh->rot.y);
     const int32_t xs[2] = { obj->draw_bounds.min.x, obj->draw_bounds.max.x };
     const int32_t zs[2] = { obj->draw_bounds.min.z, obj->draw_bounds.max.z };
 
@@ -40,14 +38,12 @@ static inline BOUNDS_32 M_GetStaticBounds(const STATIC_MESH *const mesh)
     };
     for (int32_t i = 0; i < 2; i++) {
         for (int32_t j = 0; j < 2; j++) {
-            const int32_t x =
-                mesh->pos.x + ((xs[i] * cos_y + zs[j] * sin_y) >> W2V_SHIFT);
-            const int32_t z =
-                mesh->pos.z + ((zs[j] * cos_y - xs[i] * sin_y) >> W2V_SHIFT);
-            bounds.min.x = MIN(bounds.min.x, x);
-            bounds.max.x = MAX(bounds.max.x, x);
-            bounds.min.z = MIN(bounds.min.z, z);
-            bounds.max.z = MAX(bounds.max.z, z);
+            const XYZ_32 corner = XYZ_32_OffsetLocalYaw(
+                mesh->pos, (XYZ_32) { .x = xs[i], .z = zs[j] }, mesh->rot.y);
+            bounds.min.x = MIN(bounds.min.x, corner.x);
+            bounds.max.x = MAX(bounds.max.x, corner.x);
+            bounds.min.z = MIN(bounds.min.z, corner.z);
+            bounds.max.z = MAX(bounds.max.z, corner.z);
         }
     }
 

--- a/src/trx/game/matrix.c
+++ b/src/trx/game/matrix.c
@@ -342,6 +342,15 @@ static void M_RotZ(MATRIX *const m, const int16_t angle)
     m->_21 = r1 >> W2V_SHIFT;
 }
 
+// Swaps a rotation for the one that undoes it. A rotation matrix's inverse is
+// its transpose, and these carry no scale.
+static void M_Transpose3x3(MATRIX *const m)
+{
+    SWAP(m->_01, m->_10);
+    SWAP(m->_02, m->_20);
+    SWAP(m->_12, m->_21);
+}
+
 static void M_RotYXZ(MATRIX *const m, const XYZ_16 rotation)
 {
     M_RotY(m, rotation.y);
@@ -467,26 +476,13 @@ void Matrix_ResetStack(void)
 
 void Matrix_GenerateW2V(const XYZ_32 *pos, const XYZ_16 *rot)
 {
-    const int32_t sx = Math_Sin(rot->x);
-    const int32_t cx = Math_Cos(rot->x);
-    const int32_t sy = Math_Sin(rot->y);
-    const int32_t cy = Math_Cos(rot->y);
-    const int32_t sz = Math_Sin(rot->z);
-    const int32_t cz = Math_Cos(rot->z);
-
     g_ViewPos = *pos;
-    g_ViewMatrix._00 = TRIGMULT3(sx, sy, sz) + TRIGMULT2(cy, cz);
-    g_ViewMatrix._01 = TRIGMULT2(cx, sz);
-    g_ViewMatrix._02 = TRIGMULT3(sx, cy, sz) - TRIGMULT2(sy, cz);
-    g_ViewMatrix._10 = TRIGMULT3(sx, sy, cz) - TRIGMULT2(cy, sz);
-    g_ViewMatrix._11 = TRIGMULT2(cx, cz);
-    g_ViewMatrix._12 = TRIGMULT3(sx, cy, cz) + TRIGMULT2(sy, sz);
-    g_ViewMatrix._20 = TRIGMULT2(cx, sy);
-    g_ViewMatrix._21 = -sx;
-    g_ViewMatrix._22 = TRIGMULT2(cx, cy);
-    g_ViewMatrix._03 = 0;
-    g_ViewMatrix._13 = 0;
-    g_ViewMatrix._23 = 0;
+
+    // The view takes the world into the camera's own axes, which is the
+    // rotation the camera stands at, undone.
+    g_ViewMatrix = g_IDMatrix;
+    M_RotYXZ(&g_ViewMatrix, *rot);
+    M_Transpose3x3(&g_ViewMatrix);
     M_TranslateRel(&g_ViewMatrix, (XYZ_32) { -pos->x, -pos->y, -pos->z });
 
     g_MatrixPtr = &m_MatrixStack[0];

--- a/src/trx/game/matrix.h
+++ b/src/trx/game/matrix.h
@@ -2,9 +2,6 @@
 
 #include <trx/core/math/types.h>
 
-#define TRIGMULT2(A, B) (((A) * (B)) >> W2V_SHIFT)
-#define TRIGMULT3(A, B, C) (TRIGMULT2((TRIGMULT2(A, B)), C))
-
 typedef struct QUATERNION {
     double x;
     double y;

--- a/src/trx/game/objects/creatures/big_eel.c
+++ b/src/trx/game/objects/creatures/big_eel.c
@@ -51,8 +51,8 @@ static void M_Control(const int16_t item_num)
     M_PRIV *const p = item->priv;
 
     int32_t pos = p->pos;
-    item->pos.z -= (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-    item->pos.x -= ((pos * Math_Sin(item->rot.y)) >> W2V_SHIFT);
+    item->pos = XYZ_32_Subtract(
+        item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = pos }, item->rot.y));
 
     if (item->hit_points <= 0) {
         if (pos < M_SLIDE) {
@@ -92,8 +92,8 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    item->pos.x += (pos * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.z += (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Add(
+        item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = pos }, item->rot.y));
     p->pos = pos;
 
     Item_Animate(item);

--- a/src/trx/game/objects/creatures/claw_mutant_plasma_ball.c
+++ b/src/trx/game/objects/creatures/claw_mutant_plasma_ball.c
@@ -131,11 +131,10 @@ static void M_Control(const int16_t effect_num)
         }
     }
 
-    const int32_t speed =
-        (effect->speed * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, speed);
-    effect->pos.y += effect->fall_speed
-        - ((effect->speed * Math_Sin(effect->rot.x)) >> W2V_SHIFT);
+    effect->pos = XYZ_32_Add(
+        effect->pos,
+        XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, effect->speed));
+    effect->pos.y += effect->fall_speed;
 
     const int32_t time4 = Output_GetTimeInGame() * 4;
     if ((time4 & 4) != 0) {

--- a/src/trx/game/objects/creatures/crawler_mutant.c
+++ b/src/trx/game/objects/creatures/crawler_mutant.c
@@ -177,23 +177,14 @@ static void M_TriggerGasThrower(
 
     for (int32_t i = 0; i < 2; i++) {
         const int32_t s = Random_GetControl() % (speed << 2) + 32;
-        const int32_t r = (s * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-        const XYZ_32 vel = {
-            .x = (r * Math_Sin(effect->rot.y)) >> W2V_SHIFT,
-            .y = -((s * Math_Sin(effect->rot.x)) >> W2V_SHIFT),
-            .z = (r * Math_Cos(effect->rot.y)) >> W2V_SHIFT,
-        };
+        const XYZ_32 vel = XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, s);
         M_TriggerGas(
             effect->pos, (XYZ_32) { vel.x << 5, vel.y << 5, vel.z << 5 }, -1);
     }
 
     {
-        const int32_t r = ((speed << 1) * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-        const XYZ_32 vel = {
-            .x = (r * Math_Sin(effect->rot.y)) >> W2V_SHIFT,
-            .y = -(((speed << 1) * Math_Sin(effect->rot.x)) >> W2V_SHIFT),
-            .z = (r * Math_Cos(effect->rot.y)) >> W2V_SHIFT,
-        };
+        const XYZ_32 vel =
+            XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, speed << 1);
         M_TriggerGas(
             effect->pos, (XYZ_32) { vel.x << 5, vel.y << 5, vel.z << 5 }, -2);
     }

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -205,11 +205,9 @@ static void M_MarkDragonDead(ITEM *const dragon_back_item)
 static void M_PushLaraAway(
     ITEM *const lara_item, ITEM *const dragon_item, const int32_t shift)
 {
-    const int32_t cy = Math_Cos(dragon_item->rot.y);
-    const int32_t sy = Math_Sin(dragon_item->rot.y);
     const int32_t base = shift < M_MID_SHIFT ? M_CLOSE_SHIFT : M_FAR_SHIFT;
-    lara_item->pos.x += (cy * (base - shift)) >> W2V_SHIFT;
-    lara_item->pos.z -= (sy * (base - shift)) >> W2V_SHIFT;
+    lara_item->pos = XYZ_32_OffsetYaw(
+        lara_item->pos, dragon_item->rot.y + DEG_90, base - shift);
 }
 
 static void M_PullDagger(ITEM *const lara_item, ITEM *const dragon_back_item)
@@ -295,18 +293,16 @@ static void M_Collision(
         return;
     }
 
-    const int32_t dx = lara_item->pos.x - item->pos.x;
-    const int32_t dz = lara_item->pos.z - item->pos.z;
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sy = Math_Sin(item->rot.y);
-    const int32_t side_shift = (cy * dz + sy * dx) >> W2V_SHIFT;
+    const XYZ_32 delta = XYZ_32_Subtract(lara_item->pos, item->pos);
+    const XYZ_32 local = XYZ_32_UnrotateYaw(delta, item->rot.y);
+    const int32_t side_shift = local.z;
 
     if (side_shift <= M_COL_L || side_shift >= M_COL_R) {
         Lara_Col_ItemPush(item, coll, true, false);
         return;
     }
 
-    const int32_t shift = (cy * dx - sy * dz) >> W2V_SHIFT;
+    const int32_t shift = local.x;
     const int32_t angle = lara_item->rot.y - item->rot.y;
     if (g_Input.action && item->object_id == O_DRAGON_BACK
         && M_IsTwoPhaseMode(item)

--- a/src/trx/game/objects/creatures/eel.c
+++ b/src/trx/game/objects/creatures/eel.c
@@ -50,8 +50,8 @@ static void M_Control(const int16_t item_num)
     M_PRIV *const p = item->priv;
 
     int32_t pos = p->pos;
-    item->pos.x -= (pos * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.z -= (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Subtract(
+        item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = pos }, item->rot.y));
 
     if (item->hit_points <= 0) {
         if (pos < M_SLIDE) {
@@ -98,8 +98,8 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    item->pos.x += (pos * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.z += (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Add(
+        item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = pos }, item->rot.y));
     p->pos = pos;
     Item_Animate(item);
 }

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -198,23 +198,14 @@ static int16_t M_TriggerGasThrower(
 
     for (int32_t i = 0; i < 2; i++) {
         const int32_t s = Random_GetControl() % (speed << 2) + 32;
-        const int32_t r = (s * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-        XYZ_32 vel = {
-            .x = (r * Math_Sin(effect->rot.y)) >> W2V_SHIFT,
-            .y = -((s * Math_Sin(effect->rot.x)) >> W2V_SHIFT),
-            .z = (r * Math_Cos(effect->rot.y)) >> W2V_SHIFT,
-        };
+        XYZ_32 vel = XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, s);
         M_TriggerGas(
             effect->pos, (XYZ_32) { vel.x << 5, vel.y << 5, vel.z << 5 }, -1);
     }
 
     {
-        const int32_t r = ((speed << 1) * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-        const XYZ_32 vel = {
-            .x = (r * Math_Sin(effect->rot.y)) >> W2V_SHIFT,
-            .y = -(((speed << 1) * Math_Sin(effect->rot.x)) >> W2V_SHIFT),
-            .z = (r * Math_Cos(effect->rot.y)) >> W2V_SHIFT,
-        };
+        const XYZ_32 vel =
+            XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, speed << 1);
         M_TriggerGas(
             effect->pos, (XYZ_32) { vel.x << 5, vel.y << 5, vel.z << 5 }, -2);
     }

--- a/src/trx/game/objects/creatures/rx_worker_3.c
+++ b/src/trx/game/objects/creatures/rx_worker_3.c
@@ -216,23 +216,14 @@ static void M_TriggerFlamethrower(const ITEM *const item, const int16_t speed)
 
     for (int32_t i = 0; i < 2; i++) {
         const int32_t s = Random_GetControl() % (speed << 2) + 32;
-        const int32_t r = (s * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-        const XYZ_32 vel = {
-            .x = (r * Math_Sin(effect->rot.y)) >> W2V_SHIFT,
-            .y = -((s * Math_Sin(effect->rot.x)) >> W2V_SHIFT),
-            .z = (r * Math_Cos(effect->rot.y)) >> W2V_SHIFT,
-        };
+        const XYZ_32 vel = XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, s);
         M_TriggerFlameSparks(
             effect->pos, (XYZ_32) { vel.x << 5, vel.y << 5, vel.z << 5 }, -1);
     }
 
     {
-        const int32_t r = ((speed << 1) * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-        const XYZ_32 vel = {
-            .x = (r * Math_Sin(effect->rot.y)) >> W2V_SHIFT,
-            .y = -(((speed << 1) * Math_Sin(effect->rot.x)) >> W2V_SHIFT),
-            .z = (r * Math_Cos(effect->rot.y)) >> W2V_SHIFT,
-        };
+        const XYZ_32 vel =
+            XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, speed << 1);
         M_TriggerFlameSparks(
             effect->pos, (XYZ_32) { vel.x << 5, vel.y << 5, vel.z << 5 }, -2);
     }

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -159,9 +159,11 @@ static void M_ExplodeLondonBoss(const ITEM *const item)
 
         for (int32_t j = 0; j < 8; j++) {
             M_SHIELD_POINT *const shield = &p->shield[i][j];
-            shield->pos.x = (dist * Math_Sin(angle << 4)) >> 13;
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = dist * 2 }, angle << 4);
+            shield->pos.x = ring.x;
             shield->pos.y = y;
-            shield->pos.z = (dist * Math_Cos(angle << 4)) >> 13;
+            shield->pos.z = ring.z;
 
             if (i != 0 && i != 4 && p->explode_count < 64) {
                 const int32_t r = Random_GetDraw() & 0x3F;
@@ -319,9 +321,11 @@ static void M_Initialise(const int16_t item_num)
 
         for (int32_t j = 0; j < 8; j++) {
             M_SHIELD_POINT *const shield = &p->shield[i][j];
-            shield->pos.x = (dist * Math_Sin(angle << 4)) >> 13;
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = dist * 2 }, angle << 4);
+            shield->pos.x = ring.x;
             shield->pos.y = m_Heights[i];
-            shield->pos.z = (dist * Math_Cos(angle << 4)) >> 13;
+            shield->pos.z = ring.z;
             shield->color = COLOR_RGB_888_BLACK;
             angle += 512;
         }

--- a/src/trx/game/objects/creatures/sophia_laser_bolt.c
+++ b/src/trx/game/objects/creatures/sophia_laser_bolt.c
@@ -40,9 +40,8 @@ static void M_Control(const int16_t item_num)
     const XYZ_32 old_pos = item->pos;
     const int16_t old_room_num = item->room_num;
 
-    const int32_t speed = (item->speed * Math_Cos(item->rot.x)) >> W2V_SHIFT;
-    item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, speed);
-    item->pos.y -= (item->speed * Math_Sin(item->rot.x)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Add(
+        item->pos, XYZ_32_FromYawPitch(item->rot.y, item->rot.x, item->speed));
 
     if (item->speed < M_SPEED) {
         item->speed += (item->speed >> 3) + 2;
@@ -155,12 +154,7 @@ static bool M_Draw(const ITEM *const item)
     const XYZ_32 origin = item->interp.result.pos;
     const XYZ_16 rot = item->interp.result.rot;
 
-    const int32_t beam_speed = (item->speed * Math_Cos(rot.x)) >> W2V_SHIFT;
-    const XYZ_32 dir = {
-        .x = (beam_speed * Math_Sin(rot.y)) >> W2V_SHIFT,
-        .y = -((item->speed * Math_Sin(rot.x)) >> W2V_SHIFT),
-        .z = (beam_speed * Math_Cos(rot.y)) >> W2V_SHIFT,
-    };
+    const XYZ_32 dir = XYZ_32_FromYawPitch(rot.y, rot.x, item->speed);
 
     Matrix_PushUnit();
     Matrix_Rot16(rot);

--- a/src/trx/game/objects/creatures/sophia_plasma_ball.c
+++ b/src/trx/game/objects/creatures/sophia_plasma_ball.c
@@ -102,11 +102,10 @@ static void M_Control(const int16_t effect_num)
         effect->rot.x -= 256;
     }
 
-    const int32_t speed =
-        (effect->speed * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, speed);
-    effect->pos.y += effect->fall_speed
-        - ((effect->speed * Math_Sin(effect->rot.x)) >> W2V_SHIFT);
+    effect->pos = XYZ_32_Add(
+        effect->pos,
+        XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, effect->speed));
+    effect->pos.y += effect->fall_speed;
 
     const int32_t time4 = Output_GetTimeInGame() * 4;
     if ((time4 & 0xF) == 0) {

--- a/src/trx/game/objects/creatures/tony.c
+++ b/src/trx/game/objects/creatures/tony.c
@@ -208,9 +208,11 @@ static void M_Explode(ITEM *const item)
 
         for (int32_t j = 0; j < 8; j++) {
             M_SHIELD_POINT *const shield = &p->shield[i][j];
-            shield->pos.x = (dist * Math_Sin(angle << 4)) >> 13;
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = dist * 2 }, angle << 4);
+            shield->pos.x = ring.x;
             shield->pos.y = y;
-            shield->pos.z = (dist * Math_Cos(angle << 4)) >> 13;
+            shield->pos.z = ring.z;
 
             if (i != 0 && i != 4 && p->explode_count < 64) {
                 int32_t r = (Random_GetDraw() & 0x1F) + 224;
@@ -281,9 +283,11 @@ static void M_Initialise(int16_t item_num)
 
         for (int32_t j = 0; j < 8; j++) {
             M_SHIELD_POINT *const shield = &p->shield[i][j];
-            shield->pos.x = (dist * Math_Sin(angle << 4)) >> 13;
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = dist * 2 }, angle << 4);
+            shield->pos.x = ring.x;
             shield->pos.y = m_Heights[i];
-            shield->pos.z = (dist * Math_Cos(angle << 4)) >> 13;
+            shield->pos.z = ring.z;
             shield->color = COLOR_RGB_888_BLACK;
             angle += 512;
         }

--- a/src/trx/game/objects/creatures/tony_fire_ball.c
+++ b/src/trx/game/objects/creatures/tony_fire_ball.c
@@ -144,9 +144,9 @@ static void M_Control(const int16_t effect_num)
             effect->fall_speed = 512;
         }
 
-        effect->pos.x += effect->speed * Math_Sin(effect->rot.y) >> W2V_SHIFT;
+        effect->pos =
+            XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
         effect->pos.y += effect->fall_speed >> 1;
-        effect->pos.z += effect->speed * Math_Cos(effect->rot.y) >> W2V_SHIFT;
         const int32_t dx = (old_pos.x - effect->pos.x) << 3;
         const int32_t dy = (old_pos.y - effect->pos.y) << 3;
         const int32_t dz = (old_pos.z - effect->pos.z) << 3;

--- a/src/trx/game/objects/creatures/trex_alpha.c
+++ b/src/trx/game/objects/creatures/trex_alpha.c
@@ -155,16 +155,12 @@ static bool M_CanAttack(const ITEM *const item, const ITEM *const target)
         return false;
     }
 
+    const XYZ_32 pivot =
+        XYZ_32_OffsetYaw(item->pos, item->rot.y, M_PIVOT_LENGTH);
     const XYZ_32 pos = {
-        .x =
-            ABS(target->pos.x
-                - (item->pos.x
-                   + ((M_PIVOT_LENGTH * Math_Sin(item->rot.y)) >> W2V_SHIFT))),
+        .x = ABS(target->pos.x - pivot.x),
         .y = ABS(target->pos.y - item->pos.y),
-        .z =
-            ABS(target->pos.z
-                - (item->pos.z
-                   + ((M_PIVOT_LENGTH * Math_Cos(item->rot.y)) >> W2V_SHIFT))),
+        .z = ABS(target->pos.z - pivot.z),
     };
     return pos.x < M_HIT_RADIUS && pos.y <= M_HIT_RADIUS
         && pos.z < M_HIT_RADIUS;

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -184,10 +184,12 @@ static void M_Explode(ITEM *const item)
         int32_t angle = (time4 & 0x3F) << 3;
         for (int32_t j = 0; j < 8; j++) {
             M_SHIELD_POINT *const shield = &p->shield[i][j];
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = rad * 2 }, angle << 4);
             shield->pos = (XYZ_16) {
-                .x = ((rad * Math_Sin(angle << 4)) >> 13),
+                .x = ring.x,
                 .y = y,
-                .z = ((rad * Math_Cos(angle << 4)) >> 13),
+                .z = ring.z,
             };
 
             if (i != 0 && i != 4 && p->explode_count < 64) {
@@ -557,13 +559,13 @@ static void M_TriggerElectricBeam(
     const XYZ_32 src_pos = { src->x, src->y, src->z };
     const XYZ_32 dst_pos = { target.x, target.y, target.z };
 
+    // The two strands run either side of the line to the target.
     const int16_t side_angle = (angle + 1024) & 0xFFF;
-    const int32_t x_off = (p->attack_type == M_ATTACK_HEAD)
-        ? (Math_Sin(side_angle << 4) >> 10)
-        : (Math_Sin(side_angle << 4) >> 11);
-    const int32_t z_off = (p->attack_type == M_ATTACK_HEAD)
-        ? (Math_Cos(side_angle << 4) >> 10)
-        : (Math_Cos(side_angle << 4) >> 11);
+    const XYZ_32 side = XYZ_32_RotateYaw(
+        (XYZ_32) { .z = p->attack_type == M_ATTACK_HEAD ? 16 : 8 },
+        side_angle << 4);
+    const int32_t x_off = side.x;
+    const int32_t z_off = side.z;
 
     int32_t y_off1 = 0;
     int32_t y_off2 = 0;
@@ -1122,9 +1124,11 @@ static void M_Initialise(const int16_t item_num)
         int32_t angle = 0;
 
         for (int32_t j = 0; j < 8; j++) {
-            p->shield[i][j].pos.x = (int16_t)((r * Math_Sin(angle << 4)) >> 13);
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = r * 2 }, angle << 4);
+            p->shield[i][j].pos.x = (int16_t)ring.x;
             p->shield[i][j].pos.y = (int16_t)y;
-            p->shield[i][j].pos.z = (int16_t)((r * Math_Cos(angle << 4)) >> 13);
+            p->shield[i][j].pos.z = (int16_t)ring.z;
             p->shield[i][j].color = (RGB_888) {};
             angle += 512;
         }

--- a/src/trx/game/objects/creatures/willard.c
+++ b/src/trx/game/objects/creatures/willard.c
@@ -381,9 +381,11 @@ static void M_Explode(ITEM *const item)
 
         for (int32_t j = 0; j < 8; j++) {
             M_SHIELD_POINT *const shield = &p->shield[i][j];
-            shield->pos.x = (dist * Math_Sin(angle << 4)) >> 13;
+            const XYZ_32 ring =
+                XYZ_32_RotateYaw((XYZ_32) { .z = dist * 2 }, angle << 4);
+            shield->pos.x = ring.x;
             shield->pos.y = y;
-            shield->pos.z = (dist * Math_Cos(angle << 4)) >> 13;
+            shield->pos.z = ring.z;
             shield->sub = (RGB_888) { 0, 0, 0 };
 
             if (i != 0 && i != 4 && p->explode_count < 64) {

--- a/src/trx/game/objects/creatures/willard_plasma_ball.c
+++ b/src/trx/game/objects/creatures/willard_plasma_ball.c
@@ -148,11 +148,10 @@ static void M_Control(const int16_t effect_num)
         }
     }
 
-    const int32_t speed =
-        (effect->speed * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, speed);
-    effect->pos.y += effect->fall_speed
-        - ((effect->speed * Math_Sin(effect->rot.x)) >> W2V_SHIFT);
+    effect->pos = XYZ_32_Add(
+        effect->pos,
+        XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, effect->speed));
+    effect->pos.y += effect->fall_speed;
 
     int16_t room_num = effect->room_num;
     const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);

--- a/src/trx/game/objects/effects/blood.c
+++ b/src/trx/game/objects/effects/blood.c
@@ -8,8 +8,7 @@ static void M_Control(const int16_t effect_num)
 {
     EFFECT *const effect = Effect_Get(effect_num);
     const OBJECT *const obj = Object_Get(effect->object_id);
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     effect->counter++;
     if (effect->counter == 4) {
         effect->frame_num--;

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -24,8 +24,7 @@ static void M_Control_TR12(const int16_t effect_num)
     EFFECT *const effect = Effect_Get(effect_num);
     effect->rot.x += 5 * DEG_1;
     effect->rot.z += 10 * DEG_1;
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     effect->pos.y += effect->fall_speed;
     effect->fall_speed += GRAVITY;
 
@@ -97,11 +96,11 @@ static void M_Control_TR3(const int16_t effect_num)
     effect->rot.x += 5 * DEG_1;
     effect->rot.z += 10 * DEG_1;
     effect->fall_speed += 3;
-    effect->pos.x +=
-        (effect->speed * Math_Sin(effect->rot.y)) >> (W2V_SHIFT + 2);
+    const XYZ_32 step =
+        XYZ_32_RotateYaw((XYZ_32) { .z = effect->speed }, effect->rot.y);
+    effect->pos.x += step.x >> 2;
     effect->pos.y += effect->fall_speed;
-    effect->pos.z +=
-        (effect->speed * Math_Cos(effect->rot.y)) >> (W2V_SHIFT + 2);
+    effect->pos.z += step.z >> 2;
 
     const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
     if (!(time4 & 0xC)) {
@@ -193,9 +192,8 @@ static void M_Control_TR4(const int16_t effect_num)
         effect->rot.x += effect->fall_speed * 4;
     }
     effect->fall_speed += GRAVITY;
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     effect->pos.y += effect->fall_speed;
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
 
     const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
     if ((time4 & 0xC) == 0 && (effect->counter & 3) != 0) {

--- a/src/trx/game/objects/effects/ember.c
+++ b/src/trx/game/objects/effects/ember.c
@@ -10,8 +10,7 @@ static void M_Control(const int16_t effect_num)
 {
     EFFECT *const effect = Effect_Get(effect_num);
     effect->fall_speed += GRAVITY;
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     effect->pos.y += effect->fall_speed;
 
     int16_t room_num = effect->room_num;

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -109,16 +109,6 @@ static void M_TR3_SideFlameDetection(
     }
 }
 
-static inline XYZ_32 M_OffsetPos(
-    const XYZ_32 base_pos, const int32_t dx, const int32_t dy, const int32_t dz)
-{
-    return (XYZ_32) {
-        .x = base_pos.x + dx,
-        .y = base_pos.y + dy,
-        .z = base_pos.z + dz,
-    };
-}
-
 static void M_TR3_ControlBig(
     EFFECT *const effect, const int32_t time4, const int32_t rnd)
 {
@@ -145,21 +135,21 @@ static void M_TR3_ControlSmall(
 {
     if (effect->counter >= 0) {
         const int32_t angle = ((effect->rot.y >> 4) & 4095) << 1;
-        const int32_t s = (288 * Math_Sin(angle << 3)) >> W2V_SHIFT;
-        const int32_t c = (288 * Math_Cos(angle << 3)) >> W2V_SHIFT;
+        const XYZ_32 pos = XYZ_32_OffsetLocalYaw(
+            effect->pos, (XYZ_32) { .z = 288 }, angle << 3);
 
         Sparks_TriggerStaticFlame(
-            M_OffsetPos(effect->pos, s, -192, c),
+            XYZ_32_Add(pos, (XYZ_32) { .y = -192 }),
             (Random_GetControl() & 15) + 32);
 
         if ((time4 & 0x18) != 0) {
             return;
         }
 
-        Sparks_TriggerFireFlame(M_OffsetPos(effect->pos, s, -224, c), -1, 1);
+        Sparks_TriggerFireFlame(XYZ_32_Add(pos, (XYZ_32) { .y = -224 }), -1, 1);
 
         if ((time4 & 0x18) == 0) {
-            Sparks_TriggerFireSmoke(M_OffsetPos(effect->pos, s, 0, c), -1, 1);
+            Sparks_TriggerFireSmoke(pos, -1, 1);
         }
         return;
     }
@@ -240,9 +230,11 @@ static void M_TR3_ControlJet(
     const int32_t x1 = (m_TR3_XZOffsets[idx1][0] << 4) - 512;
     const int32_t z1 = (m_TR3_XZOffsets[idx1][1] << 4) - 512;
     if ((time4 & 4) == 0) {
-        Sparks_TriggerFireFlame(M_OffsetPos(effect->pos, x0, 0, z0), -1, 2);
+        Sparks_TriggerFireFlame(
+            XYZ_32_Add(effect->pos, (XYZ_32) { .x = x0, .z = z0 }), -1, 2);
     } else {
-        Sparks_TriggerFireFlame(M_OffsetPos(effect->pos, x1, 0, z1), -1, 2);
+        Sparks_TriggerFireFlame(
+            XYZ_32_Add(effect->pos, (XYZ_32) { .x = x1, .z = z1 }), -1, 2);
     }
 }
 
@@ -252,14 +244,13 @@ static void M_TR3_ControlSide(
     // Side flames: alternate between direction and length phases.
     const int32_t dist = (rnd & 0xFF) + 512;
     const int32_t angle = (effect->rot.y >> 3) & 0x1FFE;
-    const int32_t s = (dist * Math_Sin(angle << 3)) >> W2V_SHIFT;
-    const int32_t c = (dist * Math_Cos(angle << 3)) >> W2V_SHIFT;
+    const XYZ_32 pos =
+        XYZ_32_OffsetLocalYaw(effect->pos, (XYZ_32) { .z = dist }, angle << 3);
 
     if (effect->flag2 != 0) {
         if ((time4 & 4) != 0) {
             Sparks_TriggerSideFlame(
-                M_OffsetPos(effect->pos, s, 0, c),
-                ((angle - 4096) & 0x1FFF) << 3,
+                pos, ((angle - 4096) & 0x1FFF) << 3,
                 (!(Random_GetControl() & 7)) ? 1 : 0, 1);
         }
 
@@ -275,8 +266,7 @@ static void M_TR3_ControlSide(
                 }
 
                 Sparks_TriggerSideFlame(
-                    M_OffsetPos(effect->pos, s, 0, c),
-                    ((angle + 4096) & 0x1FFE) << 3, size, 0);
+                    pos, ((angle + 4096) & 0x1FFE) << 3, size, 0);
             }
 
             effect->flag1 -= 2;

--- a/src/trx/game/objects/effects/gun_shell.c
+++ b/src/trx/game/objects/effects/gun_shell.c
@@ -21,11 +21,11 @@ static void M_Control(const int16_t effect_num)
     effect->rot.y += 182 * effect->speed;
     effect->rot.z += 4186;
 
-    effect->pos.x +=
-        (effect->speed * Math_Sin(effect->flag1)) >> (W2V_SHIFT + 1);
+    const XYZ_32 step =
+        XYZ_32_RotateYaw((XYZ_32) { .z = effect->speed }, effect->flag1);
+    effect->pos.x += step.x >> 1;
     effect->pos.y += effect->fall_speed;
-    effect->pos.z +=
-        (effect->speed * Math_Cos(effect->flag1)) >> (W2V_SHIFT + 1);
+    effect->pos.z += step.z >> 1;
 
     int16_t room_num = effect->room_num;
     const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);

--- a/src/trx/game/objects/effects/missile.c
+++ b/src/trx/game/objects/effects/missile.c
@@ -16,11 +16,14 @@
 
 static void M_Move(EFFECT *const effect)
 {
+    const XYZ_32 step =
+        XYZ_32_FromYawPitch(effect->rot.y, effect->rot.x, effect->speed);
+    effect->pos.x += step.x;
+    effect->pos.z += step.z;
+
+    // The height negates before the shift, and a missile flies for long
+    // enough that the unit between that and XYZ_32_FromYawPitch would tell.
     effect->pos.y += (effect->speed * Math_Sin(-effect->rot.x)) >> W2V_SHIFT;
-    const int32_t speed =
-        (effect->speed * Math_Cos(effect->rot.x)) >> W2V_SHIFT;
-    effect->pos.z += (speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.x += (speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
 }
 
 static bool M_HitFloorOrCeiling(EFFECT *const effect)

--- a/src/trx/game/objects/effects/snow_sprite.c
+++ b/src/trx/game/objects/effects/snow_sprite.c
@@ -14,8 +14,7 @@ static void M_Control(const int16_t effect_num)
         return;
     }
 
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     if (effect->fall_speed != 0) {
         effect->pos.y += effect->fall_speed;
         effect->fall_speed += GRAVITY;

--- a/src/trx/game/objects/effects/splash.c
+++ b/src/trx/game/objects/effects/splash.c
@@ -14,8 +14,7 @@ static void M_Control(const int16_t effect_num)
         return;
     }
 
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/effects/twinkle.c
+++ b/src/trx/game/objects/effects/twinkle.c
@@ -26,10 +26,8 @@ static XYZ_32 M_GetTargetPos(const ITEM *const item)
 {
     XYZ_32 pos = item->pos;
     if (item->object_id == O_DRAGON_FRONT) {
-        const int32_t c = Math_Cos(item->rot.y);
-        const int32_t s = Math_Sin(item->rot.y);
-        pos.x += (c * 1100 + s * 490) >> W2V_SHIFT;
-        pos.z += (c * 490 - s * 1100) >> W2V_SHIFT;
+        pos = XYZ_32_OffsetLocalYaw(
+            pos, (XYZ_32) { .x = 1100, .z = 490 }, item->rot.y);
         pos.y -= 540;
     }
     return pos;

--- a/src/trx/game/objects/effects/water_sprite.c
+++ b/src/trx/game/objects/effects/water_sprite.c
@@ -21,8 +21,7 @@ static void M_Control(const int16_t effect_num)
         return;
     }
 
-    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
-    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos = XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     if (effect->fall_speed != 0) {
         effect->pos.y += effect->fall_speed;
         effect->fall_speed += GRAVITY;

--- a/src/trx/game/objects/general/bat_emitter.c
+++ b/src/trx/game/objects/general/bat_emitter.c
@@ -290,12 +290,13 @@ static void M_Update(M_PRIV *const p)
             Sound_Effect(SFX_BATS_1, &bat->pos, SPM_NORMAL);
         }
 
-        const int16_t angle = bat->angle << 4;
-        const int32_t sin_v = Math_Sin(angle) >> 2;
-        const int32_t cos_v = Math_Cos(angle) >> 2;
-        bat->pos.x -= ((int64_t)bat->speed * cos_v) >> W2V_SHIFT;
+        // A bat flies along its angle's right hand, so the components come
+        // off a forward turn swapped.
+        const XYZ_32 step =
+            XYZ_32_RotateYaw((XYZ_32) { .z = bat->speed }, bat->angle << 4);
+        bat->pos.x -= step.z >> 2;
         bat->pos.y -= Random_GetControl() & 3;
-        bat->pos.z += ((int64_t)bat->speed * sin_v) >> W2V_SHIFT;
+        bat->pos.z += step.x >> 2;
         bat->wing_y_off = (bat->wing_y_off + 11) & 0x3F;
 
         if (bat->life < 128) {

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -36,21 +36,6 @@ static void M_SetTR3ProjectileShade(ITEM *const item)
     item->shade.value_2 = -1;
 }
 
-static XYZ_32 M_GetLocalZOffset(const ITEM *const item, const int32_t dist)
-{
-    const int32_t cx = Math_Cos(item->rot.x);
-    const int32_t sx = Math_Sin(item->rot.x);
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sy = Math_Sin(item->rot.y);
-
-    const int32_t horz = (dist * cx) >> W2V_SHIFT;
-    return (XYZ_32) {
-        .x = (horz * sy) >> W2V_SHIFT,
-        .y = -(dist * sx) >> W2V_SHIFT,
-        .z = (horz * cy) >> W2V_SHIFT,
-    };
-}
-
 static void M_Explode(int16_t grenade_item_num, const XYZ_32 pos)
 {
     const ITEM *const grenade_item = Item_Get(grenade_item_num);
@@ -141,24 +126,19 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    const int32_t cy = Math_Cos(target_item->rot.y);
-    const int32_t sy = Math_Sin(target_item->rot.y);
-    const int32_t cdx = projectile_item->pos.x - target_item->pos.x;
-    const int32_t cdz = projectile_item->pos.z - target_item->pos.z;
-    const int32_t odx = old_pos.x - target_item->pos.x;
-    const int32_t odz = old_pos.z - target_item->pos.z;
+    const XYZ_32 now = XYZ_32_UnrotateYaw(
+        XYZ_32_Subtract(projectile_item->pos, target_item->pos),
+        target_item->rot.y);
+    const XYZ_32 old = XYZ_32_UnrotateYaw(
+        XYZ_32_Subtract(old_pos.pos, target_item->pos), target_item->rot.y);
 
-    const int32_t rx = (cy * cdx - sy * cdz) >> W2V_SHIFT;
-    const int32_t sx = (cy * odx - sy * odz) >> W2V_SHIFT;
-    if ((rx + radius < bounds->min.x && sx + radius < bounds->min.x)
-        || (rx - radius > bounds->max.x && sx - radius > bounds->max.x)) {
+    if ((now.x + radius < bounds->min.x && old.x + radius < bounds->min.x)
+        || (now.x - radius > bounds->max.x && old.x - radius > bounds->max.x)) {
         return false;
     }
 
-    const int32_t rz = (sy * cdx + cy * cdz) >> W2V_SHIFT;
-    const int32_t sz = (sy * odx + cy * odz) >> W2V_SHIFT;
-    if ((rz + radius < bounds->min.z && sz + radius < bounds->min.z)
-        || (rz - radius > bounds->max.z && sz - radius > bounds->max.z)) {
+    if ((now.z + radius < bounds->min.z && old.z + radius < bounds->min.z)
+        || (now.z - radius > bounds->max.z && old.z - radius > bounds->max.z)) {
         return false;
     }
 
@@ -222,7 +202,8 @@ static void M_Control(const int16_t item_num)
     if (g_TRVersion == 3) {
         M_SetTR3ProjectileShade(item);
         if (!was_underwater && item->speed != 0) {
-            const XYZ_32 back_64 = M_GetLocalZOffset(item, -64);
+            const XYZ_32 back_64 =
+                XYZ_32_FromYawPitch(item->rot.y, item->rot.x, -64);
             Sparks_TriggerRocketSmoke(
                 (XYZ_32) {
                     .x = item->pos.x + back_64.x,
@@ -237,14 +218,10 @@ static void M_Control(const int16_t item_num)
     int32_t radius = 0;
 
     if (g_Config.gameplay.enable_bouncy_grenades) {
-        const XYZ_32 vel = {
-            .x = (item->speed * Math_Sin(item->goal_anim_state)) >> W2V_SHIFT,
-            .y = item->fall_speed,
-            .z = (item->speed * Math_Cos(item->goal_anim_state)) >> W2V_SHIFT,
-        };
-        item->pos.x += vel.x;
-        item->pos.y += vel.y;
-        item->pos.z += vel.z;
+        XYZ_32 vel = XYZ_32_RotateYaw(
+            (XYZ_32) { .z = item->speed }, item->goal_anim_state);
+        vel.y = item->fall_speed;
+        item->pos = XYZ_32_Add(item->pos, vel);
 
         const int16_t y_rot = item->rot.y;
         item->rot.y = item->goal_anim_state;
@@ -265,13 +242,10 @@ static void M_Control(const int16_t item_num)
         if (item->speed < M_FALL_SPEED) {
             item->fall_speed++;
         }
-        item->pos.y += item->fall_speed
-            - ((item->speed * Math_Sin(item->rot.x)) >> W2V_SHIFT);
-
-        const int16_t speed =
-            (item->speed * Math_Cos(item->rot.x)) >> W2V_SHIFT;
-        item->pos.z += (speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-        item->pos.x += (speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+        item->pos.y += item->fall_speed;
+        item->pos = XYZ_32_Add(
+            item->pos,
+            XYZ_32_FromYawPitch(item->rot.y, item->rot.x, item->speed));
 
         int16_t room_num = item->room_num;
         const SECTOR *const sector = Room_GetSector(item->pos, &room_num);

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -57,9 +57,8 @@ static void M_Control_TR3(const int16_t item_num)
 
     M_SetTR3ProjectileShade(item);
 
-    item->pos.x += (item->speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, item->speed);
     item->pos.y += item->fall_speed;
-    item->pos.z += (item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
@@ -103,24 +102,18 @@ static void M_Control_TR3(const int16_t item_num)
             continue;
         }
 
-        const int32_t cy = Math_Cos(target_item->rot.y);
-        const int32_t sy = Math_Sin(target_item->rot.y);
-        const int32_t cdx = item->pos.x - target_item->pos.x;
-        const int32_t cdz = item->pos.z - target_item->pos.z;
-        const int32_t odx = old_pos.x - target_item->pos.x;
-        const int32_t odz = old_pos.z - target_item->pos.z;
+        const XYZ_32 now = XYZ_32_UnrotateYaw(
+            XYZ_32_Subtract(item->pos, target_item->pos), target_item->rot.y);
+        const XYZ_32 old = XYZ_32_UnrotateYaw(
+            XYZ_32_Subtract(old_pos.pos, target_item->pos), target_item->rot.y);
 
-        const int32_t rx = (cy * cdx - sy * cdz) >> W2V_SHIFT;
-        const int32_t sx = (cy * odx - sy * odz) >> W2V_SHIFT;
-        if ((rx < bounds->min.x && sx < bounds->min.x)
-            || (rx > bounds->max.x && sx > bounds->max.x)) {
+        if ((now.x < bounds->min.x && old.x < bounds->min.x)
+            || (now.x > bounds->max.x && old.x > bounds->max.x)) {
             continue;
         }
 
-        const int32_t rz = (sy * cdx + cy * cdz) >> W2V_SHIFT;
-        const int32_t sz = (sy * odx + cy * odz) >> W2V_SHIFT;
-        if ((rz < bounds->min.z && sz < bounds->min.z)
-            || (rz > bounds->max.z && sz > bounds->max.z)) {
+        if ((now.z < bounds->min.z && old.z < bounds->min.z)
+            || (now.z > bounds->max.z && old.z > bounds->max.z)) {
             continue;
         }
 
@@ -218,8 +211,7 @@ static void M_Control_TR12(const int16_t item_num)
         item->fall_speed += GRAVITY / 2;
     }
 
-    item->pos.x += (item->speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.z += (item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, item->speed);
     item->pos.y += item->fall_speed;
 
     int16_t room_num = item->room_num;
@@ -266,24 +258,18 @@ static void M_Control_TR12(const int16_t item_num)
             continue;
         }
 
-        const int32_t cy = Math_Cos(target_item->rot.y);
-        const int32_t sy = Math_Sin(target_item->rot.y);
-        const int32_t cdx = item->pos.x - target_item->pos.x;
-        const int32_t cdz = item->pos.z - target_item->pos.z;
-        const int32_t odx = old_pos.x - target_item->pos.x;
-        const int32_t odz = old_pos.z - target_item->pos.z;
+        const XYZ_32 now = XYZ_32_UnrotateYaw(
+            XYZ_32_Subtract(item->pos, target_item->pos), target_item->rot.y);
+        const XYZ_32 old = XYZ_32_UnrotateYaw(
+            XYZ_32_Subtract(old_pos.pos, target_item->pos), target_item->rot.y);
 
-        const int32_t rx = (cy * cdx - sy * cdz) >> W2V_SHIFT;
-        const int32_t sx = (cy * odx - sy * odz) >> W2V_SHIFT;
-        if ((rx < bounds->min.x && sx < bounds->min.x)
-            || (rx > bounds->max.x && sx > bounds->max.x)) {
+        if ((now.x < bounds->min.x && old.x < bounds->min.x)
+            || (now.x > bounds->max.x && old.x > bounds->max.x)) {
             continue;
         }
 
-        const int32_t rz = (sy * cdx + cy * cdz) >> W2V_SHIFT;
-        const int32_t sz = (sy * odx + cy * odz) >> W2V_SHIFT;
-        if ((rz < bounds->min.z && sz < bounds->min.z)
-            || (rz > bounds->max.z && sz > bounds->max.z)) {
+        if ((now.z < bounds->min.z && old.z < bounds->min.z)
+            || (now.z > bounds->max.z && old.z > bounds->max.z)) {
             continue;
         }
 

--- a/src/trx/game/objects/general/lights/strobe_light.c
+++ b/src/trx/game/objects/general/lights/strobe_light.c
@@ -35,13 +35,7 @@ static void M_TriggerAlertLight(
     Room_GetSector(pos, &src.room_num);
 
     const int32_t dist = 8 * WALL_L;
-    GAME_VECTOR dst = {
-        .pos = {
-            .x = pos.x + ((dist * Math_Sin(angle)) >> W2V_SHIFT),
-            .y = pos.y,
-            .z = pos.z + ((dist * Math_Cos(angle)) >> W2V_SHIFT),
-        },
-    };
+    GAME_VECTOR dst = { .pos = XYZ_32_OffsetYaw(pos, angle, dist) };
 
     if (!LOS_Check(&src, &dst, false)) {
         Output_AddDynamicLightRGB(dst.pos, 8, color);
@@ -67,13 +61,9 @@ static void M_Control(const int16_t item_num)
         (XYZ_32) { item->pos.x, item->pos.y - WALL_L / 2, item->pos.z },
         (RGB_888) { 255, 64, 0 }, angle, item->room_num);
 
-    Output_AddDynamicLightRGB(
-        (XYZ_32) {
-            item->pos.x + ((STEP_L * Math_Sin(angle)) >> W2V_SHIFT),
-            item->pos.y - STEP_L * 3,
-            item->pos.z + ((STEP_L * Math_Cos(angle)) >> W2V_SHIFT),
-        },
-        6, (RGB_888) { 255, 96, 0 });
+    XYZ_32 lamp_pos = XYZ_32_OffsetYaw(item->pos, angle, STEP_L);
+    lamp_pos.y -= STEP_L * 3;
+    Output_AddDynamicLightRGB(lamp_pos, 6, (RGB_888) { 255, 96, 0 });
 
     const int32_t time4 = Output_GetTimeInGame() * 4;
     if (!(time4 & 0x7F)) {

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -35,21 +35,6 @@ static void M_SetTR3ProjectileShade(ITEM *const item)
     item->shade.value_2 = -1;
 }
 
-static XYZ_32 M_GetLocalZOffset(const ITEM *const item, const int32_t dist)
-{
-    const int32_t cx = Math_Cos(item->rot.x);
-    const int32_t sx = Math_Sin(item->rot.x);
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sy = Math_Sin(item->rot.y);
-
-    const int32_t horz = (dist * cx) >> W2V_SHIFT;
-    return (XYZ_32) {
-        .x = (horz * sy) >> W2V_SHIFT,
-        .y = -(dist * sx) >> W2V_SHIFT,
-        .z = (horz * cy) >> W2V_SHIFT,
-    };
-}
-
 static void M_Explode(const int16_t rocket_item_num, const XYZ_32 pos)
 {
     const ITEM *const rocket_item = Item_Get(rocket_item_num);
@@ -136,24 +121,19 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    const int32_t cy = Math_Cos(target_item->rot.y);
-    const int32_t sy = Math_Sin(target_item->rot.y);
-    const int32_t cdx = projectile_item->pos.x - target_item->pos.x;
-    const int32_t cdz = projectile_item->pos.z - target_item->pos.z;
-    const int32_t odx = old_pos.x - target_item->pos.x;
-    const int32_t odz = old_pos.z - target_item->pos.z;
+    const XYZ_32 now = XYZ_32_UnrotateYaw(
+        XYZ_32_Subtract(projectile_item->pos, target_item->pos),
+        target_item->rot.y);
+    const XYZ_32 old = XYZ_32_UnrotateYaw(
+        XYZ_32_Subtract(old_pos.pos, target_item->pos), target_item->rot.y);
 
-    const int32_t rx = (cy * cdx - sy * cdz) >> W2V_SHIFT;
-    const int32_t sx = (cy * odx - sy * odz) >> W2V_SHIFT;
-    if ((rx + radius < bounds->min.x && sx + radius < bounds->min.x)
-        || (rx - radius > bounds->max.x && sx - radius > bounds->max.x)) {
+    if ((now.x + radius < bounds->min.x && old.x + radius < bounds->min.x)
+        || (now.x - radius > bounds->max.x && old.x - radius > bounds->max.x)) {
         return false;
     }
 
-    const int32_t rz = (sy * cdx + cy * cdz) >> W2V_SHIFT;
-    const int32_t sz = (sy * odx + cy * odz) >> W2V_SHIFT;
-    if ((rz + radius < bounds->min.z && sz + radius < bounds->min.z)
-        || (rz - radius > bounds->max.z && sz - radius > bounds->max.z)) {
+    if ((now.z + radius < bounds->min.z && old.z + radius < bounds->min.z)
+        || (now.z - radius > bounds->max.z && old.z - radius > bounds->max.z)) {
         return false;
     }
 
@@ -210,20 +190,17 @@ static void M_Control(const int16_t item_num)
     if (g_TRVersion == 3) {
         M_SetTR3ProjectileShade(item);
 
-        const XYZ_32 back_128 = M_GetLocalZOffset(item, -128);
+        const XYZ_32 back_128 =
+            XYZ_32_FromYawPitch(item->rot.y, item->rot.x, -128);
         const int32_t back_dist = -1536 - (Random_GetControl() & 0x1FF);
-        const XYZ_32 back_vel = M_GetLocalZOffset(item, back_dist);
+        const XYZ_32 back_vel =
+            XYZ_32_FromYawPitch(item->rot.y, item->rot.x, back_dist);
 
         const int32_t time4 = Output_GetTimeInGame() * 4;
         if ((time4 & 4) != 0) {
             Sparks_TriggerRocketFlame(
-                back_128,
-                (XYZ_32) {
-                    .x = back_vel.x - back_128.x,
-                    .y = back_vel.y - back_128.y,
-                    .z = back_vel.z - back_128.z,
-                },
-                item_num, item->room_num);
+                back_128, XYZ_32_Subtract(back_vel, back_128), item_num,
+                item->room_num);
         }
 
         Sparks_TriggerRocketSmoke(
@@ -260,10 +237,8 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    const int32_t speed = (item->speed * Math_Cos(item->rot.x)) >> W2V_SHIFT;
-    item->pos.x += (speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.y -= (item->speed * Math_Sin(item->rot.x)) >> W2V_SHIFT;
-    item->pos.z += (speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Add(
+        item->pos, XYZ_32_FromYawPitch(item->rot.y, item->rot.x, item->speed));
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -315,11 +315,11 @@ static void M_Control(const int16_t item_num)
 
     leader_fish->swim = (leader_fish->swim + (leader_fish->speed >> 4)) & 0x3F;
 
-    const int32_t angle16 = leader_fish->angle << 4;
-    int32_t x = leader_fish->pos.x
-        - (leader_fish->speed * Math_Sin(angle16) >> (W2V_SHIFT + 1));
-    int32_t z = leader_fish->pos.z
-        + (leader_fish->speed * Math_Cos(angle16) >> (W2V_SHIFT + 1));
+    // A fish swims with its x mirrored, so the step's x comes off against it.
+    const XYZ_32 step = XYZ_32_RotateYaw(
+        (XYZ_32) { .z = leader_fish->speed }, leader_fish->angle << 4);
+    int32_t x = leader_fish->pos.x - (step.x >> 1);
+    int32_t z = leader_fish->pos.z + (step.z >> 1);
 
     if (piranha_attack == 0) {
         if (z < -leader->range.z) {
@@ -479,11 +479,10 @@ static void M_Control(const int16_t item_num)
         fish->swim =
             (fish->swim + (fish->speed >> 4) + (fish->speed >> 5)) & 0x3F;
 
-        const int32_t fish_angle16 = fish->angle << 4;
-        int32_t next_x = fish->pos.x
-            - (fish->speed * Math_Sin(fish_angle16) >> (W2V_SHIFT + 1));
-        int32_t next_z = fish->pos.z
-            + (fish->speed * Math_Cos(fish_angle16) >> (W2V_SHIFT + 1));
+        const XYZ_32 fish_step =
+            XYZ_32_RotateYaw((XYZ_32) { .z = fish->speed }, fish->angle << 4);
+        int32_t next_x = fish->pos.x - (fish_step.x >> 1);
+        int32_t next_z = fish->pos.z + (fish_step.z >> 1);
         CLAMP(next_x, -32000, 32000);
         CLAMP(next_z, -32000, 32000);
         fish->pos.x = next_x;
@@ -594,9 +593,10 @@ static bool M_Draw(const ITEM *const item)
             (swim_wibble + fish->interp.result.angle - 2048) & 0xFFF;
 
         const int32_t size = ((128 * Math_Sin(i << 10)) >> W2V_SHIFT) + 192;
-        const int32_t ang16 = ang12 << 4;
-        const int32_t back_x = x - ((size * Math_Sin(ang16)) >> W2V_SHIFT);
-        const int32_t back_z = z + ((size * Math_Cos(ang16)) >> W2V_SHIFT);
+        const XYZ_32 back =
+            XYZ_32_RotateYaw((XYZ_32) { .z = size }, ang12 << 4);
+        const int32_t back_x = x - back.x;
+        const int32_t back_z = z + back.z;
 
         const XYZ_32 tri_world[3] = {
             { .x = x, .y = y, .z = z },

--- a/src/trx/game/objects/general/smashable.c
+++ b/src/trx/game/objects/general/smashable.c
@@ -118,28 +118,22 @@ static bool M_Block(
         return false;
     }
 
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t s = Math_Sin(item->rot.y);
-    const int32_t from_dx = from.x - item->pos.x;
-    const int32_t from_dz = from.z - item->pos.z;
-    const int32_t to_dx = to.x - item->pos.x;
-    const int32_t to_dz = to.z - item->pos.z;
-    const int32_t from_rx = (c * from_dx - s * from_dz) >> W2V_SHIFT;
-    const int32_t from_rz = (c * from_dz + s * from_dx) >> W2V_SHIFT;
-    const int32_t to_rx = (c * to_dx - s * to_dz) >> W2V_SHIFT;
-    const int32_t to_rz = (c * to_dz + s * to_dx) >> W2V_SHIFT;
+    const XYZ_32 from_r =
+        XYZ_32_UnrotateYaw(XYZ_32_Subtract(from, item->pos), item->rot.y);
+    const XYZ_32 to_r =
+        XYZ_32_UnrotateYaw(XYZ_32_Subtract(to, item->pos), item->rot.y);
 
     const bool is_thin_in_z =
         bounds->max.z - bounds->min.z <= bounds->max.x - bounds->min.x;
-    const int32_t along = is_thin_in_z ? to_rx : to_rz;
+    const int32_t along = is_thin_in_z ? to_r.x : to_r.z;
     const int32_t along_min = is_thin_in_z ? bounds->min.x : bounds->min.z;
     const int32_t along_max = is_thin_in_z ? bounds->max.x : bounds->max.z;
     if (along < along_min || along > along_max) {
         return false;
     }
 
-    const int32_t from_across = is_thin_in_z ? from_rz : from_rx;
-    const int32_t to_across = is_thin_in_z ? to_rz : to_rx;
+    const int32_t from_across = is_thin_in_z ? from_r.z : from_r.x;
+    const int32_t to_across = is_thin_in_z ? to_r.z : to_r.x;
     const int32_t middle = is_thin_in_z ? (bounds->min.z + bounds->max.z) / 2
                                         : (bounds->min.x + bounds->max.x) / 2;
     return (from_across < middle) != (to_across < middle)

--- a/src/trx/game/objects/general/sphere_of_doom.c
+++ b/src/trx/game/objects/general/sphere_of_doom.c
@@ -35,10 +35,9 @@ static void M_Collision(
 
     lara_item->gravity = true;
     lara_item->fall_speed = -50;
-    lara_item->pos.x =
-        item->pos.x + (((radius + 50) * Math_Sin(angle)) >> W2V_SHIFT);
-    lara_item->pos.z =
-        item->pos.z + (((radius + 50) * Math_Cos(angle)) >> W2V_SHIFT);
+    const int32_t y = lara_item->pos.y;
+    lara_item->pos = XYZ_32_OffsetYaw(item->pos, angle, radius + 50);
+    lara_item->pos.y = y;
     lara_item->rot.x = 0;
     lara_item->rot.z = 0;
     Item_SwitchToAnim(lara_item, LA(LA_FALL_START), 0);

--- a/src/trx/game/objects/general/waterfall_mist.c
+++ b/src/trx/game/objects/general/waterfall_mist.c
@@ -32,13 +32,7 @@ static void M_Control(const int16_t item_num)
         const int32_t offset =
             g_TRVersion == 3 ? M_MIST_OFFSET_TR3 : M_MIST_OFFSET_TR4;
         if ((int32_t)Output_GetTimeInGame() % 4 == 0) {
-            const XYZ_32 pos = {
-                .x = item->pos.x
-                    + ((offset * Math_Sin(item->rot.y)) >> W2V_SHIFT),
-                .y = item->pos.y,
-                .z = item->pos.z
-                    + ((offset * Math_Cos(item->rot.y)) >> W2V_SHIFT),
-            };
+            const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, offset);
             Sparks_TriggerWaterfallMist(pos.x, pos.y, pos.z, item->rot.y);
         }
 

--- a/src/trx/game/objects/traps/dart.c
+++ b/src/trx/game/objects/traps/dart.c
@@ -76,10 +76,8 @@ static void M_Animate(ITEM *const item)
         return;
     }
 
-    const int32_t speed = (item->speed * Math_Cos(item->rot.x)) >> W2V_SHIFT;
-    item->pos.x += (speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.y -= (item->speed * Math_Sin(item->rot.x)) >> W2V_SHIFT;
-    item->pos.z += (speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Add(
+        item->pos, XYZ_32_FromYawPitch(item->rot.y, item->rot.x, item->speed));
 }
 
 static void M_Control(const int16_t item_num)
@@ -127,12 +125,9 @@ static bool M_DrawPoisonDart(const ITEM *const item)
 {
     const XYZ_32 origin = item->interp.result.pos;
     const XYZ_16 rot = item->interp.result.rot;
-    const int32_t size = (-96 * Math_Cos(rot.x)) >> W2V_SHIFT;
-    const XYZ_32 to = {
-        .x = origin.x + ((size * Math_Sin(rot.y)) >> W2V_SHIFT),
-        .y = origin.y + ((96 * Math_Sin(rot.x)) >> W2V_SHIFT),
-        .z = origin.z + ((size * Math_Cos(rot.y)) >> W2V_SHIFT),
-    };
+    // The dart is drawn as a line back along its own heading.
+    const XYZ_32 to =
+        XYZ_32_Add(origin, XYZ_32_FromYawPitch(rot.y, rot.x, -96));
     const RGBA_8888 color = { 0x78, 0x3C, 0x14, 0xFF };
     OutputSource_PolyFX_StageLineSegment(
         origin, color, to, color, 2.0f, DRAW_BLEND);

--- a/src/trx/game/objects/traps/fire_head.c
+++ b/src/trx/game/objects/traps/fire_head.c
@@ -99,11 +99,10 @@ static void M_TriggerFlame(
     spark->pos.z = pos.z + (Random_GetControl() & 0x1F) - 16;
 
     const int32_t dist = speed - (Random_GetControl() % ((speed >> 3) + 1));
-    spark->vel.x =
-        ((dist * Math_Sin(angle)) >> 13) + (Random_GetControl() & 0x7F) - 64;
+    const XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = dist * 2 }, angle);
+    spark->vel.x = dir.x + (Random_GetControl() & 0x7F) - 64;
     spark->vel.y = (Random_GetControl() & 7) + 6;
-    spark->vel.z =
-        ((dist * Math_Cos(angle)) >> 13) + (Random_GetControl() & 0x7F) - 64;
+    spark->vel.z = dir.z + (Random_GetControl() & 0x7F) - 64;
 
     spark->friction = 4;
     spark->flags = SPARK_F_ALT_SPRITE | SPARK_F_SPRITE | SPARK_F_SCALE;

--- a/src/trx/game/objects/traps/rotating_laser.c
+++ b/src/trx/game/objects/traps/rotating_laser.c
@@ -116,8 +116,10 @@ static void M_Control(const int16_t item_num)
         CLAMPL(p->velocity, -512);
     }
 
-    item->pos.x += (p->velocity * Math_Sin(item->rot.y)) >> (W2V_SHIFT + 2);
-    item->pos.z += (p->velocity * Math_Cos(item->rot.y)) >> (W2V_SHIFT + 2);
+    const XYZ_32 step =
+        XYZ_32_RotateYaw((XYZ_32) { .z = p->velocity }, item->rot.y);
+    item->pos.x += step.x >> 2;
+    item->pos.z += step.z >> 2;
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos, &room_num);
 

--- a/src/trx/game/objects/traps/train.c
+++ b/src/trx/game/objects/traps/train.c
@@ -32,15 +32,13 @@ static int32_t M_GetHeight(
     const ITEM *const item, const int32_t x, const int32_t z,
     int16_t *const room_num)
 {
-    XYZ_32 pos = item->pos;
-    const int32_t sy = Math_Sin(item->rot.y);
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sx = Math_Sin(item->rot.x);
-    const int32_t sz = Math_Sin(item->rot.z);
+    XYZ_32 pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x, .z = z }, item->rot.y);
 
-    pos.x += (z * sy + x * cy) >> W2V_SHIFT;
-    pos.z += (z * cy - x * sy) >> W2V_SHIFT;
-    pos.y = ((x * sz) >> W2V_SHIFT) + (item->pos.y - ((z * sx) >> W2V_SHIFT));
+    // The height a wheel sits at follows the train's pitch and roll, which the
+    // yaw turn above says nothing about.
+    pos.y = ((x * Math_Sin(item->rot.z)) >> W2V_SHIFT)
+        + (item->pos.y - ((z * Math_Sin(item->rot.x)) >> W2V_SHIFT));
 
     *room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, room_num);

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -109,10 +109,8 @@ static int32_t M_CheckGetOn(const int16_t item_num, const COLL_INFO *const coll)
 
     ITEM *const boat_item = Item_Get(item_num);
     const ITEM *const lara_item = Lara_GetItem();
-    const int32_t dist =
-        ((lara_item->pos.z - boat_item->pos.z) * Math_Cos(-boat_item->rot.y)
-         - (lara_item->pos.x - boat_item->pos.x) * Math_Sin(-boat_item->rot.y))
-        >> W2V_SHIFT;
+    const XYZ_32 delta = XYZ_32_Subtract(lara_item->pos, boat_item->pos);
+    const int32_t dist = XYZ_32_UnrotateYaw(delta, boat_item->rot.y).z;
 
     if (dist > 200) {
         return 0;
@@ -168,16 +166,16 @@ static int32_t M_TestWaterHeight(
     const ITEM *const item, const int32_t z_off, const int32_t x_off,
     XYZ_32 *const pos)
 {
+    *pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x_off, .z = z_off }, item->rot.y);
+
+    // The height the boat sits at follows its pitch and roll, which the yaw
+    // turn above says nothing about.
     // clang-format off
     pos->y = item->pos.y
         + ((x_off * Math_Sin(item->rot.z)) >> W2V_SHIFT)
         - ((z_off * Math_Sin(item->rot.x)) >> W2V_SHIFT);
     // clang-format on
-
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t s = Math_Sin(item->rot.y);
-    pos->x = item->pos.x + ((x_off * c + z_off * s) >> W2V_SHIFT);
-    pos->z = item->pos.z + ((z_off * c - x_off * s) >> W2V_SHIFT);
 
     int16_t room_num = item->room_num;
     Room_GetSector(*pos, &room_num);
@@ -213,13 +211,10 @@ static void M_DoWakeEffect(const ITEM *const boat_item)
         effect->room_num = boat_item->room_num;
         effect->frame_num = frame;
 
-        const int32_t c = Math_Cos(boat_item->rot.y);
-        const int32_t s = Math_Sin(boat_item->rot.y);
         const int32_t w = (1 - i) * M_SIDE;
         const int32_t h = M_WAKE_SIZE;
-        effect->pos.x = boat_item->pos.x + ((-c * w - s * h) >> W2V_SHIFT);
-        effect->pos.y = boat_item->pos.y;
-        effect->pos.z = boat_item->pos.z + ((-c * h + s * w) >> W2V_SHIFT);
+        effect->pos = XYZ_32_OffsetLocalYaw(
+            boat_item->pos, (XYZ_32) { .x = -w, .z = -h }, boat_item->rot.y);
         effect->rot.y = boat_item->rot.y + (i << W2V_SHIFT) - DEG_90;
 
         effect->counter = 20;
@@ -261,18 +256,19 @@ static void M_DoShift(const int32_t boat_num)
 
         if (item->object_id == O_GONDOLA
             && item->current_anim_state == GONDOLA_STATE_FLOATING) {
-            const int32_t c = Math_Cos(item->rot.y);
-            const int32_t s = Math_Sin(item->rot.y);
-            const int32_t ix = item->pos.x - ((s * STEP_L * 2) >> W2V_SHIFT);
-            const int32_t iz = item->pos.z - ((c * STEP_L * 2) >> W2V_SHIFT);
-            const int32_t dx = ix - boat_item->pos.x;
-            const int32_t dz = iz - boat_item->pos.z;
+            const XYZ_32 stern = XYZ_32_Subtract(
+                item->pos,
+                XYZ_32_RotateYaw((XYZ_32) { .z = STEP_L * 2 }, item->rot.y));
+            const int32_t dx = stern.x - boat_item->pos.x;
+            const int32_t dz = stern.z - boat_item->pos.z;
             const int32_t dist = SQUARE(dx) + SQUARE(dz);
 
             if (dist < SQUARE(M_RADIUS * 2)) {
                 if (boat_item->speed < M_MAX_SPEED - 10) {
-                    boat_item->pos.x = ix - SQUARE(M_RADIUS * 2) * dx / dist;
-                    boat_item->pos.z = iz - SQUARE(M_RADIUS * 2) * dz / dist;
+                    boat_item->pos.x =
+                        stern.x - SQUARE(M_RADIUS * 2) * dx / dist;
+                    boat_item->pos.z =
+                        stern.z - SQUARE(M_RADIUS * 2) * dz / dist;
                 } else if (item->pos.y - boat_item->pos.y < WALL_L * 2) {
                     Sound_Effect(SFX_BOAT_INTO_WATER, &item->pos, SPM_NORMAL);
                     item->goal_anim_state = GONDOLA_STATE_CRASH;
@@ -334,26 +330,29 @@ static int32_t M_Dynamics(const int16_t boat_num)
     boat_item->rot.y += p->extra_rotation + p->boat_turn;
     p->tilt_angle = p->boat_turn * 6;
 
-    boat_item->pos.z +=
-        (boat_item->speed * Math_Cos(boat_item->rot.y)) >> W2V_SHIFT;
-    boat_item->pos.x +=
-        (boat_item->speed * Math_Sin(boat_item->rot.y)) >> W2V_SHIFT;
+    boat_item->pos =
+        XYZ_32_OffsetYaw(boat_item->pos, boat_item->rot.y, boat_item->speed);
 
     int32_t slip = (Math_Sin(boat_item->rot.z) * 30) >> W2V_SHIFT;
     if (!slip && boat_item->rot.z) {
         slip = boat_item->rot.z > 0 ? 1 : -1;
     }
-    boat_item->pos.z -= (slip * Math_Sin(boat_item->rot.y)) >> W2V_SHIFT;
-    boat_item->pos.x += (slip * Math_Cos(boat_item->rot.y)) >> W2V_SHIFT;
+    // Sideways, along the boat's beam. Both slides read their components off
+    // a forward turn so that each rounds as it did: a slide runs frame after
+    // frame, and a unit a frame would tell.
+    const XYZ_32 roll_slip =
+        XYZ_32_RotateYaw((XYZ_32) { .z = slip }, boat_item->rot.y);
+    boat_item->pos.x += roll_slip.z;
+    boat_item->pos.z -= roll_slip.x;
 
     slip = (Math_Sin(boat_item->rot.x) * 10) >> W2V_SHIFT;
     if (!slip && boat_item->rot.x) {
         slip = boat_item->rot.x > 0 ? 1 : -1;
     }
 
-    boat_item->pos.z -= (slip * Math_Cos(boat_item->rot.y)) >> W2V_SHIFT;
-    boat_item->pos.x =
-        boat_item->pos.x - ((slip * Math_Sin(boat_item->rot.y)) >> W2V_SHIFT);
+    boat_item->pos = XYZ_32_Subtract(
+        boat_item->pos,
+        XYZ_32_RotateYaw((XYZ_32) { .z = slip }, boat_item->rot.y));
 
     XYZ_32 moved = {
         .x = boat_item->pos.x,
@@ -410,12 +409,8 @@ static int32_t M_Dynamics(const int16_t boat_num)
 
     const int32_t collide = Vehicle_GetCollisionAnim(boat_item, &moved);
     if (slip || collide) {
-        // clang-format off
-        const int32_t new_speed = (
-            (boat_item->pos.z - old.z) * Math_Cos(boat_item->rot.y) +
-            (boat_item->pos.x - old.x) * Math_Sin(boat_item->rot.y)
-        ) >> W2V_SHIFT;
-        // clang-format on
+        const XYZ_32 delta = XYZ_32_Subtract(boat_item->pos, old);
+        const int32_t new_speed = XYZ_32_UnrotateYaw(delta, boat_item->rot.y).z;
 
         if (Lara_Vehicle_GetIndex() == boat_num) {
             if (boat_item->speed > M_MAX_SPEED + M_ACCELERATION
@@ -820,13 +815,8 @@ static void M_Control(const int16_t item_num)
         lara_item->fall_speed = -40;
         Lara_Vehicle_SetIndex(NO_ITEM);
 
-        const XYZ_32 pos = {
-            .x = lara_item->pos.x
-                + ((360 * Math_Sin(lara_item->rot.y)) >> W2V_SHIFT),
-            .y = lara_item->pos.y - 90,
-            .z = lara_item->pos.z
-                + ((360 * Math_Cos(lara_item->rot.y)) >> W2V_SHIFT),
-        };
+        XYZ_32 pos = XYZ_32_OffsetYaw(lara_item->pos, lara_item->rot.y, 360);
+        pos.y -= 90;
 
         room_num = lara_item->room_num;
         sector = Room_GetSector(pos, &room_num);

--- a/src/trx/game/objects/vehicles/common.c
+++ b/src/trx/game/objects/vehicles/common.c
@@ -144,10 +144,9 @@ int32_t Vehicle_GetCollisionAnim(const ITEM *const vehicle, XYZ_32 *const moved)
     moved->z = vehicle->pos.z - moved->z;
 
     if (moved->x != 0 || moved->z != 0) {
-        const int32_t c = Math_Cos(vehicle->rot.y);
-        const int32_t s = Math_Sin(vehicle->rot.y);
-        const int32_t front = (moved->x * s + moved->z * c) >> W2V_SHIFT;
-        const int32_t side = (moved->x * c - moved->z * s) >> W2V_SHIFT;
+        const XYZ_32 local = XYZ_32_UnrotateYaw(*moved, vehicle->rot.y);
+        const int32_t front = local.z;
+        const int32_t side = local.x;
         if (ABS(front) > ABS(side)) {
             if (front > 0) {
                 return LA_VEHICLE_HIT_BACK;

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -781,10 +781,10 @@ static int32_t M_GetCollisionAnim(const ITEM *const item, int32_t x, int32_t z)
         return 0;
     }
 
-    const int32_t s = Math_Sin(item->rot.y);
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t front = (x * s + z * c) >> W2V_SHIFT;
-    const int32_t side = (x * c - z * s) >> W2V_SHIFT;
+    const XYZ_32 local =
+        XYZ_32_UnrotateYaw((XYZ_32) { .x = x, .z = z }, item->rot.y);
+    const int32_t front = local.z;
+    const int32_t side = local.x;
     if (ABS(front) <= ABS(side)) {
         if (side > 0) {
             return 3;
@@ -919,11 +919,8 @@ static void M_KayakToBackground(ITEM *const item, M_PRIV *const p)
     }
 
     if (M_GetCollisionAnim(item, old_x, old_z)) {
-        const int32_t sin_y = Math_Sin(item->rot.y);
-        const int32_t cos_y = Math_Cos(item->rot.y);
-        const int32_t dx = item->pos.x - old_pos[8].x;
-        const int32_t dz = item->pos.z - old_pos[8].z;
-        int32_t speed = (dx * sin_y + dz * cos_y) >> W2V_SHIFT;
+        const XYZ_32 delta = XYZ_32_Subtract(item->pos, old_pos[8]);
+        int32_t speed = XYZ_32_UnrotateYaw(delta, item->rot.y).z;
         speed <<= 8;
 
         if ((p->vel > 0 && speed < p->vel) || (p->vel < 0 && speed > p->vel)) {

--- a/src/trx/game/objects/vehicles/mine_cart.c
+++ b/src/trx/game/objects/vehicles/mine_cart.c
@@ -362,14 +362,13 @@ static int32_t M_GetCollision(
 
 static int32_t M_GetHeight(ITEM *const item, const int32_t x, const int32_t z)
 {
-    const int32_t s = Math_Sin(item->rot.y);
-    const int32_t c = Math_Cos(item->rot.y);
-    const XYZ_32 pos = {
-        .x = item->pos.x + ((x * c + z * s) >> W2V_SHIFT),
-        .y = (item->pos.y + ((x * Math_Sin(item->rot.z)) >> W2V_SHIFT))
-            - ((z * Math_Sin(item->rot.x)) >> W2V_SHIFT),
-        .z = item->pos.z + ((z * c - x * s) >> W2V_SHIFT),
-    };
+    XYZ_32 pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x, .z = z }, item->rot.y);
+
+    // The height a wheel sits at follows the cart's pitch and roll, which the
+    // yaw turn above says nothing about.
+    pos.y = (item->pos.y + ((x * Math_Sin(item->rot.z)) >> W2V_SHIFT))
+        - ((z * Math_Sin(item->rot.x)) >> W2V_SHIFT);
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     return Room_GetHeight(sector, pos);
@@ -783,29 +782,11 @@ static void M_Move(ITEM *const item)
         }
 
         if (p->turn.side != M_SIDE_NONE) {
-            const uint16_t quadrant = (uint16_t)item->rot.y >> W2V_SHIFT;
-            const int16_t angle = item->rot.y & M_ANGLE_CLAMP;
-
-            XZ_32 shift = {};
-            switch (quadrant) {
-            case DIR_NORTH:
-                shift.x = -Math_Cos(angle);
-                shift.z = Math_Sin(angle);
-                break;
-            case DIR_EAST:
-                shift.x = Math_Sin(angle);
-                shift.z = Math_Cos(angle);
-                break;
-            case DIR_SOUTH:
-                shift.x = Math_Cos(angle);
-                shift.z = -Math_Sin(angle);
-                break;
-            default:
-                shift.x = -Math_Sin(angle);
-                shift.z = -Math_Cos(angle);
-                break;
-            }
-
+            // The cart swings around a point off to one side, so the shift
+            // is a unit vector out to its left, at the scale the trig table
+            // works in. The original took the quadrant apart to get it.
+            XYZ_32 shift = XYZ_32_RotateYaw(
+                (XYZ_32) { .x = -(1 << W2V_SHIFT) }, item->rot.y);
             if (p->turn.side == M_SIDE_LEFT) {
                 shift.x = -shift.x;
                 shift.z = -shift.z;

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -377,8 +377,9 @@ static bool M_CheckGetOff(void)
         Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
         lara_item->current_anim_state = LS_STOP;
         lara_item->goal_anim_state = LS_STOP;
-        lara_item->pos.x -= (512 * Math_Sin(lara_item->rot.y)) >> W2V_SHIFT;
-        lara_item->pos.z -= (512 * Math_Cos(lara_item->rot.y)) >> W2V_SHIFT;
+        lara_item->pos = XYZ_32_Subtract(
+            lara_item->pos,
+            XYZ_32_RotateYaw((XYZ_32) { .z = 512 }, lara_item->rot.y));
         lara_item->rot.x = 0;
         lara_item->rot.z = 0;
         Lara_Vehicle_SetIndex(NO_ITEM);
@@ -420,14 +421,16 @@ static bool M_CheckGetOff(void)
 }
 
 static int32_t M_TestHeight(
-    const ITEM *const item, const int32_t x, const int32_t z, XYZ_32 *const pos)
+    const ITEM *const item, const int32_t z_off, const int32_t x_off,
+    XYZ_32 *const pos)
 {
-    const int32_t s = Math_Sin(item->rot.y);
-    const int32_t c = Math_Cos(item->rot.y);
-    pos->x = item->pos.x + ((z * c + x * s) >> W2V_SHIFT);
-    pos->y = item->pos.y + ((z * Math_Sin(item->rot.z)) >> W2V_SHIFT)
-        - ((x * Math_Sin(item->rot.x)) >> W2V_SHIFT);
-    pos->z = item->pos.z + ((x * c - z * s) >> W2V_SHIFT);
+    *pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x_off, .z = z_off }, item->rot.y);
+
+    // The height a wheel sits at follows the quad's pitch and roll, which the
+    // yaw turn above says nothing about.
+    pos->y = item->pos.y + ((x_off * Math_Sin(item->rot.z)) >> W2V_SHIFT)
+        - ((z_off * Math_Sin(item->rot.x)) >> W2V_SHIFT);
 
     int16_t room_num = item->room_num;
     SECTOR *const sector = Room_GetSector(*pos, &room_num);
@@ -495,12 +498,11 @@ static void M_TriggerExhaustSmoke(
         .y = pos.y + (Random_GetControl() & 0xF) - 8,
         .z = pos.z + (Random_GetControl() & 0xF) - 8,
     };
+    const XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = speed }, angle);
     spark->vel = (XYZ_32) {
-        .x = (Random_GetControl() & 0xFF) + ((speed * Math_Sin(angle)) >> 16)
-            - 128,
+        .x = (Random_GetControl() & 0xFF) + (dir.x >> 2) - 128,
         .y = -8 - (Random_GetControl() & 7),
-        .z = (Random_GetControl() & 0xFF) + ((speed * Math_Cos(angle)) >> 16)
-            - 128,
+        .z = (Random_GetControl() & 0xFF) + (dir.z >> 2) - 128,
     };
     spark->friction = 4;
 
@@ -561,10 +563,9 @@ static int32_t M_GetCollisionAnim(ITEM *const item, XYZ_32 *const pos)
         return 0;
     }
 
-    const int32_t s = Math_Sin(item->rot.y);
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t fb = (pos->x * s + pos->z * c) >> W2V_SHIFT;
-    const int32_t lr = (pos->x * c - pos->z * s) >> W2V_SHIFT;
+    const XYZ_32 local = XYZ_32_UnrotateYaw(*pos, item->rot.y);
+    const int32_t fb = local.z;
+    const int32_t lr = local.x;
 
     if (ABS(fb) > ABS(lr)) {
         return fb > 0 ? 14 : 13;
@@ -842,8 +843,7 @@ static int32_t M_SkidooDynamics(ITEM *const item)
         ? item->speed
         : (item->speed * Math_Cos(item->rot.x)) >> W2V_SHIFT;
 
-    item->pos.x += (speed * Math_Sin(quad->momentum_angle)) >> W2V_SHIFT;
-    item->pos.z += (speed * Math_Cos(quad->momentum_angle)) >> W2V_SHIFT;
+    item->pos = XYZ_32_OffsetYaw(item->pos, quad->momentum_angle, speed);
 
     int32_t slip = (100 * Math_Sin(item->rot.x)) >> W2V_SHIFT;
     if (ABS(slip) > 50) {
@@ -855,16 +855,20 @@ static int32_t M_SkidooDynamics(ITEM *const item)
             slip += 10;
         }
 
-        item->pos.x -= (slip * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-        item->pos.z -= (slip * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+        item->pos = XYZ_32_Subtract(
+            item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = slip }, item->rot.y));
     }
 
     slip = (50 * Math_Sin(item->rot.z)) >> W2V_SHIFT;
 
     if (ABS(slip) > 25) {
         m_DontExitQuad = true;
-        item->pos.x += (slip * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-        item->pos.z -= (slip * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+        // Sideways, along the quad's own x, read off a forward turn so that
+        // each component rounds as it did.
+        const XYZ_32 roll_slip =
+            XYZ_32_RotateYaw((XYZ_32) { .z = slip }, item->rot.y);
+        item->pos.x += roll_slip.z;
+        item->pos.z -= roll_slip.x;
     }
 
     new_pos.x = item->pos.x;
@@ -969,11 +973,8 @@ static int32_t M_SkidooDynamics(ITEM *const item)
     const int32_t anim = M_GetCollisionAnim(item, &new_pos);
 
     if (anim != 0) {
-        const int32_t dx = item->pos.x - old_pos.x;
-        const int32_t dz = item->pos.z - old_pos.z;
-        int32_t speed2 = (dx * Math_Sin(quad->momentum_angle)
-                          + dz * Math_Cos(quad->momentum_angle))
-            >> W2V_SHIFT;
+        const XYZ_32 delta = XYZ_32_Subtract(item->pos, old_pos);
+        int32_t speed2 = XYZ_32_UnrotateYaw(delta, quad->momentum_angle).z;
         speed2 <<= 8;
 
         if (Lara_Vehicle_GetItem() == item && quad->velocity == 0xA000

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -126,10 +126,8 @@ static M_MOUNT_TYPE M_CheckMount(
 
     ITEM *const item = Item_Get(item_num);
     ITEM *const lara_item = Lara_GetItem();
-    const int32_t dx = lara_item->pos.x - item->pos.x;
-    const int32_t dz = lara_item->pos.z - item->pos.z;
-    if ((dz * Math_Cos(-item->rot.y) - dx * Math_Sin(-item->rot.y)) >> W2V_SHIFT
-        > WALL_L / 2) {
+    const XYZ_32 delta = XYZ_32_Subtract(lara_item->pos, item->pos);
+    if (XYZ_32_UnrotateYaw(delta, item->rot.y).z > WALL_L / 2) {
         return M_MOUNT_NONE;
     }
 
@@ -431,15 +429,13 @@ static int32_t M_TestWaterHeight(
     const ITEM *const item, const int32_t z_off, const int32_t x_off,
     XYZ_32 *const pos)
 {
-    const int32_t sx = Math_Sin(item->rot.x);
-    const int32_t sz = Math_Sin(item->rot.z);
-    pos->y =
-        item->pos.y + ((x_off * sz) >> W2V_SHIFT) - ((z_off * sx) >> W2V_SHIFT);
+    *pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x_off, .z = z_off }, item->rot.y);
 
-    const int32_t sy = Math_Sin(item->rot.y);
-    const int32_t cy = Math_Cos(item->rot.y);
-    pos->x = item->pos.x + ((x_off * cy + z_off * sy) >> W2V_SHIFT);
-    pos->z = item->pos.z + ((z_off * cy - x_off * sy) >> W2V_SHIFT);
+    // The height the hull sits at follows the boat's pitch and roll, which the
+    // yaw turn above says nothing about.
+    pos->y = item->pos.y + ((x_off * Math_Sin(item->rot.z)) >> W2V_SHIFT)
+        - ((z_off * Math_Sin(item->rot.x)) >> W2V_SHIFT);
 
     int16_t room_num = item->room_num;
     Room_GetSector(*pos, &room_num);
@@ -549,15 +545,20 @@ static int32_t M_Dynamics(const int16_t item_num)
     if (slip == 0 && item->rot.z != 0) {
         slip = item->rot.z > 0 ? 1 : -1;
     }
-    item->pos.x += (slip * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-    item->pos.z -= (slip * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+    // Sideways, along the boat's beam. Both slides read their components off
+    // a forward turn so that each rounds as it did: a slide runs frame after
+    // frame, and a unit a frame would tell.
+    const XYZ_32 roll_slip =
+        XYZ_32_RotateYaw((XYZ_32) { .z = slip }, item->rot.y);
+    item->pos.x += roll_slip.z;
+    item->pos.z -= roll_slip.x;
 
     slip = (Math_Sin(item->rot.x) * 10) >> W2V_SHIFT;
     if (slip == 0 && item->rot.x != 0) {
         slip = item->rot.x > 0 ? 1 : -1;
     }
-    item->pos.x -= (slip * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-    item->pos.z -= (slip * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    item->pos = XYZ_32_Subtract(
+        item->pos, XYZ_32_RotateYaw((XYZ_32) { .z = slip }, item->rot.y));
 
     XYZ_32 moved = {
         .x = item->pos.x,
@@ -590,9 +591,8 @@ static int32_t M_Dynamics(const int16_t item_num)
     const int32_t coll_anim = Vehicle_GetCollisionAnim(item, &moved);
 
     if (slip != 0 || coll_anim != 0) {
-        const int32_t sx = (item->pos.x - old_pos.x) * Math_Sin(item->rot.y);
-        const int32_t sz = (item->pos.z - old_pos.z) * Math_Cos(item->rot.y);
-        int32_t new_speed = (sx + sz) >> W2V_SHIFT;
+        const XYZ_32 delta = XYZ_32_Subtract(item->pos, old_pos);
+        int32_t new_speed = XYZ_32_UnrotateYaw(delta, item->rot.y).z;
 
         if (Lara_Vehicle_GetIndex() == item_num
             && item->speed > (M_MAX_SPEED + M_ACCELERATION)
@@ -681,11 +681,10 @@ static void M_TriggerMist(
     spark->pos.x = pos.x + (Random_GetControl() & 0xF) - 8;
     spark->pos.y = pos.y + (Random_GetControl() & 0xF) - 8;
     spark->pos.z = pos.z + (Random_GetControl() & 0xF) - 8;
-    spark->vel.x = (Random_GetControl() & 0x7F)
-        + ((speed * Math_Sin(angle)) >> (W2V_SHIFT + 2)) - 64;
+    const XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = speed }, angle);
+    spark->vel.x = (Random_GetControl() & 0x7F) + (dir.x >> 2) - 64;
     spark->vel.y = 12 * speed;
-    spark->vel.z = (Random_GetControl() & 0x7F)
-        + ((speed * Math_Cos(angle)) >> (W2V_SHIFT + 2)) - 64;
+    spark->vel.z = (Random_GetControl() & 0x7F) + (dir.z >> 2) - 64;
     spark->friction = 3;
 
     if ((Random_GetControl() & 1) != 0) {

--- a/src/trx/game/objects/vehicles/skidoo_armed.c
+++ b/src/trx/game/objects/vehicles/skidoo_armed.c
@@ -53,13 +53,10 @@ static void M_Setup(OBJECT *const obj)
 void SkidooArmed_Push(
     const ITEM *const item, ITEM *const lara_item, const int32_t radius)
 {
-    const int32_t dx = lara_item->pos.x - item->pos.x;
-    const int32_t dz = lara_item->pos.z - item->pos.z;
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sy = Math_Sin(item->rot.y);
-
-    int32_t rx = (cy * dx - sy * dz) >> W2V_SHIFT;
-    int32_t rz = (sy * dx + cy * dz) >> W2V_SHIFT;
+    const XYZ_32 local = XYZ_32_UnrotateYaw(
+        XYZ_32_Subtract(lara_item->pos, item->pos), item->rot.y);
+    int32_t rx = local.x;
+    int32_t rz = local.z;
 
     const ANIM_FRAME *const best_frame = Item_GetBestFrame(item);
     BOUNDS_16 bounds = {
@@ -88,8 +85,10 @@ void SkidooArmed_Push(
         rz -= b;
     }
 
-    lara_item->pos.x = item->pos.x + ((rz * sy + rx * cy) >> W2V_SHIFT);
-    lara_item->pos.z = item->pos.z + ((rz * cy - rx * sy) >> W2V_SHIFT);
+    const XYZ_32 pushed = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = rx, .z = rz }, item->rot.y);
+    lara_item->pos.x = pushed.x;
+    lara_item->pos.z = pushed.z;
 }
 
 REGISTER_OBJECT(O_SKIDOO_ARMED, M_Setup)

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -266,13 +266,14 @@ int32_t Skidoo_TestHeight(
     const ITEM *const item, const int32_t z_off, const int32_t x_off,
     XYZ_32 *const out_pos)
 {
-    const int32_t sx = Math_Sin(item->rot.x);
-    const int32_t sz = Math_Sin(item->rot.z);
-    const int32_t cy = Math_Cos(item->rot.y);
-    const int32_t sy = Math_Sin(item->rot.y);
-    out_pos->x = item->pos.x + ((x_off * cy + z_off * sy) >> W2V_SHIFT);
-    out_pos->y = item->pos.y + ((x_off * sz - z_off * sx) >> W2V_SHIFT);
-    out_pos->z = item->pos.z + ((z_off * cy - x_off * sy) >> W2V_SHIFT);
+    *out_pos = XYZ_32_OffsetLocalYaw(
+        item->pos, (XYZ_32) { .x = x_off, .z = z_off }, item->rot.y);
+
+    // The height a ski sits at follows the skidoo's pitch and roll, which the
+    // yaw turn above says nothing about.
+    out_pos->y = item->pos.y
+        + ((x_off * Math_Sin(item->rot.z) - z_off * Math_Sin(item->rot.x))
+           >> W2V_SHIFT);
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(*out_pos, &room_num);
 
@@ -302,14 +303,12 @@ void Skidoo_DoSnowEffect(const ITEM *const skidoo)
         return;
     }
 
-    const int32_t sx = Math_Sin(skidoo->rot.x);
-    const int32_t sy = Math_Sin(skidoo->rot.y);
-    const int32_t cy = Math_Cos(skidoo->rot.y);
     const int32_t x = (M_SIDE * (Random_GetDraw() - 0x4000)) >> 14;
     EFFECT *const effect = Effect_Get(effect_num);
-    effect->pos.x = skidoo->pos.x - ((sy * M_SNOW + cy * x) >> W2V_SHIFT);
-    effect->pos.y = skidoo->pos.y + ((sx * M_SNOW) >> W2V_SHIFT);
-    effect->pos.z = skidoo->pos.z - ((cy * M_SNOW - sy * x) >> W2V_SHIFT);
+    effect->pos = XYZ_32_OffsetLocalYaw(
+        skidoo->pos, (XYZ_32) { .x = -x, .z = -M_SNOW }, skidoo->rot.y);
+    effect->pos.y =
+        skidoo->pos.y + ((Math_Sin(skidoo->rot.x) * M_SNOW) >> W2V_SHIFT);
     effect->room_num = skidoo->room_num;
     effect->object_id = O_SNOW_SPRITE;
     effect->frame_num = 0;
@@ -385,22 +384,25 @@ int32_t Skidoo_Dynamics(ITEM *const skidoo)
         }
     }
 
-    skidoo->pos.z +=
-        (skidoo->speed * Math_Cos(skidoo_data->momentum_angle)) >> W2V_SHIFT;
-    skidoo->pos.x +=
-        (skidoo->speed * Math_Sin(skidoo_data->momentum_angle)) >> W2V_SHIFT;
+    skidoo->pos = XYZ_32_OffsetYaw(
+        skidoo->pos, skidoo_data->momentum_angle, skidoo->speed);
 
     int32_t slip;
     slip = (M_SLIP * Math_Sin(skidoo->rot.x)) >> W2V_SHIFT;
     if (ABS(slip) > M_SLIP / 2) {
-        skidoo->pos.z -= (slip * Math_Cos(skidoo->rot.y)) >> W2V_SHIFT;
-        skidoo->pos.x -= (slip * Math_Sin(skidoo->rot.y)) >> W2V_SHIFT;
+        skidoo->pos = XYZ_32_Subtract(
+            skidoo->pos,
+            XYZ_32_RotateYaw((XYZ_32) { .z = slip }, skidoo->rot.y));
     }
 
     slip = (M_SLIP_SIDE * Math_Sin(skidoo->rot.z)) >> W2V_SHIFT;
     if (ABS(slip) > M_SLIP_SIDE / 2) {
-        skidoo->pos.z -= (slip * Math_Sin(skidoo->rot.y)) >> W2V_SHIFT;
-        skidoo->pos.x += (slip * Math_Cos(skidoo->rot.y)) >> W2V_SHIFT;
+        // Sideways, along the skidoo's own x, read off a forward turn so
+        // that each component rounds as it did.
+        const XYZ_32 roll_slip =
+            XYZ_32_RotateYaw((XYZ_32) { .z = slip }, skidoo->rot.y);
+        skidoo->pos.x += roll_slip.z;
+        skidoo->pos.z -= roll_slip.x;
     }
 
     XYZ_32 moved = {
@@ -445,11 +447,9 @@ int32_t Skidoo_Dynamics(ITEM *const skidoo)
 
     int32_t collide = Vehicle_GetCollisionAnim(skidoo, &moved);
     if (collide != 0) {
-        const int32_t c = Math_Cos(skidoo_data->momentum_angle);
-        const int32_t s = Math_Sin(skidoo_data->momentum_angle);
-        const int32_t dx = skidoo->pos.x - old.x;
-        const int32_t dz = skidoo->pos.z - old.z;
-        const int32_t new_speed = (s * dx + c * dz) >> W2V_SHIFT;
+        const XYZ_32 delta = XYZ_32_Subtract(skidoo->pos, old);
+        const int32_t new_speed =
+            XYZ_32_UnrotateYaw(delta, skidoo_data->momentum_angle).z;
 
         if (skidoo == Lara_Vehicle_GetItem()
             && skidoo->speed > SKIDOO_MAX_SPEED + M_ACCELERATION
@@ -720,10 +720,10 @@ bool Skidoo_CheckGetOff(void)
         Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
         lara_item->goal_anim_state = LS(LS_STOP);
         lara_item->current_anim_state = LS(LS_STOP);
-        lara_item->pos.x -=
-            (M_GET_OFF_DIST * Math_Sin(lara_item->rot.y)) >> W2V_SHIFT;
-        lara_item->pos.z -=
-            (M_GET_OFF_DIST * Math_Cos(lara_item->rot.y)) >> W2V_SHIFT;
+        lara_item->pos = XYZ_32_Subtract(
+            lara_item->pos,
+            XYZ_32_RotateYaw(
+                (XYZ_32) { .z = M_GET_OFF_DIST }, lara_item->rot.y));
         lara_item->rot.x = 0;
         lara_item->rot.z = 0;
         Lara_Vehicle_SetIndex(NO_ITEM);

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -159,13 +159,8 @@ static bool M_CanGetOff(const ITEM *const item)
     }
 
     const int32_t rad = WALL_L * Math_Cos(item->rot.x) >> W2V_SHIFT;
-    XYZ_32 pos = {
-        .x = item->pos.x
-            + ((rad * Math_Sin(item->rot.y + DEG_180)) >> W2V_SHIFT),
-        .y = item->pos.y - ((WALL_L * Math_Sin(item->rot.x)) >> W2V_SHIFT),
-        .z = item->pos.z
-            + ((rad * Math_Cos(item->rot.y + DEG_180)) >> W2V_SHIFT),
-    };
+    XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y + DEG_180, rad);
+    pos.y = item->pos.y - ((WALL_L * Math_Sin(item->rot.x)) >> W2V_SHIFT);
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
@@ -580,11 +575,12 @@ static void M_DoCurrent(ITEM *const item)
                                   lara_item->pos.x - camera_obj->pos.x,
                                   lara_item->pos.z - camera_obj->pos.z)
             - DEG_90;
+        // A velocity carries ten bits more than a position does.
         const int32_t speed = camera_obj->data;
-        const int32_t xvel = (speed * Math_Sin(angle)) >> 4;
-        const int32_t zvel = (speed * Math_Cos(angle)) >> 4;
-        lara->current.vel.x += ((xvel - lara->current.vel.x) >> 4);
-        lara->current.vel.z += ((zvel - lara->current.vel.z) >> 4);
+        const XYZ_32 vel =
+            XYZ_32_RotateYaw((XYZ_32) { .z = speed << 10 }, angle);
+        lara->current.vel.x += ((vel.x - lara->current.vel.x) >> 4);
+        lara->current.vel.z += ((vel.z - lara->current.vel.z) >> 4);
     } else {
         int32_t shifter;
 
@@ -764,11 +760,10 @@ static void M_TriggerMist(
     spark->pos.y = pos.y + (Random_GetControl() & 0xF) - 8;
     spark->pos.z = pos.z + (Random_GetControl() & 0xF) - 8;
 
-    spark->vel.x = (Random_GetControl() & 0x7F)
-        + ((speed * Math_Sin(angle)) >> (W2V_SHIFT + 2)) - 64;
+    const XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = speed }, angle);
+    spark->vel.x = (Random_GetControl() & 0x7F) + (dir.x >> 2) - 64;
     spark->vel.y = 0;
-    spark->vel.z = (Random_GetControl() & 0x7F)
-        + ((speed * Math_Cos(angle)) >> (W2V_SHIFT + 2)) - 64;
+    spark->vel.z = (Random_GetControl() & 0x7F) + (dir.z >> 2) - 64;
 
     spark->friction = 3;
 
@@ -900,13 +895,14 @@ bool UPV_Control(void)
             item->rot.x = -14560;
         }
 
-        item->pos.x += (Math_Cos(item->rot.x)
-                        * ((item->speed * Math_Sin(item->rot.y)) >> W2V_SHIFT))
-            >> W2V_SHIFT;
+        // As Lara's own swim does, along the heading first and foreshortened
+        // by the pitch after.
+        const XYZ_32 step =
+            XYZ_32_RotateYaw((XYZ_32) { .z = item->speed }, item->rot.y);
+        const int32_t foreshorten = Math_Cos(item->rot.x);
+        item->pos.x += (foreshorten * step.x) >> W2V_SHIFT;
         item->pos.y -= (item->speed * Math_Sin(item->rot.x)) >> W2V_SHIFT;
-        item->pos.z += (Math_Cos(item->rot.x)
-                        * ((item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT))
-            >> W2V_SHIFT;
+        item->pos.z += (foreshorten * step.z) >> W2V_SHIFT;
     }
 
     int16_t room_num = item->room_num;

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -92,11 +92,8 @@ static bool M_DrawShadow_Sprite(
                 offset.z += ((offset_b.z - offset_a.z) * frac) / rate;
             }
 
-            const int32_t sy = Math_Sin(item->interp.result.rot.y);
-            const int32_t cy = Math_Cos(item->interp.result.rot.y);
-            anchor_pos.x += (offset.x * cy + offset.z * sy) >> W2V_SHIFT;
-            anchor_pos.y += offset.y;
-            anchor_pos.z += (offset.z * cy - offset.x * sy) >> W2V_SHIFT;
+            anchor_pos = XYZ_32_OffsetLocalYaw(
+                anchor_pos, offset, item->interp.result.rot.y);
 
             int16_t room_num = item->room_num;
             const SECTOR *const sector = Room_GetSector(anchor_pos, &room_num);
@@ -123,19 +120,15 @@ static bool M_DrawShadow_Sprite(
     }
 
     const int32_t base_y = anchor_floor - 16;
-    const int32_t sy = Math_Sin(item->interp.result.rot.y);
-    const int32_t cy = Math_Cos(item->interp.result.rot.y);
 
     // Compute the world-space grid points with floor-conforming Y offsets.
     XYZ_32 grid_world[M_SHADOW_GRID_POINTS];
     for (int32_t i = 0; i < M_SHADOW_GRID_POINTS; i++) {
-        const int32_t lx = grid_local_x[i];
-        const int32_t lz = grid_local_z[i];
-        const int32_t rx = (lx * cy + lz * sy) >> W2V_SHIFT;
-        const int32_t rz = (lz * cy - lx * sy) >> W2V_SHIFT;
-
-        const int32_t wx = anchor_pos.x + rx;
-        const int32_t wz = anchor_pos.z + rz;
+        const XYZ_32 corner = XYZ_32_OffsetLocalYaw(
+            anchor_pos, (XYZ_32) { .x = grid_local_x[i], .z = grid_local_z[i] },
+            item->interp.result.rot.y);
+        const int32_t wx = corner.x;
+        const int32_t wz = corner.z;
 
         int16_t room_num = item->room_num;
         XYZ_32 test_pos = { wx, anchor_floor, wz };

--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -34,8 +34,9 @@ static OUTPUT_MESH *M_GenerateShadow(
     for (int32_t i = 0; i <= fidelity; i++) {
         const int16_t angle = ((i * DEG_360) + DEG_180) / fidelity;
         const int32_t size = WALL_L / 2;
-        const int32_t x = (Math_Sin(angle) * size) >> W2V_SHIFT;
-        const int32_t z = (Math_Cos(angle) * size) >> W2V_SHIFT;
+        const XYZ_32 point = XYZ_32_RotateYaw((XYZ_32) { .z = size }, angle);
+        const int32_t x = point.x;
+        const int32_t z = point.z;
         OUTPUT_MESH_VERTEX edge = center;
         edge.pos.x = x;
         edge.pos.z = z;

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -354,17 +354,16 @@ OUTPUT_LIGHT_INFO Output_GetLightInfo(void)
 
 void Output_RotateLight(const int16_t pitch, const int16_t yaw)
 {
-    const int32_t cp = Math_Cos(pitch);
-    const int32_t sp = Math_Sin(pitch);
-    const int32_t cy = Math_Cos(yaw);
-    const int32_t sy = Math_Sin(yaw);
-    const int32_t x = TRIGMULT2(cp, sy);
-    const int32_t y = -sp;
-    const int32_t z = TRIGMULT2(cp, cy);
+    // A direction, not a point, so the view matrix's translation stays out of
+    // it.
+    const XYZ_32 dir = XYZ_32_FromYawPitch(yaw, pitch, 1 << W2V_SHIFT);
     const MATRIX *const m = &g_ViewMatrix;
-    m_LsVectorView.x = (m->_00 * x + m->_01 * y + m->_02 * z) >> W2V_SHIFT;
-    m_LsVectorView.y = (m->_10 * x + m->_11 * y + m->_12 * z) >> W2V_SHIFT;
-    m_LsVectorView.z = (m->_20 * x + m->_21 * y + m->_22 * z) >> W2V_SHIFT;
+    m_LsVectorView.x =
+        (m->_00 * dir.x + m->_01 * dir.y + m->_02 * dir.z) >> W2V_SHIFT;
+    m_LsVectorView.y =
+        (m->_10 * dir.x + m->_11 * dir.y + m->_12 * dir.z) >> W2V_SHIFT;
+    m_LsVectorView.z =
+        (m->_20 * dir.x + m->_21 * dir.y + m->_22 * dir.z) >> W2V_SHIFT;
 }
 
 void Output_SetTR3Light(

--- a/src/trx/game/photo_mode.c
+++ b/src/trx/game/photo_mode.c
@@ -143,24 +143,10 @@ static bool M_HandleItemPositionInputs(ITEM *const item)
         return false;
     }
 
-    const int32_t pitch = item->rot.x;
-    const int32_t cos_p = Math_Cos(pitch);
-    const int32_t sin_p = Math_Sin(pitch);
-    const int32_t local_y = delta.y - TRIGMULT2(sin_p, delta.z);
-    const int32_t local_z = TRIGMULT2(cos_p, delta.z);
-    const int32_t local_x = delta.x;
-
-    const int32_t yaw = item->rot.y;
-    const int32_t cos_y = Math_Cos(yaw);
-    const int32_t sin_y = Math_Sin(yaw);
-    const int32_t world_x =
-        TRIGMULT2(cos_y, local_x) + TRIGMULT2(sin_y, local_z);
-    const int32_t world_z =
-        -TRIGMULT2(sin_y, local_x) + TRIGMULT2(cos_y, local_z);
-
-    item->pos.x += world_x;
-    item->pos.y += local_y;
-    item->pos.z += world_z;
+    // The step is given along the camera's own axes, so it meets the whole
+    // orientation rather than the yaw alone.
+    item->pos = XYZ_32_OffsetLocal(
+        item->pos, delta, (XYZ_16) { .x = item->rot.x, .y = item->rot.y });
     return true;
 }
 

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -132,10 +132,9 @@ static void M_UpdateWind(void)
         (m_TR3WindAngle + ((m_TR3DWindAngle - m_TR3WindAngle) >> 3)) & 0x1FFE;
 
     // Promote to DEG_360 for Math_Sin/Cos just at the end.
-    m_SmokeWind = (XZ_32) {
-        .x = (m_TR3Wind * Math_Sin(m_TR3WindAngle << 3)) >> W2V_SHIFT,
-        .z = (m_TR3Wind * Math_Cos(m_TR3WindAngle << 3)) >> W2V_SHIFT,
-    };
+    const XYZ_32 wind =
+        XYZ_32_RotateYaw((XYZ_32) { .z = m_TR3Wind }, m_TR3WindAngle << 3);
+    m_SmokeWind = (XZ_32) { .x = wind.x, .z = wind.z };
 
     m_HairWindZ = 0;
 }

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -97,10 +97,8 @@ void Sparks_TriggerWaterfallMist(
 
         // the sparks are spread along the line perpendicular to the flow
         const int32_t offset = (Random_GetControl() & 0x1F) + offsets[i] - 16;
-        const int32_t spread_x =
-            (offset * Math_Sin(angle + DEG_90)) >> W2V_SHIFT;
-        const int32_t spread_z =
-            (offset * Math_Cos(angle + DEG_90)) >> W2V_SHIFT;
+        const XYZ_32 spread =
+            XYZ_32_RotateYaw((XYZ_32) { .z = offset }, angle + DEG_90);
 
         *spark = (SPARK) {
             .on = true,
@@ -114,15 +112,11 @@ void Sparks_TriggerWaterfallMist(
             .dynamic = -1,
             .sprite_idx = sprite_idx,
             .pos = {
-                .x = x + (Random_GetControl() % 16) - 8 + spread_x,
+                .x = x + (Random_GetControl() % 16) - 8 + spread.x,
                 .y = y + (Random_GetControl() % 16) - 8,
-                .z = z + (Random_GetControl() % 16) - 8 + spread_z,
+                .z = z + (Random_GetControl() % 16) - 8 + spread.z,
             },
-            .vel = {
-                .x = Math_Sin(angle) >> W2V_SHIFT,
-                .y = 0,
-                .z = Math_Cos(angle) >> W2V_SHIFT,
-            },
+            .vel = XYZ_32_RotateYaw((XYZ_32) { .z = 1 }, angle),
             .gravity = 0,
             .max_y_vel = 0,
             .friction = 3,
@@ -175,9 +169,10 @@ void Sparks_TriggerSmallSplash(const XYZ_32 pos, const int32_t count)
         spark->extras = 0;
         spark->dynamic = -1;
         const int32_t ang = Random_GetDraw() & 0xFFF;
-        spark->vel.x = -Math_Sin(ang << 4) >> 7;
+        const XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = 128 }, -(ang << 4));
+        spark->vel.x = dir.x;
         spark->vel.y = -640 - (Random_GetDraw() & 0xFF);
-        spark->vel.z = Math_Cos(ang << 4) >> 7;
+        spark->vel.z = dir.z;
         spark->pos.x = pos.x + (spark->vel.x >> 3);
         spark->pos.y = pos.y - (spark->vel.y >> 5);
         spark->pos.z = pos.z + (spark->vel.z >> 3);
@@ -585,11 +580,10 @@ void Sparks_TriggerSideFlame(
     }
     dist <<= 1;
 
-    const int32_t s = (dist * Math_Sin(angle)) >> W2V_SHIFT;
-    const int32_t c = (dist * Math_Cos(angle)) >> W2V_SHIFT;
-    spark->vel.x = (int16_t)((Random_GetControl() & 0x7F) + s - 64);
+    const XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = dist }, angle);
+    spark->vel.x = (int16_t)((Random_GetControl() & 0x7F) + dir.x - 64);
     spark->vel.y = -6 - (Random_GetControl() & 7);
-    spark->vel.z = (int16_t)((Random_GetControl() & 0x7F) + c - 64);
+    spark->vel.z = (int16_t)((Random_GetControl() & 0x7F) + dir.z - 64);
     spark->friction = 4;
     spark->flags = SPARK_F_ALT_SPRITE | SPARK_F_SPRITE | SPARK_F_SCALE;
     spark->gravity = -8 - (Random_GetControl() & 0xF);
@@ -638,9 +632,11 @@ void Sparks_TriggerBlood(
         const int16_t dist = Random_GetControl() & 0xF;
         const int32_t ang =
             ((Random_GetControl() & 0x1F) + angle_12 - 16) & 0xFFF;
-        spark->vel.x = -(dist * Math_Sin(ang << 4)) >> 7;
+        const XYZ_32 dir =
+            XYZ_32_RotateYaw((XYZ_32) { .z = dist * 128 }, -(ang << 4));
+        spark->vel.x = dir.x;
         spark->vel.y = -128 - (Random_GetControl() & 0xFF);
-        spark->vel.z = dist * Math_Cos(ang << 4) >> 7;
+        spark->vel.z = dir.z;
         spark->friction = 4;
         spark->flags = SPARK_F_BLOOD | SPARK_F_SCALE;
         spark->scalar = 3;
@@ -683,9 +679,11 @@ void Sparks_TriggerBloodD(
         spark->pos.z = pos.z + (Random_GetDraw() & 0x1F) - 16;
         const int16_t dist = Random_GetDraw() & 0xF;
         const int32_t ang = ((Random_GetDraw() & 0x1F) + angle_12 - 16) & 0xFFF;
-        spark->vel.x = -(dist * Math_Sin(ang << 4)) >> 7;
+        const XYZ_32 dir =
+            XYZ_32_RotateYaw((XYZ_32) { .z = dist * 128 }, -(ang << 4));
+        spark->vel.x = dir.x;
         spark->vel.y = -128 - (Random_GetDraw() & 0xFF);
-        spark->vel.z = dist * Math_Cos(ang << 4) >> 7;
+        spark->vel.z = dir.z;
         spark->friction = 4;
         spark->flags = SPARK_F_SCALE;
         spark->scalar = 3;
@@ -1367,9 +1365,10 @@ void Sparks_TriggerRicochetTR3(
     spark->pos.y = pos.y;
     spark->pos.z = pos.z;
     int32_t ang = ((Random_GetControl() & 0x7FF) + angle - 1024) & 0xFFF;
-    spark->vel.x = -Math_Sin(ang << 4) >> 3;
+    XYZ_32 dir = XYZ_32_RotateYaw((XYZ_32) { .z = 2048 }, -(ang << 4));
+    spark->vel.x = dir.x;
     spark->vel.y = 2 * (Random_GetControl() & 0x1FF) - 768;
-    spark->vel.z = Math_Cos(ang << 4) >> 3;
+    spark->vel.z = dir.z;
     spark->friction = 1;
     spark->flags = SPARK_F_SCALE;
     spark->scalar = 3;
@@ -1405,9 +1404,10 @@ void Sparks_TriggerRicochetTR3(
     spark->pos.y = pos.y;
     spark->pos.z = pos.z;
     ang = ((Random_GetControl() & 0x7FF) + angle - 1023) & 0xFFF;
-    spark->vel.x = -Math_Sin(ang << 4) >> 3;
+    dir = XYZ_32_RotateYaw((XYZ_32) { .z = 2048 }, -(ang << 4));
+    spark->vel.x = dir.x;
     spark->vel.y = (Random_GetControl() & 0x1FF) - 384;
-    spark->vel.z = Math_Cos(ang << 4) >> 3;
+    spark->vel.z = dir.z;
     spark->friction = 33;
     spark->flags = SPARK_F_SCALE;
     spark->scalar = 3;
@@ -1448,8 +1448,10 @@ void Sparks_TriggerRicochetTR4(
             spark->vel.y = (rnd & 0xFFF) - 2048;
             spark->gravity = (rnd >> 7) & 0x1F;
             const int32_t ang = (((rnd >> 3) & 0x7FF) + angle - 1024) & 0xFFF;
-            spark->vel.x = -Math_Sin(ang << 4) >> 4;
-            spark->vel.z = Math_Cos(ang << 4) >> 4;
+            const XYZ_32 dir =
+                XYZ_32_RotateYaw((XYZ_32) { .z = 1024 }, -(ang << 4));
+            spark->vel.x = dir.x;
+            spark->vel.z = dir.z;
             spark->friction = 34;
             spark->flags = SPARK_F_NONE;
             spark->max_y_vel = 0;

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -46,8 +46,8 @@ XYZ_32 Spawn_GetRayPos(
         .y = hit_pos.y - start.y,
         .z = hit_pos.z - start.z,
     });
-    hit_pos.pos.x -= (dist * Math_Sin(angle)) >> W2V_SHIFT;
-    hit_pos.pos.z -= (dist * Math_Cos(angle)) >> W2V_SHIFT;
+    hit_pos.pos = XYZ_32_Subtract(
+        hit_pos.pos, XYZ_32_RotateYaw((XYZ_32) { .z = dist }, angle));
 
     return hit_pos.pos;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves TRX1113 / TRX204 / TRX1142.

Adds shared math functions to replace roughly 200 places where the game was manually combining `Math_Sin` and `Math_Cos`, then updates the game to use those new functions.

- `XYZ_32_RotateYaw` / `XYZ_32_UnrotateYaw`:
  Turns an offset into the world's axes, and back along an item's.
- `XYZ_32_Rotate` / `XYZ_32_Unrotate`:
  The same by a whole orientation, for an item that pitches or rolls.
- `XYZ_32_OffsetLocalYaw` / `XYZ_32_OffsetLocal`:
  The point the offset reaches, for callers that have the origin.

Repeated/stacked positioning now keeps its rounding exactly the same. A position calculated only once might still end up off by 1 unit because of rounding.

Additionally:

- The free camera in photo mode no longer slowly moves when you tilt it up or down.
- Some old rotation math (`TRIGMULT2` and `TRIGMULT3`) was removed. Camera/view rotation is now handled by `M_RotYXZ`, with its matrix transposed for the view calculation.

