### PR TITLE
Fix scenery cut off at portals

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,9 +46,12 @@
 
 **Rendering**
 - Fixed scenery in an adjoining room being cut off along the edges of the portal it is seen through
+- Fixed objects showing through rooms that share their space with the room the object stands in
+- Fixed objects that reach into a neighbouring room being cut off or vanishing when seen through that room
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold
+- Fixed the boulder in room 78 getting drawn in the overlapping room 74 in Tomb of Tihocan (regression from 1.10.1)
 - Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand
 
 **TR3**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,9 @@
 **Music and sound**
 - Fixed crystal sound effects not playing if Lara collects one underwater (OG bug)
 
+**Rendering**
+- Fixed scenery in an adjoining room being cut off along the edges of the portal it is seen through
+
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold
 - Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -31,10 +31,6 @@ static int16_t m_NextItemFree = NO_ITEM;
 static uint32_t m_ItemGens[MAX_ITEMS];
 static HANDLE_REGISTRY m_ItemHandles;
 
-// Take the item out of a room's draw queues: the room itself and every portal
-// neighbour. The exact mirror of M_AddToDrawQueues below, plus the flipped
-// room, whose portals may differ if the map has been flipped. Paired with the
-// chain unlink below; both must run when an item leaves a room.
 static void M_RemoveFromDrawQueues(
     const int16_t item_num, const int16_t room_num)
 {
@@ -51,12 +47,26 @@ static void M_RemoveFromDrawQueues(
     }
 }
 
-// Put the item into a room's draw queues: the room itself and every portal
-// neighbour, unconditionally, so the removal above undoes exactly this and an
-// item drawn from a neighbouring room - a door, seen from the far side of its
-// doorway - is queued there again after every room change. The draw pass
-// dedups per frame and clips per room, so a queue entry the camera cannot
-// reach costs one rejected clip test.
+static BOUNDS_32 M_GetOccupancyBounds(const ITEM *const item)
+{
+    const BOUNDS_16 *const b = &Object_Get(item->object_id)->anim_bounds;
+    const int32_t radius =
+        MAX(MAX(ABS((int32_t)b->min.x), ABS((int32_t)b->max.x)),
+            MAX(ABS((int32_t)b->min.z), ABS((int32_t)b->max.z)));
+    return (BOUNDS_32) {
+        .min = {
+            .x = item->pos.x - radius,
+            .y = item->pos.y + b->min.y,
+            .z = item->pos.z - radius,
+        },
+        .max = {
+            .x = item->pos.x + radius,
+            .y = item->pos.y + b->max.y,
+            .z = item->pos.z + radius,
+        },
+    };
+}
+
 static void M_AddToDrawQueues(const int16_t item_num, const int16_t room_num)
 {
     if (room_num == NO_ROOM) {
@@ -67,8 +77,12 @@ static void M_AddToDrawQueues(const int16_t item_num, const int16_t room_num)
     if (room == nullptr || room->portals == nullptr) {
         return;
     }
+    const BOUNDS_32 bounds = M_GetOccupancyBounds(&m_Items[item_num]);
     for (int32_t i = 0; i < room->portals->count; i++) {
-        Room_AddDrawnItem(room->portals->portal[i].room_num, item_num);
+        const PORTAL *const portal = &room->portals->portal[i];
+        if (Room_BoundsReachPortal(&bounds, portal)) {
+            Room_AddDrawnItem(portal->room_num, item_num);
+        }
     }
 }
 
@@ -676,9 +690,6 @@ void Item_UpdateRoom(const int16_t item_num, const int16_t room_num)
     }
 }
 
