### PR TITLE
Fix the reach for grabbing a rope

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed certain SFX, such as Lara's footsteps, playing in swamp rooms (#6248, regression from 1.0)
 - Fixed Lara being able to turn too quickly in swamp rooms (regression from 1.0)
 - Fixed Lara being able to vault or crawl through breakable walls that stand on the edge of a tile (Gameplay → Fixes → Fix breakable wall clipping) (OG bug)
+- Fixed Lara's rope-grab reach being shorter from certain directions (OG bug)
 
 **UI**
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)

--- a/src/trx/game/objects/general/rope.c
+++ b/src/trx/game/objects/general/rope.c
@@ -59,7 +59,7 @@ static void M_Collision(
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(lara_item);
     XYZ_32 test_pos = lara_item->pos;
     test_pos.y += bounds->min.y + M_GRAB_Y_OFFSET;
-    test_pos.z += (bounds->max.z * Math_Cos(lara_item->rot.y)) >> W2V_SHIFT;
+    test_pos = XYZ_32_OffsetYaw(test_pos, lara_item->rot.y, bounds->max.z);
     const int32_t radius = is_reach ? M_REACH_GRAB_RADIUS : M_JUMP_GRAB_RADIUS;
 
     const int32_t segment = Rope_NodeCollision(rope, test_pos, radius);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The rope-grab probe only accounted for Lara's forward reach along the world Z axis, putting it in the wrong place when she faced other directions. This made ropes harder to catch from some approaches.

Resolves TRX1143