### PR TITLE
kayak+lara: fix drawing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fixed z-fighting in rooms 21, 67 amd 122 in Jungle, and fixed incorrect lighting in room 87 (OG bugs)
 - Fixed missing alpha blending on the MP5 and M16 gun flare in the gym (regression from 1.7)
 - Fixed Lara being able to turn too quickly when wading (regression from 1.0)
+- Fixed the kayak at times not being drawn in certain rooms (regression from 1.10.1)
 
 **TR4**
 - Added the ability to skip in-game cutscenes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Fixed missing alpha blending on the MP5 and M16 gun flare in the gym (regression from 1.7)
 - Fixed Lara being able to turn too quickly when wading (regression from 1.0)
 - Fixed the kayak at times not being drawn in certain rooms (regression from 1.10.1)
+- Fixed some of Lara's skin joints incorrectly being drawn when riding the kayak (regression from 1.10)
 
 **TR4**
 - Added the ability to skip in-game cutscenes

--- a/src/trx/game/lara/skin/joints.c
+++ b/src/trx/game/lara/skin/joints.c
@@ -288,6 +288,12 @@ void Lara_Joints_Draw(
         return;
     }
 
+    const ITEM *const lara_item = Lara_GetItem();
+    if (!Item_IsMeshVisible(lara_item, joint->parent_mesh)
+        || !Item_IsMeshVisible(lara_item, joint->child_mesh)) {
+        return;
+    }
+
     const OBJECT_MESH *const mesh = Object_GetMesh(joint->joint_mesh_idx);
     const MATRIX *const parent = &m_State.mesh_matrices[joint->parent_mesh];
     const MATRIX *const child = &m_State.mesh_matrices[joint->child_mesh];

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -1144,10 +1144,12 @@ static void M_KayakToBaddieCollision(const ITEM *const p)
 static bool M_Draw(const ITEM *const item)
 {
     ((ITEM *)item)->pos.y += 32;
-    Object_DrawAnimatingItem(item);
+    const bool drawn = Object_DrawAnimatingItem(item);
     ((ITEM *)item)->pos.y -= 32;
-    FX_Wake_Draw(item);
-    return true;
+    if (drawn) {
+        FX_Wake_Draw(item);
+    }
+    return drawn;
 }
 
 static void M_Setup(OBJECT *const obj)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes the kayak potentially being marked as having been drawn in a room that has been clipped away. It also fixes Lara's joints being drawn when her linked meshes have been hidden (e.g. on the kayak in a TR4 outfit).

Resolves TRX1145 / TRX1146.