-// Seed every item's draw queues once the rooms are in place. Item_Initialise
-// runs before the portals have their bounds, so the neighbour test can only be
-// answered here.
 void Item_InitialiseDrawQueues(void)
 {
     for (int32_t i = 0; i < m_LevelItemCount; i++) {

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -50,31 +50,6 @@ static inline BOUNDS_32 M_GetStaticBounds(const STATIC_MESH *const mesh)
     return bounds;
 }
 
-// Whether the mesh reaches through the portal into the room behind it. A wall
-// portal stands across the mesh, so meeting its quad is the question there. A
-// floor or ceiling portal lies flat, and a mesh that clears it sits wholly in
-// the room beyond, so what counts is standing over the opening and reaching
-// past its plane.
-static inline bool M_BoundsReachPortal(
-    const BOUNDS_32 *const bounds, const PORTAL *const portal)
-{
-    if (portal->normal.y == 0) {
-        return Bounds32_Intersect(bounds, &portal->bounds);
-    }
-
-    if (bounds->min.x > portal->bounds.max.x
-        || bounds->max.x < portal->bounds.min.x
-        || bounds->min.z > portal->bounds.max.z
-        || bounds->max.z < portal->bounds.min.z) {
-        return false;
-    }
-
-    // A portal's normal points back into the room it belongs to, so a positive
-    // Y puts the room beyond above this one.
-    return portal->normal.y > 0 ? bounds->min.y <= portal->bounds.min.y
-                                : bounds->max.y >= portal->bounds.max.y;
-}
-
 static void M_ComputePortalBounds(void)
 {
     for (int32_t i = 0; i < Room_GetCount(); i++) {
@@ -158,7 +133,7 @@ static void M_FixStaticsVisibility(void)
                 const STATIC_MESH *const mesh =
                     Vector_Get(room_stat_vecs[i], m);
                 const BOUNDS_32 bounds = M_GetStaticBounds(mesh);
-                if (!M_BoundsReachPortal(&bounds, portal)) {
+                if (!Room_BoundsReachPortal(&bounds, portal)) {
                     continue;
                 }
                 if (Vector_Contains(room_stat_vecs[portal->room_num], mesh)) {
@@ -233,5 +208,6 @@ void Level_Finalize_LoadRooms(LEVEL_CONTEXT *const ctx)
     M_ComputePortalBounds();
     M_FixStaticsCollision();
     M_FixStaticsVisibility();
+    Room_InitialiseOverlapMap();
     Item_InitialiseDrawQueues();
 }

--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -11,11 +11,9 @@
 #include <trx/game/inject.h>
 #include <trx/game/level/format/format.h>
 #include <trx/game/level/sections/read.h>
-#include <trx/game/output/bind.h>
 #include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
 #include <trx/game/shell.h>
-#include <trx/game/viewport.h>
 
 #define M_NO_ROOM_LEGACY 255
 #define M_NO_BOX_TR3_LEGACY 0x7FF
@@ -475,11 +473,6 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
         room->flags.no_lens_flare = (flags & 0x80) != 0 && g_TRVersion >= 4;
         // clang-format on
 
-        OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
-        bind->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
-        bind->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
-        bind->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
-        bind->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
         room->item_num = NO_ITEM;
         room->effect_num = NO_EFFECT;
 

--- a/src/trx/game/output/bind.c
+++ b/src/trx/game/output/bind.c
@@ -3,6 +3,7 @@
 #include <trx/game/items.h>
 #include <trx/game/rooms/common.h>
 #include <trx/game/rooms/const.h>
+#include <trx/game/viewport.h>
 
 #include <string.h>
 
@@ -24,6 +25,10 @@ void Output_Bind_ResetRooms(void)
     for (int32_t i = 0; i < MAX_ROOMS; i++) {
         m_RoomBindings[i].active = false;
         m_RoomBindings[i].drawn = false;
+        m_RoomBindings[i].bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
+        m_RoomBindings[i].bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
+        m_RoomBindings[i].bound_right = Viewport_GetMinX(VIEWPORT_GAME);
+        m_RoomBindings[i].bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
     }
 }
 

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -360,6 +360,7 @@ static void M_Stage(const OBJECT_MESH *const mesh)
     }
     Output_Lights_FillInstanceLight(&light_info, g_WMatrixPtr);
 
+    const VIEWPORT_RECT *const scissor = Output_GetObjectScissor();
     const MESH_INSTANCE inst = {
         .mesh = batch->mesh_batch,
         .cwmatrix = *g_MatrixPtr,
@@ -370,6 +371,8 @@ static void M_Stage(const OBJECT_MESH *const mesh)
             (mesh->enable_caustics && Output_GetWaterEffect()) ? 1 : 0,
         .light_info = light_info,
         .room = Output_GetCurrentRoom(),
+        .enable_scissor = scissor != nullptr,
+        .scissor = scissor != nullptr ? *scissor : (VIEWPORT_RECT) {},
     };
     MeshBatcher_Stage(p->batcher, &inst, SCENE_PASS_OPAQUE);
     MeshBatcher_Stage(p->batcher, &inst, SCENE_PASS_TRANSPARENT);

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -8,6 +8,7 @@
 #include <trx/game/output/bind.h>
 #include <trx/game/output/mesh_batcher/mesh_builder.h>
 #include <trx/game/random.h>
+#include <trx/game/rooms.h>
 #include <trx/version.h>
 
 #include <math.h>
@@ -16,6 +17,7 @@ typedef struct {
     MESH_BATCHER *batcher;
     size_t mesh_count;
     OUTPUT_MESH **meshes;
+    bool *overlapping;
 } M_PRIV;
 
 static M_PRIV m_Priv = {};
@@ -172,6 +174,28 @@ static int32_t M_GetWaterEffect(const ROOM *const room)
     return Output_GetWaterEffect() ? 1 : 0;
 }
 
+static void M_PrepareOverlaps(M_PRIV *const p)
+{
+    const int32_t room_count = Room_GetCount();
+    p->overlapping = Memory_Alloc(sizeof(bool) * room_count);
+
+    for (int32_t i = 0; i < room_count; i++) {
+        for (int32_t j = i + 1; j < room_count; j++) {
+            if (p->overlapping[i] && p->overlapping[j]) {
+                continue;
+            }
+            if (Room_Get(i)->flipped_room == j
+                || Room_Get(j)->flipped_room == i) {
+                continue;
+            }
+            if (Room_CheckOverlap(i, j)) {
+                p->overlapping[i] = true;
+                p->overlapping[j] = true;
+            }
+        }
+    }
+}
+
 static void M_PrepareMeshes(M_PRIV *const p)
 {
     p->mesh_count = Room_GetCount();
@@ -227,6 +251,7 @@ static void M_FreeMeshes(M_PRIV *const p)
         }
         Memory_FreePointer(&p->meshes);
     }
