### PR TITLE
Move Lara along the camera's yaw in photo mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10)
 - Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down
+- Changed moving Lara in photo mode to follow the direction the camera looks, rather than the way she faces
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187)
 - Added a flat yellow color to the PS1 bar palettes (Graphic Options → UI → Bars) (#5227)
 - Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258)

--- a/src/trx/game/photo_mode.c
+++ b/src/trx/game/photo_mode.c
@@ -143,10 +143,7 @@ static bool M_HandleItemPositionInputs(ITEM *const item)
         return false;
     }
 
-    // The step is given along the camera's own axes, so it meets the whole
-    // orientation rather than the yaw alone.
-    item->pos = XYZ_32_OffsetLocal(
-        item->pos, delta, (XYZ_16) { .x = item->rot.x, .y = item->rot.y });
+    item->pos = XYZ_32_OffsetLocalYaw(item->pos, delta, g_Camera.target_angle);
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR makes Lara move relative to the camera in photo mode, while keeping height world-aligned.

@aredfan Please LMK if this feels more natural to you. I think I prefer it, but happy to drop this if it feels worse.