### PR TITLE
Report file and filesystem failures with a result

### DIFF
--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -83,12 +83,12 @@ const char *GamePath_Resolve(
     return entry->value;
 }
 
-bool FS_Load(
+RESULT FS_Load(
     const char *const path, char **const output_data, size_t *const output_size)
 {
     FILE *const fp = fopen(path, "rb");
     if (fp == nullptr) {
-        return false;
+        return FAIL("%s: the file could not be opened", path);
     }
     fseek(fp, 0, SEEK_END);
     const long size = ftell(fp);
@@ -101,7 +101,13 @@ bool FS_Load(
     if (output_size != nullptr) {
         *output_size = read_size;
     }
-    return true;
+    return OK;
+}
+
+bool FS_Exists(const char *const path)
+{
+    struct stat info;
+    return stat(path, &info) == 0;
 }
 
 bool FS_DirExists(const char *const path)

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -310,9 +310,12 @@ void Shell_ExitSystemFmt(const char *const fmt, ...)
     Shell_ExitSystem(fmt);
 }
 
-TRX_FILE *File_OpenPath(const char *const path, const FILE_OPEN_MODE mode)
+RESULT File_OpenPath(
+    const char *const path, const FILE_OPEN_MODE mode,
+    TRX_FILE **const out_file)
 {
-    return nullptr;
+    *out_file = nullptr;
+    return FAIL("%s: the test opens no files", path);
 }
 
 void File_WriteData(

--- a/src/tests/harness/stubs_result.c
+++ b/src/tests/harness/stubs_result.c
@@ -29,6 +29,14 @@ __attribute__((weak)) char *String_Format(const char *const fmt, ...)
     return result;
 }
 
+__attribute__((weak)) const char *String_FormatStaticV(
+    const char *const fmt, va_list args)
+{
+    static char result[1024];
+    vsnprintf(result, sizeof(result), fmt, args);
+    return result;
+}
+
 __attribute__((weak)) void Shell_ExitSystem(const char *const message)
 {
     fprintf(stderr, "unexpected engine exit: %s\n", message);

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -214,7 +214,13 @@ unit_tests += {
 
 unit_tests += {
   'name': 'trx/game/cutseq/pak',
-  'engine': ['game/cutseq/pak.c', 'core/memory.c', 'core/subsystem.c'],
+  'engine': [
+    'game/cutseq/pak.c',
+    'core/memory.c',
+    'core/result.c',
+    'core/subsystem.c',
+  ],
+  'src': ['harness/stubs_result.c'],
   'deps': [dep_zlib],
 }
 
@@ -267,12 +273,14 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/core/file',
   'engine': [
+    'core/result.c',
     'core/file.c',
     'core/filesystem.c',
     'core/memory.c',
     'core/strings/common.c',
     'core/vector.c',
   ],
+  'src': ['harness/stubs_result.c'],
   'deps': [dep_pcre2],
   'args': ['-DPCRE2_CODE_UNIT_WIDTH=8', '-D_DEFAULT_SOURCE'],
 }
@@ -280,12 +288,14 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/core/filesystem',
   'engine': [
+    'core/result.c',
     'core/file.c',
     'core/filesystem.c',
     'core/memory.c',
     'core/strings/common.c',
     'core/vector.c',
   ],
+  'src': ['harness/stubs_result.c'],
   'deps': [dep_pcre2],
   'args': ['-DPCRE2_CODE_UNIT_WIDTH=8', '-D_DEFAULT_SOURCE'],
 }

--- a/src/tests/trx/core/file.c
+++ b/src/tests/trx/core/file.c
@@ -12,6 +12,13 @@ static const char m_Bytes[] = {
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
 };
 
+static TRX_FILE *M_Open(const char *const path, const FILE_OPEN_MODE mode)
+{
+    TRX_FILE *file = nullptr;
+    CHECK(IGNORE(File_OpenPath(path, mode, &file)));
+    return file;
+}
+
 static TRX_FILE *M_Buffer(void)
 {
     return File_OpenBuffer(m_Bytes, sizeof(m_Bytes));
@@ -23,7 +30,7 @@ static TRX_FILE *M_Disk(void)
     CHECK_NOT_NULL(fp);
     fwrite(m_Bytes, 1, sizeof(m_Bytes), fp);
     fclose(fp);
-    return File_OpenPath(M_TEMP_PATH, FILE_OPEN_READ);
+    return M_Open(M_TEMP_PATH, FILE_OPEN_READ);
 }
 
 static void M_DropDisk(void)
@@ -190,14 +197,14 @@ TEST(a_file_on_disk_cannot_peek)
 
 TEST(what_was_written_reads_back)
 {
-    TRX_FILE *const file = File_OpenPath(M_TEMP_PATH, FILE_OPEN_WRITE);
+    TRX_FILE *const file = M_Open(M_TEMP_PATH, FILE_OPEN_WRITE);
     CHECK_NOT_NULL(file);
     File_WriteU8(file, 0x11);
     File_WriteU32(file, 0x44332211);
     CHECK_EQ_INT((int32_t)File_Size(file), 5);
     File_Close(file);
 
-    TRX_FILE *const read = File_OpenPath(M_TEMP_PATH, FILE_OPEN_READ);
+    TRX_FILE *const read = M_Open(M_TEMP_PATH, FILE_OPEN_READ);
     CHECK_NOT_NULL(read);
     CHECK_EQ_INT(File_ReadU8(read), 0x11);
     CHECK_EQ_INT((int32_t)File_ReadU32(read), 0x44332211);
@@ -207,17 +214,17 @@ TEST(what_was_written_reads_back)
 
 TEST(a_write_at_a_seeked_spot_leaves_the_rest_alone)
 {
-    TRX_FILE *const file = File_OpenPath(M_TEMP_PATH, FILE_OPEN_WRITE);
+    TRX_FILE *const file = M_Open(M_TEMP_PATH, FILE_OPEN_WRITE);
     File_WriteData(file, m_Bytes, sizeof(m_Bytes));
     File_Close(file);
 
-    TRX_FILE *const patch = File_OpenPath(M_TEMP_PATH, FILE_OPEN_READ_WRITE);
+    TRX_FILE *const patch = M_Open(M_TEMP_PATH, FILE_OPEN_READ_WRITE);
     CHECK_NOT_NULL(patch);
     File_Seek(patch, 3, FILE_SEEK_SET);
     File_WriteU8(patch, 0xFF);
     File_Close(patch);
 
-    TRX_FILE *const read = File_OpenPath(M_TEMP_PATH, FILE_OPEN_READ);
+    TRX_FILE *const read = M_Open(M_TEMP_PATH, FILE_OPEN_READ);
     CHECK_EQ_INT((int32_t)File_Size(read), (int32_t)sizeof(m_Bytes));
     File_Seek(read, 2, FILE_SEEK_SET);
     CHECK_EQ_INT(File_ReadU8(read), 0x03);
@@ -229,13 +236,13 @@ TEST(a_write_at_a_seeked_spot_leaves_the_rest_alone)
 
 TEST(a_file_cut_short_loses_its_tail)
 {
-    TRX_FILE *const file = File_OpenPath(M_TEMP_PATH, FILE_OPEN_WRITE);
+    TRX_FILE *const file = M_Open(M_TEMP_PATH, FILE_OPEN_WRITE);
     File_WriteData(file, m_Bytes, sizeof(m_Bytes));
-    CHECK(File_SetSize(file, 3));
+    CHECK(IGNORE(File_SetSize(file, 3)));
     CHECK_EQ_INT((int32_t)File_Size(file), 3);
     File_Close(file);
 
-    TRX_FILE *const read = File_OpenPath(M_TEMP_PATH, FILE_OPEN_READ);
+    TRX_FILE *const read = M_Open(M_TEMP_PATH, FILE_OPEN_READ);
     CHECK_EQ_INT((int32_t)File_Size(read), 3);
     CHECK_EQ_INT(File_ReadU8(read), 0x01);
     File_Close(read);
@@ -245,7 +252,7 @@ TEST(a_file_cut_short_loses_its_tail)
 TEST(a_buffer_cannot_be_resized)
 {
     TRX_FILE *const file = M_Buffer();
-    CHECK(!File_SetSize(file, 3));
+    CHECK(!IGNORE(File_SetSize(file, 3)));
     CHECK_EQ_INT((int32_t)File_Size(file), (int32_t)sizeof(m_Bytes));
     File_Close(file);
 }

--- a/src/tests/trx/game/cutseq/pak.c
+++ b/src/tests/trx/game/cutseq/pak.c
@@ -307,16 +307,16 @@ const char *GamePath_TryResolve(
     return m_FileExists ? rel : nullptr;
 }
 
-bool FS_Load(
+RESULT FS_Load(
     const char *const path, char **const output_data, size_t *const output_size)
 {
     if (!m_FileExists) {
-        return false;
+        return FAIL("%s: the file could not be opened", path);
     }
     *output_data = Memory_Alloc(m_ImageSize);
     memcpy(*output_data, m_Image, m_ImageSize);
     *output_size = m_ImageSize;
-    return true;
+    return OK;
 }
 
 OBJECT_ID Object_FromGameID(const int32_t game_id)

--- a/src/tests/trx/game/ui.c
+++ b/src/tests/trx/game/ui.c
@@ -95,7 +95,7 @@ static bool M_LoadLanguage(const char *const lang)
 
     char *data = nullptr;
     size_t size = 0;
-    if (!FS_Load(path, &data, &size)) {
+    if (!IGNORE(FS_Load(path, &data, &size))) {
         return false;
     }
     JSON_VALUE *const root = JSON_ParseEx(

--- a/src/trx/av/image.c
+++ b/src/trx/av/image.c
@@ -366,7 +366,9 @@ bool Image_SaveToFile(const IMAGE *const image, const char *const path)
         goto cleanup;
     }
 
-    FS_EnsureParentDirectories(path);
+    if (!SHOULD(FS_EnsureParentDirectories(path))) {
+        goto cleanup;
+    }
     fp = File_OpenPath(path, FILE_OPEN_WRITE);
     if (fp == nullptr) {
         LOG_ERROR("Cannot create image file: %s", path);

--- a/src/trx/av/image.c
+++ b/src/trx/av/image.c
@@ -369,9 +369,7 @@ bool Image_SaveToFile(const IMAGE *const image, const char *const path)
     if (!SHOULD(FS_EnsureParentDirectories(path))) {
         goto cleanup;
     }
-    fp = File_OpenPath(path, FILE_OPEN_WRITE);
-    if (fp == nullptr) {
-        LOG_ERROR("Cannot create image file: %s", path);
+    if (!SHOULD(File_OpenPath(path, FILE_OPEN_WRITE, &fp))) {
         goto cleanup;
     }
 

--- a/src/trx/core/file.c
+++ b/src/trx/core/file.c
@@ -8,6 +8,7 @@
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -227,8 +228,11 @@ static int32_t M_CheckCount(TRX_FILE *const file, const int32_t count)
     return count;
 }
 
-TRX_FILE *File_OpenPath(const char *const path, const FILE_OPEN_MODE mode)
+RESULT File_OpenPath(
+    const char *const path, const FILE_OPEN_MODE mode,
+    TRX_FILE **const out_file)
 {
+    *out_file = nullptr;
     const char *fopen_mode = nullptr;
     switch (mode) {
     case FILE_OPEN_WRITE:
@@ -241,14 +245,12 @@ TRX_FILE *File_OpenPath(const char *const path, const FILE_OPEN_MODE mode)
         fopen_mode = "r+b";
         break;
     }
-    if (fopen_mode == nullptr) {
-        return nullptr;
-    }
+    ASSERT(fopen_mode != nullptr);
 
     FILE *const fp = FS_PlatformFopen(path, fopen_mode);
-    if (fp == nullptr) {
-        return nullptr;
-    }
+    FAIL_IF(
+        fp == nullptr, "%s: the file could not be opened: %s", path,
+        strerror(errno));
 
     fseek(fp, 0, SEEK_END);
     const long end = ftell(fp);
@@ -264,20 +266,21 @@ TRX_FILE *File_OpenPath(const char *const path, const FILE_OPEN_MODE mode)
     file->state = disk;
     file->path = Memory_DupStr(path);
     file->size = end < 0 ? 0 : (size_t)end;
-    return file;
+    *out_file = file;
+    return OK;
 }
 
-TRX_FILE *File_OpenPathInMemory(const char *const path)
+RESULT File_OpenPathInMemory(const char *const path, TRX_FILE **const out_file)
 {
+    *out_file = nullptr;
     char *data = nullptr;
     size_t size = 0;
-    if (!SHOULD(FS_Load(path, &data, &size))) {
-        return nullptr;
-    }
+    MUST(FS_Load(path, &data, &size));
     TRX_FILE *const file = File_OpenBuffer(data, size);
     file->path = Memory_DupStr(path);
     Memory_FreePointer(&data);
-    return file;
+    *out_file = file;
+    return OK;
 }
 
 TRX_FILE *File_OpenBuffer(const char *const data, const size_t size)
@@ -482,18 +485,19 @@ int32_t File_ReadCountS32(TRX_FILE *const file)
     return M_CheckCount(file, File_ReadS32(file));
 }
 
-bool File_SetSize(TRX_FILE *const file, const size_t size)
+RESULT File_SetSize(TRX_FILE *const file, const size_t size)
 {
-    if (file->strategy->set_size == nullptr) {
-        return false;
-    }
-    if (!file->strategy->set_size(file->state, file->base + size)) {
-        return false;
-    }
+    FAIL_IF(
+        file->strategy->set_size == nullptr, "%s cannot be resized",
+        file->path != nullptr ? file->path : "a buffer");
+    FAIL_IF(
+        !file->strategy->set_size(file->state, file->base + size),
+        "%s could not be resized to %zu bytes",
+        file->path != nullptr ? file->path : "a buffer", size);
     file->size = size;
     file->pos = MIN(file->pos, size);
     file->window_size = 0;
-    return true;
+    return OK;
 }
 
 void File_WriteData(

--- a/src/trx/core/file.c
+++ b/src/trx/core/file.c
@@ -271,7 +271,7 @@ TRX_FILE *File_OpenPathInMemory(const char *const path)
 {
     char *data = nullptr;
     size_t size = 0;
-    if (!FS_Load(path, &data, &size)) {
+    if (!SHOULD(FS_Load(path, &data, &size))) {
         return nullptr;
     }
     TRX_FILE *const file = File_OpenBuffer(data, size);

--- a/src/trx/core/file.h
+++ b/src/trx/core/file.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -20,12 +22,14 @@ typedef enum {
 // memory. Reads and seeks work the same way on both.
 typedef struct TRX_FILE TRX_FILE;
 
-// Open a file on disk. Returns nullptr if the file cannot be opened.
-TRX_FILE *File_OpenPath(const char *path, FILE_OPEN_MODE mode);
+// Opens a file on disk, reporting one that will not open. Caller closes the
+// handle with File_Close().
+RESULT File_OpenPath(
+    const char *path, FILE_OPEN_MODE mode, TRX_FILE **out_file);
 
-// Open a file on disk and read all of it into memory. Only such a handle
-// supports views and peeking. Returns nullptr if the file cannot be read.
-TRX_FILE *File_OpenPathInMemory(const char *path);
+// Opens a file on disk and reads all of it into memory, reporting one that
+// will not read. Only such a handle supports views and peeking.
+RESULT File_OpenPathInMemory(const char *path, TRX_FILE **out_file);
 
 // Open a buffer that is already in memory. The handle keeps its own copy of
 // the data.
@@ -93,11 +97,11 @@ int32_t File_ReadCountS32(TRX_FILE *file);
 // file returns nullptr.
 const char *File_PeekBytes(const TRX_FILE *file, size_t *size);
 
-// Set the length of the file, cutting it short or extending it with zeros.
-// Returns false for a handle that cannot be written, such as a buffer or a
-// view. Rewriting a file with less data than it held before needs this,
-// otherwise the tail of the old data stays behind.
-bool File_SetSize(TRX_FILE *file, size_t size);
+// Sets the length of the file, cutting it short or extending it with zeros,
+// and reports a handle that cannot be written, such as a buffer or a view.
+// Rewriting a file with less data than it held before needs this, otherwise
+// the tail of the old data stays behind.
+RESULT File_SetSize(TRX_FILE *file, size_t size);
 
 void File_WriteData(TRX_FILE *file, const void *data, size_t size);
 void File_WriteItems(

--- a/src/trx/core/filesystem.c
+++ b/src/trx/core/filesystem.c
@@ -9,6 +9,7 @@
 #include <trx/debug.h>
 
 #include <dirent.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -258,49 +259,52 @@ RESULT FS_Load(const char *path, char **output_data, size_t *output_size)
     return OK;
 }
 
-void FS_CreateDirectory(const char *path)
+RESULT FS_CreateDirectory(const char *path)
 {
-    if (path == nullptr) {
-        return;
-    }
+    FAIL_IF(path == nullptr, "no directory was named");
 #if defined(_WIN32)
     wchar_t *const wide_path = M_UTF8ToWide(path);
-    _wmkdir(wide_path);
+    const bool made = _wmkdir(wide_path) == 0 || errno == EEXIST;
     Memory_Free(wide_path);
 #else
-    mkdir(path, 0775);
+    const bool made = mkdir(path, 0775) == 0 || errno == EEXIST;
 #endif
+    FAIL_IF(
+        !made, "%s: the directory could not be made: %s", path,
+        strerror(errno));
+    return OK;
 }
 
-bool FS_Delete(const char *const path)
+RESULT FS_Delete(const char *const path)
 {
-    if (path == nullptr) {
-        return false;
-    }
+    FAIL_IF(path == nullptr, "no file was named");
 #if defined(_WIN32)
     wchar_t *const wide_path = M_UTF8ToWide(path);
-    const bool result = _wremove(wide_path) == 0;
+    const bool removed = _wremove(wide_path) == 0;
     Memory_Free(wide_path);
-    return result;
 #else
-    return remove(path) == 0;
+    const bool removed = remove(path) == 0;
 #endif
+    FAIL_IF(
+        !removed, "%s: the file could not be deleted: %s", path,
+        strerror(errno));
+    return OK;
 }
 
-void FS_EnsureParentDirectories(const char *path)
+RESULT FS_EnsureParentDirectories(const char *path)
 {
     ASSERT(path != nullptr);
-    char *parent = FS_GetParentDirectory(path);
-    if (parent != nullptr) {
-        /* Only recurse/create if there is a distinct, non-empty parent */
-        if (parent[0] != '\0' && strcmp(parent, path) != 0) {
-            if (!FS_DirExists(parent)) {
-                FS_EnsureParentDirectories(parent);
-                FS_CreateDirectory(parent);
-            }
-        }
-        Memory_FreePointer(&parent);
+    AUTO_FREE char *parent = FS_GetParentDirectory(path);
+    if (parent == nullptr) {
+        return OK;
     }
+    // Only recurse/create if there is a distinct, non-empty parent
+    if (parent[0] == '\0' || strcmp(parent, path) == 0
+        || FS_DirExists(parent)) {
+        return OK;
+    }
+    MUST(FS_EnsureParentDirectories(parent));
+    return FS_CreateDirectory(parent);
 }
 
 FS_DIR *FS_OpenDirectory(const char *const path)

--- a/src/trx/core/filesystem.c
+++ b/src/trx/core/filesystem.c
@@ -236,8 +236,8 @@ RESULT FS_Load(const char *path, char **output_data, size_t *output_size)
     ASSERT(output_data != nullptr);
     *output_data = nullptr;
 
-    TRX_FILE *fp = File_OpenPath(path, FILE_OPEN_READ);
-    FAIL_IF(fp == nullptr, "%s: the file could not be opened", path);
+    TRX_FILE *fp = nullptr;
+    MUST(File_OpenPath(path, FILE_OPEN_READ, &fp));
 
     size_t data_size = File_Size(fp);
     char *data = Memory_Alloc(data_size + 1);

--- a/src/trx/core/filesystem.c
+++ b/src/trx/core/filesystem.c
@@ -230,26 +230,23 @@ bool FS_GetMeta(
     return true;
 }
 
-bool FS_Load(const char *path, char **output_data, size_t *output_size)
+RESULT FS_Load(const char *path, char **output_data, size_t *output_size)
 {
     ASSERT(output_data != nullptr);
+    *output_data = nullptr;
 
     TRX_FILE *fp = File_OpenPath(path, FILE_OPEN_READ);
-    if (!fp) {
-        LOG_ERROR("Can't open file %s", path);
-        *output_data = nullptr;
-        return false;
-    }
+    FAIL_IF(fp == nullptr, "%s: the file could not be opened", path);
 
     size_t data_size = File_Size(fp);
     char *data = Memory_Alloc(data_size + 1);
     File_ReadData(fp, data, data_size);
     if (File_Pos(fp) != data_size) {
-        *output_data = nullptr;
-        LOG_ERROR("Can't read file %s", path);
         Memory_FreePointer(&data);
         File_Close(fp);
-        return false;
+        return FAIL(
+            "%s: the file ended after %zu of %zu bytes", path,
+            (size_t)File_Pos(fp), data_size);
     }
     File_Close(fp);
     data[data_size] = '\0';
@@ -258,7 +255,7 @@ bool FS_Load(const char *path, char **output_data, size_t *output_size)
     if (output_size != nullptr) {
         *output_size = data_size;
     }
-    return true;
+    return OK;
 }
 
 void FS_CreateDirectory(const char *path)

--- a/src/trx/core/filesystem.h
+++ b/src/trx/core/filesystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -42,7 +44,9 @@ bool FS_GetMeta(const char *path, uint64_t *out_size, uint64_t *out_mtime);
 
 // Read the whole file at path into a newly allocated, zero-terminated buffer.
 // Caller must free it with Memory_Free().
-bool FS_Load(const char *path, char **output_data, size_t *output_size);
+// Reads a whole file into memory, reporting one that cannot be opened or that
+// ends early. Caller frees the data with Memory_FreePointer().
+RESULT FS_Load(const char *path, char **output_data, size_t *output_size);
 
 // Delete the file at path. Returns false if it could not be deleted.
 bool FS_Delete(const char *path);

--- a/src/trx/core/filesystem.h
+++ b/src/trx/core/filesystem.h
@@ -42,22 +42,22 @@ char *FS_GetStem(const char *path);
 // Read the size and modification time of a path without opening it.
 bool FS_GetMeta(const char *path, uint64_t *out_size, uint64_t *out_mtime);
 
-// Read the whole file at path into a newly allocated, zero-terminated buffer.
-// Caller must free it with Memory_Free().
 // Reads a whole file into memory, reporting one that cannot be opened or that
 // ends early. Caller frees the data with Memory_FreePointer().
 RESULT FS_Load(const char *path, char **output_data, size_t *output_size);
 
-// Delete the file at path. Returns false if it could not be deleted.
-bool FS_Delete(const char *path);
+// Deletes the file at path, reporting one that will not go.
+RESULT FS_Delete(const char *path);
 
 // ============================================================================
 // Directory functions
 
-// Create one directory path component.
-void FS_CreateDirectory(const char *path);
-// Recursively ensure all parent directories for `path` exist.
-void FS_EnsureParentDirectories(const char *path);
+// Creates one directory path component, reporting one that cannot be made. A
+// directory that is already there is no fault.
+RESULT FS_CreateDirectory(const char *path);
+// Recursively ensure all parent directories for `path` exist, reporting the
+// first that cannot be made.
+RESULT FS_EnsureParentDirectories(const char *path);
 
 typedef struct FS_DIR FS_DIR;
 

--- a/src/trx/core/json/util/file.c
+++ b/src/trx/core/json/util/file.c
@@ -58,10 +58,9 @@ RESULT JSONFile_Write(const char *path, JSON_VALUE *const value)
     char *out_data = JSON_WritePretty(value, "  ", "\n", &out_len);
 
     if (old_data == nullptr || strcmp(old_data, out_data) != 0) {
-        TRX_FILE *const fp = File_OpenPath(path, FILE_OPEN_WRITE);
-        if (fp == nullptr) {
-            result = FAIL("%s: the file could not be opened for writing", path);
-        } else {
+        TRX_FILE *fp = nullptr;
+        result = File_OpenPath(path, FILE_OPEN_WRITE, &fp);
+        if (IS_OK(result)) {
             LOG_DEBUG("saving JSON to %s", path);
             File_WriteData(fp, out_data, out_len - 1); // w/o \0
             File_Close(fp);

--- a/src/trx/core/json/util/file.c
+++ b/src/trx/core/json/util/file.c
@@ -17,12 +17,14 @@ RESULT JSONFile_Read(const char *const path, JSON_VALUE **const out_value)
 {
     *out_value = nullptr;
 
-    char *file_data = nullptr;
-    if (!FS_Load(path, &file_data, nullptr)) {
-        // A file that is not there is not a fault; the caller says whether it
-        // needed one.
+    // A file that is not there is not a fault; the caller says whether it
+    // needed one. One that is there and will not read is another matter.
+    if (!FS_Exists(path)) {
         return OK;
     }
+
+    char *file_data = nullptr;
+    MUST(FS_Load(path, &file_data, nullptr));
 
     JSON_PARSE_RESULT pr;
     JSON_VALUE *const value = JSON_ParseEx(
@@ -50,7 +52,7 @@ RESULT JSONFile_Write(const char *path, JSON_VALUE *const value)
 {
     RESULT result = OK;
     char *old_data = nullptr;
-    FS_Load(path, &old_data, nullptr);
+    IGNORE(FS_Load(path, &old_data, nullptr));
 
     size_t out_len;
     char *out_data = JSON_WritePretty(value, "  ", "\n", &out_len);

--- a/src/trx/core/thread_pool.c
+++ b/src/trx/core/thread_pool.c
@@ -102,7 +102,7 @@ void ThreadPool_Destroy(THREAD_POOL *const pool)
     Memory_Free(pool);
 }
 
-bool ThreadPool_AddJob(
+void ThreadPool_AddJob(
     THREAD_POOL *const pool, THREAD_FUNC func, void *const user_data)
 {
     JOB *const job = Memory_Alloc(sizeof(JOB));
@@ -119,7 +119,6 @@ bool ThreadPool_AddJob(
     }
     SDL_CondSignal(pool->queue_cond);
     SDL_UnlockMutex(pool->queue_mutex);
-    return true;
 }
 
 void ThreadPool_Wait(THREAD_POOL *pool)

--- a/src/trx/core/thread_pool.h
+++ b/src/trx/core/thread_pool.h
@@ -5,16 +5,16 @@
 typedef struct THREAD_POOL THREAD_POOL;
 typedef void (*THREAD_FUNC)(void *userdata);
 
-// Create a thread pool with the given number of worker threads.
-// Returns nullptr on failure.
+// Create a thread pool with the given number of worker threads. A count of
+// zero or less takes one thread per CPU.
 THREAD_POOL *ThreadPool_Create(int32_t num_threads);
 
 // Destroy a thread pool, freeing all resources.
 // Blocks until all worker threads have exited.
 void ThreadPool_Destroy(THREAD_POOL *pool);
 
-// Submit a job to the thread pool. Returns true on success.
-bool ThreadPool_AddJob(THREAD_POOL *pool, THREAD_FUNC func, void *user_data);
+// Submit a job to the thread pool. The queue takes every job it is given.
+void ThreadPool_AddJob(THREAD_POOL *pool, THREAD_FUNC func, void *user_data);
 
 // Wait for all submitted jobs to complete.
 void ThreadPool_Wait(THREAD_POOL *pool);

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -135,7 +135,7 @@ static void M_Shutdown(void)
     m_Initialized = false;
 }
 
-bool Catalog_Load(
+RESULT Catalog_Load(
     const CATALOG_CONTEXT context, const char *const csv_path,
     const bool allow_duplicates)
 {
@@ -144,9 +144,7 @@ bool Catalog_Load(
     }
     char *file_data;
     size_t file_size;
-    if (!FS_Load(csv_path, &file_data, &file_size)) {
-        return false;
-    }
+    MUST(FS_Load(csv_path, &file_data, &file_size));
 
     const char *pos = file_data;
     const char *end = file_data + file_size;
@@ -193,7 +191,7 @@ bool Catalog_Load(
         }
     }
     Memory_FreePointer(&file_data);
-    return true;
+    return OK;
 }
 
 bool Catalog_NameToEnum(

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <stdint.h>
 
 // Context discriminator for separate catalog namespaces
@@ -19,7 +21,7 @@ typedef int32_t CATALOG_ID;
 // game_id,name[,comment]
 // A game_id of -1 indicates no mapping for that entry.
 // Returns true on success.
-bool Catalog_Load(
+RESULT Catalog_Load(
     CATALOG_CONTEXT context, const char *csv_path, bool allow_duplicates);
 
 // Convert an item name to its CATALOG_ID within a context.

--- a/src/trx/game/cutseq/pak.c
+++ b/src/trx/game/cutseq/pak.c
@@ -42,8 +42,7 @@ static bool M_Inflate(const char *const path)
 {
     char *file_data = nullptr;
     size_t file_size = 0;
-    if (!FS_Load(path, &file_data, &file_size)) {
-        LOG_ERROR("Failed to read %s", path);
+    if (!SHOULD(FS_Load(path, &file_data, &file_size))) {
         return false;
     }
     if (file_size < sizeof(uint32_t)) {

--- a/src/trx/game/game_strings/manager.c
+++ b/src/trx/game/game_strings/manager.c
@@ -114,7 +114,7 @@ static void M_LoadLanguageNames(void)
         const M_FILE_ENTRY *const file_entry = Vector_Get(lang_entry->files, 0);
         char *data = nullptr;
         size_t size = 0;
-        if (!FS_Load(file_entry->path, &data, &size) || data == nullptr) {
+        if (!SHOULD(FS_Load(file_entry->path, &data, &size))) {
             continue;
         }
         JSON_PARSE_RESULT pr = { 0 };

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -287,9 +287,10 @@ static void M_InitialiseInjection(INJECTION *const injection)
 static void M_LoadFromFile(
     INJECTION *const injection, const char *const file_name)
 {
-    TRX_FILE *const file = File_OpenPathInMemory(file_name);
-    if (file == nullptr) {
-        LOG_WARNING("Could not open %s", file_name);
+    TRX_FILE *file = nullptr;
+    if (!SHOULD(
+            File_OpenPathInMemory(file_name, &file),
+            "the injection is left out")) {
         return;
     }
 

--- a/src/trx/game/level/cache.c
+++ b/src/trx/game/level/cache.c
@@ -211,7 +211,7 @@ TRX_FILE *LevelCache_OpenBinaryWrite(
         return nullptr;
     }
 
-    FS_EnsureParentDirectories(path);
+    SHOULD(FS_EnsureParentDirectories(path));
 
     TRX_FILE *const file = File_OpenPath(path, FILE_OPEN_WRITE);
     if (file == nullptr) {
@@ -268,7 +268,7 @@ RESULT LevelCache_WriteJSON(
         path == nullptr || root_obj == nullptr,
         "%s: there is nothing to write to the level cache", filename);
 
-    FS_EnsureParentDirectories(path);
+    MUST(FS_EnsureParentDirectories(path));
 
     JSON_ObjectAppendString(
         root_obj, "checksum", String_FormatStatic("%016" PRIx64, checksum));

--- a/src/trx/game/level/cache.c
+++ b/src/trx/game/level/cache.c
@@ -188,8 +188,8 @@ TRX_FILE *LevelCache_OpenBinaryRead(
         return nullptr;
     }
 
-    TRX_FILE *const file = File_OpenPath(path, FILE_OPEN_READ);
-    if (file == nullptr) {
+    TRX_FILE *file = nullptr;
+    if (!IGNORE(File_OpenPath(path, FILE_OPEN_READ, &file))) {
         return nullptr;
     }
 
@@ -213,8 +213,8 @@ TRX_FILE *LevelCache_OpenBinaryWrite(
 
     SHOULD(FS_EnsureParentDirectories(path));
 
-    TRX_FILE *const file = File_OpenPath(path, FILE_OPEN_WRITE);
-    if (file == nullptr) {
+    TRX_FILE *file = nullptr;
+    if (!SHOULD(File_OpenPath(path, FILE_OPEN_WRITE, &file))) {
         return nullptr;
     }
 

--- a/src/trx/game/level/format/pipeline.c
+++ b/src/trx/game/level/format/pipeline.c
@@ -91,10 +91,9 @@ const LEVEL_FORMAT_LOADER *Level_Format_LoadFromFile(
     GameBuf_Reset();
 
     BENCHMARK benchmark = Benchmark_Start();
-    TRX_FILE *const file = File_OpenPathInMemory(level->path);
-    if (file == nullptr) {
-        Shell_ExitSystemFmt("Could not open %s", level->path);
-    }
+    TRX_FILE *file = nullptr;
+    EXIT_ON_FAIL(
+        File_OpenPathInMemory(level->path, &file), "The level cannot be read");
 
     const LEVEL_FORMAT_LOADER *const loader = Level_Format_GuessLoader(file);
     if (loader == nullptr) {

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -44,9 +44,9 @@ static void M_InitialiseSamplesFromFile(
         goto finish;
     }
 
-    fp = File_OpenPath(file_name, FILE_OPEN_READ);
-    if (fp == nullptr) {
-        LOG_ERROR("Could not open %s samples file", file_name);
+    if (!SHOULD(
+            File_OpenPath(file_name, FILE_OPEN_READ, &fp),
+            "the level plays without its sounds")) {
         goto finish;
     }
     LOG_DEBUG("Loading samples from %s", file_name);

--- a/src/trx/game/music/backend_cdaudio.c
+++ b/src/trx/game/music/backend_cdaudio.c
@@ -115,8 +115,8 @@ static bool M_Init(MUSIC_BACKEND *const backend)
     M_BACKEND_DATA *const data = backend->data;
     ASSERT(data != nullptr);
 
-    TRX_FILE *const fp = File_OpenPath(data->path, FILE_OPEN_READ);
-    if (fp == nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (!IGNORE(File_OpenPath(data->path, FILE_OPEN_READ, &fp))) {
         return false;
     }
     File_Close(fp);

--- a/src/trx/game/music/backend_cdaudio.c
+++ b/src/trx/game/music/backend_cdaudio.c
@@ -34,7 +34,8 @@ static bool M_Parse(M_BACKEND_DATA *const data)
 
     char *track_content = nullptr;
     size_t track_content_size;
-    if (!FS_Load(data->control_path, &track_content, &track_content_size)) {
+    if (!IGNORE(
+            FS_Load(data->control_path, &track_content, &track_content_size))) {
         LOG_WARNING("Cannot find CDAudio control file: %s", data->control_path);
         return false;
     }

--- a/src/trx/game/music/backend_cdaudio_wad.c
+++ b/src/trx/game/music/backend_cdaudio_wad.c
@@ -67,8 +67,8 @@ static bool M_LoadTrackAsWaveFile(
         return false;
     }
 
-    TRX_FILE *const fp = File_OpenPath(data->path, FILE_OPEN_READ);
-    if (fp == nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (!IGNORE(File_OpenPath(data->path, FILE_OPEN_READ, &fp))) {
         return false;
     }
 
@@ -150,8 +150,8 @@ static bool M_Init(MUSIC_BACKEND *const backend)
     M_BACKEND_DATA *const data = backend->data;
     ASSERT(data != nullptr);
 
-    TRX_FILE *const fp = File_OpenPath(data->path, FILE_OPEN_READ);
-    if (fp == nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (!IGNORE(File_OpenPath(data->path, FILE_OPEN_READ, &fp))) {
         return false;
     }
 

--- a/src/trx/game/music/backend_files.c
+++ b/src/trx/game/music/backend_files.c
@@ -236,7 +236,7 @@ static void M_LoadCatalog(M_BACKEND_DATA *const data)
 
     char *file_data = nullptr;
     size_t file_size = 0;
-    if (!FS_Load(data->catalog_path, &file_data, &file_size)) {
+    if (!IGNORE(FS_Load(data->catalog_path, &file_data, &file_size))) {
         return;
     }
 

--- a/src/trx/game/paths.c
+++ b/src/trx/game/paths.c
@@ -1261,20 +1261,18 @@ TRX_FILE *GamePath_OpenFile(
     return File_OpenPath(resolved, mode);
 }
 
-bool GamePath_LoadFile(
+RESULT GamePath_LoadFile(
     const GAME_DYNAMIC_PATH path, const char *const rel, char **const out_data,
     size_t *const out_size)
 {
-    const char *const resolved = GamePath_TryResolve(path, rel);
-    if (resolved == nullptr) {
-        if (out_data != nullptr) {
-            *out_data = nullptr;
-        }
-        if (out_size != nullptr) {
-            *out_size = 0;
-        }
-        return false;
+    if (out_data != nullptr) {
+        *out_data = nullptr;
     }
+    if (out_size != nullptr) {
+        *out_size = 0;
+    }
+    const char *const resolved = GamePath_TryResolve(path, rel);
+    FAIL_IF(resolved == nullptr, "%s: the path names nothing", rel);
     return FS_Load(resolved, out_data, out_size);
 }
 

--- a/src/trx/game/paths.c
+++ b/src/trx/game/paths.c
@@ -1250,15 +1250,14 @@ const char *GamePath_Resolve(
     return resolved;
 }
 
-TRX_FILE *GamePath_OpenFile(
+RESULT GamePath_OpenFile(
     const GAME_DYNAMIC_PATH path, const char *const rel,
-    const FILE_OPEN_MODE mode)
+    const FILE_OPEN_MODE mode, TRX_FILE **const out_file)
 {
+    *out_file = nullptr;
     const char *const resolved = GamePath_TryResolve(path, rel);
-    if (resolved == nullptr) {
-        return nullptr;
-    }
-    return File_OpenPath(resolved, mode);
+    FAIL_IF(resolved == nullptr, "%s: the path names nothing", rel);
+    return File_OpenPath(resolved, mode, out_file);
 }
 
 RESULT GamePath_LoadFile(

--- a/src/trx/game/paths.h
+++ b/src/trx/game/paths.h
@@ -91,9 +91,10 @@ const char *GamePath_Resolve(GAME_DYNAMIC_PATH path, const char *rel);
 TRX_FILE *GamePath_OpenFile(
     GAME_DYNAMIC_PATH path, const char *rel, FILE_OPEN_MODE mode);
 
-// Resolve and load file contents into memory.
-// On failure, sets `out_data` to nullptr and `out_size` to 0 when provided.
-bool GamePath_LoadFile(
+// Resolves a path and reads the whole file into memory, reporting a path that
+// names nothing as well as a file that will not read. On failure out_data is
+// nullptr and out_size is 0.
+RESULT GamePath_LoadFile(
     GAME_DYNAMIC_PATH path, const char *rel, char **out_data, size_t *out_size);
 
 // Resolve and check whether the file exists.

--- a/src/trx/game/paths.h
+++ b/src/trx/game/paths.h
@@ -86,10 +86,11 @@ const char *GamePath_TryResolve(GAME_DYNAMIC_PATH path, const char *rel);
 // Same as GamePath_PeekResolve, but terminates the game on miss.
 const char *GamePath_Resolve(GAME_DYNAMIC_PATH path, const char *rel);
 
-// Resolve and open a file in one call.
-// Returns nullptr if resolution/open fails.
-TRX_FILE *GamePath_OpenFile(
-    GAME_DYNAMIC_PATH path, const char *rel, FILE_OPEN_MODE mode);
+// Resolves and opens a file in one call, reporting a path that names nothing
+// as well as a file that will not open.
+RESULT GamePath_OpenFile(
+    GAME_DYNAMIC_PATH path, const char *rel, FILE_OPEN_MODE mode,
+    TRX_FILE **out_file);
 
 // Resolves a path and reads the whole file into memory, reporting a path that
 // names nothing as well as a file that will not read. On failure out_data is

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -312,9 +312,9 @@ static void M_HandleGameEvent(const EVENT *const event, void *const user_data)
 void TestRecorder_Open(const char *path, VECTOR *const original_args)
 {
     M_PRIV *const p = &m_Priv;
-    p->file = File_OpenPath(path, FILE_OPEN_WRITE);
-    if (p->file == nullptr) {
-        LOG_ERROR("Cannot open record file '%s'", path);
+    if (!SHOULD(
+            File_OpenPath(path, FILE_OPEN_WRITE, &p->file),
+            "nothing is recorded")) {
         return;
     }
 

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -1012,7 +1012,7 @@ SHELL_ARGS *TestReplay_Open(const char *path)
 
     char *data = nullptr;
     size_t size = 0;
-    if (!FS_Load(path, &data, &size)) {
+    if (!SHOULD(FS_Load(path, &data, &size))) {
         Shell_ExitSystemFmt("Cannot open replay file '%s'", path);
         return nullptr;
     }

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -127,9 +127,8 @@ bool Savegame_Load(const SAVEGAME_SLOT_REF slot)
     M_LoadPreprocess();
 
     bool result = false;
-    TRX_FILE *const fp =
-        File_OpenPath(savegame_info->full_path, FILE_OPEN_READ);
-    if (fp != nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (SHOULD(File_OpenPath(savegame_info->full_path, FILE_OPEN_READ, &fp))) {
         result = SG_File_LoadFromFile(fp);
         File_Close(fp);
     }
@@ -149,9 +148,9 @@ bool Savegame_UpdateDeathCounters(
     ASSERT(savegame_info->full_path != nullptr);
 
     bool ret = false;
-    TRX_FILE *const fp =
-        File_OpenPath(savegame_info->full_path, FILE_OPEN_READ_WRITE);
-    if (fp != nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (SHOULD(File_OpenPath(
+            savegame_info->full_path, FILE_OPEN_READ_WRITE, &fp))) {
         ret = SG_File_UpdateDeathCounters(
             fp, savegame_info->level_num, death_count, savegame_info->is_quick);
         File_Close(fp);
@@ -168,9 +167,8 @@ bool Savegame_LoadOnlyResumeInfo(const SAVEGAME_SLOT_REF slot)
     ASSERT(savegame_info->full_path != nullptr);
 
     bool ret = false;
-    TRX_FILE *const fp =
-        File_OpenPath(savegame_info->full_path, FILE_OPEN_READ);
-    if (fp != nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (SHOULD(File_OpenPath(savegame_info->full_path, FILE_OPEN_READ, &fp))) {
         ret = SG_File_LoadOnlyResumeInfo(fp);
         File_Close(fp);
     }

--- a/src/trx/game/savegame/manager.c
+++ b/src/trx/game/savegame/manager.c
@@ -120,8 +120,8 @@ static bool M_FillSlot(const SAVEGAME_SLOT_REF slot, const char *const path)
         return false;
     }
     bool result = false;
-    TRX_FILE *const fp = File_OpenPath(path, FILE_OPEN_READ);
-    if (fp != nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (SHOULD(File_OpenPath(path, FILE_OPEN_READ, &fp))) {
         SAVEGAME_INFO tmp_savegame_info;
         if (SG_File_FillInfo(fp, &tmp_savegame_info)) {
             M_ClearSlot(savegame_info);
@@ -489,8 +489,8 @@ bool SG_Manager_WriteSlot(const SAVEGAME_SLOT_REF slot)
     char *file_name = String_Format(save_pattern, slot.index);
     char *full_path = M_GetSaveWritePath(file_name);
     SHOULD(FS_EnsureParentDirectories(full_path));
-    TRX_FILE *const fp = File_OpenPath(full_path, FILE_OPEN_WRITE);
-    if (fp != nullptr) {
+    TRX_FILE *fp = nullptr;
+    if (SHOULD(File_OpenPath(full_path, FILE_OPEN_WRITE, &fp))) {
         savegame_info->is_quick = slot.pool == SAVEGAME_SLOT_POOL_QUICK;
         SG_File_SaveToFile(fp, savegame_info);
         File_Close(fp);

--- a/src/trx/game/savegame/manager.c
+++ b/src/trx/game/savegame/manager.c
@@ -488,7 +488,7 @@ bool SG_Manager_WriteSlot(const SAVEGAME_SLOT_REF slot)
     const char *const save_pattern = M_GetSaveFilePatternForPool(slot.pool);
     char *file_name = String_Format(save_pattern, slot.index);
     char *full_path = M_GetSaveWritePath(file_name);
-    FS_EnsureParentDirectories(full_path);
+    SHOULD(FS_EnsureParentDirectories(full_path));
     TRX_FILE *const fp = File_OpenPath(full_path, FILE_OPEN_WRITE);
     if (fp != nullptr) {
         savegame_info->is_quick = slot.pool == SAVEGAME_SLOT_POOL_QUICK;
@@ -530,8 +530,7 @@ bool SG_Manager_Delete(const SAVEGAME_SLOT_REF slot)
         return false;
     }
 
-    const bool result = FS_Delete(savegame_info->full_path);
-    if (!result) {
+    if (!SHOULD(FS_Delete(savegame_info->full_path))) {
         return false;
     }
 

--- a/src/trx/game/screenshot.c
+++ b/src/trx/game/screenshot.c
@@ -113,7 +113,7 @@ static char *M_GetScreenshotPath(const SCREENSHOT_FORMAT format)
     char *full_path = Memory_DupStr(
         GamePath_Resolve(GAME_DYNAMIC_PATH_SCREENSHOT_WRITE_FILE, rel_path));
     Memory_FreePointer(&rel_path);
-    FS_EnsureParentDirectories(full_path);
+    SHOULD(FS_EnsureParentDirectories(full_path));
     if (FS_Exists(full_path)) {
         for (int i = 2; i < 100; i++) {
             Memory_FreePointer(&full_path);

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -83,8 +83,8 @@ static int32_t M_GuessEngineVersionFromLevelPath(const char *const path)
         return 0;
     }
 
-    TRX_FILE *const file = File_OpenPathInMemory(path);
-    if (file == nullptr) {
+    TRX_FILE *file = nullptr;
+    if (!SHOULD(File_OpenPathInMemory(path, &file))) {
         return 0;
     }
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -137,9 +137,9 @@ static void M_LoadCatalog(
 {
     const char *const path =
         GamePath_Resolve(GAME_DYNAMIC_PATH_CATALOG, filename);
-    if (!Catalog_Load(context, path, allow_duplicates)) {
-        Shell_ExitSystemFmt("Failed to load catalogs from %s", path);
-    }
+    EXIT_ON_FAIL(
+        Catalog_Load(context, path, allow_duplicates),
+        "Failed to load catalogs");
 }
 
 static void M_InitModules(void)

--- a/src/trx/game/shell/state.c
+++ b/src/trx/game/shell/state.c
@@ -77,7 +77,7 @@ void ShellState_RememberLastPlayedMod(const char *const mod_name)
 
     JSON_VALUE *const root = JSON_ValueFromObject(root_obj);
     const char *const state_path = M_GetStatePath();
-    FS_EnsureParentDirectories(state_path);
+    SHOULD(FS_EnsureParentDirectories(state_path));
     if (FS_Exists(state_path)) {
         SHOULD(JSONFile_Write(state_path, root));
     } else {

--- a/src/trx/game/shell/state.c
+++ b/src/trx/game/shell/state.c
@@ -83,8 +83,8 @@ void ShellState_RememberLastPlayedMod(const char *const mod_name)
     } else {
         size_t out_len = 0;
         char *out_data = JSON_WritePretty(root, "  ", "\n", &out_len);
-        TRX_FILE *const fp = File_OpenPath(state_path, FILE_OPEN_WRITE);
-        if (fp != nullptr) {
+        TRX_FILE *fp = nullptr;
+        if (SHOULD(File_OpenPath(state_path, FILE_OPEN_WRITE, &fp))) {
             File_WriteData(fp, out_data, out_len - 1); // w/o \0
             File_Close(fp);
         }

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -338,8 +338,8 @@ void Stats_CalculateMaxStats(void)
             continue;
         }
 
-        TRX_FILE *const file = File_OpenPathInMemory(level->path);
-        if (file == nullptr) {
+        TRX_FILE *file = nullptr;
+        if (!SHOULD(File_OpenPathInMemory(level->path, &file))) {
             continue;
         }
 

--- a/src/trx/gl/program.c
+++ b/src/trx/gl/program.c
@@ -34,7 +34,7 @@ static const char *M_LoadFileCached(const char *const path)
     }
 
     char *content = nullptr;
-    if (!FS_Load(path, &content, nullptr)) {
+    if (!SHOULD(FS_Load(path, &content, nullptr))) {
         return nullptr;
     }
     M_SHADER_FILE_CACHE_ENTRY entry = {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Opening, reading, and deleting files and creating directories now return a `RESULT` with the path and system error, instead of leaving callers to invent a generic message. Directory creation no longer fails silently, and deleting a save now says why it failed.

Optional JSON reads now distinguish a missing file from one that exists but cannot be opened. Music backends still stay quiet when their catalog is absent, since a game may simply ship without music.

The thread pool goes the other way: adding a job and creating a pool cannot fail, so their unused return values are gone.

```c
RESULT File_OpenPath(const char *path, FILE_OPEN_MODE mode, TRX_FILE **out_file);
RESULT File_OpenPathInMemory(const char *path, TRX_FILE **out_file);
RESULT File_SetSize(TRX_FILE *file, size_t size);
RESULT FS_Load(const char *path, char **output_data, size_t *output_size);
RESULT FS_Delete(const char *path);
RESULT FS_CreateDirectory(const char *path);
RESULT FS_EnsureParentDirectories(const char *path);
void ThreadPool_AddJob(THREAD_POOL *pool, THREAD_FUNC func, void *user_data);
```

The soft-failure model for reads is unchanged: normal reads are fatal, `Try*` reads return a bool and set the file error flag, and `File_HasFailed` checks a sequence of reads at once.