+    Memory_FreePointer(&p->overlapping);
 }
 
 void OutputSource_Rooms_Init(MESH_BATCHER *const batcher)
@@ -246,6 +271,7 @@ void OutputSource_Rooms_ObserveLevelLoad(void)
     M_PRIV *const p = &m_Priv;
     M_FreeMeshes(p);
     M_PrepareMeshes(p);
+    M_PrepareOverlaps(p);
 }
 
 void OutputSource_Rooms_ObserveLevelUnload(void)
@@ -275,7 +301,7 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
         .tint = Output_GetTint(),
         .wibble = Output_GetWibbleEffect(),
         .water_effect = M_GetWaterEffect(room),
-        .enable_scissor = true,
+        .enable_scissor = p->overlapping[Room_GetIndex(room)],
         .scissor = {
             .x = bind->bound_left,
             .y = bind->bound_bottom,

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -17,7 +17,6 @@ typedef struct {
     MESH_BATCHER *batcher;
     size_t mesh_count;
     OUTPUT_MESH **meshes;
-    bool *overlapping;
 } M_PRIV;
 
 static M_PRIV m_Priv = {};
@@ -174,28 +173,6 @@ static int32_t M_GetWaterEffect(const ROOM *const room)
     return Output_GetWaterEffect() ? 1 : 0;
 }
 
-static void M_PrepareOverlaps(M_PRIV *const p)
-{
-    const int32_t room_count = Room_GetCount();
-    p->overlapping = Memory_Alloc(sizeof(bool) * room_count);
-
-    for (int32_t i = 0; i < room_count; i++) {
-        for (int32_t j = i + 1; j < room_count; j++) {
-            if (p->overlapping[i] && p->overlapping[j]) {
-                continue;
-            }
-            if (Room_Get(i)->flipped_room == j
-                || Room_Get(j)->flipped_room == i) {
-                continue;
-            }
-            if (Room_CheckOverlap(i, j)) {
-                p->overlapping[i] = true;
-                p->overlapping[j] = true;
-            }
-        }
-    }
-}
-
 static void M_PrepareMeshes(M_PRIV *const p)
 {
     p->mesh_count = Room_GetCount();
@@ -251,7 +228,6 @@ static void M_FreeMeshes(M_PRIV *const p)
         }
         Memory_FreePointer(&p->meshes);
     }
-    Memory_FreePointer(&p->overlapping);
 }
 
 void OutputSource_Rooms_Init(MESH_BATCHER *const batcher)
@@ -271,7 +247,6 @@ void OutputSource_Rooms_ObserveLevelLoad(void)
     M_PRIV *const p = &m_Priv;
     M_FreeMeshes(p);
     M_PrepareMeshes(p);
