### PR TITLE
Fix the photo mode camera near vertical

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,19 +8,20 @@
 - Fixed Lara's rope-grab reach being shorter from certain directions (OG bug)
 
 **UI**
-- Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)
-- Changed Lara's outfit setting to offer only the outfits the current level can dress her in
-- Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects
-- Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10)
-- Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down
-- Changed moving Lara in photo mode to follow the direction the camera looks, rather than the way she faces
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187)
 - Added a flat yellow color to the PS1 bar palettes (Graphic Options → UI → Bars) (#5227)
-- Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258)
+- Changed Lara's outfit setting to offer only the outfits the current level can dress her in
+- Changed moving Lara in photo mode to follow the direction the camera looks, rather than the way she faces
+- Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc)
 - Changed the PS1 poison healthbar to flat yellow, as the PS1 releases had it (#5227)
-- Fixed ability to open the inventory ring while a flyby sequence has Lara's control
-- Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter
 - Changed the TR3 breeze mode to read TR3/4, as it covers both games (Graphic Options → Visuals → Breeze)
+- Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258)
+- Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter
+- Fixed ability to open the inventory ring while a flyby sequence has Lara's control
+- Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10)
+- Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects
+- Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down
+- Fixed the photo mode camera flickering and refusing to turn over when it is pitched past straight up or down, and turning in coarse steps while aimed near vertical
 
 **Developer console**
 - Added the `/outfit` console command, which shows or changes what Lara is wearing

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -306,12 +306,19 @@ void Camera_Apply(void)
     // so that the room portal culling that follows and the projection matrix
     // uploaded later in the frame agree on the same value.
     Output_ApplyFOV();
