### PR TITLE
Report startup failures rather than ending the run

### DIFF
--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -135,10 +135,10 @@ void FS_CloseDirectory(FS_DIR *const dir)
     closedir((DIR *)dir);
 }
 
-bool ConfigFile_Read(
+RESULT ConfigFile_Read(
     const char *const default_path, const char *const enforced_path)
 {
-    return false;
+    return OK;
 }
 
 bool ConfigFile_WasFound(void)

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -64,15 +64,17 @@ char *GamePath_ExpandVars(const char *const path)
 
 // Cached and valid for the run, as the engine's is: a caller may hold what it
 // was given.
-const char *GamePath_Resolve(
-    const GAME_DYNAMIC_PATH path, const char *const rel)
+RESULT GamePath_Resolve(
+    const GAME_DYNAMIC_PATH path, const char *const rel,
+    const char **const out_path)
 {
     char *const resolved = String_Format("%s/%s", TEST_SHIP_CFG_DIR, rel);
     for (const M_RESOLVED_PATH *entry = m_ResolvedPaths; entry != nullptr;
          entry = entry->next) {
         if (strcmp(entry->value, resolved) == 0) {
             Memory_Free(resolved);
-            return entry->value;
+            *out_path = entry->value;
+            return OK;
         }
     }
 
@@ -80,7 +82,8 @@ const char *GamePath_Resolve(
     entry->value = resolved;
     entry->next = m_ResolvedPaths;
     m_ResolvedPaths = entry;
-    return entry->value;
+    *out_path = entry->value;
+    return OK;
 }
 
 RESULT FS_Load(

--- a/src/tests/harness/stubs_config_file.c
+++ b/src/tests/harness/stubs_config_file.c
@@ -9,10 +9,10 @@
 
 #include <trx/config/file.h>
 
-bool ConfigFile_Read(
+RESULT ConfigFile_Read(
     const char *const default_path, const char *const enforced_path)
 {
-    return true;
+    return OK;
 }
 
 bool ConfigFile_WasFound(void)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -332,9 +332,11 @@ unit_tests += {
     'game/console/completion.c',
     'game/console/registry.c',
     'core/memory.c',
+    'core/result.c',
     'core/subsystem.c',
     'core/vector.c',
   ],
+  'src': ['harness/stubs_result.c'],
 }
 
 unit_tests += {
@@ -371,10 +373,11 @@ unit_tests += {
     'core/event_manager.c',
     'core/json/base.c',
     'core/json/parse.c',
+    'core/result.c',
     'core/subsystem.c',
     'version.c',
   ],
-  'src': ['harness/stubs_config_file.c'],
+  'src': ['harness/stubs_config_file.c', 'harness/stubs_result.c'],
 }
 
 # The migrations that carry an older release's settings file forward. They
@@ -518,7 +521,13 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/random',
   'bundles': [b_lua_surface, b_lua_math],
-  'engine': ['core/subsystem.c', 'game/lua/capi/random.c', 'game/random.c'],
+  'engine': [
+    'core/result.c',
+    'core/subsystem.c',
+    'game/lua/capi/random.c',
+    'game/random.c',
+  ],
+  'src': ['harness/stubs_result.c'],
 }
 
 unit_tests += {
@@ -891,12 +900,18 @@ unit_tests += {
 # decides rests on glyph widths, so a stub font would agree with anything.
 unit_tests += {
   'name': 'trx/game/ui/text',
-  'src': ['fakes/ui.c', 'fakes/ui_draw.c', 'harness/font_bin.c'],
+  'src': [
+    'fakes/ui.c',
+    'fakes/ui_draw.c',
+    'harness/font_bin.c',
+    'harness/stubs_result.c',
+  ],
   'engine': [
     'core/enum_map.c',
     'core/memory.c',
     'core/strings/case_funcs.c',
     'core/strings/common.c',
+    'core/result.c',
     'core/subsystem.c',
     'core/vector.c',
     'game/enum.c',
@@ -928,12 +943,13 @@ unit_tests += {
     'core/event_manager.c',
     'core/json/base.c',
     'core/json/parse.c',
+    'core/result.c',
     'core/subsystem.c',
     'game/ui/dialogs/settings_handlers.c',
     'game/ui/dialogs/settings_rows.c',
     'version.c',
   ],
-  'src': ['harness/stubs_config_file.c'],
+  'src': ['harness/stubs_config_file.c', 'harness/stubs_result.c'],
 }
 
 # The UI layout test is the widest of the unit tests: it stands up the settings
@@ -944,6 +960,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/ui',
   'src': [
+    'harness/stubs_result.c',
     'fakes/settings.c',
     'fakes/ui.c',
     'fakes/ui_draw.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -428,6 +428,7 @@ unit_tests += {
     'core/dynamic_enum.c',
     'core/enum_map.c',
     'core/memory.c',
+    'core/result.c',
     'core/value.c',
     'core/vector.c',
     'game/lua/capi/events.c',
@@ -435,7 +436,11 @@ unit_tests += {
     'game/lua/registry.c',
     'game/lua/utils.c',
   ],
-  'src': ['harness/stubs_enum_map.c', 'harness/stubs_game_script.c'],
+  'src': [
+    'harness/stubs_enum_map.c',
+    'harness/stubs_game_script.c',
+    'harness/stubs_result.c',
+  ],
   'deps': [dep_lua],
 }
 

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -99,7 +99,7 @@ void Config_ReportChange(const CONFIG_OPTION *const option, const bool persist)
     Vector_Add(m_Pending, &option);
 }
 
-bool Config_Read(
+RESULT Config_Read(
     const char *const default_path, const char *const enforced_path)
 {
     // Always initialize the config, even if the file is missing, so that
@@ -115,13 +115,8 @@ bool Config_Read(
     LOG_DEBUG("  default_path=%s", m_DefaultPath);
     LOG_DEBUG("  enforced_path=%s", m_EnforcedPath);
 
-    const bool result = ConfigFile_Read(m_DefaultPath, m_EnforcedPath);
+    const RESULT result = ConfigFile_Read(m_DefaultPath, m_EnforcedPath);
     m_FileFound = ConfigFile_WasFound();
-    if (result) {
-        LOG_DEBUG("Config loaded");
-    } else {
-        LOG_WARNING("Errors while loading config");
-    }
 
     Config_LoadFromJSON(ConfigFile_GetRoot());
     Config_Sanitize();

--- a/src/trx/config/common.h
+++ b/src/trx/config/common.h
@@ -6,7 +6,10 @@
 
 #include <stdint.h>
 
-bool Config_Read(const char *default_path, const char *enforced_path);
+// Reads the settings the session starts from. A missing file is no fault -
+// Config_IsFirstRun answers for that - while a file that does not parse is
+// reported, and the options start from their defaults.
+RESULT Config_Read(const char *default_path, const char *enforced_path);
 
 // Whether the settings file has been read. Until it has, what the options hold
 // is their defaults rather than the player's own choices.

--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -109,20 +109,15 @@ bool ConfigFile_WasFound(void)
     return m_CfgFound;
 }
 
-bool ConfigFile_Read(
+RESULT ConfigFile_Read(
     const char *const default_path, const char *const enforced_path)
 {
     ASSERT(default_path != nullptr);
     M_FreeRetained();
     m_CfgFound = FS_Exists(default_path);
 
-    bool result = false;
-    SHOULD(
-        JSONFile_Read(default_path, &m_CfgRoot),
-        "The settings start from their defaults");
-    if (m_CfgRoot != nullptr) {
-        result = true;
-    } else {
+    RESULT result = JSONFile_Read(default_path, &m_CfgRoot);
+    if (m_CfgRoot == nullptr) {
         // The settings still have to answer for themselves when the file is
         // missing, so stand an empty document in for it.
         JSON_OBJECT *const obj = JSON_ObjectNew();
@@ -131,9 +126,7 @@ bool ConfigFile_Read(
     }
     m_EnfRoot = nullptr;
     if (enforced_path != nullptr) {
-        SHOULD(
-            JSONFile_Read(enforced_path, &m_EnfRoot),
-            "The enforced settings are left out");
+        result = Result_Merge(result, JSONFile_Read(enforced_path, &m_EnfRoot));
     }
     return result;
 }

--- a/src/trx/config/file.h
+++ b/src/trx/config/file.h
@@ -11,7 +11,11 @@
 // they had to say about it. They belong to the read rather than to the process:
 // a game being swapped for another ends them.
 
-bool ConfigFile_Read(const char *default_path, const char *enforced_path);
+// Reads the settings file and the game flow's, keeping what each had to say.
+// A file that is not there is no fault and leaves the options at their
+// defaults; one that does not parse is reported, and both faults are reported
+// together where both files are wrong.
+RESULT ConfigFile_Read(const char *default_path, const char *enforced_path);
 
 // Whether the settings file was there for the last read, apart from whether it
 // parsed.

--- a/src/trx/config/presets.c
+++ b/src/trx/config/presets.c
@@ -153,6 +153,12 @@ static void M_Shutdown(void)
     M_FreeAllPresets();
 }
 
+static RESULT M_Load(void)
+{
+    Config_Presets_ScanFiles();
+    return OK;
+}
+
 void Config_Presets_ScanFiles(void)
 {
     M_FreeAllPresets();
@@ -236,6 +242,4 @@ void Config_Presets_Apply(const int32_t idx)
     SHOULD(Config_Write());
 }
 
-REGISTER_SUBSYSTEM(
-        .init = M_Init, .load = Config_Presets_ScanFiles,
-        .shutdown = M_Shutdown)
+REGISTER_SUBSYSTEM(.init = M_Init, .load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/core/subsystem.c
+++ b/src/trx/core/subsystem.c
@@ -3,10 +3,14 @@
 #include <trx/debug.h>
 
 #include <stdint.h>
+#include <string.h>
+
+// The registration macro names a module after __FILE__, which the compiler
+// spells as the path it was given, so the part above the sources is cut off.
+#define M_SOURCE_ROOT "src/trx/"
 
 typedef enum {
     M_PHASE_INIT,
-    M_PHASE_LOAD,
     M_PHASE_APPLY_CONFIG,
     M_PHASE_SHUTDOWN,
 } M_PHASE;
@@ -14,14 +18,18 @@ typedef enum {
 static SUBSYSTEM *m_First = nullptr;
 static SUBSYSTEM *m_Last = nullptr;
 
+static const char *M_TrimName(const char *const name)
+{
+    const char *const root = strstr(name, M_SOURCE_ROOT);
+    return root != nullptr ? root + strlen(M_SOURCE_ROOT) : name;
+}
+
 static SUBSYSTEM_FUNC M_GetPhaseFunc(
     const SUBSYSTEM *const subsystem, const M_PHASE phase)
 {
     switch (phase) {
     case M_PHASE_INIT:
         return subsystem->init;
-    case M_PHASE_LOAD:
-        return subsystem->load;
     case M_PHASE_APPLY_CONFIG:
         return subsystem->apply_config;
     case M_PHASE_SHUTDOWN:
@@ -51,6 +59,7 @@ static void M_RunPhase(const M_PHASE phase, const bool reverse)
 void Subsystem_Register(SUBSYSTEM *const subsystem)
 {
     ASSERT(subsystem->tier < SUBSYSTEM_TIER_NUMBER_OF);
+    subsystem->name = M_TrimName(subsystem->name);
     subsystem->prev = m_Last;
     subsystem->next = nullptr;
     if (m_Last != nullptr) {
@@ -66,9 +75,19 @@ void Subsystem_InitAll(void)
     M_RunPhase(M_PHASE_INIT, false);
 }
 
-void Subsystem_LoadAll(void)
+RESULT Subsystem_LoadAll(void)
 {
-    M_RunPhase(M_PHASE_LOAD, false);
+    for (int32_t tier = 0; tier < SUBSYSTEM_TIER_NUMBER_OF; tier++) {
+        for (SUBSYSTEM *subsystem = m_First; subsystem != nullptr;
+             subsystem = subsystem->next) {
+            if ((int32_t)subsystem->tier != tier
+                || subsystem->load == nullptr) {
+                continue;
+            }
+            MUST(subsystem->load(), "%s", subsystem->name);
+        }
+    }
+    return OK;
 }
 
 void Subsystem_ApplyConfigAll(void)

--- a/src/trx/core/subsystem.h
+++ b/src/trx/core/subsystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 // The lifecycle of a module that stands itself up and needs no other module to
 // have been brought up first.
 //
@@ -14,6 +16,10 @@
 
 typedef void (*SUBSYSTEM_FUNC)(void);
 
+// A phase that can fail and says so. What it reports carries the module's
+// name, so the shell names the module that stopped the game.
+typedef RESULT (*SUBSYSTEM_RESULT_FUNC)(void);
+
 // A tier comes up before the tiers after it and goes down after them. Within a
 // tier the order is the linker's, which is the order the source list happens to
 // be in, so nothing may rest on it.
@@ -27,10 +33,15 @@ typedef enum {
 // A module names only the phases it has.
 typedef struct SUBSYSTEM {
     SUBSYSTEM_TIER tier;
+    // What the module is called in a report. This is the source file it
+    // registers from, unless the registration names something else.
+    const char *name;
     // Stand the module up. Only the tiers below this one are up.
     SUBSYSTEM_FUNC init;
     // Read what the module keeps on disk. The mod's paths are resolved by now.
-    SUBSYSTEM_FUNC load;
+    // A module that cannot read what it needs reports it rather than ending
+    // the run, and the shell decides what that costs.
+    SUBSYSTEM_RESULT_FUNC load;
     // Take the config as first read. This is the work the module already does
     // when one of its options is written later.
     SUBSYSTEM_FUNC apply_config;
@@ -50,7 +61,9 @@ void Subsystem_Register(SUBSYSTEM *subsystem);
 void Subsystem_InitAll(void);
 
 // Read what each subsystem keeps on disk, once the mod's paths are resolved.
-void Subsystem_LoadAll(void);
+// Reports the first module that could not read what it needs, naming it, and
+// leaves the modules after it unread.
+RESULT Subsystem_LoadAll(void);
 
 // Hand each subsystem the config the session starts with.
 void Subsystem_ApplyConfigAll(void);
@@ -61,7 +74,9 @@ void Subsystem_ShutdownAll(void);
 #define M_REGISTER_SUBSYSTEM(tier_, ...)                                       \
     __attribute__((constructor)) static void M_RegisterSubsystem(void)         \
     {                                                                          \
-        static SUBSYSTEM m_Subsystem = { .tier = (tier_), __VA_ARGS__ };       \
+        static SUBSYSTEM m_Subsystem = { .tier = (tier_),                      \
+                                         .name = __FILE__,                     \
+                                         __VA_ARGS__ };                        \
         Subsystem_Register(&m_Subsystem);                                      \
     }
 

--- a/src/trx/game/console/common.c
+++ b/src/trx/game/console/common.c
@@ -28,11 +28,12 @@ static void M_Shutdown(void)
     m_IsOpened = false;
 }
 
-static void M_Load(void)
+static RESULT M_Load(void)
 {
     UI_Console_Init(&m_UIState);
 
     Console_History_Init();
+    return OK;
 }
 
 void Console_Open(void)

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -241,9 +241,12 @@ static bool M_Play(const char *const file_name)
         return false;
     }
 
-    M_RENDER_CONTEXT render_ctx = {
-        .renderer_2d = Output_Quad_Create(),
-    };
+    M_RENDER_CONTEXT render_ctx = {};
+    if (!SHOULD(
+            Output_Quad_Create(&render_ctx.renderer_2d),
+            "the video cannot be drawn")) {
+        return false;
+    }
 
     Video_SetSurfaceAllocatorFunc(video, M_AllocateSurface, nullptr);
     Video_SetSurfaceDeallocatorFunc(video, M_DeallocateSurface, nullptr);

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -1061,6 +1061,7 @@ static RESULT M_LoadGameFlowDoc(
 static RESULT M_LoadGameFlowEx(
     const char *const path, const bool validation_mode, char **const error_out)
 {
+    FAIL_IF(path == nullptr, "the game flow file is not where TRX looked");
     JSON_VALUE *doc = nullptr;
     const RESULT read = JSONFile_ReadRequired(path, &doc);
     if (!IS_OK(read)) {

--- a/src/trx/game/gun/vars.c
+++ b/src/trx/game/gun/vars.c
@@ -227,7 +227,7 @@ static RESULT M_LoadFrom(const char *const path)
     return result;
 }
 
-static void M_Load(void)
+static RESULT M_Load(void)
 {
     const char *path = nullptr;
     RESULT result = GamePath_Resolve(
@@ -235,7 +235,7 @@ static void M_Load(void)
     if (IS_OK(result)) {
         result = M_LoadFrom(path);
     }
-    EXIT_ON_FAIL(result, "Failed to load the weapon settings");
+    return result;
 }
 
 REGISTER_SUBSYSTEM(.load = M_Load)

--- a/src/trx/game/gun/vars.c
+++ b/src/trx/game/gun/vars.c
@@ -229,9 +229,13 @@ static RESULT M_LoadFrom(const char *const path)
 
 static void M_Load(void)
 {
-    const char *const path =
-        GamePath_Resolve(GAME_DYNAMIC_PATH_COMMON_CONFIG, "weapons.json5");
-    EXIT_ON_FAIL(M_LoadFrom(path), "Failed to load the weapon settings");
+    const char *path = nullptr;
+    RESULT result = GamePath_Resolve(
+        GAME_DYNAMIC_PATH_COMMON_CONFIG, "weapons.json5", &path);
+    if (IS_OK(result)) {
+        result = M_LoadFrom(path);
+    }
+    EXIT_ON_FAIL(result, "Failed to load the weapon settings");
 }
 
 REGISTER_SUBSYSTEM(.load = M_Load)

--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -254,7 +254,7 @@ static void M_SaveSection(JSON_OBJECT *const input_obj)
     }
 }
 
-static void M_Load(void)
+static RESULT M_Load(void)
 {
     for (int32_t i = 0; m_HoldChecks[i].role != (INPUT_ROLE)-1; i++) {
         m_HoldChecks[i].delay_timer.type = CLOCK_TIMER_REAL;
@@ -268,6 +268,7 @@ static void M_Load(void)
             impl->init();
         }
     }
+    return OK;
 }
 
 static void M_ApplyConfig(void)

--- a/src/trx/game/inventory_ring/vars.c
+++ b/src/trx/game/inventory_ring/vars.c
@@ -97,7 +97,7 @@ static RESULT M_LoadFrom(const char *const path)
     return result;
 }
 
-static void M_Load(void)
+static RESULT M_Load(void)
 {
     const char *path = nullptr;
     RESULT result = GamePath_Resolve(
@@ -105,7 +105,7 @@ static void M_Load(void)
     if (IS_OK(result)) {
         result = M_LoadFrom(path);
     }
-    EXIT_ON_FAIL(result, "Failed to load the inventory ring");
+    return result;
 }
 
 REGISTER_SUBSYSTEM(.init = M_Init, .load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/game/inventory_ring/vars.c
+++ b/src/trx/game/inventory_ring/vars.c
@@ -99,9 +99,13 @@ static RESULT M_LoadFrom(const char *const path)
 
 static void M_Load(void)
 {
-    const char *const path =
-        GamePath_Resolve(GAME_DYNAMIC_PATH_COMMON_CONFIG, "inv_ring.json5");
-    EXIT_ON_FAIL(M_LoadFrom(path), "Failed to load the inventory ring");
+    const char *path = nullptr;
+    RESULT result = GamePath_Resolve(
+        GAME_DYNAMIC_PATH_COMMON_CONFIG, "inv_ring.json5", &path);
+    if (IS_OK(result)) {
+        result = M_LoadFrom(path);
+    }
+    EXIT_ON_FAIL(result, "Failed to load the inventory ring");
 }
 
 REGISTER_SUBSYSTEM(.init = M_Init, .load = M_Load, .shutdown = M_Shutdown)

--- a/src/trx/game/lara/pose.c
+++ b/src/trx/game/lara/pose.c
@@ -74,10 +74,10 @@ static RESULT M_LoadPosesArray(JSON_READ_IO *const io, VECTOR *const poses)
     return OK;
 }
 
-static void M_LoadPoses(void)
+static RESULT M_LoadPoses(void)
 {
     if (m_Poses != nullptr) {
-        return;
+        return OK;
     }
     m_Poses = Vector_Create(sizeof(LARA_POSE));
     ASSERT(m_Poses != nullptr);
@@ -85,18 +85,19 @@ static void M_LoadPoses(void)
     const char *const poses_path =
         GamePath_TryResolve(GAME_DYNAMIC_PATH_COMMON_CONFIG, "poses.json5");
     if (poses_path == nullptr) {
-        return;
+        return OK;
     }
     JSON_VALUE *doc = nullptr;
     SHOULD(JSONFile_Read(poses_path, &doc), "Lara keeps her default poses");
     if (doc == nullptr) {
-        return;
+        return OK;
     }
 
     JSON_READ_IO *const io = JSON_ReadIO_Create(doc, 0, poses_path);
     SHOULD(M_LoadPosesArray(io, m_Poses), "Lara keeps her default poses");
     JSON_ReadIO_Destroy(io);
     JSON_ValueFree(doc);
+    return OK;
 }
 
 static void M_Shutdown(void)

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -496,9 +496,13 @@ static RESULT M_LoadFrom(const char *const source_path)
 
 static void M_Load(void)
 {
-    const char *const source_path =
-        GamePath_Resolve(GAME_DYNAMIC_PATH_COMMON_CONFIG, "outfits.json5");
-    EXIT_ON_FAIL(M_LoadFrom(source_path), "Failed to load the outfits");
+    const char *source_path = nullptr;
+    RESULT result = GamePath_Resolve(
+        GAME_DYNAMIC_PATH_COMMON_CONFIG, "outfits.json5", &source_path);
+    if (IS_OK(result)) {
+        result = M_LoadFrom(source_path);
+    }
+    EXIT_ON_FAIL(result, "Failed to load the outfits");
 }
 
 LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -494,7 +494,7 @@ static RESULT M_LoadFrom(const char *const source_path)
     return result;
 }
 
-static void M_Load(void)
+static RESULT M_Load(void)
 {
     const char *source_path = nullptr;
     RESULT result = GamePath_Resolve(
@@ -502,7 +502,7 @@ static void M_Load(void)
     if (IS_OK(result)) {
         result = M_LoadFrom(source_path);
     }
-    EXIT_ON_FAIL(result, "Failed to load the outfits");
+    return result;
 }
 
 LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -138,34 +138,33 @@ static void M_RegisterTRXPreloadEmbedded(
     lua_pop(L, 2);
 }
 
-// Fatal for the reason a failure to seal is, in M_SealPublicAPI.
-static void M_RequireTRXModule(lua_State *const L, const char *name)
+static RESULT M_RequireTRXModule(lua_State *const L, const char *name)
 {
     lua_getglobal(L, "require");
     lua_pushstring(L, name);
-    if (lua_pcall(L, 1, LUA_MULTRET, 0) != LUA_OK) {
-        Shell_ExitSystemFmt("failed to load %s: %s", name, lua_tostring(L, -1));
-    }
+    FAIL_IF(
+        lua_pcall(L, 1, LUA_MULTRET, 0) != LUA_OK, "%s: %s", name,
+        lua_tostring(L, -1));
     lua_settop(L, 0);
+    return OK;
 }
 
-static void M_SealPublicAPI(lua_State *const L)
+// Sealing audits the API too, and only engine scripts declare, so a failure
+// here says TRX's own data is wrong.
+static RESULT M_SealPublicAPI(lua_State *const L)
 {
-    // Sealing audits the API too, and only engine scripts declare - so a
-    // failure here means our own data is wrong. Fatal, like any other bad
-    // engine data.
-    if (!LUA_API_PushEntrypoint(L, "seal")) {
-        Shell_ExitSystem("the Lua API registry handed over no sealer");
-    }
-    if (lua_pcall(L, 0, 0, 0) != LUA_OK) {
-        Shell_ExitSystemFmt(
-            "failed to seal the Lua API: %s", lua_tostring(L, -1));
-    }
+    FAIL_IF(
+        !LUA_API_PushEntrypoint(L, "seal"),
+        "the Lua API registry handed over no sealer");
+    FAIL_IF(
+        lua_pcall(L, 0, 0, 0) != LUA_OK, "the Lua API would not seal: %s",
+        lua_tostring(L, -1));
     lua_pushnil(L);
     lua_setglobal(L, "trxc");
+    return OK;
 }
 
-static void M_LoadTRXModules(lua_State *const L)
+static RESULT M_LoadTRXModules(lua_State *const L)
 {
     // Register every module's preload entry before requiring any of them.
     // Doing both in one pass would mean a module could only ever require one
@@ -185,30 +184,32 @@ static void M_LoadTRXModules(lua_State *const L)
          script->path != nullptr; script++) {
         LOG_DEBUG("Loading TRX module %s", script->path);
         char *name = M_DeriveTRXModuleName(script->path);
-        M_RequireTRXModule(L, name);
+        const RESULT result = M_RequireTRXModule(L, name);
         Memory_FreePointer(&name);
+        MUST(result);
     }
+    return OK;
 }
 
 // Run after M_SealPublicAPI, so a script reaches all of trx.* without naming
 // the parts it wants, and api.define raises by then: it cannot extend the API
 // it consumes.
-static void M_RunTRXRuntimeScripts(lua_State *const L)
+static RESULT M_RunTRXRuntimeScripts(lua_State *const L)
 {
     for (const LUA_EMBEDDED_SCRIPT *script = g_LUA_EmbeddedRuntimeScripts;
          script->path != nullptr; script++) {
         LOG_DEBUG("Running TRX script %s", script->path);
         const char *const chunk_name =
             String_FormatStatic("@trx/%s", script->path);
-        if (luaL_loadbuffer(
+        FAIL_IF(
+            luaL_loadbuffer(
                 L, (const char *)script->data, script->size, chunk_name)
-                != LUA_OK
-            || lua_pcall(L, 0, 0, 0) != LUA_OK) {
-            Shell_ExitSystemFmt(
-                "failed to run %s: %s", script->path, lua_tostring(L, -1));
-        }
+                    != LUA_OK
+                || lua_pcall(L, 0, 0, 0) != LUA_OK,
+            "%s: %s", script->path, lua_tostring(L, -1));
         lua_settop(L, 0);
     }
+    return OK;
 }
 
 // One or more segments joined by '.', as Lua names any other module:
@@ -389,7 +390,7 @@ static int M_L_Require(lua_State *const L)
     return 1;
 }
 
-void LUA_Init(void)
+RESULT LUA_Init(void)
 {
     lua_State *const L = luaL_newstate();
     ASSERT(L != nullptr);
@@ -406,11 +407,12 @@ void LUA_Init(void)
     M_PRIV *const p = &m_Priv;
     p->state = L;
 
-    M_LoadTRXModules(L);
-    M_SealPublicAPI(L);
-    M_RunTRXRuntimeScripts(L);
+    MUST(M_LoadTRXModules(L));
+    MUST(M_SealPublicAPI(L));
+    MUST(M_RunTRXRuntimeScripts(L));
     LUA_HardenGlobals(L);
     LUA_InstallModRequire(L);
+    return OK;
 }
 
 void LUA_Shutdown(void)

--- a/src/trx/game/lua/common.h
+++ b/src/trx/game/lua/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trx/config/option.h>
+#include <trx/core/result.h>
 #include <trx/game/game_flow/types.h>
 
 #include <lualib.h>
@@ -18,7 +19,7 @@ typedef enum {
     LUA_CONTEXT_NUMBER_OF,
 } LUA_CONTEXT;
 
-void LUA_Init(void);
+RESULT LUA_Init(void);
 void LUA_Shutdown(void);
 
 // Prints the full public API surface as JSON: the C-side FIELD_DESC tables plus

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -1,4 +1,5 @@
 #include <trx/config.h>
+#include <trx/core/log.h>
 #include <trx/core/math/geom.h>
 #include <trx/core/utils.h>
 #include <trx/game/creature.h>
@@ -10,7 +11,6 @@
 #include <trx/game/objects/property.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
-#include <trx/game/shell.h>
 #include <trx/game/spawn.h>
 
 // clang-format off
@@ -565,7 +565,13 @@ static void M_Setup(OBJECT *const obj)
 
     obj->priv_size = sizeof(M_PRIV);
     if (!Object_Get(O_MESH_SWAP_2)->loaded) {
-        Shell_ExitSystem("Monkey requires O_MESH_SWAP_2 (pickups)");
+        // The level names the creature but ships no pickups to swap in, so it
+        // is left out rather than drawn wrong.
+        LOG_ERROR(
+            "Monkey needs O_MESH_SWAP_2 (pickups), which the level does not "
+            "have");
+        obj->loaded = false;
+        return;
     }
 
     obj->initialise_func = M_Initialise;

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -1,5 +1,6 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
+#include <trx/core/log.h>
 #include <trx/core/utils.h>
 #include <trx/game/creature.h>
 #include <trx/game/lara.h>
@@ -9,7 +10,6 @@
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
-#include <trx/game/shell.h>
 #include <trx/game/sound.h>
 #include <trx/game/sparks.h>
 #include <trx/game/spawn.h>
@@ -496,7 +496,13 @@ static void M_Setup(OBJECT *const obj)
     }
 
     if (!Object_Get(O_MESH_SWAP_1)->loaded) {
-        Shell_ExitSystem("Shiva requires O_MESH_SWAP_1 (statue)");
+        // The level names the creature but ships no statue to swap in, so it
+        // is left out rather than drawn wrong.
+        LOG_ERROR(
+            "Shiva needs O_MESH_SWAP_1 (statue), which the level does not "
+            "have");
+        obj->loaded = false;
+        return;
     }
 
     obj->initialise_func = M_Initialise;

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -69,14 +69,14 @@ static void M_Shutdown(void)
     Output_Lights_Shutdown();
 }
 
-void Output_Init(void)
+RESULT Output_Init(void)
 {
     SceneCompositor_Init();
     Output_Textures_Init();
 
     m_Uniforms = Output_Uniforms_Create();
-    m_ShaderWorld = Output_MeshShader_Create();
-    m_ShaderUI = Output_UIShader_Create();
+    MUST(Output_MeshShader_Create(&m_ShaderWorld));
+    MUST(Output_UIShader_Create(&m_ShaderUI));
     m_Batcher = MeshBatcher_Create();
     OutputSource_Sky_Init();
     SceneCompositor_AddSource(MeshBatcher_AsSource(m_Batcher));
@@ -94,6 +94,7 @@ void Output_Init(void)
     OutputSource_UI_Init();
 
     Output_ApplyRenderSettings();
+    return OK;
 }
 
 bool Output_IsHeadless(void)

--- a/src/trx/game/output/common.h
+++ b/src/trx/game/output/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/objects/types.h>
 #include <trx/game/output/shaders/mesh.h>
 #include <trx/game/output/shaders/ui.h>
@@ -7,7 +8,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/viewport.h>
 
-void Output_Init(void);
+RESULT Output_Init(void);
 bool Output_IsHeadless(void);
 
 const OUTPUT_UNIFORMS *Output_GetUniforms(void);

--- a/src/trx/game/output/quad.c
+++ b/src/trx/game/output/quad.c
@@ -145,8 +145,9 @@ static void M_UploadVertices(OUTPUT_QUAD *const r)
     TRX_GL_CheckError();
 }
 
-OUTPUT_QUAD *Output_Quad_Create(void)
+RESULT Output_Quad_Create(OUTPUT_QUAD **const out_quad)
 {
+    *out_quad = nullptr;
     OUTPUT_QUAD *const r = Memory_Alloc(sizeof(OUTPUT_QUAD));
 
     r->effect = OUTPUT_QUAD_EFFECT_NONE;
@@ -188,7 +189,7 @@ OUTPUT_QUAD *Output_Quad_Create(void)
     glGenTextures(1, &r->texture);
     TRX_GL_CheckError();
 
-    r->shader = Output_Shader_Create("2d.glsl");
+    MUST(Output_Shader_Create("2d.glsl", &r->shader));
 
     r->loc[M_UNIFORM_TEXTURE_MAIN] =
         Output_Shader_LookupUniform(r->shader, "uTexMain");
@@ -223,7 +224,8 @@ OUTPUT_QUAD *Output_Quad_Create(void)
         r->global_tint.b);
     TRX_GL_CheckError();
 
-    return r;
+    *out_quad = r;
+    return OK;
 }
 
 void Output_Quad_Destroy(OUTPUT_QUAD *const r)

--- a/src/trx/game/output/quad.h
+++ b/src/trx/game/output/quad.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trx/core/colors.h>
+#include <trx/core/result.h>
 #include <trx/gl/enum.h>
 
 #include <GL/glew.h>
@@ -49,7 +50,7 @@ typedef enum {
 } OUTPUT_QUAD_FIT_MODE;
 
 // Create a quad renderer instance and initialize GL resources.
-OUTPUT_QUAD *Output_Quad_Create(void);
+RESULT Output_Quad_Create(OUTPUT_QUAD **out_quad);
 // Destroy a quad renderer instance and release its GL resources.
 void Output_Quad_Destroy(OUTPUT_QUAD *renderer);
 

--- a/src/trx/game/output/shaders/generic.c
+++ b/src/trx/game/output/shaders/generic.c
@@ -73,15 +73,18 @@ static void M_DebugUBO(const GLuint program_id, const GLuint block_idx)
     Memory_Free(block_name);
 }
 
-OUTPUT_SHADER *Output_Shader_Create(const char *const path)
+RESULT Output_Shader_Create(
+    const char *const path, OUTPUT_SHADER **const out_shader)
 {
+    *out_shader = nullptr;
     OUTPUT_SHADER *const shader = Memory_Alloc(sizeof(OUTPUT_SHADER));
 
-    TRX_GL_Program_Init(&shader->program);
-    TRX_GL_Program_AttachShader(&shader->program, GL_VERTEX_SHADER, path);
-    TRX_GL_Program_AttachShader(&shader->program, GL_FRAGMENT_SHADER, path);
+    MUST(TRX_GL_Program_Init(&shader->program));
+    MUST(TRX_GL_Program_AttachShader(&shader->program, GL_VERTEX_SHADER, path));
+    MUST(TRX_GL_Program_AttachShader(
+        &shader->program, GL_FRAGMENT_SHADER, path));
     TRX_GL_Program_FragmentData(&shader->program, "outColor");
-    TRX_GL_Program_Link(&shader->program);
+    MUST(TRX_GL_Program_Link(&shader->program));
 
 #if 0
     M_DebugUBO(shader->program.id, 0);
@@ -118,7 +121,8 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
     }
 
     TRX_GL_Program_Bind(&shader->program);
-    return shader;
+    *out_shader = shader;
+    return OK;
 }
 
 void Output_Shader_Free(OUTPUT_SHADER *const shader)

--- a/src/trx/game/output/shaders/generic.h
+++ b/src/trx/game/output/shaders/generic.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <GL/glew.h>
 
 typedef struct OUTPUT_SHADER OUTPUT_SHADER;
 
-OUTPUT_SHADER *Output_Shader_Create(const char *path);
+RESULT Output_Shader_Create(const char *path, OUTPUT_SHADER **out_shader);
 void Output_Shader_Free(OUTPUT_SHADER *shader);
 void Output_Shader_Bind(const OUTPUT_SHADER *shader);
 

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -68,8 +68,9 @@ static void M_UploadEnvMapRect(
     }
 }
 
-OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
+RESULT Output_MeshShader_Create(OUTPUT_MESH_SHADER **const out_shader)
 {
+    *out_shader = nullptr;
     OUTPUT_MESH_SHADER *const shader = Memory_Alloc(sizeof(*shader));
     for (int32_t i = 0; i < M_VARIANT_COUNT; i++) {
         shader->has_model_matrix[i] = false;
@@ -82,7 +83,7 @@ OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
         shader->tint[i] = (RGBA_F) { 0.0f, 0.0f, 0.0f, 0.0f };
         shader->env_map_rect[i] = (OUTPUT_ATLAS_RECT) { .layer = -1 };
 
-        shader->base[i] = Output_Shader_Create(m_VariantPaths[i]);
+        MUST(Output_Shader_Create(m_VariantPaths[i], &shader->base[i]));
         Output_Shader_Bind(shader->base[i]);
         TRX_GL_TRACK_UNIFORM(
             glUniform1i,
@@ -95,7 +96,8 @@ OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
             TRX_GL_TRACK_UNIFORM(glUniform1i, loc, 1);
         }
     }
-    return shader;
+    *out_shader = shader;
+    return OK;
 }
 
 void Output_MeshShader_Bind(OUTPUT_MESH_SHADER *const shader)

--- a/src/trx/game/output/shaders/mesh.h
+++ b/src/trx/game/output/shaders/mesh.h
@@ -39,7 +39,7 @@ typedef enum {
 
 typedef struct OUTPUT_MESH_SHADER OUTPUT_MESH_SHADER;
 
-OUTPUT_MESH_SHADER *Output_MeshShader_Create(void);
+RESULT Output_MeshShader_Create(OUTPUT_MESH_SHADER **out_shader);
 void Output_MeshShader_Free(OUTPUT_MESH_SHADER *shader);
 void Output_MeshShader_Bind(OUTPUT_MESH_SHADER *shader);
 

--- a/src/trx/game/output/shaders/ui.c
+++ b/src/trx/game/output/shaders/ui.c
@@ -2,12 +2,15 @@
 
 #include <trx/gl/utils.h>
 
-OUTPUT_UI_SHADER *Output_UIShader_Create(void)
+RESULT Output_UIShader_Create(OUTPUT_UI_SHADER **const out_shader)
 {
-    OUTPUT_SHADER *const shader = Output_Shader_Create("ui.glsl");
+    *out_shader = nullptr;
+    OUTPUT_SHADER *shader = nullptr;
+    MUST(Output_Shader_Create("ui.glsl", &shader));
     TRX_GL_TRACK_UNIFORM(
         glUniform1i, Output_Shader_LookupUniform(shader, "uTexAtlas"), 0);
-    return shader;
+    *out_shader = shader;
+    return OK;
 }
 
 void Output_UIShader_Bind(const OUTPUT_UI_SHADER *const shader)

--- a/src/trx/game/output/shaders/ui.h
+++ b/src/trx/game/output/shaders/ui.h
@@ -4,6 +4,6 @@
 
 typedef OUTPUT_SHADER OUTPUT_UI_SHADER;
 
-OUTPUT_UI_SHADER *Output_UIShader_Create(void);
+RESULT Output_UIShader_Create(OUTPUT_UI_SHADER **out_shader);
 void Output_UIShader_Free(OUTPUT_UI_SHADER *shader);
 void Output_UIShader_Bind(const OUTPUT_UI_SHADER *shader);

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -1052,10 +1052,16 @@ void Output_Overlay_DrawBlackRectangle(const float opacity, const bool post_ui)
 void OutputSource_Overlay_Init(void)
 {
     M_PRIV *const p = &m_Priv;
-    p->renderer = Output_Quad_Create();
-    p->image.renderer = Output_Quad_Create();
-    p->snapshot.renderer = Output_Quad_Create();
-    p->pattern.renderer = Output_Quad_Create();
+    SHOULD(Output_Quad_Create(&p->renderer), "the overlay cannot be drawn");
+    SHOULD(
+        Output_Quad_Create(&p->image.renderer),
+        "the overlay image cannot be drawn");
+    SHOULD(
+        Output_Quad_Create(&p->snapshot.renderer),
+        "the overlay snapshot cannot be drawn");
+    SHOULD(
+        Output_Quad_Create(&p->pattern.renderer),
+        "the overlay pattern cannot be drawn");
     p->pattern.uploaded = false;
     M_EnsureSolidBlackTexture();
 

--- a/src/trx/game/paths.c
+++ b/src/trx/game/paths.c
@@ -1240,14 +1240,13 @@ const char *GamePath_TryResolve(
     return resolved;
 }
 
-const char *GamePath_Resolve(
-    const GAME_DYNAMIC_PATH path, const char *const rel)
+RESULT GamePath_Resolve(
+    const GAME_DYNAMIC_PATH path, const char *const rel,
+    const char **const out_path)
 {
-    const char *const resolved = GamePath_PeekResolve(path, rel);
-    if (resolved == nullptr) {
-        Shell_ExitSystem(M_GetResolveError(path, rel));
-    }
-    return resolved;
+    *out_path = GamePath_PeekResolve(path, rel);
+    FAIL_IF(*out_path == nullptr, "%s", M_GetResolveError(path, rel));
+    return OK;
 }
 
 RESULT GamePath_OpenFile(

--- a/src/trx/game/paths.h
+++ b/src/trx/game/paths.h
@@ -84,7 +84,9 @@ const char *GamePath_PeekResolve(GAME_DYNAMIC_PATH path, const char *rel);
 // Same as GamePath_PeekResolve, but logs an error on miss.
 const char *GamePath_TryResolve(GAME_DYNAMIC_PATH path, const char *rel);
 // Same as GamePath_PeekResolve, but terminates the game on miss.
-const char *GamePath_Resolve(GAME_DYNAMIC_PATH path, const char *rel);
+// Works out where a path names a file, reporting one that names nothing.
+RESULT GamePath_Resolve(
+    GAME_DYNAMIC_PATH path, const char *rel, const char **out_path);
 
 // Resolves and opens a file in one call, reporting a path that names nothing
 // as well as a file that will not open.

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -844,8 +844,8 @@ static bool M_ParseStartup(const char *const line, M_PARSE_CTX *const ctx)
             String_FormatStatic("%.*s", (int)str_len, str);
         ctx->startup.settings.mod = Shell_GetModByName(mod_name);
         if (ctx->startup.settings.mod == nullptr) {
-            Shell_ExitSystemFmt(
-                "Replay references unavailable mod '%s'", mod_name);
+            LOG_ERROR("the replay names a game that is not here: %s", mod_name);
+            return false;
         }
         if (ctx->startup.settings.engine_version <= 0) {
             ctx->startup.settings.engine_version =
@@ -908,7 +908,9 @@ static bool M_ParseArgs(const char *const line, M_PARSE_CTX *const ctx)
             p++;
         }
     }
-    ctx->args = Shell_ParseArgs(raw_args);
+    if (!Result_Absorb(Shell_ParseArgs(raw_args, &ctx->args))) {
+        return false;
+    }
     return true;
 }
 
@@ -1013,7 +1015,6 @@ SHELL_ARGS *TestReplay_Open(const char *path)
     char *data = nullptr;
     size_t size = 0;
     if (!SHOULD(FS_Load(path, &data, &size))) {
-        Shell_ExitSystemFmt("Cannot open replay file '%s'", path);
         return nullptr;
     }
     p->data = data;
@@ -1134,7 +1135,7 @@ SHELL_ARGS *TestReplay_Open(const char *path)
         M_ResetParseArgs(&ctx);
         ctx.args = M_BuildArgsFromStartupSnapshot(&ctx);
     } else if (ctx.args == nullptr) {
-        ctx.args = Shell_ParseArgs(nullptr);
+        IGNORE(Shell_ParseArgs(nullptr, &ctx.args));
     }
     if (ctx.used_deprecated_args && !ctx.startup.seen) {
         LOG_WARNING(

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -66,7 +66,7 @@ static JSON_VALUE *M_ReadRaw(TRX_FILE *const fp, int32_t *const version_out)
     return result;
 }
 
-static void M_SaveRaw(
+static RESULT M_SaveRaw(
     TRX_FILE *const fp, const JSON_VALUE *const root, const int32_t level_num,
     const bool is_quick)
 {
@@ -79,7 +79,9 @@ static void M_SaveRaw(
         (Bytef *)compressed, &compressed_size, (const Bytef *)uncompressed,
         (uLongf)uncompressed_size);
     if (result != Z_OK) {
-        Shell_ExitSystem("Failed to compress savegame data");
+        Memory_FreePointer(&uncompressed);
+        Memory_FreePointer(&compressed);
+        return FAIL("the savegame data would not compress");
     }
 
     const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
@@ -107,6 +109,7 @@ static void M_SaveRaw(
 
     Memory_FreePointer(&uncompressed);
     Memory_FreePointer(&compressed);
+    return OK;
 }
 
 static RESULT M_Load(JSON_READ_IO *const io)
@@ -153,7 +156,7 @@ bool SG_File_LoadFromFile(TRX_FILE *const fp)
     return result;
 }
 
-void SG_File_SaveToFile(TRX_FILE *const fp, SAVEGAME_INFO *const info)
+RESULT SG_File_SaveToFile(TRX_FILE *const fp, SAVEGAME_INFO *const info)
 {
     const GF_LEVEL *const current_level = Game_GetCurrentLevel();
     JSON_WRITE_IO *const io = JSON_WriteIO_Create();
@@ -171,10 +174,11 @@ void SG_File_SaveToFile(TRX_FILE *const fp, SAVEGAME_INFO *const info)
     SG_File_DumpRules(io);
     SG_File_DumpMisc(io);
 
-    M_SaveRaw(
+    const RESULT result = M_SaveRaw(
         fp, JSON_WriteIO_GetRoot(io), current_level->num,
         info != nullptr && info->is_quick);
     JSON_WriteIO_Destroy(io);
+    return result;
 }
 
 bool SG_File_FillInfo(TRX_FILE *const fp, SAVEGAME_INFO *const info)
@@ -284,7 +288,9 @@ bool SG_File_UpdateDeathCounters(
     }
 
     File_Seek(fp, 0, FILE_SEEK_SET);
-    M_SaveRaw(fp, root, level_num, is_quick);
+    if (!IS_OK(M_SaveRaw(fp, root, level_num, is_quick))) {
+        goto cleanup;
+    }
     result = true;
 
 cleanup:

--- a/src/trx/game/savegame/file.h
+++ b/src/trx/game/savegame/file.h
@@ -15,7 +15,7 @@ const char *SG_File_GetQuickSaveFilePattern(void);
 bool SG_File_FillInfo(TRX_FILE *fp, SAVEGAME_INFO *info);
 bool SG_File_LoadFromFile(TRX_FILE *fp);
 bool SG_File_LoadOnlyResumeInfo(TRX_FILE *fp);
-void SG_File_SaveToFile(TRX_FILE *fp, SAVEGAME_INFO *info);
+RESULT SG_File_SaveToFile(TRX_FILE *fp, SAVEGAME_INFO *info);
 bool SG_File_UpdateDeathCounters(
     TRX_FILE *fp, int32_t level_num, int32_t death_count, bool is_quick);
 

--- a/src/trx/game/savegame/manager.c
+++ b/src/trx/game/savegame/manager.c
@@ -492,9 +492,9 @@ bool SG_Manager_WriteSlot(const SAVEGAME_SLOT_REF slot)
     TRX_FILE *fp = nullptr;
     if (SHOULD(File_OpenPath(full_path, FILE_OPEN_WRITE, &fp))) {
         savegame_info->is_quick = slot.pool == SAVEGAME_SLOT_POOL_QUICK;
-        SG_File_SaveToFile(fp, savegame_info);
+        const RESULT written = SG_File_SaveToFile(fp, savegame_info);
         File_Close(fp);
-        result = true;
+        result = Result_Absorb(written);
     }
     if (result) {
         M_FillSlot(slot, full_path);

--- a/src/trx/game/screenshot.c
+++ b/src/trx/game/screenshot.c
@@ -110,17 +110,27 @@ static char *M_GetScreenshotPath(const SCREENSHOT_FORMAT format)
     const char *const ext = M_GetScreenshotFileExt(format);
     char *rel_path = String_Format("%s.%s", base_name, ext);
 
-    char *full_path = Memory_DupStr(
-        GamePath_Resolve(GAME_DYNAMIC_PATH_SCREENSHOT_WRITE_FILE, rel_path));
+    const char *resolved =
+        GamePath_PeekResolve(GAME_DYNAMIC_PATH_SCREENSHOT_WRITE_FILE, rel_path);
     Memory_FreePointer(&rel_path);
+    if (resolved == nullptr) {
+        Memory_FreePointer(&base_name);
+        return nullptr;
+    }
+    char *full_path = Memory_DupStr(resolved);
     SHOULD(FS_EnsureParentDirectories(full_path));
     if (FS_Exists(full_path)) {
         for (int i = 2; i < 100; i++) {
             Memory_FreePointer(&full_path);
             rel_path = String_Format("%s_%d.%s", base_name, i, ext);
-            full_path = Memory_DupStr(GamePath_Resolve(
-                GAME_DYNAMIC_PATH_SCREENSHOT_WRITE_FILE, rel_path));
+            resolved = GamePath_PeekResolve(
+                GAME_DYNAMIC_PATH_SCREENSHOT_WRITE_FILE, rel_path);
             Memory_FreePointer(&rel_path);
+            if (resolved == nullptr) {
+                Memory_FreePointer(&base_name);
+                return nullptr;
+            }
+            full_path = Memory_DupStr(resolved);
             if (!FS_Exists(full_path)) {
                 break;
             }

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -94,8 +94,9 @@ static int32_t M_GuessEngineVersionFromLevelPath(const char *const path)
     return game_version;
 }
 
-SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
+RESULT Shell_ParseArgs(VECTOR *const args, SHELL_ARGS **const out_args)
 {
+    *out_args = nullptr;
     SHELL_ARGS *const result = Memory_Alloc(sizeof(SHELL_ARGS));
     bool wants_gold = false;
     bool explicit_engine_version = false;
@@ -135,7 +136,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
             M_ShowHelp();
             Shell_FreeArgs(result);
-            return nullptr;
+            return OK; // nothing to play; the caller sees no args
         }
         if (!strcmp(arg, "--dump-lua-api")) {
             // Handled after LUA_Init: the dump combines the C field tables with
@@ -197,18 +198,21 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                                 result->startup.level_request.path);
                     }
                     if (result->startup.engine_version == 0) {
-                        Shell_ExitSystem(
-                            "Cannot determine engine version for --level. "
-                            "Please provide --engine.");
+                        Shell_FreeArgs(result);
+                        return FAIL(
+                            "--level does not say which engine to play it "
+                            "with. Please give --engine as well.");
                     }
                     result->startup.mod = Shell_GetModByType(
                         MOD_DIRECT_LEVEL, result->startup.engine_version);
                     if (result->startup.mod == nullptr) {
-                        Shell_ExitSystemFmt(
-                            "Engine %d does not support --level with a file "
-                            "path because no direct-level mod is available "
-                            "for that engine.",
-                            result->startup.engine_version);
+                        const int32_t engine_version =
+                            result->startup.engine_version;
+                        Shell_FreeArgs(result);
+                        return FAIL(
+                            "engine %d takes no --level with a file path, "
+                            "because it ships no direct-level game.",
+                            engine_version);
                     }
                 } else {
                     result->startup.level_request.query = next_arg;
@@ -273,7 +277,8 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
     }
 
-    return result;
+    *out_args = result;
+    return OK;
 }
 
 void Shell_FreeArgs(SHELL_ARGS *const args)

--- a/src/trx/game/shell/args.h
+++ b/src/trx/game/shell/args.h
@@ -40,6 +40,6 @@ typedef struct {
 // - `raw_args` items must be `char *` allocated on heap (or nullptr).
 // - ownership of vector + strings transfers to returned SHELL_ARGS.
 // - caller must not free or mutate `raw_args` after this call.
-SHELL_ARGS *Shell_ParseArgs(VECTOR *raw_args);
+RESULT Shell_ParseArgs(VECTOR *raw_args, SHELL_ARGS **out_args);
 // Frees SHELL_ARGS and its adopted `original_args` vector + strings.
 void Shell_FreeArgs(SHELL_ARGS *args);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -263,7 +263,7 @@ static RESULT M_PrepareSystem(void)
     MUST(M_LoadCatalog(CATALOG_LARA_ANIMS, "catalog_lara_anims.csv", false));
     MUST(
         M_LoadCatalog(CATALOG_ITEM_ACTIONS, "catalog_item_actions.csv", false));
-    Subsystem_LoadAll();
+    MUST(Subsystem_LoadAll());
 
     if (test_replay_path != nullptr) {
         TestReplay_Start();

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -55,7 +55,7 @@ static RESULT M_CreateGameWindow(void)
     return OK;
 }
 
-static RESULT M_FailUnsupportedGraphics(void)
+static RESULT M_FailUnsupportedGraphics(const RESULT cause)
 {
     char *driver = TRX_GL_Context_DescribeDriver(m_Window);
 
@@ -76,7 +76,7 @@ static RESULT M_FailUnsupportedGraphics(void)
         "Installing the latest drivers for the graphics card usually helps.%s",
         driver != nullptr ? driver : "unknown", hint);
 
-    const RESULT result = FAIL("%s", message);
+    const RESULT result = Result_Prefix(cause, "%s", message);
 
     Memory_FreePointer(&message);
     Memory_FreePointer(&driver);
@@ -92,8 +92,9 @@ static RESULT M_CreateGLContext(void)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(
         SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    if (!TRX_GL_Context_Attach(m_Window)) {
-        return M_FailUnsupportedGraphics();
+    const RESULT attached = TRX_GL_Context_Attach(m_Window);
+    if (!IS_OK(attached)) {
+        return M_FailUnsupportedGraphics(attached);
     }
     return OK;
 }
@@ -363,7 +364,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     GamePath_Init(s->args);
     EXIT_ON_FAIL(M_CreateGameWindow(), "TRX could not open a window");
     EXIT_ON_FAIL(M_CreateGLContext(), "TRX cannot draw the game");
-    Output_Init();
+    EXIT_ON_FAIL(Output_Init(), "TRX cannot draw the game");
     if (!s->args->headless) {
         M_ShowWindow();
     }

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -273,11 +273,11 @@ static RESULT M_PrepareSystem(void)
         FAIL_IF(
             engine_config_path == nullptr,
             "the settings file path could not be worked out");
-        if (!Config_Read(
+        SHOULD(
+            Config_Read(
                 engine_config_path,
-                Shell_GetGameFlowPath(s->args->startup.mod))) {
-            LOG_WARNING("Failed to read the settings file");
-        }
+                Shell_GetGameFlowPath(s->args->startup.mod)),
+            "The settings start from their defaults");
         Memory_FreePointer(&engine_config_path);
 
         if (s->args->test_record_path != nullptr) {

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -156,7 +156,7 @@ static RESULT M_InitModules(void)
     // up, so the platform stands first.
     Subsystem_InitAll();
 
-    LUA_Init();
+    MUST(LUA_Init(), "the Lua runtime could not be brought up");
 
     const SHELL_ARGS *const args = Shell_GetArgs();
     if (args != nullptr && args->startup.dump_lua_api) {

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -38,23 +38,24 @@ static bool m_PrevQuiet = false;
 // leave a copy behind.
 static int32_t m_ConfigListener = -1;
 
-static void M_CreateGameWindow(void)
+static RESULT M_CreateGameWindow(void)
 {
     if (m_Window != nullptr) {
-        return; // Window persists across mod switches
+        return OK; // Window persists across mod switches
     }
     m_Window = SDL_CreateWindow(
         "TRX", g_Config.window.x, g_Config.window.y, g_Config.window.width,
         g_Config.window.height,
         SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
 
-    if (m_Window == nullptr) {
-        Shell_ExitSystemFmt("Failed to create SDL window: %s", SDL_GetError());
-    }
+    FAIL_IF(
+        m_Window == nullptr, "the game window could not be created: %s",
+        SDL_GetError());
     Shell_EnableThemeSupport(m_Window);
+    return OK;
 }
 
-static void M_ExitUnsupportedGraphics(void)
+static RESULT M_FailUnsupportedGraphics(void)
 {
     char *driver = TRX_GL_Context_DescribeDriver(m_Window);
 
@@ -75,24 +76,26 @@ static void M_ExitUnsupportedGraphics(void)
         "Installing the latest drivers for the graphics card usually helps.%s",
         driver != nullptr ? driver : "unknown", hint);
 
-    Shell_ExitSystem(message);
+    const RESULT result = FAIL("%s", message);
 
     Memory_FreePointer(&message);
     Memory_FreePointer(&driver);
+    return result;
 }
 
-static void M_CreateGLContext(void)
+static RESULT M_CreateGLContext(void)
 {
     if (TRX_GL_Context_GetWindowHandle() != nullptr) {
-        return; // GL context persists across mod switches
+        return OK; // GL context persists across mod switches
     }
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(
         SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     if (!TRX_GL_Context_Attach(m_Window)) {
-        M_ExitUnsupportedGraphics();
+        return M_FailUnsupportedGraphics();
     }
+    return OK;
 }
 
 static void M_ShowWindow(void)
@@ -108,16 +111,17 @@ static void M_HandleConfigChange(const EVENT *const event, void *const data)
     Shell_HandleConfigChange(event->data);
 }
 
-static void M_SetupSDL(void)
+static RESULT M_SetupSDL(void)
 {
     SDL_version compiled;
     SDL_VERSION(&compiled);
     LOG_INFO(
         "SDL version: %d.%d.%d", compiled.major, compiled.minor,
         compiled.patch);
-    if (SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO) < 0) {
-        Shell_ExitSystemFmt("Cannot initialize SDL: %s", SDL_GetError());
-    }
+    FAIL_IF(
+        SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO) < 0,
+        "SDL could not be brought up: %s", SDL_GetError());
+    return OK;
 }
 
 static void M_SetupGL(void)
@@ -131,22 +135,20 @@ static void M_SetupGL(void)
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 }
 
-static void M_LoadCatalog(
+static RESULT M_LoadCatalog(
     const CATALOG_CONTEXT context, const char *const filename,
     const bool allow_duplicates)
 {
     const char *const path =
         GamePath_Resolve(GAME_DYNAMIC_PATH_CATALOG, filename);
-    EXIT_ON_FAIL(
-        Catalog_Load(context, path, allow_duplicates),
-        "Failed to load catalogs");
+    return Catalog_Load(context, path, allow_duplicates);
 }
 
-static void M_InitModules(void)
+static RESULT M_InitModules(void)
 {
     Shell_SetupHiDPI();
     Shell_SetupLibAV();
-    M_SetupSDL();
+    MUST(M_SetupSDL());
     M_SetupGL();
 
     // Some of the subsystems read the clock or the video state as they come
@@ -160,6 +162,7 @@ static void M_InitModules(void)
         LUA_DumpAPI();
         exit(0);
     }
+    return OK;
 }
 
 static void M_ShutdownModules(void)
@@ -183,16 +186,16 @@ static void M_ShutdownModules(void)
     Subsystem_ShutdownAll();
 }
 
-static void M_PrepareSystem(void)
+static RESULT M_PrepareSystem(void)
 {
     SHELL_SESSION *const s = m_Session;
     ASSERT(s != nullptr);
     const char *const test_replay_path = s->args->test_replay_path;
 
-    if (s->args->test_record_path != nullptr
-        && s->args->test_replay_path != nullptr) {
-        Shell_ExitSystem("Cannot use both --test-record and --test-replay");
-    }
+    FAIL_IF(
+        s->args->test_record_path != nullptr
+            && s->args->test_replay_path != nullptr,
+        "--test-record and --test-replay cannot both be given");
 
     if (test_replay_path != nullptr) {
         // Allow inferring engine version from outer args for replays lacking
@@ -206,7 +209,7 @@ static void M_PrepareSystem(void)
             ShellSession_UseArgs(s, tmp_args);
         }
     } else if (s->args->headless) {
-        Shell_ExitSystem("--headless can only be used with --test-replay");
+        return FAIL("--headless can only be given with --test-replay");
     }
 
     g_TRVersion = s->args->startup.engine_version;
@@ -222,24 +225,24 @@ static void M_PrepareSystem(void)
             : s->args->startup.mod_request;
         const char *const reason = Shell_GetModRejection(name);
         if (reason != nullptr) {
-            Shell_ExitSystemFmt("Cannot play %s.\n\n%s", name, reason);
+            return FAIL("%s cannot be played.\n\n%s", name, reason);
         }
         if (requested_mod == nullptr) {
-            Shell_ExitSystemFmt("There is no game called %s.", name);
+            return FAIL("there is no game called %s.", name);
         }
-        Shell_ExitSystemFmt("Cannot play %s.", name);
+        return FAIL("%s cannot be played.", name);
     }
 
     if (s->args->startup.engine_version <= 0
         || s->args->startup.mod == nullptr) {
         const char *const rejections = Shell_GetModRejections();
         if (rejections != nullptr) {
-            Shell_ExitSystemFmt(
-                "No playable mods available.\n\nThe following were passed "
+            return FAIL(
+                "There is no game to play.\n\nThe following were passed "
                 "over:\n%s",
                 rejections);
         }
-        Shell_ExitSystem("No playable mods available.");
+        return FAIL("There is no game to play.");
     }
     if (s->args->startup.mod->mod_type != MOD_DIRECT_LEVEL
         && test_replay_path == nullptr) {
@@ -252,12 +255,13 @@ static void M_PrepareSystem(void)
 
     // The catalogs name the objects, samples and music the subsystem loads
     // look themselves up in.
-    M_LoadCatalog(CATALOG_OBJECTS, "catalog_objects.csv", false);
-    M_LoadCatalog(CATALOG_MUSIC, "catalog_music.csv", false);
-    M_LoadCatalog(CATALOG_SAMPLES, "catalog_samples.csv", true);
-    M_LoadCatalog(CATALOG_LARA_STATES, "catalog_lara_states.csv", false);
-    M_LoadCatalog(CATALOG_LARA_ANIMS, "catalog_lara_anims.csv", false);
-    M_LoadCatalog(CATALOG_ITEM_ACTIONS, "catalog_item_actions.csv", false);
+    MUST(M_LoadCatalog(CATALOG_OBJECTS, "catalog_objects.csv", false));
+    MUST(M_LoadCatalog(CATALOG_MUSIC, "catalog_music.csv", false));
+    MUST(M_LoadCatalog(CATALOG_SAMPLES, "catalog_samples.csv", true));
+    MUST(M_LoadCatalog(CATALOG_LARA_STATES, "catalog_lara_states.csv", false));
+    MUST(M_LoadCatalog(CATALOG_LARA_ANIMS, "catalog_lara_anims.csv", false));
+    MUST(
+        M_LoadCatalog(CATALOG_ITEM_ACTIONS, "catalog_item_actions.csv", false));
     Subsystem_LoadAll();
 
     if (test_replay_path != nullptr) {
@@ -265,9 +269,9 @@ static void M_PrepareSystem(void)
     } else {
         char *engine_config_path =
             GamePath_ExpandVars("%config_dir%/TR%tr_version%X.json5");
-        if (engine_config_path == nullptr) {
-            Shell_ExitSystem("Failed to resolve engine config path");
-        }
+        FAIL_IF(
+            engine_config_path == nullptr,
+            "the settings file path could not be worked out");
         if (!Config_Read(
                 engine_config_path,
                 Shell_GetGameFlowPath(s->args->startup.mod))) {
@@ -283,6 +287,7 @@ static void M_PrepareSystem(void)
     m_ConfigListener = Config_SubscribeChanges(M_HandleConfigChange, nullptr);
 
     Subsystem_ApplyConfigAll();
+    return OK;
 }
 
 void Shell_RequestModSwitch(const char *const mod_name)
@@ -349,15 +354,15 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
 
     LOG_INFO("Game directory: %s", GamePath_Get(GAME_PATH_TRX_DIR));
 
-    M_InitModules();
-    M_PrepareSystem();
+    EXIT_ON_FAIL(M_InitModules(), "TRX could not start");
+    EXIT_ON_FAIL(M_PrepareSystem(), "TRX could not start");
     if (s->args->startup.mod == nullptr) {
         Shell_ExitSystem("No --mod specified.");
         return 1;
     }
     GamePath_Init(s->args);
-    M_CreateGameWindow();
-    M_CreateGLContext();
+    EXIT_ON_FAIL(M_CreateGameWindow(), "TRX could not open a window");
+    EXIT_ON_FAIL(M_CreateGLContext(), "TRX cannot draw the game");
     Output_Init();
     if (!s->args->headless) {
         M_ShowWindow();

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -140,8 +140,8 @@ static RESULT M_LoadCatalog(
     const CATALOG_CONTEXT context, const char *const filename,
     const bool allow_duplicates)
 {
-    const char *const path =
-        GamePath_Resolve(GAME_DYNAMIC_PATH_CATALOG, filename);
+    const char *path = nullptr;
+    MUST(GamePath_Resolve(GAME_DYNAMIC_PATH_CATALOG, filename, &path));
     return Catalog_Load(context, path, allow_duplicates);
 }
 

--- a/src/trx/game/shell/main.c
+++ b/src/trx/game/shell/main.c
@@ -19,8 +19,11 @@ int main(int argc, char *argv[])
     }
 
     GamePath_Init(nullptr);
-    Shell_ScanAvailableMods();
-    SHELL_ARGS *args = Shell_ParseArgs(raw_args);
+    EXIT_ON_FAIL(Shell_ScanAvailableMods(), "TRX cannot find the games");
+    SHELL_ARGS *args = nullptr;
+    EXIT_ON_FAIL(
+        Shell_ParseArgs(raw_args, &args),
+        "TRX cannot make sense of how it was started");
     if (args == nullptr) {
         return 0;
     }

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -177,7 +177,7 @@ static void M_ReadModMetaForKnownMods(void)
         }
 
         const char *const gameflow_path =
-            GamePath_Resolve(GAME_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
+            GamePath_PeekResolve(GAME_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
         if (gameflow_path == nullptr) {
             continue;
         }
@@ -539,5 +539,5 @@ char *Shell_GetGameStringsPath(const SHELL_MOD *const mod)
 
 const char *Shell_GetGameFlowPath(const SHELL_MOD *const mod)
 {
-    return GamePath_Resolve(GAME_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
+    return GamePath_PeekResolve(GAME_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
 }

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -229,13 +229,13 @@ static void M_ValidateEngineVersions(void)
     }
 }
 
-static void M_ValidateNoMixedModLayouts(void)
+static RESULT M_ValidateNoMixedModLayouts(void)
 {
     const char *const games_dir = GamePath_Get(GAME_PATH_GAMES_DIR);
     const char *const config_dir = GamePath_Get(GAME_PATH_CONFIG_DIR);
     if (games_dir == nullptr || config_dir == nullptr
         || strcmp(games_dir, config_dir) == 0) {
-        return;
+        return OK;
     }
 
     for (int32_t i = 0; i < m_Mods->count; i++) {
@@ -248,7 +248,7 @@ static void M_ValidateNoMixedModLayouts(void)
         if (FS_Exists(legacy_gameflow)) {
             // The paths are long enough that the message box cannot fit them
             // on one line, and it does not wrap.
-            Shell_ExitSystemFmt(
+            return FAIL(
                 "Mixed mod layout detected.\n"
                 "\n"
                 "Legacy mod data found at:\n"
@@ -262,6 +262,7 @@ static void M_ValidateNoMixedModLayouts(void)
                 legacy_gameflow, games_dir, mod->name, games_dir, mod->name);
         }
     }
+    return OK;
 }
 
 static char *M_GetModStringsPath(const char *const mod_id)
@@ -354,7 +355,7 @@ const char *Shell_GetModRejections(void)
     return m_RejectionSummary;
 }
 
-void Shell_ScanAvailableMods(void)
+RESULT Shell_ScanAvailableMods(void)
 {
     if (m_Mods != nullptr) {
         M_Shutdown();
@@ -372,7 +373,7 @@ void Shell_ScanAvailableMods(void)
         mod->is_valid = mod->is_available;
     }
 
-    M_ValidateNoMixedModLayouts();
+    MUST(M_ValidateNoMixedModLayouts());
     M_ScanForCustomMods();
 
     // Mark availability for newly added custom mods.
@@ -387,6 +388,7 @@ void Shell_ScanAvailableMods(void)
 
     M_ReadModMetaForKnownMods();
     M_ValidateEngineVersions();
+    return OK;
 }
 
 void Shell_ValidateMods(void)

--- a/src/trx/game/shell/mod.h
+++ b/src/trx/game/shell/mod.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <stdint.h>
 
 typedef enum {
@@ -20,7 +22,7 @@ typedef struct {
     bool is_valid;
 } SHELL_MOD;
 
-void Shell_ScanAvailableMods(void);
+RESULT Shell_ScanAvailableMods(void);
 
 // Why the scan passed over the game directories it could not use, one per
 // line, or nullptr where it passed over none. Points at the file and, for a

--- a/src/trx/game/ui/settings.c
+++ b/src/trx/game/ui/settings.c
@@ -671,9 +671,13 @@ static RESULT M_LoadFrom(const char *const path)
 
 static void M_Load(void)
 {
-    const char *const path =
-        GamePath_Resolve(GAME_DYNAMIC_PATH_COMMON_CONFIG, "ui.json5");
-    EXIT_ON_FAIL(M_LoadFrom(path), "Failed to load the interface settings");
+    const char *path = nullptr;
+    RESULT result =
+        GamePath_Resolve(GAME_DYNAMIC_PATH_COMMON_CONFIG, "ui.json5", &path);
+    if (IS_OK(result)) {
+        result = M_LoadFrom(path);
+    }
+    EXIT_ON_FAIL(result, "Failed to load the interface settings");
 }
 
 bool UI_Settings_IsCurrentBarLookPS1(void)

--- a/src/trx/game/ui/settings.c
+++ b/src/trx/game/ui/settings.c
@@ -669,7 +669,7 @@ static RESULT M_LoadFrom(const char *const path)
     return result;
 }
 
-static void M_Load(void)
+static RESULT M_Load(void)
 {
     const char *path = nullptr;
     RESULT result =
@@ -677,7 +677,7 @@ static void M_Load(void)
     if (IS_OK(result)) {
         result = M_LoadFrom(path);
     }
-    EXIT_ON_FAIL(result, "Failed to load the interface settings");
+    return result;
 }
 
 bool UI_Settings_IsCurrentBarLookPS1(void)

--- a/src/trx/gl/context.c
+++ b/src/trx/gl/context.c
@@ -78,20 +78,19 @@ VIEWPORT_SPACE TRX_GL_Context_GetViewport(void)
     return m_Context.space;
 }
 
-bool TRX_GL_Context_Attach(void *window_handle)
+RESULT TRX_GL_Context_Attach(void *window_handle)
 {
     const char *shading_ver;
 
     if (m_Context.window_handle) {
-        LOG_ERROR("Context already attached");
-        return false;
+        return FAIL("the OpenGL context is already attached");
     }
 
     LOG_INFO("Attaching to window %p", window_handle);
     m_Context.context = SDL_GL_CreateContext(window_handle);
     if (m_Context.context == nullptr) {
-        LOG_ERROR("Can't create OpenGL context: %s", SDL_GetError());
-        return false;
+        return FAIL(
+            "the OpenGL context could not be created: %s", SDL_GetError());
     }
 
     m_Context.config.line_width = 1;
@@ -101,16 +100,17 @@ bool TRX_GL_Context_Attach(void *window_handle)
 
     m_Context.window_handle = window_handle;
 
-    if (SDL_GL_MakeCurrent(m_Context.window_handle, m_Context.context)) {
-        Shell_ExitSystemFmt(
-            "Can't activate OpenGL context: %s", SDL_GetError());
-    }
+    FAIL_IF(
+        SDL_GL_MakeCurrent(m_Context.window_handle, m_Context.context),
+        "the OpenGL context could not be activated: %s", SDL_GetError());
 
     const GLenum err = glewInit();
     if (err != GLEW_OK) {
         if (err != 4) {
-            Shell_ExitSystemFmt(
-                "Can't initialize GLEW for OpenGL extension loading: %d", err);
+            return FAIL(
+                "GLEW could not be brought up to load the OpenGL "
+                "extensions: %d",
+                err);
         }
         // https://github.com/nigels-com/glew/issues/417
         LOG_WARNING("GLEW failed to init: %d", err);
@@ -143,10 +143,10 @@ bool TRX_GL_Context_Attach(void *window_handle)
 
     m_Context.renderer = &g_TRX_GL_Renderer;
     if (m_Context.renderer->init != nullptr) {
-        m_Context.renderer->init(m_Context.renderer, &m_Context.config);
+        MUST(m_Context.renderer->init(m_Context.renderer, &m_Context.config));
     }
 
-    return true;
+    return OK;
 }
 
 char *TRX_GL_Context_DescribeDriver(void *const window_handle)

--- a/src/trx/gl/context.h
+++ b/src/trx/gl/context.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/viewport.h>
 #include <trx/gl/enum.h>
 #include <trx/gl/renderer.h>
 
 #include <stdint.h>
 
-bool TRX_GL_Context_Attach(void *window_handle);
+RESULT TRX_GL_Context_Attach(void *window_handle);
 void TRX_GL_Context_Detach(void);
 
 // Describes the OpenGL driver the system offers, in the shape of

--- a/src/trx/gl/program.c
+++ b/src/trx/gl/program.c
@@ -60,10 +60,12 @@ __attribute__((destructor)) static void M_ShutdownCache(void)
     m_ShaderFileCache = nullptr;
 }
 
-static char *M_PreprocessIncludes(const char *src, const char *dir)
+static RESULT M_PreprocessIncludes(
+    const char *src, const char *dir, char **out_result)
 {
     ASSERT(src != nullptr);
     ASSERT(dir != nullptr);
+    *out_result = nullptr;
 
     const char *p = src;
     size_t result_cap = strlen(src) + 1;
@@ -102,8 +104,8 @@ static char *M_PreprocessIncludes(const char *src, const char *dir)
         const char *end_quote =
             start_quote ? strchr(start_quote + 1, '"') : nullptr;
         if (!start_quote || !end_quote) {
-            Shell_ExitSystemFmt(
-                "Malformed #include directive near: %.32s", include);
+            Memory_FreePointer(&result);
+            return FAIL("a #include says no file name near: %.32s", include);
         }
 
         char filename[512];
@@ -116,14 +118,20 @@ static char *M_PreprocessIncludes(const char *src, const char *dir)
 
         const char *const include_src = M_LoadFileCached(full_path);
         if (include_src == nullptr) {
-            Shell_ExitSystemFmt("Failed to include shader file: %s", full_path);
+            Memory_FreePointer(&result);
+            return FAIL("%s: the included shader could not be read", full_path);
         }
 
         // Handle nested includes
         char *include_dir = FS_GetParentDirectory(full_path);
-        char *processed_include =
-            M_PreprocessIncludes(include_src, include_dir ? include_dir : dir);
+        char *processed_include = nullptr;
+        const RESULT included = M_PreprocessIncludes(
+            include_src, include_dir ? include_dir : dir, &processed_include);
         Memory_FreePointer(&include_dir);
+        if (!IS_OK(included)) {
+            Memory_FreePointer(&result);
+            return included;
+        }
 
         // Append included content
         size_t block_len = strlen(processed_include);
@@ -143,7 +151,8 @@ static char *M_PreprocessIncludes(const char *src, const char *dir)
     }
 
     result[used] = '\0';
-    return result;
+    *out_result = result;
+    return OK;
 }
 
 static char *M_Preprocess(const char *content, GLenum type)
@@ -177,16 +186,13 @@ static char *M_Preprocess(const char *content, GLenum type)
     return processed_content;
 }
 
-bool TRX_GL_Program_Init(TRX_GL_PROGRAM *const program)
+RESULT TRX_GL_Program_Init(TRX_GL_PROGRAM *const program)
 {
     ASSERT(program != nullptr);
     program->id = glCreateProgram();
     TRX_GL_CheckError();
-    if (!program->id) {
-        LOG_ERROR("Can't create shader program");
-        return false;
-    }
-    return true;
+    FAIL_IF(!program->id, "the shader program could not be created");
+    return OK;
 }
 
 void TRX_GL_Program_Close(TRX_GL_PROGRAM *const program)
@@ -207,7 +213,7 @@ void TRX_GL_Program_Bind(const TRX_GL_PROGRAM *const program)
     TRX_GL_CheckError();
 }
 
-void TRX_GL_Program_AttachShader(
+RESULT TRX_GL_Program_AttachShader(
     TRX_GL_PROGRAM *program, GLenum type, const char *path)
 {
     ASSERT(program != nullptr);
@@ -220,20 +226,19 @@ void TRX_GL_Program_AttachShader(
 
     GLuint shader_id = glCreateShader(type);
     TRX_GL_CheckError();
-    if (!shader_id) {
-        Shell_ExitSystem("Failed to create shader");
-    }
+    FAIL_IF(!shader_id, "%s: the shader could not be created", program->path);
 
     const char *content = M_LoadFileCached(program->path);
     char *processed_content = nullptr;
-    if (content == nullptr) {
-        Shell_ExitSystemFmt("Unable to find shader file: %s", program->path);
-    }
+    FAIL_IF(
+        content == nullptr, "%s: the shader could not be read", program->path);
 
     char *shader_dir = FS_GetParentDirectory(program->path);
-    processed_content = M_PreprocessIncludes(content, shader_dir);
-    ASSERT(processed_content != nullptr);
+    const RESULT preprocessed =
+        M_PreprocessIncludes(content, shader_dir, &processed_content);
     Memory_FreePointer(&shader_dir);
+    MUST(preprocessed, "%s", program->path);
+    ASSERT(processed_content != nullptr);
 
     char *expanded_content = processed_content;
     processed_content = M_Preprocess(expanded_content, type);
@@ -257,12 +262,13 @@ void TRX_GL_Program_AttachShader(
         glGetShaderInfoLog(shader_id, info_log_size, &info_log_size, info_log);
         TRX_GL_CheckError();
 
+        Memory_FreePointer(&processed_content);
+        glDeleteShader(shader_id);
         if (info_log[0]) {
-            Shell_ExitSystemFmt(
-                "%s: compilation failed\n%s", program->path, info_log);
-        } else {
-            Shell_ExitSystemFmt("%s: compilation failed.", program->path);
+            return FAIL(
+                "%s: the shader did not compile\n%s", program->path, info_log);
         }
+        return FAIL("%s: the shader did not compile", program->path);
     }
 
     Memory_FreePointer(&processed_content);
@@ -272,9 +278,10 @@ void TRX_GL_Program_AttachShader(
 
     glDeleteShader(shader_id);
     TRX_GL_CheckError();
+    return OK;
 }
 
-void TRX_GL_Program_Link(TRX_GL_PROGRAM *const program)
+RESULT TRX_GL_Program_Link(TRX_GL_PROGRAM *const program)
 {
     ASSERT(program != nullptr);
     glLinkProgram(program->id);
@@ -291,12 +298,13 @@ void TRX_GL_Program_Link(TRX_GL_PROGRAM *const program)
             program->id, info_log_size, &info_log_size, info_log);
         TRX_GL_CheckError();
         if (info_log[0]) {
-            Shell_ExitSystemFmt(
-                "%s: shader linking failed\n%s", program->path, info_log);
-        } else {
-            Shell_ExitSystemFmt("%s: shader linking failed", program->path);
+            return FAIL(
+                "%s: the shader program did not link\n%s", program->path,
+                info_log);
         }
+        return FAIL("%s: the shader program did not link", program->path);
     }
+    return OK;
 }
 
 void TRX_GL_Program_FragmentData(

--- a/src/trx/gl/program.c
+++ b/src/trx/gl/program.c
@@ -219,8 +219,8 @@ RESULT TRX_GL_Program_AttachShader(
     ASSERT(program != nullptr);
     ASSERT(path != nullptr);
 
-    const char *const resolved_path =
-        GamePath_Resolve(GAME_DYNAMIC_PATH_SHADER_FILE, path);
+    const char *resolved_path = nullptr;
+    MUST(GamePath_Resolve(GAME_DYNAMIC_PATH_SHADER_FILE, path, &resolved_path));
     Memory_FreePointer(&program->path);
     program->path = Memory_DupStr(resolved_path);
 

--- a/src/trx/gl/program.h
+++ b/src/trx/gl/program.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/gl/enum.h>
 
 #include <GL/glew.h>
@@ -10,13 +11,13 @@ typedef struct {
     GLuint id;
 } TRX_GL_PROGRAM;
 
-bool TRX_GL_Program_Init(TRX_GL_PROGRAM *program);
+RESULT TRX_GL_Program_Init(TRX_GL_PROGRAM *program);
 void TRX_GL_Program_Close(TRX_GL_PROGRAM *program);
 
 void TRX_GL_Program_Bind(const TRX_GL_PROGRAM *program);
-void TRX_GL_Program_AttachShader(
+RESULT TRX_GL_Program_AttachShader(
     TRX_GL_PROGRAM *program, GLenum type, const char *path);
-void TRX_GL_Program_Link(TRX_GL_PROGRAM *program);
+RESULT TRX_GL_Program_Link(TRX_GL_PROGRAM *program);
 void TRX_GL_Program_FragmentData(TRX_GL_PROGRAM *program, const char *name);
 GLint TRX_GL_Program_UniformLocation(TRX_GL_PROGRAM *program, const char *name);
 

--- a/src/trx/gl/renderer.c
+++ b/src/trx/gl/renderer.c
@@ -209,7 +209,7 @@ static void M_SwapBuffers(TRX_GL_RENDERER *const renderer)
     TRX_GL_Context_SwitchToViewport(VIEWPORT_GAME);
 }
 
-static void M_Init(
+static RESULT M_Init(
     TRX_GL_RENDERER *const renderer, const TRX_GL_CONFIG *const config)
 {
     ASSERT(renderer != nullptr);
@@ -241,11 +241,13 @@ static void M_Init(
     TRX_GL_Sampler_Parameteri(&p->sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     TRX_GL_Sampler_Parameteri(&p->sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    TRX_GL_Program_Init(&p->program);
-    TRX_GL_Program_AttachShader(&p->program, GL_VERTEX_SHADER, "fbo.glsl");
-    TRX_GL_Program_AttachShader(&p->program, GL_FRAGMENT_SHADER, "fbo.glsl");
+    MUST(TRX_GL_Program_Init(&p->program));
+    MUST(
+        TRX_GL_Program_AttachShader(&p->program, GL_VERTEX_SHADER, "fbo.glsl"));
+    MUST(TRX_GL_Program_AttachShader(
+        &p->program, GL_FRAGMENT_SHADER, "fbo.glsl"));
     TRX_GL_Program_FragmentData(&p->program, "outColor");
-    TRX_GL_Program_Link(&p->program);
+    MUST(TRX_GL_Program_Link(&p->program));
     TRX_GL_Program_Bind(&p->program);
     TRX_GL_Program_Uniform1i(
         &p->program, TRX_GL_Program_UniformLocation(&p->program, "uTex0"), 0);
@@ -265,6 +267,7 @@ static void M_Init(
     rect = Viewport_GetRect(VIEWPORT_UI);
     TRX_GL_FBO_Init(
         &p->ui_fbo, rect.width, rect.height, 1, GL_RGBA8, GL_RGBA, false);
+    return OK;
 }
 
 static void M_Shutdown(TRX_GL_RENDERER *renderer)

--- a/src/trx/gl/renderer.h
+++ b/src/trx/gl/renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/gl/config.h>
 #include <trx/gl/texture.h>
 
@@ -7,7 +8,8 @@
 #include <stdint.h>
 
 typedef struct TRX_GL_Renderer {
-    void (*init)(struct TRX_GL_Renderer *renderer, const TRX_GL_CONFIG *config);
+    RESULT (*init)(
+        struct TRX_GL_Renderer *renderer, const TRX_GL_CONFIG *config);
     void (*shutdown)(struct TRX_GL_Renderer *renderer);
     void (*swap_buffers)(struct TRX_GL_Renderer *renderer);
     void *priv;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Startup failures now return a `RESULT` to the shell instead of exiting at the point of failure. This covers:

- SDL,
- window and graphics setup,
- shaders,
- catalogs,
- arguments,
- mods,
- subsystem loading,
- path resolution,
- settings.

The shell reports these errors in one place while preserving the startup stage and stack.

- Settings parse errors now include the file, line, and column, with game flow and player settings errors handled consistently.
- Recoverable failures should no longer bring the game down.
- Malformed settings fall back to defaults.
- Save compression errors affect only the failed save.
- Replays for games that are not installed are refused.
- Shiva and the monkey are skipped when their replacement meshes are missing.

Additionally, subsystem modules now have names, allowing the shell to identify which module failed during startup. By default, the name comes from the module's source file, but registration can override it. `GamePath_Resolve` also reports unresolved paths instead of terminating the game, while callers where a missing path is expected use `GamePath_PeekResolve`.

```c
RESULT Subsystem_LoadAll(void);
RESULT GamePath_Resolve(
    GAME_DYNAMIC_PATH path, const char *rel, const char **out_path);
RESULT Config_Read(const char *default_path, const char *enforced_path);
RESULT ConfigFile_Read(const char *default_path, const char *enforced_path);
RESULT TRX_GL_Context_Attach(void *window_handle);
RESULT TRX_GL_Program_Init(TRX_GL_PROGRAM *program);
RESULT TRX_GL_Program_AttachShader(
    TRX_GL_PROGRAM *program, GLenum type, const char *path);
RESULT TRX_GL_Program_Link(TRX_GL_PROGRAM *program);
```

Players who hit a broken driver, shader, mod or settings file are told what is wrong and where, instead of the game closing on them. Mod authors get the same for a file their mod ships that the game cannot read.

The missing `--mod` case still exits early, since no reporting session exists that soon.