-    M_PrepareOverlaps(p);
 }
 
 void OutputSource_Rooms_ObserveLevelUnload(void)
@@ -301,7 +276,7 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
         .tint = Output_GetTint(),
         .wibble = Output_GetWibbleEffect(),
         .water_effect = M_GetWaterEffect(room),
-        .enable_scissor = p->overlapping[Room_GetIndex(room)],
+        .enable_scissor = Room_IsOverlapping(Room_GetIndex(room)),
         .scissor = {
             .x = bind->bound_left,
             .y = bind->bound_bottom,

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -40,6 +40,8 @@ static float m_DepthFactor = 0.0f;
 static float m_DepthUnits = 0.0f;
 
 static const ROOM *m_CurrentRoom = nullptr;
+static VIEWPORT_RECT m_ObjectScissor = {};
+static bool m_ObjectScissorEnabled = false;
 static int32_t m_LsAdder = 0;
 static int32_t m_LsDivider = 0;
 static XYZ_32 m_LsVectorView = {};
@@ -309,6 +311,19 @@ void Output_SetCurrentRoom(const ROOM *const room)
 const ROOM *Output_GetCurrentRoom(void)
 {
     return m_CurrentRoom;
+}
+
+void Output_SetObjectScissor(const VIEWPORT_RECT *const rect)
+{
+    m_ObjectScissorEnabled = rect != nullptr;
+    if (rect != nullptr) {
+        m_ObjectScissor = *rect;
+    }
+}
+
+const VIEWPORT_RECT *Output_GetObjectScissor(void)
+{
+    return m_ObjectScissorEnabled ? &m_ObjectScissor : nullptr;
 }
 
 int32_t Output_GetLightAdder(void)

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -4,6 +4,7 @@
 #include <trx/core/math/types.h>
 #include <trx/game/output/uniforms.h>
 #include <trx/game/rooms.h>
+#include <trx/game/viewport.h>
 
 #include <GL/glew.h>
 
@@ -46,6 +47,11 @@ int32_t Output_GetFarZ_UI(void);
 
 void Output_SetCurrentRoom(const ROOM *room_num);
 const ROOM *Output_GetCurrentRoom(void);
+
+// Clips object meshes staged after this call to the given game viewport
+// rectangle. Passing nullptr disables the object clip.
+void Output_SetObjectScissor(const VIEWPORT_RECT *rect);
+const VIEWPORT_RECT *Output_GetObjectScissor(void);
 
 int32_t Output_GetLightAdder(void);
 int32_t Output_GetLightDivider(void);

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -33,6 +33,7 @@ static int32_t m_FlipEffect = -1;
 static int32_t m_FlipTimer = 0;
 static FLIP_SLOT m_FlipSlots[MAX_FLIP_MAPS] = {};
 
+static bool *m_OverlapMap = nullptr;
 static int16_t *m_OutsideRoomTable = nullptr;
 static uint16_t *m_OutsideRoomOffsets = nullptr;
 static int32_t m_OutsideGridX = 0;
@@ -50,6 +51,7 @@ static void M_Shutdown(void)
     memset(m_FlipGroupStatus, 0, sizeof(m_FlipGroupStatus));
     memset(m_FlipSlots, 0, sizeof(m_FlipSlots));
 
+    Memory_FreePointer(&m_OverlapMap);
     m_OutsideRoomTable = nullptr;
     m_OutsideRoomOffsets = nullptr;
     m_OutsideGridX = 0;
@@ -689,6 +691,33 @@ bool Room_CheckOverlap(const int16_t room_num_0, const int16_t room_num_1)
         room_0_bounds.min.z < room_1_bounds.max.z &&
         room_0_bounds.max.z > room_1_bounds.min.z);
     // clang-format on