-    Matrix_LookAt(
-        g_Camera.interp.result.pos.x,
-        g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
-        g_Camera.interp.result.pos.z, g_Camera.interp.result.target.x,
-        g_Camera.interp.result.target.y, g_Camera.interp.result.target.z,
-        g_Camera.roll);
+    const XYZ_32 view_pos = {
+        .x = g_Camera.interp.result.pos.x,
+        .y = g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
+        .z = g_Camera.interp.result.pos.z,
+    };
+    if (g_Camera.type == CAM_PHOTO_MODE) {
+        Matrix_GenerateW2V(&view_pos, &g_Camera.interp.result.rot);
+    } else {
+        Matrix_LookAt(
+            view_pos.x, view_pos.y, view_pos.z, g_Camera.interp.result.target.x,
+            g_Camera.interp.result.target.y, g_Camera.interp.result.target.z,
+            g_Camera.roll);
+    }
 
     XYZ_32 poison_scale;
     if (Lara_Poison_GetViewScale(&poison_scale)) {

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -14,7 +14,6 @@
 #define MIN_PHOTO_FOV 10
 #define MAX_PHOTO_FOV 150
 #define PHOTO_ROT_SHIFT (DEG_1 * 4)
-#define PHOTO_MAX_PITCH_ROLL (DEG_90 - DEG_1)
 #define PHOTO_MAX_SPEED 100
 
 static int32_t m_PhotoSpeed = 0;
@@ -121,11 +120,14 @@ static void M_ApplyRotation(
     }
     roll += d_roll;
 
-    // handle pivoting
-    if (pitch >= DEG_90 || pitch <= -DEG_90) {
-        roll += DEG_180;
+    if (pitch > DEG_90) {
+        pitch = DEG_180 - pitch;
         yaw += DEG_180;
-        pitch = g_Camera.target_elevation;
+        roll += DEG_180;
+    } else if (pitch < -DEG_90) {
+        pitch = -DEG_180 - pitch;
+        yaw += DEG_180;
+        roll += DEG_180;
     }
 
     g_Camera.target_angle = yaw;

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -63,6 +63,7 @@ static void M_ResetCamera(const bool exiting)
     g_Camera = exiting ? m_OriginalCamera : m_StartingCamera;
     // ensure Camera_EnsureEnvironment() picks up the flag change
     g_Camera.underwater = camera.underwater;
+    g_Camera.interp = camera.interp;
     // Cinematic cameras control the FOV during their sequences, so avoid
     // resetting to user FOV on exit to prevent a 1-frame flicker.
     Viewport_AlterFOV(
@@ -85,12 +86,8 @@ static int32_t M_GetRotSpeed(void)
 // world's.
 static XYZ_32 M_GetShift(const int32_t dx, const int32_t dy, const int32_t dz)
 {
-    const XYZ_16 rot = {
-        .x = g_Camera.target_elevation,
-        .y = g_Camera.target_angle,
-        .z = g_Camera.roll,
-    };
-    return XYZ_32_Rotate((XYZ_32) { .x = dx, .y = dy, .z = dz }, rot);
+    return XYZ_32_Rotate(
+        (XYZ_32) { .x = dx, .y = dy, .z = dz }, Camera_PhotoMode_GetRot());
 }
 
 static void M_ShiftCamera(int32_t dx, int32_t dy, int32_t dz)
@@ -282,6 +279,15 @@ static bool M_HandleFOVInputs(void)
     CLAMP(m_CurrentFOV, MIN_PHOTO_FOV, MAX_PHOTO_FOV);
     Viewport_AlterFOV(m_CurrentFOV * DEG_1, m_CurrentFOVMode);
     return true;
+}
+
+XYZ_16 Camera_PhotoMode_GetRot(void)
+{
+    return (XYZ_16) {
+        .x = g_Camera.target_elevation,
+        .y = g_Camera.target_angle,
+        .z = g_Camera.roll,
+    };
 }
 
 void Camera_PhotoMode_Enter(void)

--- a/src/trx/game/camera/photo_mode.h
+++ b/src/trx/game/camera/photo_mode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <trx/core/math/types.h>
+
+XYZ_16 Camera_PhotoMode_GetRot(void);
+
 void Camera_PhotoMode_Enter(void);
 void Camera_PhotoMode_Exit(void);
 void Camera_PhotoMode_Update(void);

--- a/src/trx/game/camera/types.h
+++ b/src/trx/game/camera/types.h
@@ -56,6 +56,7 @@ typedef struct {
         struct {
             XYZ_32 target;
             XYZ_32 pos;
+            XYZ_16 rot;
             int32_t shift;
             int16_t fov;
         } result, prev;

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -7,6 +7,7 @@
 #include <trx/game/effects.h>
 #include <trx/game/game/state.h>
 #include <trx/game/lara.h>
+#include <trx/game/matrix.h>
 #include <trx/game/rooms.h>
 #include <trx/game/shell.h>
 #include <trx/game/viewport.h>
@@ -155,6 +156,9 @@ static XYZ_32 M_GetEffectMaxDelta(const EFFECT *const effect)
 static void M_RememberCamera(void)
 {
     m_PrevCameraType = g_Camera.type;
+    if (g_Camera.type == CAM_PHOTO_MODE) {
+        g_Camera.interp.prev.rot = Camera_PhotoMode_GetRot();
+    }
     REMEMBER(&g_Camera, fov);
     REMEMBER(&g_Camera, shift);
     REMEMBER(&g_Camera, pos.x);
@@ -508,17 +512,27 @@ void Interpolation_Interpolate(void)
         g_Camera.fov = Viewport_GetEffectiveFOV();
         INTERPOLATE(&g_Camera, fov, m_CameraRate, FOV_MAX_DELTA);
 
-        if (!sustained_binoculars
+        const bool snap = !sustained_binoculars
             && (DIFF(&g_Camera, shift) >= 128
                 || DIFF(&g_Camera, pos.x) >= CAM_MAX_DELTA
                 || DIFF(&g_Camera, pos.y) >= CAM_MAX_DELTA
                 || DIFF(&g_Camera, pos.z) >= CAM_MAX_DELTA
                 || DIFF(&g_Camera, target.x) >= CAM_MAX_DELTA
                 || DIFF(&g_Camera, target.y) >= CAM_MAX_DELTA
-                || DIFF(&g_Camera, target.z) >= CAM_MAX_DELTA)) {
+                || DIFF(&g_Camera, target.z) >= CAM_MAX_DELTA);
+        if (snap) {
             M_CommitCamera();
         } else {
             M_InterpolateCamera(m_CameraRate);
+        }
+
+        if (g_Camera.type == CAM_PHOTO_MODE) {
+            const XYZ_16 rot = Camera_PhotoMode_GetRot();
+            g_Camera.interp.result.rot =
+                snap || m_PrevCameraType != CAM_PHOTO_MODE
+                ? rot
+                : Matrix_SlerpRot16(
+                      g_Camera.interp.prev.rot, rot, m_CameraRate);
         }
 
         g_Camera.interp.room_num = g_Camera.pos.room_num;

--- a/src/trx/game/matrix.c
+++ b/src/trx/game/matrix.c
@@ -9,6 +9,7 @@
 
 #define MAX_MATRICES 40
 #define MAX_NESTED_MATRICES 32
+#define M_ROT_LOCK_EPSILON 1e-3
 
 static MATRIX m_MatrixStack[MAX_MATRICES] = {};
 static MATRIX m_WMatrixStack[MAX_MATRICES] = {};
@@ -370,13 +371,15 @@ static XYZ_16 M_ToRot16(const MATRIX *const m)
 
     double sin_x = -e[1][2];
     CLAMP(sin_x, -1.0, 1.0);
-    const double x = asin(sin_x);
+    const double cos_x = sqrt(e[0][2] * e[0][2] + e[2][2] * e[2][2]);
+    double x = asin(sin_x);
     double y;
     double z;
-    if (fabs(sin_x) < 1.0 - 1e-9) {
+    if (cos_x > M_ROT_LOCK_EPSILON) {
         y = atan2(e[0][2], e[2][2]);
         z = atan2(e[1][0], e[1][1]);
     } else {
+        x = sin_x < 0.0 ? -M_PI / 2.0 : M_PI / 2.0;
         y = atan2(-e[2][0], e[0][0]);
         z = 0.0;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR makes the photo mode camera rotate smoothly through vertical and continue into an upside-down view, while also making roll frame-rate independent like pitch and yaw. Previously, the camera would flip back and forth at vertical, and rotation near vertical became coarse because the view reconstructed its orientation from the camera target rather than photo mode’s own angles.