### PR TITLE
objects/sentry_gun: let a trigger set it firing

### DIFF
--- a/data/te/tr1/Properties/extra.xml
+++ b/data/te/tr1/Properties/extra.xml
@@ -336,6 +336,7 @@
     <!--placeholder for O_SENTRY_GUN-->
     <moveable id="-1">
         <property category="TRX" defaultValue="10" description="Damage dealt when the sentry gun hits Lara." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Require an alert, such as a security laser Lara has crossed, before the sentry gun opens fire. With this off, it fires for as long as its own trigger is active." displayName="Requires Alert" internalName="requires_alert" type="Bool" />
         <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
     </moveable>
     <!--placeholder for O_SHARK-->

--- a/data/te/tr2/Properties/extra.xml
+++ b/data/te/tr2/Properties/extra.xml
@@ -335,6 +335,7 @@
     <!--placeholder for O_SENTRY_GUN-->
     <moveable id="-1">
         <property category="TRX" defaultValue="10" description="Damage dealt when the sentry gun hits Lara." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Require an alert, such as a security laser Lara has crossed, before the sentry gun opens fire. With this off, it fires for as long as its own trigger is active." displayName="Requires Alert" internalName="requires_alert" type="Bool" />
         <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
     </moveable>
     <!--placeholder for O_SHIVA-->

--- a/data/te/tr3/Properties/default.xml
+++ b/data/te/tr3/Properties/default.xml
@@ -168,6 +168,7 @@
     </moveable>
     <moveable id="64">
         <property category="TRX" defaultValue="10" description="Damage dealt when the sentry gun hits Lara." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Require an alert, such as a security laser Lara has crossed, before the sentry gun opens fire. With this off, it fires for as long as its own trigger is active." displayName="Requires Alert" internalName="requires_alert" type="Bool" />
         <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
     </moveable>
     <moveable id="65">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 **Level and game data**
 - Added Natla as an outfit for Lara, selectable in every game (Graphic Options → Visuals → Lara's outfit)
 - Added injection support for putting a room in a flip group, which only TR4 levels carry themselves (#5336)
+- Added a `requires_alert` property to the sentry gun, which lets a plain trigger set it firing where it would otherwise wait for a security laser (#1141)
 - Changed a missing or unknown `lara_outfit` in a level to fall back to the default outfit, rather than stopping the game from starting
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -1311,6 +1311,7 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3 (64)</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>damage</code></td><td colspan="3" align="center">10</td><td>Damage dealt when the sentry gun hits Lara.</td></tr>
+<tr><td><code>requires_alert</code></td><td colspan="3" align="center">true</td><td>Require an alert, such as a security laser Lara has crossed, before the sentry gun opens fire. With this off, it fires for as long as its own trigger is active.</td></tr>
 <tr><td><code>max_hit_points</code></td><td colspan="3" align="center">100</td><td>Maximum hit points.</td></tr>
 </tbody>
 </table>

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -1,6 +1,7 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/game/creature.h>
+#include <trx/game/items.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/property.h>
@@ -23,6 +24,7 @@ typedef enum {
 
 typedef struct {
     int32_t damage;
+    bool requires_alert;
     int16_t active_muzzle;
     int16_t muzzle_flash_timer;
     bool is_alerted;
@@ -123,6 +125,10 @@ static void M_Control(const int16_t item_num)
     CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
+    }
+
+    if (!p->requires_alert) {
+        p->is_alerted = Item_IsTriggerActive(item);
     }
 
     if (item->hit_status) {
@@ -250,6 +256,11 @@ static void M_Setup(OBJECT *const obj)
         OBJECT_PROPERTY(
             M_PRIV, damage, M_DEFAULT_DAMAGE,
             "Damage dealt when the sentry gun hits Lara."),
+        OBJECT_PROPERTY(
+            M_PRIV, requires_alert, true,
+            "Require an alert, such as a security laser Lara has crossed, "
+            "before the sentry gun opens fire. With this off, it fires for as "
+            "long as its own trigger is active."),
         ITEM_PROPERTY_MAX_HIT_POINTS(100));
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A sentry gun normally waits for an alert, either from Lara crossing a security laser or from one of her bullets. Triggering the gun by itself only makes it active, so in a level without a security laser, it never fires.

Add a `requires_alert` property, enabled by default to match the original games. When disabled, triggering the gun also alerts it, a timer controls how long it keeps firing, and an antitrigger shuts it down.

Resolves TRX1141.