+}
+
+void Room_InitialiseOverlapMap(void)
+{
+    Memory_FreePointer(&m_OverlapMap);
+    m_OverlapMap = Memory_Alloc(sizeof(bool) * m_RoomCount);
+
+    for (int32_t i = 0; i < m_RoomCount; i++) {
+        for (int32_t j = i + 1; j < m_RoomCount; j++) {
+            if (m_OverlapMap[i] && m_OverlapMap[j]) {
+                continue;
+            }
+            if (Room_Get(i)->flipped_room == j
+                || Room_Get(j)->flipped_room == i) {
+                continue;
+            }
+            if (Room_CheckOverlap(i, j)) {
+                m_OverlapMap[i] = true;
+                m_OverlapMap[j] = true;
+            }
+        }
+    }
+}
+
+bool Room_IsOverlapping(const int16_t room_num)
+{
+    return m_OverlapMap != nullptr && m_OverlapMap[room_num];
 }
 
 bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -682,12 +682,12 @@ bool Room_CheckOverlap(const int16_t room_num_0, const int16_t room_num_1)
 
     // clang-format off
     return (
-        room_0_bounds.min.x <= room_1_bounds.max.x &&
-        room_0_bounds.max.x >= room_1_bounds.min.x &&
-        room_0_bounds.min.y <= room_1_bounds.max.y &&
-        room_0_bounds.max.y >= room_1_bounds.min.y &&
-        room_0_bounds.min.z <= room_1_bounds.max.z &&
-        room_0_bounds.max.z >= room_1_bounds.min.z);
+        room_0_bounds.min.x < room_1_bounds.max.x &&
+        room_0_bounds.max.x > room_1_bounds.min.x &&
+        room_0_bounds.min.y < room_1_bounds.max.y &&
+        room_0_bounds.max.y > room_1_bounds.min.y &&
+        room_0_bounds.min.z < room_1_bounds.max.z &&
+        room_0_bounds.max.z > room_1_bounds.min.z);
     // clang-format on
 }
 

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -67,7 +67,12 @@ int32_t Room_GetOutsideStatus(
     XYZ_32 pos, int16_t *out_room_num, int16_t *out_bbox_room_num);
 
 bool Room_PointInside(const ROOM *room, XYZ_32 point);
+
+// Returns whether the two rooms share space. Rooms that merely touch, such
+// as neighbours meeting at a shared wall or stacked floor to ceiling, do not
+// count as overlapping.
 bool Room_CheckOverlap(int16_t room_num_0, int16_t room_num_1);
+
 void Room_GetNearbyRooms(XYZ_32 pos, int32_t r, int32_t h, int16_t room_num);
 
 bool Room_FindValidPos(XYZ_32 *out_pos, int16_t *out_room_num);

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -73,6 +73,13 @@ bool Room_PointInside(const ROOM *room, XYZ_32 point);
 // count as overlapping.
 bool Room_CheckOverlap(int16_t room_num_0, int16_t room_num_1);
 
+// Builds the per-room overlap map after room bounds are finalized. A room and
+// its flip alternative occupy the same space by design and do not count.
+void Room_InitialiseOverlapMap(void);
+
+// Returns whether the room shares space with any other non-flip room.
+bool Room_IsOverlapping(int16_t room_num);
+
 void Room_GetNearbyRooms(XYZ_32 pos, int32_t r, int32_t h, int16_t room_num);
 
 bool Room_FindValidPos(XYZ_32 *out_pos, int16_t *out_room_num);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -328,6 +328,42 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
         return;
     }
 
+    int32_t left = Viewport_GetMaxX(VIEWPORT_GAME);
+    int32_t top = Viewport_GetMaxY(VIEWPORT_GAME);
+    int32_t right = Viewport_GetMinX(VIEWPORT_GAME);
+    int32_t bottom = Viewport_GetMinY(VIEWPORT_GAME);
+    bool overlap = false;
+    for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
+        const int16_t room_num = Room_DrawGetRoom(i);
+        const ROOM *const room = Room_Get(room_num);
+        if (!M_DrawSet_Has(&room->drawn_items, item_num)) {
+            continue;
+        }
+        const OUTPUT_ROOM_BIND *const room_bind = Output_Bind_GetRoom(room);
+        CLAMPG(left, room_bind->bound_left);
+        CLAMPG(top, room_bind->bound_top);
+        CLAMPL(right, room_bind->bound_right);
+        CLAMPL(bottom, room_bind->bound_bottom);
+        overlap = overlap || Room_IsOverlapping(room_num);
+    }
+
+    const int32_t old_left = g_PhdLeft;
+    const int32_t old_top = g_PhdTop;
+    const int32_t old_right = g_PhdRight;
+    const int32_t old_bottom = g_PhdBottom;
+    g_PhdLeft = left;
+    g_PhdTop = top;
+    g_PhdRight = right;
+    g_PhdBottom = bottom;
+    if (overlap) {
+        Output_SetObjectScissor(&(VIEWPORT_RECT) {
+            .x = left,
+            .y = bottom,
+            .width = right - left,
+            .height = bottom - top,
+        });
+    }
+
     M_SetupWaterStatus(Room_Get(item->room_num));
 
     // A fading body scales down the tint already in force rather than
