### PR TITLE
Fix a crash when another game is switched to in a vehicle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Changed a broken settings, strings or game data file to say what is wrong with it and where
 - Changed Lara turning to gold on the Midas hand to gild the outfit she has on, rather than swap her for a golden model
 - Fixed the game closing when a language with a broken strings file is picked
+- Fixed the game closing when another game is switched to while Lara is riding a vehicle
 - Fixed a false warning that the settings could not be saved
 
 **Lua**

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -111,7 +111,9 @@ static XYZ_32 M_GetItemMaxDelta(const ITEM *const item)
     case O_LARA:
     case O_LARA_EXTRA: {
         const ITEM *const vehicle = Lara_Vehicle_GetItem();
-        if (vehicle == nullptr) {
+        if (vehicle == nullptr || vehicle == item
+            || vehicle->object_id == O_LARA
+            || vehicle->object_id == O_LARA_EXTRA) {
             break;
         }
         return M_GetItemMaxDelta(vehicle);

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -41,6 +41,7 @@ void Level_Unload(void)
     Sound_ResetSamples();
 
     Lara_InitialiseLoad(NO_ITEM);
+    Lara_Vehicle_SetIndex(NO_ITEM);
 
     Gym_TrackManager_Reset(GYM_TRACK_ASSAULT);
     Gym_TrackManager_Reset(GYM_TRACK_QUAD);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Switching games while Lara was riding any vehicle could crash the game. The vehicle index survived the level unload, causing interpolation to recurse until the stack ran out. `Level_Unload` now clears the vehicle index, and maximum delta lookup no longer recurses.

Resolves TRX1148