@@ -342,6 +378,12 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
     if (is_fading) {
         Output_PopTintOverride();
     }
+
+    Output_SetObjectScissor(nullptr);
+    g_PhdLeft = old_left;
+    g_PhdTop = old_top;
+    g_PhdRight = old_right;
+    g_PhdBottom = old_bottom;
 
     if (Output_IsControlFrame()) {
         Item_ControlDraw(item);
@@ -420,11 +462,6 @@ static void M_DrawSingleRoom(const ROOM *const room)
     }
 
     Matrix_Pop();
-
-    bind->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
-    bind->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
-    bind->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
-    bind->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
 }
 
 static void M_Shutdown(void)
@@ -476,7 +513,6 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     bind->test_right = Viewport_GetMaxX(VIEWPORT_GAME);
     bind->test_bottom = Viewport_GetMaxY(VIEWPORT_GAME);
     bind->active = true;
-    bind->drawn = false;
 
     g_PhdLeft = bind->test_left;
     g_PhdTop = bind->test_top;
@@ -512,11 +548,7 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
 
     for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
         const int16_t draw_room_num = Room_DrawGetRoom(i);
-        const ROOM *const draw_room = Room_Get(draw_room_num);
-        M_DrawSingleRoom(draw_room);
-        OUTPUT_ROOM_BIND *const draw_bind = Output_Bind_GetRoom(draw_room);
-        draw_bind->active = false;
-        draw_bind->drawn = false;
+        M_DrawSingleRoom(Room_Get(draw_room_num));
     }
 
     // A title level running behind the menu may hold her object without ever

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -1,6 +1,7 @@
 #include <trx/game/rooms/geometry.h>
 
 #include <trx/config.h>
+#include <trx/core/math/util.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
@@ -182,6 +183,24 @@ static bool M_IsPortalSolid(
     default:
         return false;
     }
+}
+
+bool Room_BoundsReachPortal(
+    const BOUNDS_32 *const bounds, const PORTAL *const portal)
+{
+    if (portal->normal.y == 0) {
+        return Bounds32_Intersect(bounds, &portal->bounds);
+    }
+
+    if (bounds->min.x > portal->bounds.max.x
+        || bounds->max.x < portal->bounds.min.x
+        || bounds->min.z > portal->bounds.max.z
+        || bounds->max.z < portal->bounds.min.z) {
+        return false;
+    }
+
+    return portal->normal.y > 0 ? bounds->min.y <= portal->bounds.min.y
+                                : bounds->max.y >= portal->bounds.max.y;
 }
 
 BOUNDS_32 Room_GetRoomBounds(const ROOM *const room)

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -3,6 +3,12 @@
 #include <trx/game/rooms/types.h>
 
 BOUNDS_32 Room_GetRoomBounds(const ROOM *room);
+
+// Returns whether the box reaches through the portal into the room behind it.
+// Wall portals match on full bounds intersection. Floor and ceiling portals
+// match when the box stands over the opening and crosses the portal plane.
+// Portal bounds must already be finalized.
+bool Room_BoundsReachPortal(const BOUNDS_32 *bounds, const PORTAL *portal);
 SECTOR *Room_GetSector(XYZ_32 pos, int16_t *room_num);
 SECTOR *Room_GetSectorOnWalkable(XYZ_32 pos, int16_t *room_num);
 SECTOR *Room_GetWorldSector(const ROOM *room, int32_t x_pos, int32_t z_pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where items in overlapping rooms could appear through the wrong room. This was most visible in Tomb of Tihocan, where the boulder showed in the room beside it before it rolled through.

Before this, items were queued for every neighbouring room and the first room that drew one set its screen bounds. In overlapping geometry, that could give the item the camera room's full window instead of the rooms it occupied.

Items now use the draw windows of their own room and any portal neighbour their bounds reach. Overlapping rooms also clip object meshes to that combined window, matching room meshes without cutting items at ordinary builder portals.

The draw queue history this settles:
- f6bd91f785: rewrote item scheduling (1.9)
- d2d20fd49c: bled protruding statics into nearby rooms
- 130a66db76: queued items into the rooms they reach (TRX854)
- cd2f0ce6b5: removed items from flipped rooms (TRX1072)
- 26abe06fae: queued items into every neighbour (TRX1097), which regressed this

Resolves TRX1168 / TRX1159