### PR TITLE
Report why a level or a saved game will not load

### DIFF
--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -250,7 +250,9 @@ unit_tests += {
     'core/bson/write.c',
     'core/json/base.c',
     'core/memory.c',
+    'core/result.c',
   ],
+  'src': ['harness/stubs_result.c'],
 }
 
 unit_tests += {

--- a/src/tests/trx/core/bson.c
+++ b/src/tests/trx/core/bson.c
@@ -13,15 +13,17 @@ static int64_t M_RoundTrip(const int64_t value)
     JSON_VALUE *const root = JSON_ValueFromObject(obj);
 
     size_t size = 0;
-    void *const blob = BSON_Write(root, &size);
+    void *blob = nullptr;
+    const bool written = IGNORE(BSON_Write(root, &blob, &size));
     JSON_ValueFree(root);
-    if (blob == nullptr) {
+    if (!written) {
         return M_UNREAD;
     }
 
-    JSON_VALUE *const parsed = BSON_Parse(blob, size);
+    JSON_VALUE *parsed = nullptr;
+    const bool read = IGNORE(BSON_Parse(blob, size, &parsed));
     Memory_Free(blob);
-    if (parsed == nullptr) {
+    if (!read) {
         return M_UNREAD;
     }
 
@@ -71,13 +73,13 @@ TEST(a_document_mixing_widths_writes_the_size_it_measured)
     JSON_VALUE *const root = JSON_ValueFromObject(obj);
 
     size_t size = 0;
-    void *const blob = BSON_Write(root, &size);
+    void *blob = nullptr;
+    CHECK(IGNORE(BSON_Write(root, &blob, &size)));
     JSON_ValueFree(root);
-    CHECK(blob != nullptr);
 
-    JSON_VALUE *const parsed = BSON_Parse(blob, size);
+    JSON_VALUE *parsed = nullptr;
+    CHECK(IGNORE(BSON_Parse(blob, size, &parsed)));
     Memory_Free(blob);
-    CHECK(parsed != nullptr);
 
     const JSON_OBJECT *const read = JSON_ValueAsObject(parsed);
     CHECK_EQ_INT(JSON_ObjectGetInt(read, "small", -1), 7);

--- a/src/trx/core/bson/parse.c
+++ b/src/trx/core/bson/parse.c
@@ -636,9 +636,16 @@ static void M_HandleValue(M_STATE *state, JSON_VALUE *value, uint8_t marker)
     }
 }
 
-JSON_VALUE *BSON_Parse(const char *src, size_t src_size)
+RESULT BSON_Parse(
+    const char *const src, const size_t src_size, JSON_VALUE **const out_value)
 {
-    return BSON_ParseEx(src, src_size, nullptr);
+    BSON_PARSE_RESULT parse_result = {};
+    *out_value = BSON_ParseEx(src, src_size, &parse_result);
+    FAIL_IF(
+        *out_value == nullptr, "%s at byte %zu",
+        BSON_GetErrorDescription(parse_result.error),
+        parse_result.error_offset);
+    return OK;
 }
 
 JSON_VALUE *BSON_ParseEx(

--- a/src/trx/core/bson/parse.h
+++ b/src/trx/core/bson/parse.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <trx/core/bson/types.h>
+#include <trx/core/result.h>
 
-// Parse a BSON file, returning a pointer to the root of the JSON structure.
-// Returns nullptr if an error occurred (malformed BSON input, or malloc
-// failed).
-JSON_VALUE *BSON_Parse(const char *src, size_t src_size);
+// Reads BSON into a JSON structure, reporting what it could not make sense of
+// and where. Caller frees the value with JSON_ValueFree().
+RESULT BSON_Parse(const char *src, size_t src_size, JSON_VALUE **out_value);
 
 JSON_VALUE *BSON_ParseEx(
     const char *src, size_t src_size, BSON_PARSE_RESULT *result);

--- a/src/trx/core/bson/write.c
+++ b/src/trx/core/bson/write.c
@@ -524,26 +524,24 @@ static char *M_WriteValueWrapped(
     }
 }
 
-void *BSON_Write(const JSON_VALUE *value, size_t *out_size)
+RESULT BSON_Write(
+    const JSON_VALUE *const value, void **const out_data,
+    size_t *const out_size)
 {
     ASSERT(value != nullptr);
+    *out_data = nullptr;
     *out_size = -1;
-    if (value == nullptr) {
-        return nullptr;
-    }
 
     size_t size = 0;
-    if (!M_GetValueSize(&size, value)) {
-        return nullptr;
-    }
+    FAIL_IF(
+        !M_GetValueSize(&size, value),
+        "the data does not fit what BSON can hold");
 
     char *data = Memory_Alloc(size);
     char *data_end = M_WriteValue(data, value);
     ASSERT((size_t)(data_end - data) == size);
 
-    if (out_size != nullptr) {
-        *out_size = size;
-    }
-
-    return data;
+    *out_data = data;
+    *out_size = size;
+    return OK;
 }

--- a/src/trx/core/bson/write.h
+++ b/src/trx/core/bson/write.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <trx/core/bson/types.h>
+#include <trx/core/result.h>
 
-/* Write out a BSON binary string. Return 0 if an error occurred (malformed
- * JSON input, or malloc failed). The out_size parameter is optional. */
-void *BSON_Write(const JSON_VALUE *value, size_t *out_size);
+// Writes a JSON structure out as BSON, reporting data BSON cannot hold.
+// Caller frees the bytes with Memory_Free().
+RESULT BSON_Write(const JSON_VALUE *value, void **out_data, size_t *out_size);

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -269,7 +269,7 @@ GF_COMMAND GF_InterpretSequence(
         }
     }
     if (seq_ctx != GFSC_STORY || level->type == GFL_CUTSCENE) {
-        if (!Level_Initialise(level, seq_ctx)) {
+        if (!Result_Absorb(Level_Initialise(level, seq_ctx))) {
             Game_SetCurrentLevel(nullptr);
             GF_SetCurrentLevel(nullptr);
             if (level->type == GFL_TITLE) {

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -12,10 +12,10 @@
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 
-static GF_COMMAND M_RunEvent(
+static RESULT M_RunEvent(
     const GF_LEVEL *const level, const GF_SEQUENCE *const sequence,
     const int32_t event_idx, const GF_SEQUENCE_CONTEXT seq_ctx,
-    void *const seq_ctx_arg)
+    void *const seq_ctx_arg, GF_COMMAND *const out_cmd)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
     const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
@@ -27,17 +27,20 @@ static GF_COMMAND M_RunEvent(
     const GF_SEQUENCE_EVENT_HANDLER event_handler =
         GF_GetSequenceEventHandler(event->type);
     if (event_handler == nullptr) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
 
-    gf_cmd = event_handler(level, sequence, event_idx, seq_ctx, seq_ctx_arg);
+    MUST(event_handler(
+        level, sequence, event_idx, seq_ctx, seq_ctx_arg, &gf_cmd));
     LOG_DEBUG(
         "event type=%s(%d) data=0x%x finished, result: action=%s, "
         "param=%d",
         ENUM_MAP_TO_STRING(GF_SEQUENCE_EVENT_TYPE, event->type), event->type,
         event->data, ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action),
         gf_cmd.param);
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 // Events whose effects the level loader bakes into static data (e.g. the
@@ -125,9 +128,9 @@ static bool M_IsLevelDescendantOf(
     return false;
 }
 
-GF_COMMAND GF_InterpretSequence(
+RESULT GF_InterpretSequence(
     const GF_LEVEL *const level, GF_SEQUENCE_CONTEXT seq_ctx,
-    void *const seq_ctx_arg)
+    void *const seq_ctx_arg, GF_COMMAND *const out_cmd)
 {
     ASSERT(level != nullptr);
     LOG_DEBUG(
@@ -135,7 +138,8 @@ GF_COMMAND GF_InterpretSequence(
         level->type, seq_ctx);
 
     if (level->type == GFL_DUMMY || level->type == GFL_CURRENT) {
-        return (GF_COMMAND) { .action = GF_NOOP };
+        *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+        return OK;
     }
 
     M_PreSequenceHook(seq_ctx, seq_ctx_arg);
@@ -265,7 +269,9 @@ GF_COMMAND GF_InterpretSequence(
     const GF_SEQUENCE *const sequence = &level->sequence;
     for (int32_t i = 0; i < sequence->length; i++) {
         if (M_IsPreLoadEvent(sequence->events[i].type)) {
-            M_RunEvent(level, sequence, i, seq_ctx, seq_ctx_arg);
+            GF_COMMAND pre_cmd;
+            MUST(
+                M_RunEvent(level, sequence, i, seq_ctx, seq_ctx_arg, &pre_cmd));
         }
     }
     if (seq_ctx != GFSC_STORY || level->type == GFL_CUTSCENE) {
@@ -285,9 +291,10 @@ GF_COMMAND GF_InterpretSequence(
         if (M_IsPreLoadEvent(event->type)) {
             continue;
         }
-        gf_cmd = M_RunEvent(level, sequence, i, seq_ctx, seq_ctx_arg);
+        MUST(M_RunEvent(level, sequence, i, seq_ctx, seq_ctx_arg, &gf_cmd));
         if (gf_cmd.action != GF_NOOP) {
-            return gf_cmd;
+            *out_cmd = gf_cmd;
+            return OK;
         }
 
         // Update sequence context if necessary
@@ -297,5 +304,6 @@ GF_COMMAND GF_InterpretSequence(
     LOG_DEBUG(
         "sequence finished: action=%s param=%d",
         ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action), gf_cmd.param);
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -188,7 +188,7 @@ RESULT GF_InterpretSequence(
             // select level feature
             SG_Resume_ResetAllEntries();
             if (level->num > GF_GetFirstLevel()->num) {
-                Savegame_LoadOnlyResumeInfo(slot);
+                SHOULD(Savegame_LoadOnlyResumeInfo(slot));
 
                 const int32_t prev_level_num =
                     SG_Resume_GetEntry(level)->prev_level;

--- a/src/trx/game/game_flow/sequencer.h
+++ b/src/trx/game/game_flow/sequencer.h
@@ -16,9 +16,14 @@ GF_COMMAND GF_RunGlobeSelect(const char *background_path);
 
 // Act on what the flow asks for, starting from the given command, until it
 // asks to leave the game or switch mod. Leaves no level loaded.
-void GF_RunUntilExit(GF_COMMAND gf_cmd);
+// Runs the game flow until it says to stop. Reports a game flow with no
+// title level to fall back to.
+RESULT GF_RunUntilExit(GF_COMMAND gf_cmd);
 
-GF_COMMAND GF_DoFrontendSequence(void);
+// Works out what the game does first, from the arguments the player started
+// it with or the title level. Reports an argument naming a level that is not
+// there.
+RESULT GF_DoFrontendSequence(GF_COMMAND *out_cmd);
 GF_COMMAND GF_DoDemoSequence(int32_t demo_num);
 GF_COMMAND GF_DoCutsceneSequence(int32_t cutscene_num, bool cross_fade_in);
 

--- a/src/trx/game/game_flow/sequencer.h
+++ b/src/trx/game/game_flow/sequencer.h
@@ -9,7 +9,8 @@ GF_COMMAND GF_EnterPhotoMode(void);
 GF_COMMAND GF_PauseGame(void);
 GF_COMMAND GF_ShowInventory(INVENTORY_MODE inv_mode);
 bool GF_ShowInventoryKeys(OBJECT_ID receptacle_type_id);
-GF_COMMAND GF_RunTitle(void);
+// Shows the title screen. Reports a title level that will not load.
+RESULT GF_RunTitle(GF_COMMAND *out_cmd);
 GF_COMMAND GF_RunDemo(int32_t demo_num);
 GF_COMMAND GF_RunCutscene(int32_t cutscene_num, bool cross_fade_in);
 GF_COMMAND GF_RunGame(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);

--- a/src/trx/game/game_flow/sequencer.h
+++ b/src/trx/game/game_flow/sequencer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/game_flow/types.h>
 #include <trx/game/inventory_ring/types.h>
 #include <trx/game/savegame/types.h>
@@ -24,13 +25,19 @@ RESULT GF_RunUntilExit(GF_COMMAND gf_cmd);
 // it with or the title level. Reports an argument naming a level that is not
 // there.
 RESULT GF_DoFrontendSequence(GF_COMMAND *out_cmd);
-GF_COMMAND GF_DoDemoSequence(int32_t demo_num);
-GF_COMMAND GF_DoCutsceneSequence(int32_t cutscene_num, bool cross_fade_in);
+// Plays a demo. Reports a demo the game flow names but does not have.
+RESULT GF_DoDemoSequence(int32_t demo_num, GF_COMMAND *out_cmd);
 
-GF_COMMAND GF_InterpretSequence(
-    const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg);
+// Plays a cutscene. Reports a cutscene the game flow names but does not have.
+RESULT GF_DoCutsceneSequence(
+    int32_t cutscene_num, bool cross_fade_in, GF_COMMAND *out_cmd);
 
-GF_COMMAND GF_DoLevelSequence(
-    const GF_LEVEL *start_level, GF_SEQUENCE_CONTEXT seq_ctx);
+RESULT GF_InterpretSequence(
+    const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg,
+    GF_COMMAND *out_cmd);
 
-GF_COMMAND GF_PlayAvailableStory(SAVEGAME_SLOT_REF slot);
+RESULT GF_DoLevelSequence(
+    const GF_LEVEL *start_level, GF_SEQUENCE_CONTEXT seq_ctx,
+    GF_COMMAND *out_cmd);
+
+RESULT GF_PlayAvailableStory(SAVEGAME_SLOT_REF slot, GF_COMMAND *out_cmd);

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -21,10 +21,10 @@
 #include <trx/version.h>
 
 #define M_GF_HANDLER(name)                                                     \
-    static GF_COMMAND name(                                                    \
+    static RESULT name(                                                        \
         const GF_LEVEL *const level, const GF_SEQUENCE *const sequence,        \
         const int32_t event_idx, const GF_SEQUENCE_CONTEXT seq_ctx,            \
-        void *const seq_ctx_arg)
+        void *const seq_ctx_arg, GF_COMMAND *const out_cmd)
 
 // clang-format off
 #define X_EVENT_HANDLER_LIST \
@@ -92,20 +92,23 @@ static const GF_LEVEL *M_GetCanonicalNextLevel(const GF_LEVEL *const level)
 
 M_GF_HANDLER(M_HandleExitToTitle)
 {
-    return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+    *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleLevelComplete)
 {
     if (seq_ctx != GFSC_NORMAL) {
-        return (GF_COMMAND) { .action = GF_NOOP };
+        *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+        return OK;
     }
     M_FinishLevelBasic();
     const GF_LEVEL *const current_level = Game_GetCurrentLevel();
     const GF_LEVEL *const next_level = M_GetCanonicalNextLevel(current_level);
 
     if (next_level == nullptr) {
-        return (GF_COMMAND) { .action = GF_NOOP };
+        *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+        return OK;
     }
     SG_Resume_StoreGameToEntry(next_level);
     RESUME_INFO *const next_resume = SG_Resume_GetEntry(next_level);
@@ -113,12 +116,14 @@ M_GF_HANDLER(M_HandleLevelComplete)
         next_resume->prev_level = current_level->num;
     }
     if (next_level->type == GFL_BONUS && !Stats_CheckAllSecretsCollected()) {
-        return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+        *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+        return OK;
     }
-    return (GF_COMMAND) {
+    *out_cmd = (GF_COMMAND) {
         .action = GF_START_GAME,
         .param = next_level->num,
     };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandlePlayLevel)
@@ -128,9 +133,11 @@ M_GF_HANDLER(M_HandlePlayLevel)
     if (seq_ctx == GFSC_STORY) {
         const int32_t savegame_level_num = (int32_t)(intptr_t)seq_ctx_arg;
         if (savegame_level_num == level->num) {
-            return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            return OK;
         } else {
-            return (GF_COMMAND) { .action = GF_NOOP };
+            *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+            return OK;
         }
     }
 
@@ -150,7 +157,8 @@ M_GF_HANDLER(M_HandlePlayLevel)
             LOG_ERROR("Failed to load save file!");
             Game_SetCurrentLevel(nullptr);
             GF_SetCurrentLevel(nullptr);
-            return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            return OK;
         }
         break;
     }
@@ -190,7 +198,8 @@ M_GF_HANDLER(M_HandlePlayLevel)
     if (gf_cmd.action == GF_LEVEL_COMPLETE) {
         gf_cmd.action = GF_NOOP;
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandlePlayCutscene)
@@ -203,12 +212,13 @@ M_GF_HANDLER(M_HandlePlayCutscene)
     const bool cross_fade_in =
         prev_event != nullptr && prev_event->type == GFS_LOOP_GAME;
     if (seq_ctx != GFSC_SAVED && g_Config.gameplay.enable_cutscenes) {
-        gf_cmd = GF_DoCutsceneSequence(cutscene_num, cross_fade_in);
+        MUST(GF_DoCutsceneSequence(cutscene_num, cross_fade_in, &gf_cmd));
         if (gf_cmd.action == GF_LEVEL_COMPLETE) {
             gf_cmd.action = GF_NOOP;
         }
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandlePlayFMV)
@@ -217,24 +227,30 @@ M_GF_HANDLER(M_HandlePlayFMV)
     const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
     const int16_t fmv_id = (int16_t)(intptr_t)event->data;
     if (seq_ctx == GFSC_SAVED) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     if (fmv_id < 0 || fmv_id >= g_GameFlow.fmv_count) {
         LOG_ERROR("Invalid FMV number: %d", fmv_id);
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
     if (fmv->is_intro && g_Config.gameplay.intro_fmv_mode == INTRO_FMV_LAUNCH) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     if (fmv->is_legal && !g_Config.gameplay.enable_legal) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     if (fmv->is_credit && !g_Config.gameplay.enable_credits) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     FMV_Play(fmv->path);
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandlePlayMusic)
@@ -244,7 +260,8 @@ M_GF_HANDLER(M_HandlePlayMusic)
         Music_SetVolume(g_Config.audio.music_volume);
         Music_Play_Direct((int32_t)(intptr_t)event->data, MPM_ONCE);
     }
-    return (GF_COMMAND) { .action = GF_NOOP };
+    *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandlePicture)
@@ -257,28 +274,35 @@ M_GF_HANDLER(M_HandlePicture)
         prev_event != nullptr && prev_event->type == GFS_PLAY_FMV;
     if (event->type == GFS_LOADING_SCREEN) {
         if (g_Config.gameplay.loading_screens == LOADING_SCREENS_DISABLED) {
-            return gf_cmd;
+            *out_cmd = gf_cmd;
+            return OK;
         } else if (seq_ctx == GFSC_STORY) {
-            return gf_cmd;
+            *out_cmd = gf_cmd;
+            return OK;
         } else if (
             g_Config.gameplay.loading_screens == LOADING_SCREENS_NEW_GAMES
             && seq_ctx != GFSC_NORMAL && seq_ctx != GFSC_SELECT) {
-            return gf_cmd;
+            *out_cmd = gf_cmd;
+            return OK;
         }
         Music_Stop();
     } else if (seq_ctx == GFSC_SAVED) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
 
     GF_DISPLAY_PICTURE_DATA *data = event->data;
     if (data->path == nullptr) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     if (data->is_legal && !g_Config.gameplay.enable_legal) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     if (data->is_credit && !g_Config.gameplay.enable_credits) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
 
     PHASE *const phase = Phase_Picture_Create((PHASE_PICTURE_ARGS) {
@@ -292,20 +316,23 @@ M_GF_HANDLER(M_HandlePicture)
     });
     gf_cmd = PhaseExecutor_Run(phase);
     Phase_Picture_Destroy(phase);
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleInventoryModifier)
 {
     // handled in GF_InventoryModifier_Apply
-    return (GF_COMMAND) { .action = GF_NOOP };
+    *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleLevelStats)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
     if (seq_ctx != GFSC_NORMAL) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
 
     PHASE *const phase = Phase_Stats_Create((PHASE_STATS_ARGS) {
@@ -317,17 +344,20 @@ M_GF_HANDLER(M_HandleLevelStats)
     });
     gf_cmd = PhaseExecutor_Run(phase);
     Phase_Stats_Destroy(phase);
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleTotalStats)
 {
     GF_COMMAND gf_cmd = { .action = GF_EXIT_TO_TITLE };
     if (seq_ctx != GFSC_NORMAL) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     if (!g_Config.gameplay.enable_total_stats) {
-        return gf_cmd;
+        *out_cmd = gf_cmd;
+        return OK;
     }
     const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
     PHASE *const phase = Phase_Stats_Create((PHASE_STATS_ARGS) {
@@ -339,13 +369,15 @@ M_GF_HANDLER(M_HandleTotalStats)
     });
     gf_cmd = PhaseExecutor_Run(phase);
     Phase_Stats_Destroy(phase);
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleGlobeSelect)
 {
     if (seq_ctx != GFSC_NORMAL) {
-        return (GF_COMMAND) { .action = GF_NOOP };
+        *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+        return OK;
     }
     M_FinishLevelBasic();
     const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
@@ -364,7 +396,8 @@ M_GF_HANDLER(M_HandleGlobeSelect)
             }
         }
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleSetStartAnim)
@@ -374,7 +407,8 @@ M_GF_HANDLER(M_HandleSetStartAnim)
     if (seq_ctx != GFSC_STORY) {
         Lara_SetStartAnimState((LARA_EXTRA_STATE)(intptr_t)event->data);
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleEnableSunset)
@@ -383,7 +417,8 @@ M_GF_HANDLER(M_HandleEnableSunset)
     if (seq_ctx != GFSC_STORY) {
         Output_SetSunsetEnabled(true);
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleSetupHorizon)
@@ -395,7 +430,8 @@ M_GF_HANDLER(M_HandleSetupHorizon)
         Output_Sky_SetColorAdd(data->color_add);
         Output_Sky_SetFogGradient(data->fog_gradient);
     }
-    return (GF_COMMAND) { .action = GF_NOOP };
+    *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleSetupUVRotate)
@@ -404,7 +440,8 @@ M_GF_HANDLER(M_HandleSetupUVRotate)
         const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
         Output_SetUVRotateSpeed((int32_t)(intptr_t)event->data);
     }
-    return (GF_COMMAND) { .action = GF_NOOP };
+    *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleEnableLightning)
@@ -412,7 +449,8 @@ M_GF_HANDLER(M_HandleEnableLightning)
     if (seq_ctx != GFSC_STORY) {
         Output_Sky_SetLightningEnabled(true);
     }
-    return (GF_COMMAND) { .action = GF_NOOP };
+    *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleSetupLensFlare)
@@ -429,7 +467,8 @@ M_GF_HANDLER(M_HandleSetupLensFlare)
         };
         Output_LensFlares_SetSun(pos, data->color);
     }
-    return (GF_COMMAND) { .action = GF_NOOP };
+    *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+    return OK;
 }
 
 M_GF_HANDLER(M_HandleDisableFloor)
@@ -439,7 +478,8 @@ M_GF_HANDLER(M_HandleDisableFloor)
         const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
         Room_SetAbyssHeight((int32_t)(intptr_t)event->data);
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 GF_SEQUENCE_EVENT_HANDLER GF_GetSequenceEventHandler(

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -153,8 +153,7 @@ M_GF_HANDLER(M_HandlePlayLevel)
     switch (seq_ctx) {
     case GFSC_SAVED: {
         const SAVEGAME_SLOT_REF slot = SG_Manager_GetBoundSlot();
-        if (!Savegame_Load(slot)) {
-            LOG_ERROR("Failed to load save file!");
+        if (!SHOULD(Savegame_Load(slot))) {
             Game_SetCurrentLevel(nullptr);
             GF_SetCurrentLevel(nullptr);
             *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };

--- a/src/trx/game/game_flow/sequencer_events.h
+++ b/src/trx/game/game_flow/sequencer_events.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/game_flow/types.h>
 
-typedef GF_COMMAND (*GF_SEQUENCE_EVENT_HANDLER)(
+typedef RESULT (*GF_SEQUENCE_EVENT_HANDLER)(
     const GF_LEVEL *, const GF_SEQUENCE *, int32_t event_id,
-    GF_SEQUENCE_CONTEXT, void *);
+    GF_SEQUENCE_CONTEXT, void *, GF_COMMAND *out_cmd);
 
 GF_SEQUENCE_EVENT_HANDLER GF_GetSequenceEventHandler(
     GF_SEQUENCE_EVENT_TYPE event_type);

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -124,57 +124,59 @@ GF_COMMAND GF_RunGlobeSelect(const char *const background_path)
     return gf_cmd;
 }
 
-GF_COMMAND GF_DoFrontendSequence(void)
+RESULT GF_DoFrontendSequence(GF_COMMAND *const out_cmd)
 {
     const SHELL_ARGS *const args = Shell_GetArgs();
     if (args != nullptr) {
         if (args->startup.save_to_load >= 0) {
-            return (GF_COMMAND) {
+            *out_cmd = (GF_COMMAND) {
                 .action = GF_START_SAVED_GAME,
                 .param = SG_Manager_SlotToParam(
                     SG_Manager_NormalSlot(args->startup.save_to_load)),
             };
+            return OK;
         }
 
         if (args->startup.level_request.num >= 0) {
             const GF_LEVEL *const level = GF_GetLevelByOrdinalNumber(
                 GFLT_MAIN, args->startup.level_request.num);
-            if (level == nullptr) {
-                Shell_ExitSystemFmt(
-                    "Invalid level number: %d",
-                    args->startup.level_request.num);
-            }
-            return (GF_COMMAND) {
+            FAIL_IF(
+                level == nullptr, "there is no level number %d",
+                args->startup.level_request.num);
+            *out_cmd = (GF_COMMAND) {
                 .action = GF_SELECT_GAME,
                 .param = level->num,
             };
+            return OK;
         }
 
         if (args->startup.level_request.query != nullptr) {
             const GF_LEVEL *const level =
                 GF_FindPlayableLevelByQuery(args->startup.level_request.query);
-            if (level == nullptr) {
-                Shell_ExitSystemFmt(
-                    "Cannot find level file '%s', and no game-flow level "
-                    "title matched it.",
-                    args->startup.level_request.query);
-            }
-            return (GF_COMMAND) {
+            FAIL_IF(
+                level == nullptr,
+                "there is no level file '%s', and no game flow level title "
+                "matches it",
+                args->startup.level_request.query);
+            *out_cmd = (GF_COMMAND) {
                 .action = GF_SELECT_GAME,
                 .param = level->num,
             };
+            return OK;
         }
 
         if (args->startup.level_request.path != nullptr) {
-            return (GF_COMMAND) {
+            *out_cmd = (GF_COMMAND) {
                 .action = GF_START_GAME,
                 .param = 0,
             };
+            return OK;
         }
     }
 
     if (g_GameFlow.title_level == nullptr) {
-        return (GF_COMMAND) { .action = GF_NOOP };
+        *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+        return OK;
     }
 
     const GF_COMMAND gf_cmd =
@@ -182,7 +184,8 @@ GF_COMMAND GF_DoFrontendSequence(void)
     if (gf_cmd.action == GF_NOOP || gf_cmd.action == GF_EXIT_TO_TITLE) {
         M_PlayIntroFMVs();
     }
-    return gf_cmd;
+    *out_cmd = gf_cmd;
+    return OK;
 }
 
 GF_COMMAND GF_DoLevelSequence(
@@ -242,7 +245,8 @@ GF_COMMAND GF_PlayAvailableStory(const SAVEGAME_SLOT_REF slot)
     CONFIG_SET(g_Config.gameplay.enable_legal, false);
 
     // Play intro FMVs and cutscenes
-    GF_DoFrontendSequence();
+    GF_COMMAND intro_cmd;
+    IGNORE(GF_DoFrontendSequence(&intro_cmd));
 
     const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
     for (int32_t i = 0; i <= MIN(savegame_level, level_table->count); i++) {
@@ -324,7 +328,7 @@ bool GF_HasAvailableStory(const SAVEGAME_SLOT_REF slot)
     return false;
 }
 
-void GF_RunUntilExit(GF_COMMAND gf_cmd)
+RESULT GF_RunUntilExit(GF_COMMAND gf_cmd)
 {
     bool loop_continue = !Shell_IsExiting();
     while (loop_continue) {
@@ -392,7 +396,7 @@ void GF_RunUntilExit(GF_COMMAND gf_cmd)
             if (Shell_GetArgs()->startup.level_request.path != nullptr) {
                 gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
             } else if (g_GameFlow.title_level == nullptr) {
-                Shell_ExitSystem("Missing title level");
+                return FAIL("the game flow names no title level");
             } else {
                 gf_cmd = GF_RunTitle();
             }
@@ -415,4 +419,5 @@ void GF_RunUntilExit(GF_COMMAND gf_cmd)
     }
     Game_SetCurrentLevel(nullptr);
     GF_SetCurrentLevel(nullptr);
+    return OK;
 }

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -246,7 +246,9 @@ GF_COMMAND GF_PlayAvailableStory(const SAVEGAME_SLOT_REF slot)
 
     // Play intro FMVs and cutscenes
     GF_COMMAND intro_cmd;
-    IGNORE(GF_DoFrontendSequence(&intro_cmd));
+    SHOULD(
+        GF_DoFrontendSequence(&intro_cmd),
+        "The story plays from the save rather than from the start");
 
     const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
     for (int32_t i = 0; i <= MIN(savegame_level, level_table->count); i++) {

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -37,7 +37,7 @@ GF_COMMAND GF_RunTitle(void)
     SG_Manager_UnbindSlot();
     GameStringTable_Apply(nullptr);
     const GF_LEVEL *const title_level = GF_GetTitleLevel();
-    if (!Level_Initialise(title_level, GFSC_NORMAL)) {
+    if (!Result_Absorb(Level_Initialise(title_level, GFSC_NORMAL))) {
         return (GF_COMMAND) { .action = GF_EXIT_GAME };
     }
     return GF_ShowInventory(INV_TITLE_MODE);

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -32,15 +32,14 @@ static void M_PlayIntroFMVs(void)
     }
 }
 
-GF_COMMAND GF_RunTitle(void)
+RESULT GF_RunTitle(GF_COMMAND *const out_cmd)
 {
     SG_Manager_UnbindSlot();
     GameStringTable_Apply(nullptr);
     const GF_LEVEL *const title_level = GF_GetTitleLevel();
-    if (!Result_Absorb(Level_Initialise(title_level, GFSC_NORMAL))) {
-        return (GF_COMMAND) { .action = GF_EXIT_GAME };
-    }
-    return GF_ShowInventory(INV_TITLE_MODE);
+    MUST(Level_Initialise(title_level, GFSC_NORMAL), "the title level");
+    *out_cmd = GF_ShowInventory(INV_TITLE_MODE);
+    return OK;
 }
 
 GF_COMMAND GF_EnterPhotoMode(void)
@@ -401,7 +400,7 @@ RESULT GF_RunUntilExit(GF_COMMAND gf_cmd)
             } else if (g_GameFlow.title_level == nullptr) {
                 return FAIL("the game flow names no title level");
             } else {
-                gf_cmd = GF_RunTitle();
+                MUST(GF_RunTitle(&gf_cmd));
             }
             break;
 

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -179,8 +179,9 @@ RESULT GF_DoFrontendSequence(GF_COMMAND *const out_cmd)
         return OK;
     }
 
-    const GF_COMMAND gf_cmd =
-        GF_InterpretSequence(g_GameFlow.title_level, GFSC_NORMAL, nullptr);
+    GF_COMMAND gf_cmd;
+    MUST(GF_InterpretSequence(
+        g_GameFlow.title_level, GFSC_NORMAL, nullptr, &gf_cmd));
     if (gf_cmd.action == GF_NOOP || gf_cmd.action == GF_EXIT_TO_TITLE) {
         M_PlayIntroFMVs();
     }
@@ -188,57 +189,55 @@ RESULT GF_DoFrontendSequence(GF_COMMAND *const out_cmd)
     return OK;
 }
 
-GF_COMMAND GF_DoLevelSequence(
-    const GF_LEVEL *const start_level, const GF_SEQUENCE_CONTEXT seq_ctx)
+RESULT GF_DoLevelSequence(
+    const GF_LEVEL *const start_level, const GF_SEQUENCE_CONTEXT seq_ctx,
+    GF_COMMAND *const out_cmd)
 {
     const GF_LEVEL *current_level = start_level;
     const GF_LEVEL_TABLE_TYPE level_table_type =
         GF_GetLevelTableType(current_level->type);
     const int32_t level_count = GF_GetLevelTable(level_table_type)->count;
     while (true) {
-        const GF_COMMAND gf_cmd =
-            GF_InterpretSequence(current_level, seq_ctx, nullptr);
+        GF_COMMAND gf_cmd;
+        MUST(GF_InterpretSequence(current_level, seq_ctx, nullptr, &gf_cmd));
 
         if (gf_cmd.action != GF_NOOP && gf_cmd.action != GF_LEVEL_COMPLETE) {
-            return gf_cmd;
+            *out_cmd = gf_cmd;
+            return OK;
         }
-        if (Game_IsInGym()) {
-            return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
-        }
-        if (current_level->num + 1 >= level_count) {
-            return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+        if (Game_IsInGym() || current_level->num + 1 >= level_count) {
+            *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            return OK;
         }
         current_level++;
     }
 }
 
-GF_COMMAND GF_DoDemoSequence(int32_t demo_num)
+RESULT GF_DoDemoSequence(int32_t demo_num, GF_COMMAND *const out_cmd)
 {
     demo_num = Demo_ChooseLevel(demo_num);
     if (demo_num < 0) {
-        return (GF_COMMAND) { .action = GF_NOOP };
+        // There is nothing to demonstrate, which is not a fault.
+        *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
+        return OK;
     }
     const GF_LEVEL *const level = GF_GetLevel(GFLT_DEMOS, demo_num);
-    if (level == nullptr) {
-        LOG_ERROR("Missing demo: %d", demo_num);
-        return (GF_COMMAND) { .action = GF_NOOP };
-    }
-    return GF_InterpretSequence(level, GFSC_NORMAL, nullptr);
+    FAIL_IF(level == nullptr, "the game flow has no demo %d", demo_num);
+    return GF_InterpretSequence(level, GFSC_NORMAL, nullptr, out_cmd);
 }
 
-GF_COMMAND GF_DoCutsceneSequence(
-    const int32_t cutscene_num, const bool cross_fade_in)
+RESULT GF_DoCutsceneSequence(
+    const int32_t cutscene_num, const bool cross_fade_in,
+    GF_COMMAND *const out_cmd)
 {
     const GF_LEVEL *const level = GF_GetLevel(GFLT_CUTSCENES, cutscene_num);
-    if (level == nullptr) {
-        LOG_ERROR("Missing cutscene: %d", cutscene_num);
-        return (GF_COMMAND) { .action = GF_NOOP };
-    }
+    FAIL_IF(level == nullptr, "the game flow has no cutscene %d", cutscene_num);
     return GF_InterpretSequence(
-        level, GFSC_NORMAL, (void *)(intptr_t)cross_fade_in);
+        level, GFSC_NORMAL, (void *)(intptr_t)cross_fade_in, out_cmd);
 }
 
-GF_COMMAND GF_PlayAvailableStory(const SAVEGAME_SLOT_REF slot)
+RESULT GF_PlayAvailableStory(
+    const SAVEGAME_SLOT_REF slot, GF_COMMAND *const out_cmd)
 {
     const int32_t savegame_level = SG_Manager_GetLevelNumber(slot);
     const bool prev_enable_legal = g_Config.gameplay.enable_legal;
@@ -256,8 +255,9 @@ GF_COMMAND GF_PlayAvailableStory(const SAVEGAME_SLOT_REF slot)
         if (level->type == GFL_GYM) {
             continue;
         }
-        const GF_COMMAND gf_cmd = GF_InterpretSequence(
-            level, GFSC_STORY, (void *)(intptr_t)savegame_level);
+        GF_COMMAND gf_cmd;
+        MUST(GF_InterpretSequence(
+            level, GFSC_STORY, (void *)(intptr_t)savegame_level, &gf_cmd));
         if (gf_cmd.action == GF_EXIT_TO_TITLE
             || gf_cmd.action == GF_EXIT_GAME) {
             break;
@@ -265,7 +265,8 @@ GF_COMMAND GF_PlayAvailableStory(const SAVEGAME_SLOT_REF slot)
     }
 
     CONFIG_SET(g_Config.gameplay.enable_legal, prev_enable_legal);
-    return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+    *out_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+    return OK;
 }
 
 bool GF_HasAvailableStory(const SAVEGAME_SLOT_REF slot)
@@ -346,7 +347,7 @@ RESULT GF_RunUntilExit(GF_COMMAND gf_cmd)
             const GF_SEQUENCE_CONTEXT seq_ctx =
                 gf_cmd.action == GF_SELECT_GAME ? GFSC_SELECT : GFSC_NORMAL;
             if (level != nullptr) {
-                gf_cmd = GF_DoLevelSequence(level, seq_ctx);
+                MUST(GF_DoLevelSequence(level, seq_ctx, &gf_cmd));
             }
             break;
         }
@@ -365,28 +366,28 @@ RESULT GF_RunUntilExit(GF_COMMAND gf_cmd)
             } else {
                 SG_Manager_BindSlot(slot);
                 const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
-                gf_cmd = GF_DoLevelSequence(level, GFSC_SAVED);
+                MUST(GF_DoLevelSequence(level, GFSC_SAVED, &gf_cmd));
             }
             break;
         }
 
         case GF_RESTART_GAME: {
             const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, gf_cmd.param);
-            gf_cmd = GF_InterpretSequence(level, GFSC_RESTART, nullptr);
+            MUST(GF_InterpretSequence(level, GFSC_RESTART, nullptr, &gf_cmd));
             break;
         }
 
         case GF_STORY_SO_FAR:
-            gf_cmd =
-                GF_PlayAvailableStory(SG_Manager_SlotFromParam(gf_cmd.param));
+            MUST(GF_PlayAvailableStory(
+                SG_Manager_SlotFromParam(gf_cmd.param), &gf_cmd));
             break;
 
         case GF_START_CINE:
-            gf_cmd = GF_DoCutsceneSequence(gf_cmd.param, false);
+            MUST(GF_DoCutsceneSequence(gf_cmd.param, false, &gf_cmd));
             break;
 
         case GF_START_DEMO:
-            gf_cmd = GF_DoDemoSequence(gf_cmd.param);
+            MUST(GF_DoDemoSequence(gf_cmd.param, &gf_cmd));
             break;
 
         case GF_NOOP:

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -205,9 +205,10 @@ static void M_ReadFile(
         file_name == nullptr ? M_VIRTUAL_NAME : file_name;
     char *payload = nullptr;
     injection->path = Memory_DupStr(inj_name);
+    File_SetSoftFailure(file, true);
 
     const uint32_t magic = File_ReadU32(file);
-    if (magic != INJECTION_MAGIC) {
+    if (File_HasFailed(file) || magic != INJECTION_MAGIC) {
         LOG_WARNING("Invalid injection magic in %s", inj_name);
         goto cleanup;
     }
@@ -249,6 +250,7 @@ static void M_ReadFile(
     }
 
     injection->fp = File_OpenBuffer(payload, uncompressed_size);
+    File_SetSoftFailure(injection->fp, true);
     if (m_Context.mode != INJECTION_MODE_STATS) {
         LOG_INFO("%s queued for injection", inj_name);
     }

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -61,7 +61,7 @@ void Level_Unload(void)
     Viewport_AlterFOV(-1, FOV_MODE_GAME);
 }
 
-bool Level_Initialise(
+RESULT Level_Initialise(
     const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -89,7 +89,7 @@ bool Level_Initialise(
     }
 
     if (level == nullptr) {
-        return false;
+        return FAIL("there is no level to load");
     }
 
     // Read here rather than at the first cutscene trigger, so a scene starts
@@ -101,7 +101,7 @@ bool Level_Initialise(
     // by any other path - the title screen among them - still runs its own.
     LUA_RunLevelScript(level);
 
-    Level_Pipeline_Load(level);
+    MUST(Level_Pipeline_Load(level));
 
     UI_LoadText();
     Output_SetSkyboxEnabled(Object_Get(O_SKYBOX)->loaded);
@@ -135,5 +135,5 @@ bool Level_Initialise(
     }
 
     Benchmark_End(&benchmark, nullptr);
-    return true;
+    return OK;
 }

--- a/src/trx/game/level/common.h
+++ b/src/trx/game/level/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/game_flow/types.h>
 
 void Level_Unload(void);
-bool Level_Initialise(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);
+RESULT Level_Initialise(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);

--- a/src/trx/game/level/format/format.h
+++ b/src/trx/game/level/format/format.h
@@ -25,7 +25,7 @@ typedef enum {
 typedef struct LEVEL_FORMAT_LOADER {
     int32_t game_version;
     LEVEL_FORMAT_LAYOUT layout;
-    bool (*probe)(
+    RESULT (*probe)(
         const struct LEVEL_FORMAT_LOADER *, TRX_FILE *file,
         LEVEL_FORMAT_PROBE_MODE mode);
     RESULT (*load)(const struct LEVEL_FORMAT_LOADER *, TRX_FILE *file);

--- a/src/trx/game/level/format/format.h
+++ b/src/trx/game/level/format/format.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trx/core/file.h>
+#include <trx/core/result.h>
 #include <trx/game/game_flow/types.h>
 
 typedef enum {
@@ -27,9 +28,12 @@ typedef struct LEVEL_FORMAT_LOADER {
     bool (*probe)(
         const struct LEVEL_FORMAT_LOADER *, TRX_FILE *file,
         LEVEL_FORMAT_PROBE_MODE mode);
-    bool (*load)(const struct LEVEL_FORMAT_LOADER *, TRX_FILE *file);
+    RESULT (*load)(const struct LEVEL_FORMAT_LOADER *, TRX_FILE *file);
 } LEVEL_FORMAT_LOADER;
 
 LEVEL_FORMAT_LAYOUT Level_Format_GuessLayout(TRX_FILE *file);
 const LEVEL_FORMAT_LOADER *Level_Format_GuessLoader(TRX_FILE *file);
-const LEVEL_FORMAT_LOADER *Level_Format_LoadFromFile(const GF_LEVEL *level);
+// Reads a level from the path the game flow gives it, reporting a level that
+// cannot be opened or is in no format TRX knows.
+RESULT Level_Format_LoadFromFile(
+    const GF_LEVEL *level, const LEVEL_FORMAT_LOADER **out_loader);

--- a/src/trx/game/level/format/format_tr1.c
+++ b/src/trx/game/level/format/format_tr1.c
@@ -8,7 +8,7 @@
 
 #define M_SAMPLE_COUNT 256
 
-static bool M_Probe(
+static RESULT M_Probe(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file,
     const LEVEL_FORMAT_PROBE_MODE mode)
 {
@@ -20,7 +20,7 @@ static bool M_Probe(
     int32_t version;
     LEVEL_FORMAT_TRY_OR_FAIL(File_TryReadS32(file, &version));
     if (version != 32) {
-        return false;
+        return ERR;
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(TEXTURE_PAGE_SIZE); // textures
@@ -48,7 +48,7 @@ static bool M_Probe(
 
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(2); // floor data
     } else {
-        Level_Section_ReadRooms(&probe_ctx, file);
+        MUST(Level_Section_ReadRooms(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(2); // object meshes
@@ -63,7 +63,7 @@ static bool M_Probe(
     if (mode == LEVEL_FORMAT_PROBE_MINIMAL) {
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(18); // objects
     } else {
-        Level_Section_ReadObjects(&probe_ctx, file);
+        MUST(Level_Section_ReadObjects(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(32); // static objects
@@ -89,7 +89,7 @@ static bool M_Probe(
     if (mode == LEVEL_FORMAT_PROBE_MINIMAL) {
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(22); // items
     } else {
-        Level_Section_ReadItems(&probe_ctx, file);
+        MUST(Level_Section_ReadItems(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_OR_FAIL(32 * 256); // light table
@@ -112,7 +112,7 @@ static bool M_Probe(
         LEVEL_FORMAT_TRY_OR_FAIL(inj_magic == INJECTION_MAGIC);
     }
 
-    return true;
+    return OK;
 }
 
 static RESULT M_Load(
@@ -128,7 +128,7 @@ static RESULT M_Load(
     const int32_t file_level_num = File_ReadS32(file);
     LOG_INFO("file level num: %d", file_level_num);
 
-    Level_Section_ReadRooms(ctx, file);
+    MUST(Level_Section_ReadRooms(ctx, file));
     Level_Section_ReadObjectMeshes(ctx, file);
     Level_Section_ReadAnims(ctx, file);
     Level_Section_ReadAnimChanges(ctx, file);
@@ -136,11 +136,11 @@ static RESULT M_Load(
     Level_Section_ReadAnimCommands(ctx, file);
     Level_Section_ReadAnimBones(ctx, file);
     Level_Section_ReadAnimFrames(ctx, file);
-    Level_Section_ReadObjects(ctx, file);
-    Level_Section_ReadStaticObjects(ctx, file);
+    MUST(Level_Section_ReadObjects(ctx, file));
+    MUST(Level_Section_ReadStaticObjects(ctx, file));
     Level_Section_ReadObjectTextures(ctx, file);
     Level_Section_ReadSpriteTextures(ctx, file);
-    Level_Section_ReadSpriteSequences(ctx, file);
+    MUST(Level_Section_ReadSpriteSequences(ctx, file));
 
     if (loader->layout == LEVEL_FORMAT_LAYOUT_TR1_DEMO_PC) {
         Level_Section_ReadPalettes(ctx, file);
@@ -150,7 +150,7 @@ static RESULT M_Load(
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
     Level_Section_ReadAnimatedTextureRanges(ctx, file);
-    Level_Section_ReadItems(ctx, file);
+    MUST(Level_Section_ReadItems(ctx, file));
     Level_Section_ReadLightMap(ctx, file);
 
     if (loader->layout != LEVEL_FORMAT_LAYOUT_TR1_DEMO_PC) {

--- a/src/trx/game/level/format/format_tr1.c
+++ b/src/trx/game/level/format/format_tr1.c
@@ -115,7 +115,7 @@ static bool M_Probe(
     return true;
 }
 
-static bool M_Load(
+static RESULT M_Load(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file)
 {
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
@@ -171,7 +171,7 @@ static bool M_Load(
     Level_Section_ReadTexturePages(ctx, file);
     Level_Section_PrepareTR123FlybyCameras();
 
-    return true;
+    return OK;
 }
 
 static const LEVEL_FORMAT_LOADER m_LevelLoaderTR1 = {

--- a/src/trx/game/level/format/format_tr1.c
+++ b/src/trx/game/level/format/format_tr1.c
@@ -129,37 +129,37 @@ static RESULT M_Load(
     LOG_INFO("file level num: %d", file_level_num);
 
     MUST(Level_Section_ReadRooms(ctx, file));
-    Level_Section_ReadObjectMeshes(ctx, file);
-    Level_Section_ReadAnims(ctx, file);
-    Level_Section_ReadAnimChanges(ctx, file);
-    Level_Section_ReadAnimRanges(ctx, file);
-    Level_Section_ReadAnimCommands(ctx, file);
-    Level_Section_ReadAnimBones(ctx, file);
-    Level_Section_ReadAnimFrames(ctx, file);
+    MUST(Level_Section_ReadObjectMeshes(ctx, file));
+    MUST(Level_Section_ReadAnims(ctx, file));
+    MUST(Level_Section_ReadAnimChanges(ctx, file));
+    MUST(Level_Section_ReadAnimRanges(ctx, file));
+    MUST(Level_Section_ReadAnimCommands(ctx, file));
+    MUST(Level_Section_ReadAnimBones(ctx, file));
+    MUST(Level_Section_ReadAnimFrames(ctx, file));
     MUST(Level_Section_ReadObjects(ctx, file));
     MUST(Level_Section_ReadStaticObjects(ctx, file));
-    Level_Section_ReadObjectTextures(ctx, file);
-    Level_Section_ReadSpriteTextures(ctx, file);
+    MUST(Level_Section_ReadObjectTextures(ctx, file));
+    MUST(Level_Section_ReadSpriteTextures(ctx, file));
     MUST(Level_Section_ReadSpriteSequences(ctx, file));
 
     if (loader->layout == LEVEL_FORMAT_LAYOUT_TR1_DEMO_PC) {
-        Level_Section_ReadPalettes(ctx, file);
+        MUST(Level_Section_ReadPalettes(ctx, file));
     }
 
-    Level_Section_ReadCamerasAndSinks(ctx, file);
-    Level_Section_ReadSoundSources(ctx, file);
-    Level_Section_ReadPathingData(ctx, file);
-    Level_Section_ReadAnimatedTextureRanges(ctx, file);
+    MUST(Level_Section_ReadCamerasAndSinks(ctx, file));
+    MUST(Level_Section_ReadSoundSources(ctx, file));
+    MUST(Level_Section_ReadPathingData(ctx, file));
+    MUST(Level_Section_ReadAnimatedTextureRanges(ctx, file));
     MUST(Level_Section_ReadItems(ctx, file));
-    Level_Section_ReadLightMap(ctx, file);
+    MUST(Level_Section_ReadLightMap(ctx, file));
 
     if (loader->layout != LEVEL_FORMAT_LAYOUT_TR1_DEMO_PC) {
-        Level_Section_ReadPalettes(ctx, file);
+        MUST(Level_Section_ReadPalettes(ctx, file));
     }
 
-    Level_Section_ReadCinematicFrames(ctx, file);
-    Level_Section_ReadDemoData(ctx, file);
-    Level_Section_ReadSamples(ctx, file);
+    MUST(Level_Section_ReadCinematicFrames(ctx, file));
+    MUST(Level_Section_ReadDemoData(ctx, file));
+    MUST(Level_Section_ReadSamples(ctx, file));
 
     if (loader->layout == LEVEL_FORMAT_LAYOUT_TR1X) {
         TRX_FILE *const embedded_injection =
@@ -168,7 +168,7 @@ static RESULT M_Load(
     }
 
     File_Seek(file, 4, FILE_SEEK_SET);
-    Level_Section_ReadTexturePages(ctx, file);
+    MUST(Level_Section_ReadTexturePages(ctx, file));
     Level_Section_PrepareTR123FlybyCameras();
 
     return OK;

--- a/src/trx/game/level/format/format_tr2.c
+++ b/src/trx/game/level/format/format_tr2.c
@@ -109,36 +109,36 @@ static RESULT M_Load(
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
     File_Seek(file, 4, FILE_SEEK_SET);
 
-    Level_Section_ReadPalettes(ctx, file);
-    Level_Section_ReadTexturePages(ctx, file);
+    MUST(Level_Section_ReadPalettes(ctx, file));
+    MUST(Level_Section_ReadTexturePages(ctx, file));
     File_Skip(file, 4);
     MUST(Level_Section_ReadRooms(ctx, file));
 
-    Level_Section_ReadObjectMeshes(ctx, file);
+    MUST(Level_Section_ReadObjectMeshes(ctx, file));
 
-    Level_Section_ReadAnims(ctx, file);
-    Level_Section_ReadAnimChanges(ctx, file);
-    Level_Section_ReadAnimRanges(ctx, file);
-    Level_Section_ReadAnimCommands(ctx, file);
-    Level_Section_ReadAnimBones(ctx, file);
-    Level_Section_ReadAnimFrames(ctx, file);
+    MUST(Level_Section_ReadAnims(ctx, file));
+    MUST(Level_Section_ReadAnimChanges(ctx, file));
+    MUST(Level_Section_ReadAnimRanges(ctx, file));
+    MUST(Level_Section_ReadAnimCommands(ctx, file));
+    MUST(Level_Section_ReadAnimBones(ctx, file));
+    MUST(Level_Section_ReadAnimFrames(ctx, file));
 
     MUST(Level_Section_ReadObjects(ctx, file));
     MUST(Level_Section_ReadStaticObjects(ctx, file));
-    Level_Section_ReadObjectTextures(ctx, file);
+    MUST(Level_Section_ReadObjectTextures(ctx, file));
 
-    Level_Section_ReadSpriteTextures(ctx, file);
+    MUST(Level_Section_ReadSpriteTextures(ctx, file));
     MUST(Level_Section_ReadSpriteSequences(ctx, file));
-    Level_Section_ReadCamerasAndSinks(ctx, file);
-    Level_Section_ReadSoundSources(ctx, file);
-    Level_Section_ReadPathingData(ctx, file);
-    Level_Section_ReadAnimatedTextureRanges(ctx, file);
+    MUST(Level_Section_ReadCamerasAndSinks(ctx, file));
+    MUST(Level_Section_ReadSoundSources(ctx, file));
+    MUST(Level_Section_ReadPathingData(ctx, file));
+    MUST(Level_Section_ReadAnimatedTextureRanges(ctx, file));
     MUST(Level_Section_ReadItems(ctx, file));
 
-    Level_Section_ReadLightMap(ctx, file);
-    Level_Section_ReadCinematicFrames(ctx, file);
-    Level_Section_ReadDemoData(ctx, file);
-    Level_Section_ReadSamples(ctx, file);
+    MUST(Level_Section_ReadLightMap(ctx, file));
+    MUST(Level_Section_ReadCinematicFrames(ctx, file));
+    MUST(Level_Section_ReadDemoData(ctx, file));
+    MUST(Level_Section_ReadSamples(ctx, file));
 
     if (loader->layout == LEVEL_FORMAT_LAYOUT_TR2X) {
         TRX_FILE *const embedded_injection =

--- a/src/trx/game/level/format/format_tr2.c
+++ b/src/trx/game/level/format/format_tr2.c
@@ -103,7 +103,7 @@ static bool M_Probe(
     return true;
 }
 
-static bool M_Load(
+static RESULT M_Load(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file)
 {
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
@@ -147,7 +147,7 @@ static bool M_Load(
     }
 
     Level_Section_PrepareTR123FlybyCameras();
-    return true;
+    return OK;
 }
 
 static const LEVEL_FORMAT_LOADER m_LevelLoaderTR2 = {

--- a/src/trx/game/level/format/format_tr2.c
+++ b/src/trx/game/level/format/format_tr2.c
@@ -7,7 +7,7 @@
 
 #define M_SAMPLE_COUNT 370
 
-static bool M_Probe(
+static RESULT M_Probe(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file,
     const LEVEL_FORMAT_PROBE_MODE mode)
 {
@@ -19,7 +19,7 @@ static bool M_Probe(
     int32_t version;
     LEVEL_FORMAT_TRY_OR_FAIL(File_TryReadS32(file, &version));
     if (version != 45) {
-        return false;
+        return ERR;
     }
 
     LEVEL_FORMAT_SKIP_OR_FAIL(1792); // palettes
@@ -48,7 +48,7 @@ static bool M_Probe(
 
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(2); // floor data
     } else {
-        Level_Section_ReadRooms(&probe_ctx, file);
+        MUST(Level_Section_ReadRooms(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(2); // object meshes
@@ -63,7 +63,7 @@ static bool M_Probe(
     if (mode == LEVEL_FORMAT_PROBE_MINIMAL) {
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(18); // objects
     } else {
-        Level_Section_ReadObjects(&probe_ctx, file);
+        MUST(Level_Section_ReadObjects(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(32); // static objects
@@ -84,7 +84,7 @@ static bool M_Probe(
     if (mode == LEVEL_FORMAT_PROBE_MINIMAL) {
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(24); // items
     } else {
-        Level_Section_ReadItems(&probe_ctx, file);
+        MUST(Level_Section_ReadItems(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_OR_FAIL(32 * 256); // light table
@@ -100,7 +100,7 @@ static bool M_Probe(
         LEVEL_FORMAT_TRY_OR_FAIL(inj_magic == INJECTION_MAGIC);
     }
 
-    return true;
+    return OK;
 }
 
 static RESULT M_Load(
@@ -112,7 +112,7 @@ static RESULT M_Load(
     Level_Section_ReadPalettes(ctx, file);
     Level_Section_ReadTexturePages(ctx, file);
     File_Skip(file, 4);
-    Level_Section_ReadRooms(ctx, file);
+    MUST(Level_Section_ReadRooms(ctx, file));
 
     Level_Section_ReadObjectMeshes(ctx, file);
 
@@ -123,17 +123,17 @@ static RESULT M_Load(
     Level_Section_ReadAnimBones(ctx, file);
     Level_Section_ReadAnimFrames(ctx, file);
 
-    Level_Section_ReadObjects(ctx, file);
-    Level_Section_ReadStaticObjects(ctx, file);
+    MUST(Level_Section_ReadObjects(ctx, file));
+    MUST(Level_Section_ReadStaticObjects(ctx, file));
     Level_Section_ReadObjectTextures(ctx, file);
 
     Level_Section_ReadSpriteTextures(ctx, file);
-    Level_Section_ReadSpriteSequences(ctx, file);
+    MUST(Level_Section_ReadSpriteSequences(ctx, file));
     Level_Section_ReadCamerasAndSinks(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
     Level_Section_ReadAnimatedTextureRanges(ctx, file);
-    Level_Section_ReadItems(ctx, file);
+    MUST(Level_Section_ReadItems(ctx, file));
 
     Level_Section_ReadLightMap(ctx, file);
     Level_Section_ReadCinematicFrames(ctx, file);

--- a/src/trx/game/level/format/format_tr3.c
+++ b/src/trx/game/level/format/format_tr3.c
@@ -109,37 +109,37 @@ static RESULT M_Load(
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
     File_Seek(file, 4, FILE_SEEK_SET);
 
-    Level_Section_ReadPalettes(ctx, file);
-    Level_Section_ReadTexturePages(ctx, file);
+    MUST(Level_Section_ReadPalettes(ctx, file));
+    MUST(Level_Section_ReadTexturePages(ctx, file));
     File_Skip(file, 4);
     MUST(Level_Section_ReadRooms(ctx, file));
 
-    Level_Section_ReadObjectMeshes(ctx, file);
+    MUST(Level_Section_ReadObjectMeshes(ctx, file));
 
-    Level_Section_ReadAnims(ctx, file);
-    Level_Section_ReadAnimChanges(ctx, file);
-    Level_Section_ReadAnimRanges(ctx, file);
-    Level_Section_ReadAnimCommands(ctx, file);
-    Level_Section_ReadAnimBones(ctx, file);
-    Level_Section_ReadAnimFrames(ctx, file);
+    MUST(Level_Section_ReadAnims(ctx, file));
+    MUST(Level_Section_ReadAnimChanges(ctx, file));
+    MUST(Level_Section_ReadAnimRanges(ctx, file));
+    MUST(Level_Section_ReadAnimCommands(ctx, file));
+    MUST(Level_Section_ReadAnimBones(ctx, file));
+    MUST(Level_Section_ReadAnimFrames(ctx, file));
 
     MUST(Level_Section_ReadObjects(ctx, file));
     MUST(Level_Section_ReadStaticObjects(ctx, file));
 
-    Level_Section_ReadSpriteTextures(ctx, file);
+    MUST(Level_Section_ReadSpriteTextures(ctx, file));
     MUST(Level_Section_ReadSpriteSequences(ctx, file));
-    Level_Section_ReadCamerasAndSinks(ctx, file);
-    Level_Section_ReadSoundSources(ctx, file);
-    Level_Section_ReadPathingData(ctx, file);
+    MUST(Level_Section_ReadCamerasAndSinks(ctx, file));
+    MUST(Level_Section_ReadSoundSources(ctx, file));
+    MUST(Level_Section_ReadPathingData(ctx, file));
 
-    Level_Section_ReadAnimatedTextureRanges(ctx, file);
-    Level_Section_ReadObjectTextures(ctx, file);
+    MUST(Level_Section_ReadAnimatedTextureRanges(ctx, file));
+    MUST(Level_Section_ReadObjectTextures(ctx, file));
     MUST(Level_Section_ReadItems(ctx, file));
 
-    Level_Section_ReadLightMap(ctx, file);
-    Level_Section_ReadCinematicFrames(ctx, file);
-    Level_Section_ReadDemoData(ctx, file);
-    Level_Section_ReadSamples(ctx, file);
+    MUST(Level_Section_ReadLightMap(ctx, file));
+    MUST(Level_Section_ReadCinematicFrames(ctx, file));
+    MUST(Level_Section_ReadDemoData(ctx, file));
+    MUST(Level_Section_ReadSamples(ctx, file));
 
     if (loader->layout == LEVEL_FORMAT_LAYOUT_TR3X) {
         TRX_FILE *const embedded_injection =

--- a/src/trx/game/level/format/format_tr3.c
+++ b/src/trx/game/level/format/format_tr3.c
@@ -7,7 +7,7 @@
 
 #define M_SAMPLE_COUNT 370
 
-static bool M_Probe(
+static RESULT M_Probe(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file,
     const LEVEL_FORMAT_PROBE_MODE mode)
 {
@@ -19,7 +19,7 @@ static bool M_Probe(
     uint32_t version;
     LEVEL_FORMAT_TRY_OR_FAIL(File_TryReadU32(file, &version));
     if (!(version == 0xFF080038ULL || version == 0xFF180038ULL)) {
-        return false;
+        return ERR;
     }
 
     LEVEL_FORMAT_SKIP_OR_FAIL(1792); // palettes
@@ -48,7 +48,7 @@ static bool M_Probe(
 
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(2); // floor data
     } else {
-        Level_Section_ReadRooms(&probe_ctx, file);
+        MUST(Level_Section_ReadRooms(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(2); // object meshes
@@ -63,7 +63,7 @@ static bool M_Probe(
     if (mode == LEVEL_FORMAT_PROBE_MINIMAL) {
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(18); // objects
     } else {
-        Level_Section_ReadObjects(&probe_ctx, file);
+        MUST(Level_Section_ReadObjects(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(32); // static objects
@@ -84,7 +84,7 @@ static bool M_Probe(
     if (mode == LEVEL_FORMAT_PROBE_MINIMAL) {
         LEVEL_FORMAT_SKIP_ARR_S32_OR_FAIL(24); // items
     } else {
-        Level_Section_ReadItems(&probe_ctx, file);
+        MUST(Level_Section_ReadItems(&probe_ctx, file));
     }
 
     LEVEL_FORMAT_SKIP_OR_FAIL(32 * 256); // light table
@@ -100,7 +100,7 @@ static bool M_Probe(
         LEVEL_FORMAT_TRY_OR_FAIL(inj_magic == INJECTION_MAGIC);
     }
 
-    return true;
+    return OK;
 }
 
 static RESULT M_Load(
@@ -112,7 +112,7 @@ static RESULT M_Load(
     Level_Section_ReadPalettes(ctx, file);
     Level_Section_ReadTexturePages(ctx, file);
     File_Skip(file, 4);
-    Level_Section_ReadRooms(ctx, file);
+    MUST(Level_Section_ReadRooms(ctx, file));
 
     Level_Section_ReadObjectMeshes(ctx, file);
 
@@ -123,18 +123,18 @@ static RESULT M_Load(
     Level_Section_ReadAnimBones(ctx, file);
     Level_Section_ReadAnimFrames(ctx, file);
 
-    Level_Section_ReadObjects(ctx, file);
-    Level_Section_ReadStaticObjects(ctx, file);
+    MUST(Level_Section_ReadObjects(ctx, file));
+    MUST(Level_Section_ReadStaticObjects(ctx, file));
 
     Level_Section_ReadSpriteTextures(ctx, file);
-    Level_Section_ReadSpriteSequences(ctx, file);
+    MUST(Level_Section_ReadSpriteSequences(ctx, file));
     Level_Section_ReadCamerasAndSinks(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
 
     Level_Section_ReadAnimatedTextureRanges(ctx, file);
     Level_Section_ReadObjectTextures(ctx, file);
-    Level_Section_ReadItems(ctx, file);
+    MUST(Level_Section_ReadItems(ctx, file));
 
     Level_Section_ReadLightMap(ctx, file);
     Level_Section_ReadCinematicFrames(ctx, file);

--- a/src/trx/game/level/format/format_tr3.c
+++ b/src/trx/game/level/format/format_tr3.c
@@ -103,7 +103,7 @@ static bool M_Probe(
     return true;
 }
 
-static bool M_Load(
+static RESULT M_Load(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file)
 {
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
@@ -148,7 +148,7 @@ static bool M_Load(
     }
 
     Level_Section_PrepareTR123FlybyCameras();
-    return true;
+    return OK;
 }
 
 static const LEVEL_FORMAT_LOADER m_LevelLoaderTR3X = {

--- a/src/trx/game/level/format/format_tr4.c
+++ b/src/trx/game/level/format/format_tr4.c
@@ -51,14 +51,14 @@ static TRX_FILE *M_ReadChunk(TRX_FILE *const file, const char *const name)
     return result;
 }
 
-static bool M_Probe(
+static RESULT M_Probe(
     const LEVEL_FORMAT_LOADER *const, TRX_FILE *const file,
     const LEVEL_FORMAT_PROBE_MODE)
 {
     File_Seek(file, 0, FILE_SEEK_SET);
     uint32_t version;
     LEVEL_FORMAT_TRY_OR_FAIL(File_TryReadU32(file, &version));
-    return version == M_VERSION_TR45;
+    return version == M_VERSION_TR45 ? OK : ERR;
 }
 
 static void M_InitialiseDummyPalette(LEVEL_CONTEXT *const ctx)
@@ -71,7 +71,7 @@ static void M_InitialiseDummyPalette(LEVEL_CONTEXT *const ctx)
     memset(info->palette.data_32, 0, sizeof(RGB_888) * info->palette.size);
 }
 
-static bool M_ReadImages(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+static RESULT M_ReadImages(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     M_IMAGE_META image_meta = {
         .room_pages = File_ReadU16(file),
@@ -83,8 +83,7 @@ static bool M_ReadImages(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 
     TRX_FILE *const images32 = M_ReadChunk(file, "images32");
     if (images32 == nullptr) {
-        Shell_ExitSystem("Failed to read TR4 32-bit images");
-        return false;
+        return FAIL("the 32-bit images could not be read");
     }
 
     LEVEL_CONTEXT_INFO *const info = &ctx->info;
@@ -112,15 +111,13 @@ static bool M_ReadImages(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 
     TRX_FILE *const images16 = M_ReadChunk(file, "images16");
     if (images16 == nullptr) {
-        Shell_ExitSystem("Failed to read TR4 16-bit images");
-        return false;
+        return FAIL("the 16-bit images could not be read");
     }
     File_Close(images16);
 
     TRX_FILE *const sky_font = M_ReadChunk(file, "sky/font");
     if (sky_font == nullptr) {
-        Shell_ExitSystem("Failed to read TR4 sky/font images");
-        return false;
+        return FAIL("the sky and font images could not be read");
     }
     // The chunk holds two raw 256x256 BGRA images: the font, then the sky.
     // The sky becomes an extra texture page for the flat sky layers.
@@ -138,7 +135,7 @@ static bool M_ReadImages(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     File_Close(sky_font);
 
     M_InitialiseDummyPalette(ctx);
-    return true;
+    return OK;
 }
 
 static void M_ReadAnimatedTextureRangesTR4(
@@ -226,16 +223,17 @@ static void M_ReadSpriteTexturesTR4(
     }
 }
 
-static void M_ReadItemsTR4(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+static RESULT M_ReadItemsTR4(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
+    RESULT result = OK;
     BENCHMARK benchmark = Benchmark_Start();
     LEVEL_CONTEXT_INFO *const info = &ctx->info;
     const int32_t num_items = File_ReadCountS32(file);
     LOG_INFO("items: %d", num_items);
     if (num_items > MAX_ITEMS) {
-        Shell_ExitSystem("Too many items");
-        Benchmark_End(&benchmark, nullptr);
-        return;
+        result =
+            FAIL("too many items: %d, at most %d fit", num_items, MAX_ITEMS);
+        goto finish;
     }
 
     info->tr4.item_count = num_items;
@@ -268,7 +266,10 @@ static void M_ReadItemsTR4(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
             LOG_WARNING("Unsupported TR4 item object %d on item %d", obj_id, i);
         }
     }
+
+finish:
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }
 
 static void M_ReadAIItemsTR4(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
@@ -329,17 +330,14 @@ static RESULT M_Load(
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
     File_Seek(file, sizeof(uint32_t), FILE_SEEK_SET);
 
-    if (!M_ReadImages(ctx, file)) {
-        return ERR;
-    }
+    MUST(M_ReadImages(ctx, file));
     TRX_FILE *const level_data = M_ReadChunk(file, "level data");
     if (level_data == nullptr) {
-        Shell_ExitSystem("Failed to read TR4 level data");
-        return ERR;
+        return FAIL("the level data could not be read");
     }
 
     File_ReadU32(level_data); // level number
-    Level_Section_ReadRooms(ctx, level_data);
+    MUST(Level_Section_ReadRooms(ctx, level_data));
     Level_Section_ReadObjectMeshes(ctx, level_data);
     Level_Section_ReadAnims(ctx, level_data);
     Level_Section_ReadAnimChanges(ctx, level_data);
@@ -347,17 +345,17 @@ static RESULT M_Load(
     Level_Section_ReadAnimCommands(ctx, level_data);
     Level_Section_ReadAnimBones(ctx, level_data);
     Level_Section_ReadAnimFrames(ctx, level_data);
-    Level_Section_ReadObjects(ctx, level_data);
-    Level_Section_ReadStaticObjects(ctx, level_data);
+    MUST(Level_Section_ReadObjects(ctx, level_data));
+    MUST(Level_Section_ReadStaticObjects(ctx, level_data));
     M_ReadSpriteTexturesTR4(ctx, level_data);
-    Level_Section_ReadSpriteSequences(ctx, level_data);
+    MUST(Level_Section_ReadSpriteSequences(ctx, level_data));
     Level_Section_ReadCamerasAndSinks(ctx, level_data);
     Level_Section_ReadFlybyCameras(ctx, level_data);
     Level_Section_ReadSoundSources(ctx, level_data);
     Level_Section_ReadPathingData(ctx, level_data);
     M_ReadAnimatedTextureRangesTR4(ctx, level_data);
     M_ReadObjectTexturesTR4(ctx, level_data);
-    M_ReadItemsTR4(ctx, level_data);
+    MUST(M_ReadItemsTR4(ctx, level_data));
     M_ReadAIItemsTR4(ctx, level_data);
     Level_Section_ReadDemoData(ctx, level_data);
     Level_Section_ReadSamples(ctx, level_data);

--- a/src/trx/game/level/format/format_tr4.c
+++ b/src/trx/game/level/format/format_tr4.c
@@ -323,19 +323,19 @@ static void M_ReadSampleData(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     }
 }
 
-static bool M_Load(
+static RESULT M_Load(
     const LEVEL_FORMAT_LOADER *const loader, TRX_FILE *const file)
 {
     LEVEL_CONTEXT *const ctx = Level_Context_Get();
     File_Seek(file, sizeof(uint32_t), FILE_SEEK_SET);
 
     if (!M_ReadImages(ctx, file)) {
-        return false;
+        return ERR;
     }
     TRX_FILE *const level_data = M_ReadChunk(file, "level data");
     if (level_data == nullptr) {
         Shell_ExitSystem("Failed to read TR4 level data");
-        return false;
+        return ERR;
     }
 
     File_ReadU32(level_data); // level number
@@ -366,7 +366,7 @@ static bool M_Load(
     File_Close(level_data);
 
     M_ReadSampleData(ctx, file);
-    return true;
+    return OK;
 }
 
 static const LEVEL_FORMAT_LOADER m_LevelLoaderTR4 = {

--- a/src/trx/game/level/format/format_tr4.c
+++ b/src/trx/game/level/format/format_tr4.c
@@ -338,27 +338,27 @@ static RESULT M_Load(
 
     File_ReadU32(level_data); // level number
     MUST(Level_Section_ReadRooms(ctx, level_data));
-    Level_Section_ReadObjectMeshes(ctx, level_data);
-    Level_Section_ReadAnims(ctx, level_data);
-    Level_Section_ReadAnimChanges(ctx, level_data);
-    Level_Section_ReadAnimRanges(ctx, level_data);
-    Level_Section_ReadAnimCommands(ctx, level_data);
-    Level_Section_ReadAnimBones(ctx, level_data);
-    Level_Section_ReadAnimFrames(ctx, level_data);
+    MUST(Level_Section_ReadObjectMeshes(ctx, level_data));
+    MUST(Level_Section_ReadAnims(ctx, level_data));
+    MUST(Level_Section_ReadAnimChanges(ctx, level_data));
+    MUST(Level_Section_ReadAnimRanges(ctx, level_data));
+    MUST(Level_Section_ReadAnimCommands(ctx, level_data));
+    MUST(Level_Section_ReadAnimBones(ctx, level_data));
+    MUST(Level_Section_ReadAnimFrames(ctx, level_data));
     MUST(Level_Section_ReadObjects(ctx, level_data));
     MUST(Level_Section_ReadStaticObjects(ctx, level_data));
     M_ReadSpriteTexturesTR4(ctx, level_data);
     MUST(Level_Section_ReadSpriteSequences(ctx, level_data));
-    Level_Section_ReadCamerasAndSinks(ctx, level_data);
-    Level_Section_ReadFlybyCameras(ctx, level_data);
-    Level_Section_ReadSoundSources(ctx, level_data);
-    Level_Section_ReadPathingData(ctx, level_data);
+    MUST(Level_Section_ReadCamerasAndSinks(ctx, level_data));
+    MUST(Level_Section_ReadFlybyCameras(ctx, level_data));
+    MUST(Level_Section_ReadSoundSources(ctx, level_data));
+    MUST(Level_Section_ReadPathingData(ctx, level_data));
     M_ReadAnimatedTextureRangesTR4(ctx, level_data);
     M_ReadObjectTexturesTR4(ctx, level_data);
     MUST(M_ReadItemsTR4(ctx, level_data));
     M_ReadAIItemsTR4(ctx, level_data);
-    Level_Section_ReadDemoData(ctx, level_data);
-    Level_Section_ReadSamples(ctx, level_data);
+    MUST(Level_Section_ReadDemoData(ctx, level_data));
+    MUST(Level_Section_ReadSamples(ctx, level_data));
     File_Skip(level_data, 6); // trailing zero padding
 
     File_Close(level_data);

--- a/src/trx/game/level/format/pipeline.c
+++ b/src/trx/game/level/format/pipeline.c
@@ -94,6 +94,7 @@ RESULT Level_Format_LoadFromFile(
     BENCHMARK benchmark = Benchmark_Start();
     TRX_FILE *file = nullptr;
     MUST(File_OpenPathInMemory(level->path, &file));
+    File_SetSoftFailure(file, true);
 
     const LEVEL_FORMAT_LOADER *const loader = Level_Format_GuessLoader(file);
     if (loader == nullptr) {
@@ -103,7 +104,10 @@ RESULT Level_Format_LoadFromFile(
     g_TRVersion = loader->game_version;
     Level_Context_Reset(loader);
     ASSERT(loader->load != nullptr);
-    const RESULT result = loader->load(loader, file);
+    RESULT result = loader->load(loader, file);
+    if (IS_OK(result) && File_HasFailed(file)) {
+        result = FAIL("the level ends before its data does");
+    }
 
     File_Close(file);
     Benchmark_End(&benchmark, nullptr);

--- a/src/trx/game/level/format/pipeline.c
+++ b/src/trx/game/level/format/pipeline.c
@@ -67,7 +67,7 @@ const LEVEL_FORMAT_LOADER *Level_Format_GuessLoader(TRX_FILE *const file)
     const int32_t loader_count = M_GetRegisteredLoaderCount();
     for (int32_t i = 0; i < loader_count; i++) {
         const LEVEL_FORMAT_LOADER *const loader = M_GetRegisteredLoader(i);
-        if (loader->probe(loader, file, LEVEL_FORMAT_PROBE_MINIMAL)) {
+        if (IS_OK(loader->probe(loader, file, LEVEL_FORMAT_PROBE_MINIMAL))) {
             result = loader;
             break;
         }

--- a/src/trx/game/level/format/pipeline.c
+++ b/src/trx/game/level/format/pipeline.c
@@ -85,26 +85,29 @@ LEVEL_FORMAT_LAYOUT Level_Format_GuessLayout(TRX_FILE *const file)
     return LEVEL_FORMAT_LAYOUT_UNKNOWN;
 }
 
-const LEVEL_FORMAT_LOADER *Level_Format_LoadFromFile(
-    const GF_LEVEL *const level)
+RESULT Level_Format_LoadFromFile(
+    const GF_LEVEL *const level, const LEVEL_FORMAT_LOADER **const out_loader)
 {
+    *out_loader = nullptr;
     GameBuf_Reset();
 
     BENCHMARK benchmark = Benchmark_Start();
     TRX_FILE *file = nullptr;
-    EXIT_ON_FAIL(
-        File_OpenPathInMemory(level->path, &file), "The level cannot be read");
+    MUST(File_OpenPathInMemory(level->path, &file));
 
     const LEVEL_FORMAT_LOADER *const loader = Level_Format_GuessLoader(file);
     if (loader == nullptr) {
-        Shell_ExitSystemFmt("Failed to load %s", level->path);
+        File_Close(file);
+        return FAIL("%s: the level is in no format TRX knows", level->path);
     }
     g_TRVersion = loader->game_version;
     Level_Context_Reset(loader);
     ASSERT(loader->load != nullptr);
-    loader->load(loader, file);
+    const RESULT result = loader->load(loader, file);
 
     File_Close(file);
     Benchmark_End(&benchmark, nullptr);
-    return loader;
+    MUST(result, "%s", level->path);
+    *out_loader = loader;
+    return OK;
 }

--- a/src/trx/game/level/format/priv.h
+++ b/src/trx/game/level/format/priv.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trx/core/file.h>
+#include <trx/core/result.h>
 #include <trx/core/utils.h>
 #include <trx/game/level/format/format.h>
 
@@ -16,10 +17,12 @@ void Level_Format_RegisterLoader(
 
 // Helper control-flow macros
 // =============================================================================
+// If the read fails, leave the enclosing function with ERR. The file reads
+// hand back a plain bool, so this cannot be MUST.
 #define LEVEL_FORMAT_TRY_OR_FAIL(call_)                                        \
     do {                                                                       \
         if (!(call_)) {                                                        \
-            return false;                                                      \
+            return ERR;                                                        \
         }                                                                      \
     } while (0)
 

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -49,6 +49,7 @@ static void M_InitialiseSamplesFromFile(
             "the level plays without its sounds")) {
         goto finish;
     }
+    File_SetSoftFailure(fp, true);
     LOG_DEBUG("Loading samples from %s", file_name);
 
     const int32_t sample_count = info->samples.offset_count;

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -181,15 +181,19 @@ static void M_CompleteSetup(
     Benchmark_End(&benchmark, nullptr);
 }
 
-void Level_Pipeline_Load(const GF_LEVEL *const level)
+RESULT Level_Pipeline_Load(const GF_LEVEL *const level)
 {
     LOG_INFO("%d (%s)", level->num, level->path);
     BENCHMARK benchmark = Benchmark_Start();
 
     Inject_InitLevel(level, INJECTION_MODE_FULL);
-    const LEVEL_FORMAT_LOADER *const loader = Level_Format_LoadFromFile(level);
-    M_CompleteSetup(loader, level);
+    const LEVEL_FORMAT_LOADER *loader = nullptr;
+    const RESULT result = Level_Format_LoadFromFile(level, &loader);
+    if (IS_OK(result)) {
+        M_CompleteSetup(loader, level);
+    }
     Inject_Cleanup();
 
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }

--- a/src/trx/game/level/pipeline.h
+++ b/src/trx/game/level/pipeline.h
@@ -6,4 +6,4 @@
 #include <trx/game/level/sections/append.h>
 #include <trx/game/level/sections/read.h>
 
-void Level_Pipeline_Load(const GF_LEVEL *level);
+RESULT Level_Pipeline_Load(const GF_LEVEL *level);

--- a/src/trx/game/level/sections/anims.c
+++ b/src/trx/game/level/sections/anims.c
@@ -17,7 +17,7 @@ static void M_ReadPosition(XYZ_32 *const pos, TRX_FILE *const file)
     pos->z = File_ReadS32(file);
 }
 
-void Level_Section_ReadAnims(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadAnims(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_anims = File_ReadCountS32(file);
@@ -27,6 +27,7 @@ void Level_Section_ReadAnims(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
     Level_Section_AppendAnims(0, num_anims, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendAnims(
@@ -60,7 +61,7 @@ void Level_Section_AppendAnims(
     }
 }
 
-void Level_Section_ReadAnimChanges(
+RESULT Level_Section_ReadAnimChanges(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -72,6 +73,7 @@ void Level_Section_ReadAnimChanges(
         num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
     Level_Section_AppendAnimChanges(0, num_anim_changes, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendAnimChanges(
@@ -85,7 +87,7 @@ void Level_Section_AppendAnimChanges(
     }
 }
 
-void Level_Section_ReadAnimRanges(
+RESULT Level_Section_ReadAnimRanges(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -97,6 +99,7 @@ void Level_Section_ReadAnimRanges(
         num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
     Level_Section_AppendAnimRanges(0, num_anim_ranges, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendAnimRanges(
@@ -111,7 +114,7 @@ void Level_Section_AppendAnimRanges(
     }
 }
 
-void Level_Section_ReadAnimCommands(
+RESULT Level_Section_ReadAnimCommands(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -124,6 +127,7 @@ void Level_Section_ReadAnimCommands(
         * (num_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
     Level_Section_AppendAnimCommands(0, num_commands, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendAnimCommands(
@@ -134,7 +138,8 @@ void Level_Section_AppendAnimCommands(
         file, &info->anims.commands[base_idx], sizeof(int16_t) * num_commands);
 }
 
-void Level_Section_ReadAnimBones(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadAnimBones(
+    LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_anim_bones = File_ReadCountS32(file) / ANIM_BONE_SIZE;
@@ -144,6 +149,7 @@ void Level_Section_ReadAnimBones(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
     Level_Section_AppendAnimBones(0, num_anim_bones, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendAnimBones(
@@ -161,7 +167,7 @@ void Level_Section_AppendAnimBones(
     }
 }
 
-void Level_Section_ReadAnimFrames(
+RESULT Level_Section_ReadAnimFrames(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -174,6 +180,7 @@ void Level_Section_ReadAnimFrames(
         * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
     Level_Section_AppendAnimFrames(0, raw_data_count, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendAnimFrames(

--- a/src/trx/game/level/sections/audio.c
+++ b/src/trx/game/level/sections/audio.c
@@ -25,7 +25,7 @@ static size_t M_GetSampleCount(const LEVEL_FORMAT_LOADER *const loader)
     return 0;
 }
 
-void Level_Section_ReadSamples(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadSamples(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
     const LEVEL_FORMAT_LOADER *const loader = ctx->loader;
@@ -127,4 +127,5 @@ void Level_Section_ReadSamples(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     Memory_Free(sample_lut);
     Memory_Free(sample_lut_inv);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }

--- a/src/trx/game/level/sections/cinematics.c
+++ b/src/trx/game/level/sections/cinematics.c
@@ -29,7 +29,7 @@ static void M_ReadObjectVector(OBJECT_VECTOR *const obj, TRX_FILE *const file)
     obj->flags = File_ReadS16(file);
 }
 
-void Level_Section_ReadCinematicFrames(
+RESULT Level_Section_ReadCinematicFrames(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -46,9 +46,10 @@ void Level_Section_ReadCinematicFrames(
     }
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
-void Level_Section_ReadCamerasAndSinks(
+RESULT Level_Section_ReadCamerasAndSinks(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -60,6 +61,7 @@ void Level_Section_ReadCamerasAndSinks(
     }
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_PrepareTR123FlybyCameras(void)
@@ -68,7 +70,7 @@ void Level_Section_PrepareTR123FlybyCameras(void)
     Camera_InitialiseFlybys(inject_count);
 }
 
-void Level_Section_ReadFlybyCameras(
+RESULT Level_Section_ReadFlybyCameras(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -82,6 +84,7 @@ void Level_Section_ReadFlybyCameras(
     Level_Section_AppendFlybyCameras(0, num_cameras, file);
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendFlybyCameras(
@@ -122,16 +125,18 @@ void Level_Section_AppendFlybyCameras(
     }
 }
 
-void Level_Section_ReadDemoData(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadDemoData(
+    LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
     const uint16_t size = File_ReadU16(file);
     LOG_INFO("demo buffer size: %d", size);
     Demo_LoadData(file, size);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
-void Level_Section_ReadSoundSources(
+RESULT Level_Section_ReadSoundSources(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -143,4 +148,5 @@ void Level_Section_ReadSoundSources(
     }
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }

--- a/src/trx/game/level/sections/meshes.c
+++ b/src/trx/game/level/sections/meshes.c
@@ -139,7 +139,7 @@ static void M_ReadObjectMesh(OBJECT_MESH *const mesh, TRX_FILE *const file)
     }
 }
 
-void Level_Section_ReadObjectMeshes(
+RESULT Level_Section_ReadObjectMeshes(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -167,6 +167,7 @@ void Level_Section_ReadObjectMeshes(
     Memory_FreePointer(&mesh_offsets);
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendObjectMeshes(

--- a/src/trx/game/level/sections/objects.c
+++ b/src/trx/game/level/sections/objects.c
@@ -39,8 +39,9 @@ static void M_ReadBounds16(BOUNDS_16 *const bounds, TRX_FILE *const file)
     bounds->max.z = File_ReadS16(file);
 }
 
-void Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
+    RESULT result = OK;
     BENCHMARK benchmark = Benchmark_Start();
     const LEVEL_FORMAT_LOADER *const loader = ctx->loader;
     const int32_t num_objects = File_ReadCountS32(file);
@@ -56,7 +57,8 @@ void Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
                 // stable TRX catalog entry yet.
                 obj = &spare_obj;
             } else {
-                Shell_ExitSystemFmt("Invalid object ID: %d", game_obj_id);
+                result = FAIL("invalid object id %d", game_obj_id);
+                goto finish;
             }
         }
         obj->mesh_count = File_ReadS16(file);
@@ -71,12 +73,15 @@ void Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
         }
     }
 
+finish:
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }
 
-void Level_Section_ReadStaticObjects(
+RESULT Level_Section_ReadStaticObjects(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
+    RESULT result = OK;
     BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_objects = File_ReadCountS32(file);
     LOG_INFO("static objects: %d", num_objects);
@@ -96,8 +101,8 @@ void Level_Section_ReadStaticObjects(
     for (int32_t i = 0; i < num_objects; i++) {
         tmp_statics[i].static_id = File_ReadS32(file);
         if (tmp_statics[i].static_id < 0) {
-            Shell_ExitSystemFmt(
-                "Invalid static ID: %d", tmp_statics[i].static_id);
+            result = FAIL("invalid static id %d", tmp_statics[i].static_id);
+            goto finish;
         }
         max_static_id = MAX(max_static_id, tmp_statics[i].static_id);
 
@@ -129,13 +134,16 @@ void Level_Section_ReadStaticObjects(
         Object_GetMesh(obj->mesh_idx)->enable_caustics = obj->visible;
     }
 
+finish:
     Memory_FreePointer(&tmp_statics);
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }
 
-void Level_Section_ReadSpriteSequences(
+RESULT Level_Section_ReadSpriteSequences(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
+    RESULT result = OK;
     BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_sequences = File_ReadCountS32(file);
     LOG_DEBUG("sprite sequences: %d", num_sequences);
@@ -167,8 +175,8 @@ void Level_Section_ReadSpriteSequences(
         } else {
             STATIC_OBJECT_2D *const obj = Object_Get2DStatic(static_id);
             if (obj == nullptr) {
-                Shell_ExitSystemFmt("Invalid sprite slot (%d)", id);
-                break;
+                result = FAIL("invalid sprite slot %d", id);
+                goto finish;
             }
             obj->frame_count = ABS(num_meshes);
             obj->texture_idx = mesh_idx;
@@ -177,17 +185,21 @@ void Level_Section_ReadSpriteSequences(
         }
     }
 
+finish:
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }
 
-void Level_Section_ReadItems(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadItems(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
+    RESULT result = OK;
     BENCHMARK benchmark = Benchmark_Start();
     const LEVEL_FORMAT_LOADER *const loader = ctx->loader;
     const int32_t num_items = File_ReadCountS32(file);
     LOG_INFO("items: %d", num_items);
     if (num_items > MAX_ITEMS) {
-        Shell_ExitSystem("Too many items");
+        result =
+            FAIL("too many items: %d, at most %d fit", num_items, MAX_ITEMS);
         goto finish;
     }
 
@@ -197,7 +209,7 @@ void Level_Section_ReadItems(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
         const int16_t obj_id = File_ReadS16(file);
         item->object_id = Object_FromGameID(obj_id);
         if (item->object_id == NO_OBJECT) {
-            Shell_ExitSystemFmt("Bad object number (%d) on item %d", obj_id, i);
+            result = FAIL("item %d names no object: %d", i, obj_id);
             goto finish;
         }
 
@@ -210,4 +222,5 @@ void Level_Section_ReadItems(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 
 finish:
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }

--- a/src/trx/game/level/sections/pathing.c
+++ b/src/trx/game/level/sections/pathing.c
@@ -7,7 +7,7 @@
 
 #include <string.h>
 
-void Level_Section_ReadPathingData(
+RESULT Level_Section_ReadPathingData(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -60,4 +60,5 @@ void Level_Section_ReadPathingData(
     }
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }

--- a/src/trx/game/level/sections/read.h
+++ b/src/trx/game/level/sections/read.h
@@ -6,30 +6,30 @@
 
 #define ANIM_BONE_SIZE 4
 
-void Level_Section_ReadPalettes(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadTexturePages(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadPalettes(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadTexturePages(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 RESULT Level_Section_ReadRooms(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadObjectMeshes(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnims(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnimChanges(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnimRanges(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnimCommands(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnimBones(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnimFrames(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadObjectMeshes(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnims(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnimChanges(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnimRanges(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnimCommands(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnimBones(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnimFrames(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 RESULT Level_Section_ReadObjects(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 RESULT Level_Section_ReadStaticObjects(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadObjectTextures(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadSpriteTextures(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadObjectTextures(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadSpriteTextures(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 RESULT Level_Section_ReadSpriteSequences(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadPathingData(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadAnimatedTextureRanges(
+RESULT Level_Section_ReadPathingData(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadAnimatedTextureRanges(
     LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadLightMap(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadCinematicFrames(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadCamerasAndSinks(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadLightMap(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadCinematicFrames(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadCamerasAndSinks(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_PrepareTR123FlybyCameras(void);
-void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 RESULT Level_Section_ReadItems(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadDemoData(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadSoundSources(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadSamples(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadDemoData(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadSoundSources(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadSamples(LEVEL_CONTEXT *ctx, TRX_FILE *file);

--- a/src/trx/game/level/sections/read.h
+++ b/src/trx/game/level/sections/read.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <trx/core/file.h>
+#include <trx/core/result.h>
 #include <trx/game/level/context.h>
 
 #define ANIM_BONE_SIZE 4
 
 void Level_Section_ReadPalettes(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadTexturePages(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadRooms(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadRooms(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadObjectMeshes(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadAnims(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadAnimChanges(LEVEL_CONTEXT *ctx, TRX_FILE *file);
@@ -15,11 +16,11 @@ void Level_Section_ReadAnimRanges(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadAnimCommands(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadAnimBones(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadAnimFrames(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadObjects(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadStaticObjects(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadObjects(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadStaticObjects(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadObjectTextures(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadSpriteTextures(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadSpriteSequences(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadSpriteSequences(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadPathingData(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadAnimatedTextureRanges(
     LEVEL_CONTEXT *ctx, TRX_FILE *file);
@@ -28,7 +29,7 @@ void Level_Section_ReadCinematicFrames(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadCamerasAndSinks(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_PrepareTR123FlybyCameras(void);
 void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *ctx, TRX_FILE *file);
-void Level_Section_ReadItems(LEVEL_CONTEXT *ctx, TRX_FILE *file);
+RESULT Level_Section_ReadItems(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadDemoData(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadSoundSources(LEVEL_CONTEXT *ctx, TRX_FILE *file);
 void Level_Section_ReadSamples(LEVEL_CONTEXT *ctx, TRX_FILE *file);

--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -270,15 +270,17 @@ static XYZ_16 M_ComputePortalNormal(PORTAL *const p)
     return (XYZ_16) { n.x, n.y, n.z };
 }
 
-void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
+    RESULT result = OK;
     BENCHMARK benchmark = Benchmark_Start();
     const LEVEL_FORMAT_LOADER *const loader = ctx->loader;
 
     const int32_t num_rooms = File_ReadCountS16(file);
     LOG_INFO("rooms: %d", num_rooms);
     if (num_rooms > MAX_ROOMS) {
-        Shell_ExitSystem("Too many rooms");
+        result =
+            FAIL("too many rooms: %d, at most %d fit", num_rooms, MAX_ROOMS);
         goto finish;
     }
 
@@ -527,4 +529,5 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 
 finish:
     Benchmark_End(&benchmark, nullptr);
+    return result;
 }

--- a/src/trx/game/level/sections/textures.c
+++ b/src/trx/game/level/sections/textures.c
@@ -71,7 +71,8 @@ static void M_Decode16BitTexturePage(void *const userdata)
     }
 }
 
-void Level_Section_ReadPalettes(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadPalettes(
+    LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
 
@@ -106,9 +107,10 @@ void Level_Section_ReadPalettes(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     }
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
-void Level_Section_ReadTexturePages(
+RESULT Level_Section_ReadTexturePages(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -163,9 +165,10 @@ void Level_Section_ReadTexturePages(
     ThreadPool_Destroy(pool);
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
-void Level_Section_ReadObjectTextures(
+RESULT Level_Section_ReadObjectTextures(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -177,6 +180,7 @@ void Level_Section_ReadObjectTextures(
         num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
     Level_Section_AppendObjectTextures(0, 0, num_textures, file);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendObjectTextures(
@@ -209,7 +213,7 @@ void Level_Section_AppendObjectTextures(
     }
 }
 
-void Level_Section_ReadSpriteTextures(
+RESULT Level_Section_ReadSpriteTextures(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -222,6 +226,7 @@ void Level_Section_ReadSpriteTextures(
     Level_Section_AppendSpriteTextures(0, 0, num_textures, file);
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
 void Level_Section_AppendSpriteTextures(
@@ -244,7 +249,7 @@ void Level_Section_AppendSpriteTextures(
     }
 }
 
-void Level_Section_ReadAnimatedTextureRanges(
+RESULT Level_Section_ReadAnimatedTextureRanges(
     LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -273,9 +278,11 @@ void Level_Section_ReadAnimatedTextureRanges(
 
     File_Seek(file, end_position, FILE_SEEK_SET);
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }
 
-void Level_Section_ReadLightMap(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
+RESULT Level_Section_ReadLightMap(
+    LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
     for (int32_t i = 0; i < 32; i++) {
@@ -293,4 +300,5 @@ void Level_Section_ReadLightMap(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
     }
 
     Benchmark_End(&benchmark, nullptr);
+    return OK;
 }

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -44,11 +44,12 @@ static void M_SetAnchorRoom(ITEM *const item, const TRX_VALUE *const in)
     p->anchor_z = room->pos.z + room->size.z * (WALL_L >> 1);
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "status", &p->status));
-    SHOULD(JSON_READ_OPT(io, "death_count", &p->death_count));
+    MUST(JSON_READ_OPT(io, "status", &p->status));
+    MUST(JSON_READ_OPT(io, "death_count", &p->death_count));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/claw_mutant.c
+++ b/src/trx/game/objects/creatures/claw_mutant.c
@@ -62,10 +62,11 @@ static const BITE m_PlasmaEmitter = {
     .mesh_num = 13,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "recently_fired", &p->recently_fired));
+    MUST(JSON_READ_OPT(io, "recently_fired", &p->recently_fired));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -74,13 +74,14 @@ static void M_Initialise(const int16_t item_num)
     p->shared->attack_lara = false;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "scared_timer", &p->scared_timer));
-    SHOULD(JSON_READ_OPT(io, "attack_lara", &p->attack_lara));
-    SHOULD(JSON_READ_OPT(io, "shared_scared_timer", &p->shared->scared_timer));
-    SHOULD(JSON_READ_OPT(io, "shared_attack_lara", &p->shared->attack_lara));
+    MUST(JSON_READ_OPT(io, "scared_timer", &p->scared_timer));
+    MUST(JSON_READ_OPT(io, "attack_lara", &p->attack_lara));
+    MUST(JSON_READ_OPT(io, "shared_scared_timer", &p->shared->scared_timer));
+    MUST(JSON_READ_OPT(io, "shared_attack_lara", &p->shared->attack_lara));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/crawler_mutant.c
+++ b/src/trx/game/objects/creatures/crawler_mutant.c
@@ -40,10 +40,11 @@ static const BITE m_Gas = {
     .mesh_num = 10,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "burn_timer", &p->burn_timer));
+    MUST(JSON_READ_OPT(io, "burn_timer", &p->burn_timer));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -84,10 +84,11 @@ static const BITE m_DragonMouth = {
     .mesh_num = 12,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "mode", &p->mode));
+    MUST(JSON_READ_OPT(io, "mode", &p->mode));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -78,12 +78,13 @@ static const BITE m_Bite = {
     .mesh_num = 13,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "stick_initialised", &p->stick.initialised));
-    SHOULD(JSON_READ_OPT(io, "stick_on_fire", &p->stick.on_fire));
-    SHOULD(JSON_READ_OPT(io, "stick_hit_count", &p->stick.hit_count));
+    MUST(JSON_READ_OPT(io, "stick_initialised", &p->stick.initialised));
+    MUST(JSON_READ_OPT(io, "stick_on_fire", &p->stick.on_fire));
+    MUST(JSON_READ_OPT(io, "stick_hit_count", &p->stick.hit_count));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -193,10 +193,11 @@ static void M_Damage(
     }
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "effect_mesh", &p->effect_mesh));
+    MUST(JSON_READ_OPT(io, "effect_mesh", &p->effect_mesh));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -52,10 +52,11 @@ static const CREATURE_GUN m_KidGun2 = {
     .muzzle = { .pos = { 0, 150, 37 }, .mesh_num = 4 },
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "speech_started", &p->speech_started));
+    MUST(JSON_READ_OPT(io, "speech_started", &p->speech_started));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -278,17 +278,18 @@ static int16_t M_FindFuseBox(const ITEM *const item)
     return fuse_box_num;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "dropped_item", &p->dropped_item));
-    SHOULD(JSON_READ_OPT(io, "ring_count", &p->ring_count));
-    SHOULD(JSON_READ_OPT(io, "explode_count", &p->explode_count));
-    SHOULD(JSON_READ_OPT(io, "dead", &p->dead));
-    SHOULD(JSON_READ_OPT(io, "charged", &p->charged));
-    SHOULD(JSON_READ_OPT(io, "death_counter", &p->death_counter));
-    SHOULD(JSON_READ_OPT(io, "hp_counter", &p->hp_counter));
-    SHOULD(JSON_READ_OPT(io, "fuse_box_num", &p->fuse_box_num));
+    MUST(JSON_READ_OPT(io, "dropped_item", &p->dropped_item));
+    MUST(JSON_READ_OPT(io, "ring_count", &p->ring_count));
+    MUST(JSON_READ_OPT(io, "explode_count", &p->explode_count));
+    MUST(JSON_READ_OPT(io, "dead", &p->dead));
+    MUST(JSON_READ_OPT(io, "charged", &p->charged));
+    MUST(JSON_READ_OPT(io, "death_counter", &p->death_counter));
+    MUST(JSON_READ_OPT(io, "hp_counter", &p->hp_counter));
+    MUST(JSON_READ_OPT(io, "fuse_box_num", &p->fuse_box_num));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/tony.c
+++ b/src/trx/game/objects/creatures/tony.c
@@ -66,15 +66,16 @@ static const int32_t m_DHeights2[5] = { -1536, -1152, -768, -384, 0 };
 static int32_t m_DeathDist[5] = {};
 static int32_t m_DeathHeights[5] = {};
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "dropped_item", &p->dropped_item));
-    SHOULD(JSON_READ_OPT(io, "ring_count", &p->ring_count));
-    SHOULD(JSON_READ_OPT(io, "explode_count", &p->explode_count));
-    SHOULD(JSON_READ_OPT(io, "dead", &p->dead));
-    SHOULD(JSON_READ_OPT(io, "phase", &p->phase));
-    SHOULD(JSON_READ_OPT(io, "attack_toggle", &p->attack_toggle));
+    MUST(JSON_READ_OPT(io, "dropped_item", &p->dropped_item));
+    MUST(JSON_READ_OPT(io, "ring_count", &p->ring_count));
+    MUST(JSON_READ_OPT(io, "explode_count", &p->explode_count));
+    MUST(JSON_READ_OPT(io, "dead", &p->dead));
+    MUST(JSON_READ_OPT(io, "phase", &p->phase));
+    MUST(JSON_READ_OPT(io, "attack_toggle", &p->attack_toggle));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/trex_alpha.c
+++ b/src/trx/game/objects/creatures/trex_alpha.c
@@ -70,11 +70,12 @@ static BITE m_Bite = {
     .mesh_num = 13,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "aggression_timer", &p->aggression_timer));
-    SHOULD(JSON_READ_OPT(io, "distraction_count", &p->distraction_count));
+    MUST(JSON_READ_OPT(io, "aggression_timer", &p->aggression_timer));
+    MUST(JSON_READ_OPT(io, "distraction_count", &p->distraction_count));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/tribe_axeman.c
+++ b/src/trx/game/objects/creatures/tribe_axeman.c
@@ -109,10 +109,11 @@ static int32_t M_GetAttackDamage(const ITEM *const item)
     }
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "wants_wait_2", &p->wants_wait_2));
+    MUST(JSON_READ_OPT(io, "wants_wait_2", &p->wants_wait_2));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -1022,28 +1022,29 @@ static bool M_Draw(const ITEM *const item)
     return true;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     p->shared = &m_SharedPriv;
-    SHOULD(JSON_READ_OPT(io, "dead", &p->dead));
-    SHOULD(JSON_READ_OPT(io, "attack_count", &p->attack_count));
-    SHOULD(JSON_READ_OPT(io, "death_count", &p->death_count));
-    SHOULD(JSON_READ_OPT(io, "attack_flag", &p->attack_flag));
-    SHOULD(JSON_READ_OPT(io, "attack_type", &p->attack_type));
-    SHOULD(JSON_READ_OPT(io, "attack_head_count", &p->attack_head_count));
-    SHOULD(JSON_READ_OPT(io, "ring_count", &p->ring_count));
-    SHOULD(JSON_READ_OPT(io, "explode_count", &p->explode_count));
-    SHOULD(JSON_READ_OPT(io, "lizard_item_num", &p->lizard_item_num));
-    SHOULD(JSON_READ_OPT(io, "lizard_room_num", &p->lizard_room_num));
-    SHOULD(JSON_READ_OPT(io, "dropped_item", &p->dropped_item));
-    SHOULD(JSON_READ_OPT(io, "shield_on", &p->shield_on));
-    SHOULD(JSON_READ_OPT(io, "shield_active", &p->shield_active));
-    SHOULD(JSON_READ_OPT(io, "turned", &p->turned));
-    SHOULD(JSON_READ_OPT(io, "beam_target_x", &p->beam_target.x));
-    SHOULD(JSON_READ_OPT(io, "beam_target_y", &p->beam_target.y));
-    SHOULD(JSON_READ_OPT(io, "beam_target_z", &p->beam_target.z));
-    SHOULD(JSON_READ(io, "shared_lizard_active", &p->shared->lizard_active));
+    MUST(JSON_READ_OPT(io, "dead", &p->dead));
+    MUST(JSON_READ_OPT(io, "attack_count", &p->attack_count));
+    MUST(JSON_READ_OPT(io, "death_count", &p->death_count));
+    MUST(JSON_READ_OPT(io, "attack_flag", &p->attack_flag));
+    MUST(JSON_READ_OPT(io, "attack_type", &p->attack_type));
+    MUST(JSON_READ_OPT(io, "attack_head_count", &p->attack_head_count));
+    MUST(JSON_READ_OPT(io, "ring_count", &p->ring_count));
+    MUST(JSON_READ_OPT(io, "explode_count", &p->explode_count));
+    MUST(JSON_READ_OPT(io, "lizard_item_num", &p->lizard_item_num));
+    MUST(JSON_READ_OPT(io, "lizard_room_num", &p->lizard_room_num));
+    MUST(JSON_READ_OPT(io, "dropped_item", &p->dropped_item));
+    MUST(JSON_READ_OPT(io, "shield_on", &p->shield_on));
+    MUST(JSON_READ_OPT(io, "shield_active", &p->shield_active));
+    MUST(JSON_READ_OPT(io, "turned", &p->turned));
+    MUST(JSON_READ_OPT(io, "beam_target_x", &p->beam_target.x));
+    MUST(JSON_READ_OPT(io, "beam_target_y", &p->beam_target.y));
+    MUST(JSON_READ_OPT(io, "beam_target_z", &p->beam_target.z));
+    MUST(JSON_READ(io, "shared_lizard_active", &p->shared->lizard_active));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/wasp_mutant.c
+++ b/src/trx/game/objects/creatures/wasp_mutant.c
@@ -49,10 +49,11 @@ static const BITE m_Sting = {
     .mesh_num = 12,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "light", &p->light));
+    MUST(JSON_READ_OPT(io, "light", &p->light));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/willard.c
+++ b/src/trx/game/objects/creatures/willard.c
@@ -123,12 +123,13 @@ static void M_ResetPriv(M_PRIV *const p)
     p->desired_direction = 1;
 }
 
-static void M_LoadShieldPoint(
+static RESULT M_LoadShieldPoint(
     JSON_READ_IO *const io, M_SHIELD_POINT *const point)
 {
-    SHOULD(JSON_READ_OPT(io, "pos", &point->pos));
-    SHOULD(JSON_READ_OPT(io, "sub", &point->sub));
-    SHOULD(JSON_READ_OPT(io, "color", &point->color));
+    MUST(JSON_READ_OPT(io, "pos", &point->pos));
+    MUST(JSON_READ_OPT(io, "sub", &point->sub));
+    MUST(JSON_READ_OPT(io, "color", &point->color));
+    return OK;
 }
 
 static void M_SaveShieldPoint(
@@ -141,10 +142,11 @@ static void M_SaveShieldPoint(
     JSONW_POP_AND_APPEND(io);
 }
 
-static void M_LoadAIPoint(JSON_READ_IO *const io, M_AI_POINT *const point)
+static RESULT M_LoadAIPoint(JSON_READ_IO *const io, M_AI_POINT *const point)
 {
-    SHOULD(JSON_READ_OPT(io, "pos", &point->pos));
-    SHOULD(JSON_READ_OPT(io, "rot", &point->rot));
+    MUST(JSON_READ_OPT(io, "pos", &point->pos));
+    MUST(JSON_READ_OPT(io, "rot", &point->rot));
+    return OK;
 }
 
 static void M_SaveAIPoint(
@@ -156,20 +158,20 @@ static void M_SaveAIPoint(
     JSONW_POP_AND_APPEND(io);
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     M_ResetPriv(p);
-    SHOULD(JSON_READ_OPT(io, "puzzle_ready", &p->puzzle_ready));
-    SHOULD(JSON_READ_OPT(io, "ring_count", &p->ring_count));
-    SHOULD(JSON_READ_OPT(io, "explode_count", &p->explode_count));
-    SHOULD(JSON_READ_OPT(io, "dead", &p->dead));
-    SHOULD(JSON_READ_OPT(io, "death_count", &p->death_count));
-    SHOULD(JSON_READ_OPT(io, "direction", &p->direction));
-    SHOULD(JSON_READ_OPT(io, "desired_direction", &p->desired_direction));
-    SHOULD(JSON_READ_OPT(io, "closest_ai_path", &p->closest_ai_path));
-    SHOULD(JSON_READ_OPT(io, "lara_ai_path", &p->lara_ai_path));
-    SHOULD(JSON_READ_OPT(io, "lara_junction", &p->lara_junction));
+    MUST(JSON_READ_OPT(io, "puzzle_ready", &p->puzzle_ready));
+    MUST(JSON_READ_OPT(io, "ring_count", &p->ring_count));
+    MUST(JSON_READ_OPT(io, "explode_count", &p->explode_count));
+    MUST(JSON_READ_OPT(io, "dead", &p->dead));
+    MUST(JSON_READ_OPT(io, "death_count", &p->death_count));
+    MUST(JSON_READ_OPT(io, "direction", &p->direction));
+    MUST(JSON_READ_OPT(io, "desired_direction", &p->desired_direction));
+    MUST(JSON_READ_OPT(io, "closest_ai_path", &p->closest_ai_path));
+    MUST(JSON_READ_OPT(io, "lara_ai_path", &p->lara_ai_path));
+    MUST(JSON_READ_OPT(io, "lara_junction", &p->lara_junction));
 
     if (SHOULD(JSON_PUSH(io, "shield"))) {
         for (int32_t i = 0; i < 5; i++) {
@@ -180,19 +182,19 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
                 if (!SHOULD(JSON_PUSH_INDEX(io, j))) {
                     continue;
                 }
-                M_LoadShieldPoint(io, &p->shield[i][j]);
-                SHOULD(JSON_POP(io));
+                MUST(M_LoadShieldPoint(io, &p->shield[i][j]));
+                MUST(JSON_POP(io));
             }
-            SHOULD(JSON_POP(io));
+            MUST(JSON_POP(io));
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
 
     if (SHOULD(JSON_PUSH(io, "junction_index"))) {
         for (int32_t i = 0; i < 4; i++) {
-            SHOULD(JSON_READ_A(io, i, &p->junction_index[i]));
+            MUST(JSON_READ_A(io, i, &p->junction_index[i]));
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
 
     if (SHOULD(JSON_PUSH(io, "ai_path"))) {
@@ -200,10 +202,10 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
             if (!SHOULD(JSON_PUSH_INDEX(io, i))) {
                 continue;
             }
-            M_LoadAIPoint(io, &p->ai_path[i]);
-            SHOULD(JSON_POP(io));
+            MUST(M_LoadAIPoint(io, &p->ai_path[i]));
+            MUST(JSON_POP(io));
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
 
     if (SHOULD(JSON_PUSH(io, "ai_junction"))) {
@@ -211,11 +213,12 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
             if (!SHOULD(JSON_PUSH_INDEX(io, i))) {
                 continue;
             }
-            M_LoadAIPoint(io, &p->ai_junction[i]);
-            SHOULD(JSON_POP(io));
+            MUST(M_LoadAIPoint(io, &p->ai_junction[i]));
+            MUST(JSON_POP(io));
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -48,11 +48,12 @@ static bool M_CanBeExploded(const ITEM *const item)
     return false;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "knockdown_timer", &p->knockdown_timer));
-    SHOULD(JSON_READ_OPT(io, "spawn_checked", &p->spawn_checked));
+    MUST(JSON_READ_OPT(io, "knockdown_timer", &p->knockdown_timer));
+    MUST(JSON_READ_OPT(io, "spawn_checked", &p->spawn_checked));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -27,14 +27,15 @@ static bool M_ShouldSpawnBlood(const ITEM *const item)
     return false;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "x_rot_speed", &p->x_rot_speed));
-    SHOULD(JSON_READ_OPT(io, "bounce_stage", &p->bounce_stage));
-    SHOULD(JSON_READ_OPT(io, "destroyed", &p->destroyed));
+    MUST(JSON_READ_OPT(io, "x_rot_speed", &p->x_rot_speed));
+    MUST(JSON_READ_OPT(io, "bounce_stage", &p->bounce_stage));
+    MUST(JSON_READ_OPT(io, "destroyed", &p->destroyed));
     p->targetable = !p->destroyed;
-    SHOULD(JSON_READ_OPT(io, "targetable", &p->targetable));
+    MUST(JSON_READ_OPT(io, "targetable", &p->targetable));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/bat_emitter.c
+++ b/src/trx/game/objects/general/bat_emitter.c
@@ -111,11 +111,11 @@ static uint8_t M_GetInterpolatedWingYOffset(
     return (uint8_t)wing_interp;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "bats_triggered", &p->bats_triggered));
-    SHOULD(JSON_READ_OPT(io, "bats_alive", &p->bats_alive));
+    MUST(JSON_READ_OPT(io, "bats_triggered", &p->bats_triggered));
+    MUST(JSON_READ_OPT(io, "bats_alive", &p->bats_alive));
 
     for (int32_t i = 0; i < M_MAX_BATS; i++) {
         p->bats[i] = (M_BAT) {};
@@ -126,20 +126,21 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
             const char *const key = String_FormatStatic("bat_%d", i);
             if (SHOULD(JSON_PUSH(io, key))) {
                 M_BAT *const bat = &p->bats[i];
-                SHOULD(JSON_READ_OPT(io, "pos", &bat->pos));
-                SHOULD(JSON_READ_OPT(io, "angle", &bat->angle));
-                SHOULD(JSON_READ_OPT(io, "speed", &bat->speed));
-                SHOULD(JSON_READ_OPT(io, "wing_y_off", &bat->wing_y_off));
-                SHOULD(JSON_READ_OPT(io, "active", &bat->active));
-                SHOULD(JSON_READ_OPT(io, "life", &bat->life));
-                SHOULD(JSON_POP(io));
+                MUST(JSON_READ_OPT(io, "pos", &bat->pos));
+                MUST(JSON_READ_OPT(io, "angle", &bat->angle));
+                MUST(JSON_READ_OPT(io, "speed", &bat->speed));
+                MUST(JSON_READ_OPT(io, "wing_y_off", &bat->wing_y_off));
+                MUST(JSON_READ_OPT(io, "active", &bat->active));
+                MUST(JSON_READ_OPT(io, "life", &bat->life));
+                MUST(JSON_POP(io));
             }
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
 
     p->draw.prepared = false;
     p->draw.valid = false;
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -68,21 +68,22 @@ static const LARA_TRX_STATE m_ClimbingStates[] = {
     // clang-format on
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "start_height", &p->start_height));
-    SHOULD(JSON_READ_OPT(io, "wait_time", &p->wait_timer));
-    SHOULD(JSON_READ_OPT(io, "is_moving", &p->is_moving));
+    MUST(JSON_READ_OPT(io, "start_height", &p->start_height));
+    MUST(JSON_READ_OPT(io, "wait_time", &p->wait_timer));
+    MUST(JSON_READ_OPT(io, "is_moving", &p->is_moving));
     for (int32_t i = 0; i < M_NUM_SECTORS; i++) {
         const char *const key = String_FormatStatic("linked_%d", i);
         if (SHOULD(JSON_PUSH(io, key))) {
-            SHOULD(JSON_READ_OPT(io, "x", &p->linked[i].pos.x));
-            SHOULD(JSON_READ_OPT(io, "y", &p->linked[i].pos.y));
-            SHOULD(JSON_READ_OPT(io, "z", &p->linked[i].pos.z));
-            SHOULD(JSON_POP(io));
+            MUST(JSON_READ_OPT(io, "x", &p->linked[i].pos.x));
+            MUST(JSON_READ_OPT(io, "y", &p->linked[i].pos.y));
+            MUST(JSON_READ_OPT(io, "z", &p->linked[i].pos.z));
+            MUST(JSON_POP(io));
         }
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/lights/electrical_light.c
+++ b/src/trx/game/objects/general/lights/electrical_light.c
@@ -58,10 +58,11 @@ static void M_Control(const int16_t item_num)
     Output_AddDynamicLightRGB(item->pos, 16, (RGB_888) { rg, rg, b });
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "life", &p->life));
+    MUST(JSON_READ_OPT(io, "life", &p->life));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/lights/strobe_light.c
+++ b/src/trx/game/objects/general/lights/strobe_light.c
@@ -13,11 +13,12 @@ typedef struct {
     bool requires_alarm_active;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "life", &p->life));
-    SHOULD(JSON_READ_OPT(io, "alarm_active", &p->alarm_active));
+    MUST(JSON_READ_OPT(io, "life", &p->life));
+    MUST(JSON_READ_OPT(io, "alarm_active", &p->alarm_active));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -138,10 +138,11 @@ static const XYZ_32 m_PickupPositionScion = { .x = 0, .y = 0, .z = -310 };
 static const XYZ_32 m_PickupPositionHidden = { .x = 0, .y = 0, .z = -690 };
 static const XYZ_32 m_PickupPositionCrowbar = { .x = 0, .y = 0, .z = 225 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "animate", &p->animate));
+    MUST(JSON_READ_OPT(io, "animate", &p->animate));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/pulley_switch.c
+++ b/src/trx/game/objects/general/pulley_switch.c
@@ -41,12 +41,13 @@ static int32_t M_RemainingPulls(const M_PRIV *const p)
     return MAX(0, p->required_pulls - p->pulls_done);
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "is_on", &p->is_on));
-    SHOULD(JSON_READ_OPT(io, "is_locked", &p->is_locked));
-    SHOULD(JSON_READ_OPT(io, "pulls_done", &p->pulls_done));
+    MUST(JSON_READ_OPT(io, "is_on", &p->is_on));
+    MUST(JSON_READ_OPT(io, "is_locked", &p->is_locked));
+    MUST(JSON_READ_OPT(io, "pulls_done", &p->pulls_done));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -70,13 +70,14 @@ static const LARA_TRX_STATE m_StopStates[] = {
     // clang-format on
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "counted_for_stats", &p->counted_for_stats));
-    SHOULD(JSON_READ_OPT(io, "used_for_save", &p->used_for_save));
-    SHOULD(JSON_READ_OPT(io, "initialised", &p->initialised));
-    SHOULD(JSON_READ_OPT(io, "initial_angle", &p->initial_angle));
+    MUST(JSON_READ_OPT(io, "counted_for_stats", &p->counted_for_stats));
+    MUST(JSON_READ_OPT(io, "used_for_save", &p->used_for_save));
+    MUST(JSON_READ_OPT(io, "initialised", &p->initialised));
+    MUST(JSON_READ_OPT(io, "initial_angle", &p->initial_angle));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -65,19 +65,19 @@ static void M_ResetFishInterp(M_FISH *const fish)
     fish->interp.result.swim = fish->swim;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "piranha_hit_wait", &p->piranha_hit_wait));
+    MUST(JSON_READ_OPT(io, "piranha_hit_wait", &p->piranha_hit_wait));
 
     if (SHOULD(JSON_PUSH(io, "leader"))) {
         M_LEADER *const leader = &p->leader;
-        SHOULD(JSON_READ_OPT(io, "on", &leader->on));
-        SHOULD(JSON_READ_OPT(io, "angle", &leader->angle));
-        SHOULD(JSON_READ_OPT(io, "speed", &leader->speed));
-        SHOULD(JSON_READ_OPT(io, "angle_time", &leader->angle_time));
-        SHOULD(JSON_READ_OPT(io, "speed_time", &leader->speed_time));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "on", &leader->on));
+        MUST(JSON_READ_OPT(io, "angle", &leader->angle));
+        MUST(JSON_READ_OPT(io, "speed", &leader->speed));
+        MUST(JSON_READ_OPT(io, "angle_time", &leader->angle_time));
+        MUST(JSON_READ_OPT(io, "speed_time", &leader->speed_time));
+        MUST(JSON_POP(io));
     }
 
     if (SHOULD(JSON_PUSH(io, "fish"))) {
@@ -87,17 +87,18 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
                 break;
             }
             M_FISH *const fish = &p->fish[i];
-            SHOULD(JSON_READ_OPT(io, "pos", &fish->pos));
-            SHOULD(JSON_READ_OPT(io, "angle", &fish->angle));
-            SHOULD(JSON_READ_OPT(io, "dest_y", &fish->dest_y));
-            SHOULD(JSON_READ_OPT(io, "ang_add", &fish->ang_add));
-            SHOULD(JSON_READ_OPT(io, "speed", &fish->speed));
-            SHOULD(JSON_READ_OPT(io, "swim", &fish->swim));
+            MUST(JSON_READ_OPT(io, "pos", &fish->pos));
+            MUST(JSON_READ_OPT(io, "angle", &fish->angle));
+            MUST(JSON_READ_OPT(io, "dest_y", &fish->dest_y));
+            MUST(JSON_READ_OPT(io, "ang_add", &fish->ang_add));
+            MUST(JSON_READ_OPT(io, "speed", &fish->speed));
+            MUST(JSON_READ_OPT(io, "swim", &fish->swim));
             M_ResetFishInterp(fish);
-            SHOULD(JSON_POP(io));
+            MUST(JSON_POP(io));
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/cleaner.c
+++ b/src/trx/game/objects/traps/cleaner.c
@@ -35,12 +35,13 @@ static const M_SPARK_NODE m_Nodes[M_NODE_COUNT] = {
     { .joint_idx = 13, .node_idx = 11 },
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "resume", &p->resume));
-    SHOULD(JSON_READ_OPT(io, "turn", &p->turn));
-    SHOULD(JSON_READ_OPT(io, "velocity", &p->velocity));
+    MUST(JSON_READ_OPT(io, "resume", &p->resume));
+    MUST(JSON_READ_OPT(io, "turn", &p->turn));
+    MUST(JSON_READ_OPT(io, "velocity", &p->velocity));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/dart_emitter.c
+++ b/src/trx/game/objects/traps/dart_emitter.c
@@ -24,10 +24,11 @@ typedef struct {
     int32_t fire_timer;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "fire_timer", &p->fire_timer));
+    MUST(JSON_READ_OPT(io, "fire_timer", &p->fire_timer));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/fire_head.c
+++ b/src/trx/game/objects/traps/fire_head.c
@@ -39,17 +39,18 @@ static const BITE m_Mouth = {
     .mesh_num = 7,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     if (SHOULD(JSON_PUSH(io, "blow_loops"))) {
-        SHOULD(JSON_READ_OPT(io, "max", &p->blow_loops.max));
-        SHOULD(JSON_READ_OPT(io, "current", &p->blow_loops.current));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "max", &p->blow_loops.max));
+        MUST(JSON_READ_OPT(io, "current", &p->blow_loops.current));
+        MUST(JSON_POP(io));
     }
-    SHOULD(JSON_READ_OPT(io, "speed", &p->speed));
-    SHOULD(JSON_READ_OPT(io, "deadly_range", &p->deadly_range));
-    SHOULD(JSON_READ_OPT(io, "stop", &p->stop));
+    MUST(JSON_READ_OPT(io, "speed", &p->speed));
+    MUST(JSON_READ_OPT(io, "deadly_range", &p->deadly_range));
+    MUST(JSON_READ_OPT(io, "stop", &p->stop));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/flame_emitter.c
+++ b/src/trx/game/objects/traps/flame_emitter.c
@@ -24,13 +24,14 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "fx_num", Effect_GetInOrderNum(p->effect_num));
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     if (!g_Config.gameplay.enable_enhanced_saves) {
-        return;
+        return OK;
     }
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "fx_num", &p->effect_num));
+    MUST(JSON_READ_OPT(io, "fx_num", &p->effect_num));
+    return OK;
 }
 
 static void M_KillIfAlive(const ITEM *const item)

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -158,31 +158,32 @@ static void M_UpdateStoppers(const ITEM *const item, const bool enabled)
     sector->stopper = enabled;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "gravity_frames", &p->gravity_frames));
-    SHOULD(JSON_READ_OPT(io, "is_push_pull", &p->is_push_pull));
-    SHOULD(JSON_READ_OPT(io, "is_forced_moving", &p->is_forced_moving));
+    MUST(JSON_READ_OPT(io, "gravity_frames", &p->gravity_frames));
+    MUST(JSON_READ_OPT(io, "is_push_pull", &p->is_push_pull));
+    MUST(JSON_READ_OPT(io, "is_forced_moving", &p->is_forced_moving));
 
     if (SHOULD(JSON_PUSH(io, "linked"))) {
-        SHOULD(JSON_READ_OPT(io, "x", &p->linked.pos.x));
-        SHOULD(JSON_READ_OPT(io, "y", &p->linked.pos.y));
-        SHOULD(JSON_READ_OPT(io, "z", &p->linked.pos.z));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "x", &p->linked.pos.x));
+        MUST(JSON_READ_OPT(io, "y", &p->linked.pos.y));
+        MUST(JSON_READ_OPT(io, "z", &p->linked.pos.z));
+        MUST(JSON_POP(io));
     }
 
-    SHOULD(JSON_READ_OPT(io, "counter_rot_0", &p->extra_rotations[0]));
-    SHOULD(JSON_READ_OPT(io, "counter_rot_1", &p->extra_rotations[1]));
-    SHOULD(JSON_READ_OPT(io, "counter_rot_2", &p->extra_rotations[2]));
-    SHOULD(JSON_READ_OPT(io, "original_rot", &p->original_rot));
-    SHOULD(JSON_READ_OPT(io, "interaction_rot", &p->interaction_rot));
+    MUST(JSON_READ_OPT(io, "counter_rot_0", &p->extra_rotations[0]));
+    MUST(JSON_READ_OPT(io, "counter_rot_1", &p->extra_rotations[1]));
+    MUST(JSON_READ_OPT(io, "counter_rot_2", &p->extra_rotations[2]));
+    MUST(JSON_READ_OPT(io, "original_rot", &p->original_rot));
+    MUST(JSON_READ_OPT(io, "interaction_rot", &p->interaction_rot));
 
     if (SHOULD(JSON_PUSH(io, "move_origin"))) {
-        SHOULD(JSON_READ_OPT(io, "x", &p->move_origin.x));
-        SHOULD(JSON_READ_OPT(io, "z", &p->move_origin.z));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "x", &p->move_origin.x));
+        MUST(JSON_READ_OPT(io, "z", &p->move_origin.z));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/pendulum.c
+++ b/src/trx/game/objects/traps/pendulum.c
@@ -28,14 +28,15 @@ typedef struct {
     int16_t effect_num;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "initialised", &p->initialised));
-    SHOULD(JSON_READ_OPT(io, "on_fire", &p->on_fire));
+    MUST(JSON_READ_OPT(io, "initialised", &p->initialised));
+    MUST(JSON_READ_OPT(io, "on_fire", &p->on_fire));
     if (g_Config.gameplay.enable_enhanced_saves) {
-        SHOULD(JSON_READ_OPT(io, "fx_num", &p->effect_num));
+        MUST(JSON_READ_OPT(io, "fx_num", &p->effect_num));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/raptor_emitter.c
+++ b/src/trx/game/objects/traps/raptor_emitter.c
@@ -71,10 +71,11 @@ static int32_t M_GetEmptySlot(const M_PRIV *const p)
     return -1;
 }
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "cooldown", &p->cooldown));
+    MUST(JSON_READ_OPT(io, "cooldown", &p->cooldown));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/rotating_laser.c
+++ b/src/trx/game/objects/traps/rotating_laser.c
@@ -21,14 +21,15 @@ typedef struct {
     int16_t reverse_timer;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "origin", &p->origin));
-    SHOULD(JSON_READ_OPT(io, "target", &p->target));
-    SHOULD(JSON_READ_OPT(io, "direction", &p->direction));
-    SHOULD(JSON_READ_OPT(io, "velocity", &p->velocity));
-    SHOULD(JSON_READ_OPT(io, "reverse_timer", &p->reverse_timer));
+    MUST(JSON_READ_OPT(io, "origin", &p->origin));
+    MUST(JSON_READ_OPT(io, "target", &p->target));
+    MUST(JSON_READ_OPT(io, "direction", &p->direction));
+    MUST(JSON_READ_OPT(io, "velocity", &p->velocity));
+    MUST(JSON_READ_OPT(io, "reverse_timer", &p->reverse_timer));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -61,13 +61,14 @@ static const CREATURE_GUN m_FireRight = {
     .tr3_flash_rot_x = -DEG_180,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "active_muzzle", &p->active_muzzle));
-    SHOULD(JSON_READ_OPT(io, "muzzle_flash_timer", &p->muzzle_flash_timer));
-    SHOULD(JSON_READ_OPT(io, "is_alerted", &p->is_alerted));
-    SHOULD(JSON_READ_OPT(io, "has_fired", &p->has_fired));
+    MUST(JSON_READ_OPT(io, "active_muzzle", &p->active_muzzle));
+    MUST(JSON_READ_OPT(io, "muzzle_flash_timer", &p->muzzle_flash_timer));
+    MUST(JSON_READ_OPT(io, "is_alerted", &p->is_alerted));
+    MUST(JSON_READ_OPT(io, "has_fired", &p->has_fired));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/sliding_pillar.c
+++ b/src/trx/game/objects/traps/sliding_pillar.c
@@ -30,15 +30,16 @@ typedef struct {
     GAME_VECTOR linked;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     if (SHOULD(JSON_PUSH(io, "linked"))) {
-        SHOULD(JSON_READ_OPT(io, "x", &p->linked.pos.x));
-        SHOULD(JSON_READ_OPT(io, "y", &p->linked.pos.y));
-        SHOULD(JSON_READ_OPT(io, "z", &p->linked.pos.z));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "x", &p->linked.pos.x));
+        MUST(JSON_READ_OPT(io, "y", &p->linked.pos.y));
+        MUST(JSON_READ_OPT(io, "z", &p->linked.pos.z));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -18,18 +18,19 @@ typedef struct {
     int16_t slots[M_MAX_SLOTS];
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "cooldown", &p->cooldown));
-    SHOULD(JSON_READ_OPT(io, "spawn_count", &p->spawn_count));
-    SHOULD(JSON_READ_OPT(io, "spawn_total", &p->spawn_total));
+    MUST(JSON_READ_OPT(io, "cooldown", &p->cooldown));
+    MUST(JSON_READ_OPT(io, "spawn_count", &p->spawn_count));
+    MUST(JSON_READ_OPT(io, "spawn_total", &p->spawn_total));
     if (SHOULD(JSON_PUSH(io, "slots"))) {
         for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
-            SHOULD(JSON_READ_A(io, i, &p->slots[i]));
+            MUST(JSON_READ_A(io, i, &p->slots[i]));
         }
-        SHOULD(JSON_POP(io));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/anims/types.h>
 #include <trx/game/collision.h>
 #include <trx/game/effects/types.h>
@@ -102,7 +103,7 @@ typedef struct OBJECT {
         int32_t *damage);
     void (*handle_flip_func)(ITEM *item, ROOM_FLIP_STATUS flip_status);
     void (*handle_save_func)(ITEM *item, SAVEGAME_STAGE stage);
-    void (*priv_load_func)(ITEM *item, JSON_READ_IO *io);
+    RESULT (*priv_load_func)(ITEM *item, JSON_READ_IO *io);
     void (*priv_save_func)(const ITEM *item, JSON_WRITE_IO *io);
     const OBJECT_BOUNDS *(*bounds_func)(void);
     bool (*is_usable_func)(int16_t item_num);

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -76,16 +76,17 @@ typedef struct {
     int32_t pitch;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "boat_turn", &p->boat_turn));
-    SHOULD(JSON_READ_OPT(io, "left_fallspeed", &p->left_fallspeed));
-    SHOULD(JSON_READ_OPT(io, "right_fallspeed", &p->right_fallspeed));
-    SHOULD(JSON_READ_OPT(io, "tilt_angle", &p->tilt_angle));
-    SHOULD(JSON_READ_OPT(io, "extra_rotation", &p->extra_rotation));
-    SHOULD(JSON_READ_OPT(io, "water", &p->water));
-    SHOULD(JSON_READ_OPT(io, "pitch", &p->pitch));
+    MUST(JSON_READ_OPT(io, "boat_turn", &p->boat_turn));
+    MUST(JSON_READ_OPT(io, "left_fallspeed", &p->left_fallspeed));
+    MUST(JSON_READ_OPT(io, "right_fallspeed", &p->right_fallspeed));
+    MUST(JSON_READ_OPT(io, "tilt_angle", &p->tilt_angle));
+    MUST(JSON_READ_OPT(io, "extra_rotation", &p->extra_rotation));
+    MUST(JSON_READ_OPT(io, "water", &p->water));
+    MUST(JSON_READ_OPT(io, "pitch", &p->pitch));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -98,23 +98,24 @@ static const XZ_16 m_MistPos[10] = {
 };
 // clang-format on
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "vel", &p->vel));
-    SHOULD(JSON_READ_OPT(io, "rot", &p->rot));
-    SHOULD(JSON_READ_OPT(io, "fall_speed_f", &p->fall_speed_f));
-    SHOULD(JSON_READ_OPT(io, "fall_speed_l", &p->fall_speed_l));
-    SHOULD(JSON_READ_OPT(io, "fall_speed_r", &p->fall_speed_r));
-    SHOULD(JSON_READ_OPT(io, "water", &p->water));
-    SHOULD(JSON_READ_OPT(io, "old_pos", &p->old_pos));
-    SHOULD(JSON_READ_OPT(io, "turn", &p->turn));
-    SHOULD(JSON_READ_OPT(io, "forward", &p->forward));
-    SHOULD(JSON_READ_OPT(io, "true_water", &p->true_water));
-    SHOULD(JSON_READ_OPT(io, "counter", &p->counter));
-    SHOULD(JSON_READ(io, "paddle_frame2_latched", &p->paddle.frame2_latched));
-    SHOULD(JSON_READ_OPT(io, "paddle_stroke_count", &p->paddle.stroke_count));
-    SHOULD(JSON_READ_OPT(io, "paddle_equipped", &p->paddle.equipped));
+    MUST(JSON_READ_OPT(io, "vel", &p->vel));
+    MUST(JSON_READ_OPT(io, "rot", &p->rot));
+    MUST(JSON_READ_OPT(io, "fall_speed_f", &p->fall_speed_f));
+    MUST(JSON_READ_OPT(io, "fall_speed_l", &p->fall_speed_l));
+    MUST(JSON_READ_OPT(io, "fall_speed_r", &p->fall_speed_r));
+    MUST(JSON_READ_OPT(io, "water", &p->water));
+    MUST(JSON_READ_OPT(io, "old_pos", &p->old_pos));
+    MUST(JSON_READ_OPT(io, "turn", &p->turn));
+    MUST(JSON_READ_OPT(io, "forward", &p->forward));
+    MUST(JSON_READ_OPT(io, "true_water", &p->true_water));
+    MUST(JSON_READ_OPT(io, "counter", &p->counter));
+    MUST(JSON_READ(io, "paddle_frame2_latched", &p->paddle.frame2_latched));
+    MUST(JSON_READ_OPT(io, "paddle_stroke_count", &p->paddle.stroke_count));
+    MUST(JSON_READ_OPT(io, "paddle_equipped", &p->paddle.equipped));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/mine_cart.c
+++ b/src/trx/game/objects/vehicles/mine_cart.c
@@ -105,30 +105,31 @@ typedef struct {
     } flags;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "speed", &p->speed));
-    SHOULD(JSON_READ_OPT(io, "mid_pos", &p->mid_pos));
-    SHOULD(JSON_READ_OPT(io, "front_pos", &p->front_pos));
-    SHOULD(JSON_READ_OPT(io, "y_velocity", &p->y_velocity));
-    SHOULD(JSON_READ_OPT(io, "gradient", &p->gradient));
-    SHOULD(JSON_READ_OPT(io, "stop_delay", &p->stop_delay));
+    MUST(JSON_READ_OPT(io, "speed", &p->speed));
+    MUST(JSON_READ_OPT(io, "mid_pos", &p->mid_pos));
+    MUST(JSON_READ_OPT(io, "front_pos", &p->front_pos));
+    MUST(JSON_READ_OPT(io, "y_velocity", &p->y_velocity));
+    MUST(JSON_READ_OPT(io, "gradient", &p->gradient));
+    MUST(JSON_READ_OPT(io, "stop_delay", &p->stop_delay));
     if (SHOULD(JSON_PUSH(io, "turn"))) {
-        SHOULD(JSON_READ_OPT(io, "pos.x", &p->turn.pos.x));
-        SHOULD(JSON_READ_OPT(io, "pos.z", &p->turn.pos.z));
-        SHOULD(JSON_READ_OPT(io, "angle", &p->turn.angle));
-        SHOULD(JSON_READ_OPT(io, "length", &p->turn.length));
-        SHOULD(JSON_READ_OPT(io, "side", &p->turn.side));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "pos.x", &p->turn.pos.x));
+        MUST(JSON_READ_OPT(io, "pos.z", &p->turn.pos.z));
+        MUST(JSON_READ_OPT(io, "angle", &p->turn.angle));
+        MUST(JSON_READ_OPT(io, "length", &p->turn.length));
+        MUST(JSON_READ_OPT(io, "side", &p->turn.side));
+        MUST(JSON_POP(io));
     }
     if (SHOULD(JSON_PUSH(io, "flags"))) {
-        SHOULD(JSON_READ_OPT(io, "control", &p->flags.control));
-        SHOULD(JSON_READ_OPT(io, "dead", &p->flags.dead));
-        SHOULD(JSON_READ_OPT(io, "stopped", &p->flags.stopped));
-        SHOULD(JSON_READ_OPT(io, "suppress_anim", &p->flags.suppress_anim));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "control", &p->flags.control));
+        MUST(JSON_READ_OPT(io, "dead", &p->flags.dead));
+        MUST(JSON_READ_OPT(io, "stopped", &p->flags.stopped));
+        MUST(JSON_READ_OPT(io, "suppress_anim", &p->flags.suppress_anim));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/mounted_gun.c
+++ b/src/trx/game/objects/vehicles/mounted_gun.c
@@ -54,15 +54,16 @@ typedef enum {
     M_ANIM_TILT,
 } M_ANIM;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "state", &p->state));
-    SHOULD(JSON_READ_OPT(io, "fire_count", &p->fire_count));
-    SHOULD(JSON_READ_OPT(io, "tilt", &p->tilt));
-    SHOULD(JSON_READ_OPT(io, "yaw", &p->yaw));
-    SHOULD(JSON_READ_OPT(io, "yaw_offset", &p->yaw_offset));
-    SHOULD(JSON_READ_OPT(io, "yaw_speed", &p->yaw_speed));
+    MUST(JSON_READ_OPT(io, "state", &p->state));
+    MUST(JSON_READ_OPT(io, "fire_count", &p->fire_count));
+    MUST(JSON_READ_OPT(io, "tilt", &p->tilt));
+    MUST(JSON_READ_OPT(io, "yaw", &p->yaw));
+    MUST(JSON_READ_OPT(io, "yaw_offset", &p->yaw_offset));
+    MUST(JSON_READ_OPT(io, "yaw_speed", &p->yaw_speed));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -105,22 +105,23 @@ static bool m_HandbrakeStarting;
 static bool m_CanHandbrakeStart;
 static uint8_t m_ExhaustSmokeVel;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "velocity", &p->quad.velocity));
-    SHOULD(JSON_READ_OPT(io, "front_rot", &p->quad.front_rot));
-    SHOULD(JSON_READ_OPT(io, "rear_rot", &p->quad.rear_rot));
-    SHOULD(JSON_READ_OPT(io, "revs", &p->quad.revs));
-    SHOULD(JSON_READ_OPT(io, "engine_revs", &p->quad.engine_revs));
-    SHOULD(JSON_READ_OPT(io, "track_mesh", &p->quad.track_mesh));
-    SHOULD(JSON_READ_OPT(io, "skidoo_turn", &p->quad.skidoo_turn));
-    SHOULD(JSON_READ_OPT(io, "left_fall_speed", &p->quad.left_fall_speed));
-    SHOULD(JSON_READ_OPT(io, "right_fall_speed", &p->quad.right_fall_speed));
-    SHOULD(JSON_READ_OPT(io, "momentum_angle", &p->quad.momentum_angle));
-    SHOULD(JSON_READ_OPT(io, "extra_rotation", &p->quad.extra_rotation));
-    SHOULD(JSON_READ_OPT(io, "pitch", &p->quad.pitch));
-    SHOULD(JSON_READ_OPT(io, "flags", &p->quad.flags));
+    MUST(JSON_READ_OPT(io, "velocity", &p->quad.velocity));
+    MUST(JSON_READ_OPT(io, "front_rot", &p->quad.front_rot));
+    MUST(JSON_READ_OPT(io, "rear_rot", &p->quad.rear_rot));
+    MUST(JSON_READ_OPT(io, "revs", &p->quad.revs));
+    MUST(JSON_READ_OPT(io, "engine_revs", &p->quad.engine_revs));
+    MUST(JSON_READ_OPT(io, "track_mesh", &p->quad.track_mesh));
+    MUST(JSON_READ_OPT(io, "skidoo_turn", &p->quad.skidoo_turn));
+    MUST(JSON_READ_OPT(io, "left_fall_speed", &p->quad.left_fall_speed));
+    MUST(JSON_READ_OPT(io, "right_fall_speed", &p->quad.right_fall_speed));
+    MUST(JSON_READ_OPT(io, "momentum_angle", &p->quad.momentum_angle));
+    MUST(JSON_READ_OPT(io, "extra_rotation", &p->quad.extra_rotation));
+    MUST(JSON_READ_OPT(io, "pitch", &p->quad.pitch));
+    MUST(JSON_READ_OPT(io, "flags", &p->quad.flags));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -82,17 +82,18 @@ static const BITE m_Propeller = {
     .mesh_num = 2,
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "boat_turn", &p->boat_turn));
-    SHOULD(JSON_READ_OPT(io, "left_fallspeed", &p->left_fallspeed));
-    SHOULD(JSON_READ_OPT(io, "right_fallspeed", &p->right_fallspeed));
-    SHOULD(JSON_READ_OPT(io, "tilt_angle", &p->tilt_angle));
-    SHOULD(JSON_READ_OPT(io, "extra_rotation", &p->extra_rotation));
-    SHOULD(JSON_READ_OPT(io, "water", &p->water));
-    SHOULD(JSON_READ_OPT(io, "pitch", &p->pitch));
-    SHOULD(JSON_READ_OPT(io, "propeller_roll", &p->propeller_roll));
+    MUST(JSON_READ_OPT(io, "boat_turn", &p->boat_turn));
+    MUST(JSON_READ_OPT(io, "left_fallspeed", &p->left_fallspeed));
+    MUST(JSON_READ_OPT(io, "right_fallspeed", &p->right_fallspeed));
+    MUST(JSON_READ_OPT(io, "tilt_angle", &p->tilt_angle));
+    MUST(JSON_READ_OPT(io, "extra_rotation", &p->extra_rotation));
+    MUST(JSON_READ_OPT(io, "water", &p->water));
+    MUST(JSON_READ_OPT(io, "pitch", &p->pitch));
+    MUST(JSON_READ_OPT(io, "propeller_roll", &p->propeller_roll));
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -5,16 +5,17 @@
 #include <trx/game/objects/vehicles/common.h>
 #include <trx/game/objects/vehicles/skidoo_common.h>
 
-static void M_PrivLoad(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_PrivLoad(ITEM *const item, JSON_READ_IO *const io)
 {
     SKIDOO_INFO *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "track_mesh", &p->track_mesh));
-    SHOULD(JSON_READ_OPT(io, "skidoo_turn", &p->skidoo_turn));
-    SHOULD(JSON_READ_OPT(io, "left_fallspeed", &p->left_fallspeed));
-    SHOULD(JSON_READ_OPT(io, "right_fallspeed", &p->right_fallspeed));
-    SHOULD(JSON_READ_OPT(io, "momentum_angle", &p->momentum_angle));
-    SHOULD(JSON_READ_OPT(io, "extra_rotation", &p->extra_rotation));
-    SHOULD(JSON_READ_OPT(io, "pitch", &p->pitch));
+    MUST(JSON_READ_OPT(io, "track_mesh", &p->track_mesh));
+    MUST(JSON_READ_OPT(io, "skidoo_turn", &p->skidoo_turn));
+    MUST(JSON_READ_OPT(io, "left_fallspeed", &p->left_fallspeed));
+    MUST(JSON_READ_OPT(io, "right_fallspeed", &p->right_fallspeed));
+    MUST(JSON_READ_OPT(io, "momentum_angle", &p->momentum_angle));
+    MUST(JSON_READ_OPT(io, "extra_rotation", &p->extra_rotation));
+    MUST(JSON_READ_OPT(io, "pitch", &p->pitch));
+    return OK;
 }
 
 static void M_PrivSave(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -76,22 +76,23 @@ static const BITE m_UPVBites[6] = {
     { .pos = { .x = 0, .y = 0, .z = -64 }, .mesh_num = 2 },
 };
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static RESULT M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
-    SHOULD(JSON_READ_OPT(io, "vel", &p->vel));
-    SHOULD(JSON_READ_OPT(io, "rot", &p->rot));
-    SHOULD(JSON_READ_OPT(io, "rot_x", &p->rot_x));
-    SHOULD(JSON_READ_OPT(io, "fan_rot", &p->fan_rot));
-    SHOULD(JSON_READ_OPT(io, "weapon_timer", &p->weapon_timer));
-    SHOULD(JSON_READ_OPT(io, "current_weapon", &p->current_weapon));
+    MUST(JSON_READ_OPT(io, "vel", &p->vel));
+    MUST(JSON_READ_OPT(io, "rot", &p->rot));
+    MUST(JSON_READ_OPT(io, "rot_x", &p->rot_x));
+    MUST(JSON_READ_OPT(io, "fan_rot", &p->fan_rot));
+    MUST(JSON_READ_OPT(io, "weapon_timer", &p->weapon_timer));
+    MUST(JSON_READ_OPT(io, "current_weapon", &p->current_weapon));
     if (SHOULD(JSON_PUSH(io, "flags"))) {
-        SHOULD(JSON_READ_OPT(io, "control", &p->flags.control));
-        SHOULD(JSON_READ_OPT(io, "surface", &p->flags.surface));
-        SHOULD(JSON_READ_OPT(io, "dive", &p->flags.dive));
-        SHOULD(JSON_READ_OPT(io, "dead", &p->flags.dead));
-        SHOULD(JSON_POP(io));
+        MUST(JSON_READ_OPT(io, "control", &p->flags.control));
+        MUST(JSON_READ_OPT(io, "surface", &p->flags.surface));
+        MUST(JSON_READ_OPT(io, "dive", &p->flags.dive));
+        MUST(JSON_READ_OPT(io, "dead", &p->flags.dead));
+        MUST(JSON_POP(io));
     }
+    return OK;
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -116,19 +116,18 @@ bool Savegame_Save(const SAVEGAME_SLOT_REF slot)
     return SG_Manager_WriteSlot(slot);
 }
 
-bool Savegame_Load(const SAVEGAME_SLOT_REF slot)
+RESULT Savegame_Load(const SAVEGAME_SLOT_REF slot)
 {
     const SAVEGAME_INFO *const savegame_info = SG_Manager_GetSavegameInfo(slot);
-    if (savegame_info == nullptr) {
-        return false;
-    }
+    FAIL_IF(savegame_info == nullptr, "the slot holds no saved game");
     ASSERT(savegame_info->full_path != nullptr);
 
     M_LoadPreprocess();
 
-    bool result = false;
     TRX_FILE *fp = nullptr;
-    if (SHOULD(File_OpenPath(savegame_info->full_path, FILE_OPEN_READ, &fp))) {
+    RESULT result =
+        File_OpenPath(savegame_info->full_path, FILE_OPEN_READ, &fp);
+    if (IS_OK(result)) {
         result = SG_File_LoadFromFile(fp);
         File_Close(fp);
     }
@@ -138,43 +137,37 @@ bool Savegame_Load(const SAVEGAME_SLOT_REF slot)
     return result;
 }
 
-bool Savegame_UpdateDeathCounters(
+RESULT Savegame_UpdateDeathCounters(
     const SAVEGAME_SLOT_REF slot, const int32_t death_count)
 {
     const SAVEGAME_INFO *const savegame_info = SG_Manager_GetSavegameInfo(slot);
-    if (savegame_info == nullptr) {
-        return false;
-    }
+    FAIL_IF(savegame_info == nullptr, "the slot holds no saved game");
     ASSERT(savegame_info->full_path != nullptr);
 
-    bool ret = false;
     TRX_FILE *fp = nullptr;
-    if (SHOULD(File_OpenPath(
-            savegame_info->full_path, FILE_OPEN_READ_WRITE, &fp))) {
-        ret = SG_File_UpdateDeathCounters(
-            fp, savegame_info->level_num, death_count, savegame_info->is_quick);
-        File_Close(fp);
-    }
-    return ret;
+    MUST(File_OpenPath(savegame_info->full_path, FILE_OPEN_READ_WRITE, &fp));
+    const RESULT result = SG_File_UpdateDeathCounters(
+        fp, savegame_info->level_num, death_count, savegame_info->is_quick);
+    File_Close(fp);
+    return result;
 }
 
-bool Savegame_LoadOnlyResumeInfo(const SAVEGAME_SLOT_REF slot)
+RESULT Savegame_LoadOnlyResumeInfo(const SAVEGAME_SLOT_REF slot)
 {
     const SAVEGAME_INFO *const savegame_info = SG_Manager_GetSavegameInfo(slot);
-    if (savegame_info == nullptr) {
-        return false;
-    }
+    FAIL_IF(savegame_info == nullptr, "the slot holds no saved game");
     ASSERT(savegame_info->full_path != nullptr);
 
-    bool ret = false;
     TRX_FILE *fp = nullptr;
-    if (SHOULD(File_OpenPath(savegame_info->full_path, FILE_OPEN_READ, &fp))) {
-        ret = SG_File_LoadOnlyResumeInfo(fp);
+    RESULT result =
+        File_OpenPath(savegame_info->full_path, FILE_OPEN_READ, &fp);
+    if (IS_OK(result)) {
+        result = SG_File_LoadOnlyResumeInfo(fp);
         File_Close(fp);
     }
 
     Savegame_SetInitialVersion(savegame_info->initial_version);
-    return ret;
+    return result;
 }
 
 bool Savegame_RestartAvailable(const SAVEGAME_SLOT_REF slot)

--- a/src/trx/game/savegame/common.h
+++ b/src/trx/game/savegame/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/savegame/types.h>
 
 // Loading a saved game is divided into two phases. First, the game reads the
@@ -21,7 +22,8 @@ bool Savegame_RestartAvailable(SAVEGAME_SLOT_REF slot);
 
 void Savegame_ProcessItemsBeforeLoad(void);
 void Savegame_ProcessItemsBeforeSave(void);
-bool Savegame_Load(SAVEGAME_SLOT_REF slot);
+RESULT Savegame_Load(SAVEGAME_SLOT_REF slot);
 bool Savegame_Save(SAVEGAME_SLOT_REF slot);
-bool Savegame_UpdateDeathCounters(SAVEGAME_SLOT_REF slot, int32_t death_count);
-bool Savegame_LoadOnlyResumeInfo(SAVEGAME_SLOT_REF slot);
+RESULT Savegame_UpdateDeathCounters(
+    SAVEGAME_SLOT_REF slot, int32_t death_count);
+RESULT Savegame_LoadOnlyResumeInfo(SAVEGAME_SLOT_REF slot);

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -58,13 +58,16 @@ static RESULT M_ParseFromBuffer(
 static RESULT M_ReadRaw(
     TRX_FILE *const fp, int32_t *const version_out, JSON_VALUE **const out_root)
 {
+    File_SetSoftFailure(fp, true);
     const size_t buffer_size = File_Size(fp);
-    char *buffer = Memory_Alloc(buffer_size);
+    AUTO_FREE char *buffer = Memory_Alloc(buffer_size);
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_ReadData(fp, buffer, buffer_size);
+    if (File_HasFailed(fp)) {
+        return FAIL("%s: the saved game ends early", File_GetPath(fp));
+    }
 
     const RESULT result = M_ParseFromBuffer(buffer, version_out, out_root);
-    Memory_FreePointer(&buffer);
     return Result_Prefix(result, "%s", File_GetPath(fp));
 }
 

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -2,14 +2,12 @@
 
 #include <trx/core/bson.h>
 #include <trx/core/file.h>
-#include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/savegame.h>
-#include <trx/game/shell.h>
 #include <trx/version.h>
 
 #include <string.h>
@@ -20,16 +18,16 @@
 #define M_MAGIC_TR2X MKTAG('T', '2', 'X', 'B') // TOOD: remove me after TRX 1.5
 #define M_MAGIC_TRX MKTAG('T', 'R', 'X', 'S')
 
-static JSON_VALUE *M_ReadRaw(TRX_FILE *fp, int32_t *version_out);
-
-static JSON_VALUE *M_ParseFromBuffer(
-    const char *const buffer, int32_t *const version_out)
+static RESULT M_ParseFromBuffer(
+    const char *const buffer, int32_t *const version_out,
+    JSON_VALUE **const out_root)
 {
+    *out_root = nullptr;
+
     const SAVEGAME_BSON_HEADER *const header = (SAVEGAME_BSON_HEADER *)buffer;
     if (header->magic != M_MAGIC_TR1X && header->magic != M_MAGIC_TR2X
         && header->magic != M_MAGIC_TRX) {
-        LOG_ERROR("Invalid savegame magic");
-        return nullptr;
+        return FAIL("the file is not a savegame");
     }
 
     if (version_out != nullptr) {
@@ -44,26 +42,29 @@ static JSON_VALUE *M_ParseFromBuffer(
         (Bytef *)uncompressed, &uncompressed_size, (const Bytef *)compressed,
         (uLongf)header->compressed_size);
     if (error_code != Z_OK) {
-        LOG_ERROR("Failed to decompress the data (error %d)", error_code);
         Memory_FreePointer(&uncompressed);
-        return nullptr;
+        return FAIL(
+            "the savegame data would not decompress (error %d)", error_code);
     }
 
     JSON_VALUE *const root = BSON_Parse(uncompressed, uncompressed_size);
     Memory_FreePointer(&uncompressed);
-    return root;
+    FAIL_IF(root == nullptr, "the savegame data does not read as BSON");
+    *out_root = root;
+    return OK;
 }
 
-static JSON_VALUE *M_ReadRaw(TRX_FILE *const fp, int32_t *const version_out)
+static RESULT M_ReadRaw(
+    TRX_FILE *const fp, int32_t *const version_out, JSON_VALUE **const out_root)
 {
     const size_t buffer_size = File_Size(fp);
     char *buffer = Memory_Alloc(buffer_size);
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_ReadData(fp, buffer, buffer_size);
 
-    JSON_VALUE *const result = M_ParseFromBuffer(buffer, version_out);
+    const RESULT result = M_ParseFromBuffer(buffer, version_out, out_root);
     Memory_FreePointer(&buffer);
-    return result;
+    return Result_Prefix(result, "%s", File_GetPath(fp));
 }
 
 static RESULT M_SaveRaw(
@@ -145,12 +146,14 @@ const char *SG_File_GetQuickSaveFilePattern(void)
     return String_FormatStatic("%.*sq%s", prefix_size, pattern, placeholder);
 }
 
-bool SG_File_LoadFromFile(TRX_FILE *const fp)
+RESULT SG_File_LoadFromFile(TRX_FILE *const fp)
 {
     int32_t sg_version = -1;
-    JSON_VALUE *const root = M_ReadRaw(fp, &sg_version);
-    JSON_READ_IO *const io = JSON_ReadIO_Create(root, sg_version, nullptr);
-    const bool result = SHOULD(M_Load(io));
+    JSON_VALUE *root = nullptr;
+    MUST(M_ReadRaw(fp, &sg_version, &root));
+    JSON_READ_IO *const io =
+        JSON_ReadIO_Create(root, sg_version, File_GetPath(fp));
+    const RESULT result = M_Load(io);
     JSON_ReadIO_Destroy(io);
     JSON_ValueFree(root);
     return result;
@@ -181,26 +184,23 @@ RESULT SG_File_SaveToFile(TRX_FILE *const fp, SAVEGAME_INFO *const info)
     return result;
 }
 
-bool SG_File_FillInfo(TRX_FILE *const fp, SAVEGAME_INFO *const info)
+RESULT SG_File_FillInfo(TRX_FILE *const fp, SAVEGAME_INFO *const info)
 {
     *info = (SAVEGAME_INFO) {};
 
     SAVEGAME_BSON_HEADER header = {};
     File_Seek(fp, 0, FILE_SEEK_SET);
-    if (!File_TryReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER))) {
-        return false;
-    }
-    if (header.magic != M_MAGIC_TR1X && header.magic != M_MAGIC_TR2X
-        && header.magic != M_MAGIC_TRX) {
-        return false;
-    }
-
-    if (header.version < SG_MIN_SUPPORTED_VERSION) {
-        LOG_WARNING(
-            "Too old SG version: %d (min supported: %d)", header.version,
-            SG_MIN_SUPPORTED_VERSION);
-        return false;
-    }
+    FAIL_IF(
+        !File_TryReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER)),
+        "%s: the savegame header could not be read", File_GetPath(fp));
+    FAIL_IF(
+        header.magic != M_MAGIC_TR1X && header.magic != M_MAGIC_TR2X
+            && header.magic != M_MAGIC_TRX,
+        "%s: the file is not a savegame", File_GetPath(fp));
+    FAIL_IF(
+        header.version < SG_MIN_SUPPORTED_VERSION,
+        "%s: the savegame is version %d, older than the %d TRX reads",
+        File_GetPath(fp), header.version, SG_MIN_SUPPORTED_VERSION);
     info->initial_version = header.initial_version;
     info->features.restart = header.initial_version >= SG_VERSION_LEGACY;
     info->features.select_level = header.initial_version >= SG_VERSION_1;
@@ -214,15 +214,19 @@ bool SG_File_FillInfo(TRX_FILE *const fp, SAVEGAME_INFO *const info)
         info->is_quick = (extra_header.flags & SAVEGAME_EXT_FLAG_QUICK) != 0;
         info->level_title = Memory_Alloc(extra_header.title_size + 1);
         File_ReadData(fp, info->level_title, extra_header.title_size);
-        return true;
+        return OK;
     }
 
     // recover the slot information from the savegame structures
-    bool result = false;
     File_Seek(fp, 0, FILE_SEEK_SET);
-    JSON_VALUE *root = M_ReadRaw(fp, nullptr);
-    JSON_OBJECT *root_obj = JSON_ValueAsObject(root);
-    if (root_obj != nullptr) {
+    JSON_VALUE *root = nullptr;
+    MUST(M_ReadRaw(fp, nullptr, &root));
+    JSON_OBJECT *const root_obj = JSON_ValueAsObject(root);
+    RESULT result = OK;
+    if (root_obj == nullptr) {
+        result =
+            FAIL("%s: the savegame holds no root object", File_GetPath(fp));
+    } else {
         info->counter = JSON_ObjectGetInt(root_obj, "save_counter", -1);
         info->level_num = JSON_ObjectGetInt(root_obj, "level_num", -1);
         const char *level_title =
@@ -230,39 +234,47 @@ bool SG_File_FillInfo(TRX_FILE *const fp, SAVEGAME_INFO *const info)
         if (level_title != nullptr) {
             info->level_title = Memory_DupStr(level_title);
         }
-        result = info->level_num != -1;
+        if (info->level_num == -1) {
+            result = FAIL(
+                "%s: the savegame names no level number", File_GetPath(fp));
+        }
     }
     JSON_ValueFree(root);
 
     return result;
 }
 
-bool SG_File_LoadOnlyResumeInfo(TRX_FILE *const fp)
+RESULT SG_File_LoadOnlyResumeInfo(TRX_FILE *const fp)
 {
     int32_t sg_version = -1;
-    JSON_VALUE *const root = M_ReadRaw(fp, &sg_version);
-    JSON_READ_IO *const io = JSON_ReadIO_Create(root, sg_version, nullptr);
-    const bool result = SHOULD(SG_File_LoadResumeInfoList(io));
+    JSON_VALUE *root = nullptr;
+    MUST(M_ReadRaw(fp, &sg_version, &root));
+    JSON_READ_IO *const io =
+        JSON_ReadIO_Create(root, sg_version, File_GetPath(fp));
+    const RESULT result = SG_File_LoadResumeInfoList(io);
     JSON_ReadIO_Destroy(io);
     JSON_ValueFree(root);
     return result;
 }
 
-bool SG_File_UpdateDeathCounters(
+RESULT SG_File_UpdateDeathCounters(
     TRX_FILE *const fp, int32_t level_num, const int32_t death_count,
     const bool is_quick)
 {
-    bool result = false;
-    JSON_VALUE *const root = M_ReadRaw(fp, nullptr);
+    JSON_VALUE *root = nullptr;
+    MUST(M_ReadRaw(fp, nullptr, &root));
+
+    RESULT result = OK;
     JSON_OBJECT *const root_obj = JSON_ValueAsObject(root);
     if (root_obj == nullptr) {
-        LOG_ERROR("Cannot find the root object");
+        result =
+            FAIL("%s: the savegame holds no root object", File_GetPath(fp));
         goto cleanup;
     }
 
     JSON_OBJECT *const misc_obj = JSON_ObjectGetObject(root_obj, "misc");
     if (misc_obj == nullptr) {
-        LOG_ERROR("Cannot find the misc object");
+        result = FAIL("%s: the savegame holds no 'misc'", File_GetPath(fp));
         goto cleanup;
     }
     JSON_ObjectEvictKey(misc_obj, "death_count");
@@ -288,10 +300,7 @@ bool SG_File_UpdateDeathCounters(
     }
 
     File_Seek(fp, 0, FILE_SEEK_SET);
-    if (!IS_OK(M_SaveRaw(fp, root, level_num, is_quick))) {
-        goto cleanup;
-    }
-    result = true;
+    result = M_SaveRaw(fp, root, level_num, is_quick);
 
 cleanup:
     JSON_ValueFree(root);

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -47,9 +47,10 @@ static RESULT M_ParseFromBuffer(
             "the savegame data would not decompress (error %d)", error_code);
     }
 
-    JSON_VALUE *const root = BSON_Parse(uncompressed, uncompressed_size);
+    JSON_VALUE *root = nullptr;
+    const RESULT result = BSON_Parse(uncompressed, uncompressed_size, &root);
     Memory_FreePointer(&uncompressed);
-    FAIL_IF(root == nullptr, "the savegame data does not read as BSON");
+    MUST(result, "the savegame data does not read as BSON");
     *out_root = root;
     return OK;
 }
@@ -71,8 +72,9 @@ static RESULT M_SaveRaw(
     TRX_FILE *const fp, const JSON_VALUE *const root, const int32_t level_num,
     const bool is_quick)
 {
-    size_t uncompressed_size;
-    char *uncompressed = BSON_Write(root, &uncompressed_size);
+    size_t uncompressed_size = 0;
+    char *uncompressed = nullptr;
+    MUST(BSON_Write(root, (void **)&uncompressed, &uncompressed_size));
 
     uLongf compressed_size = compressBound(uncompressed_size);
     char *compressed = Memory_Alloc(compressed_size);

--- a/src/trx/game/savegame/file.h
+++ b/src/trx/game/savegame/file.h
@@ -12,11 +12,11 @@
 
 const char *SG_File_GetSaveFilePattern(void);
 const char *SG_File_GetQuickSaveFilePattern(void);
-bool SG_File_FillInfo(TRX_FILE *fp, SAVEGAME_INFO *info);
-bool SG_File_LoadFromFile(TRX_FILE *fp);
-bool SG_File_LoadOnlyResumeInfo(TRX_FILE *fp);
+RESULT SG_File_FillInfo(TRX_FILE *fp, SAVEGAME_INFO *info);
+RESULT SG_File_LoadFromFile(TRX_FILE *fp);
+RESULT SG_File_LoadOnlyResumeInfo(TRX_FILE *fp);
 RESULT SG_File_SaveToFile(TRX_FILE *fp, SAVEGAME_INFO *info);
-bool SG_File_UpdateDeathCounters(
+RESULT SG_File_UpdateDeathCounters(
     TRX_FILE *fp, int32_t level_num, int32_t death_count, bool is_quick);
 
 // Start of reader functions ===================================================

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -727,7 +727,9 @@ skip_flags:
             : (JSON_ReadIO_HasKey(io, "data") ? "data" : nullptr);
         if (priv_key != nullptr) {
             MUST(JSON_PUSH(io, priv_key));
-            obj->priv_load_func(item, io);
+            MUST(
+                obj->priv_load_func(item, io), "%s",
+                Object_GetName(item->object_id));
             MUST(JSON_POP(io));
         }
     }

--- a/src/trx/game/savegame/manager.c
+++ b/src/trx/game/savegame/manager.c
@@ -123,7 +123,7 @@ static bool M_FillSlot(const SAVEGAME_SLOT_REF slot, const char *const path)
     TRX_FILE *fp = nullptr;
     if (SHOULD(File_OpenPath(path, FILE_OPEN_READ, &fp))) {
         SAVEGAME_INFO tmp_savegame_info;
-        if (SG_File_FillInfo(fp, &tmp_savegame_info)) {
+        if (SHOULD(SG_File_FillInfo(fp, &tmp_savegame_info))) {
             M_ClearSlot(savegame_info);
             *savegame_info = tmp_savegame_info;
             savegame_info->is_quick = slot.pool == SAVEGAME_SLOT_POOL_QUICK;

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -394,7 +394,10 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     }
 
     Stats_CalculateMaxStats();
-    GF_RunUntilExit(GF_DoFrontendSequence());
+    GF_COMMAND gf_cmd;
+    EXIT_ON_FAIL(
+        GF_DoFrontendSequence(&gf_cmd), "Cannot work out where to start");
+    EXIT_ON_FAIL(GF_RunUntilExit(gf_cmd), "The game flow could not carry on");
 
     if (m_PendingMod != nullptr) {
         if (TestReplay_IsOpened()) {

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -214,7 +214,7 @@ void Stats_AddDeath(void)
     stats->death_count++;
     const SAVEGAME_SLOT_REF save_slot = SG_Manager_GetBoundSlot();
     if (SG_Manager_IsValidSlotRef(save_slot)) {
-        Savegame_UpdateDeathCounters(save_slot, stats->death_count);
+        SHOULD(Savegame_UpdateDeathCounters(save_slot, stats->death_count));
     }
 }
 

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -353,7 +353,7 @@ void Stats_CalculateMaxStats(void)
             LUA_RunLevelScript(level);
 
             Inject_InitLevel(level, INJECTION_MODE_STATS);
-            if (loader->probe(loader, file, LEVEL_FORMAT_PROBE_STATS)) {
+            if (IS_OK(loader->probe(loader, file, LEVEL_FORMAT_PROBE_STATS))) {
                 Inject_AllInjections();
                 M_SetupStatsFullInitObjects();
 

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -342,6 +342,7 @@ void Stats_CalculateMaxStats(void)
         if (!SHOULD(File_OpenPathInMemory(level->path, &file))) {
             continue;
         }
+        File_SetSoftFailure(file, true);
 
         const LEVEL_FORMAT_LOADER *const loader =
             Level_Format_GuessLoader(file);
@@ -353,7 +354,8 @@ void Stats_CalculateMaxStats(void)
             LUA_RunLevelScript(level);
 
             Inject_InitLevel(level, INJECTION_MODE_STATS);
-            if (IS_OK(loader->probe(loader, file, LEVEL_FORMAT_PROBE_STATS))) {
+            if (IS_OK(loader->probe(loader, file, LEVEL_FORMAT_PROBE_STATS))
+                && !File_HasFailed(file)) {
                 Inject_AllInjections();
                 M_SetupStatsFullInitObjects();
 

--- a/src/trx/game/ui/dialogs/select_level.c
+++ b/src/trx/game/ui/dialogs/select_level.c
@@ -40,7 +40,7 @@ UI_SELECT_LEVEL_DIALOG_STATE *UI_SelectLevelDialog_Init(
     ASSERT(info != nullptr);
     ASSERT(info->features.select_level);
 
-    Savegame_LoadOnlyResumeInfo(save_slot);
+    SHOULD(Savegame_LoadOnlyResumeInfo(save_slot));
     const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
     for (int32_t i = 0; i <= info->level_num && i < level_table->count; i++) {
         const GF_LEVEL *const level = &level_table->levels[i];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Continues the migration to `RESULT`, so errors from level loading, game flow, and savegame loading can be handled instead of aborting or leaving the game in a broken state.

- Level loading errors now report the level name and return to the title screen.
- Truncated levels, sounds, injections, and saves now return errors instead of hitting assertions.
- Missing levels, demos, and cutscenes are now reported to the shell.
- Savegame errors now explain what failed, including invalid formats, decompression errors, unsupported versions, and malformed JSON.
- Object savegame readers now reject values of the wrong type while remaining compatible with older saves that omit them.
- `BSON_Parse` now reports read and write errors with their locations and uses an out parameter for the parsed value, matching the JSON reader.
- The stats probe now skips unreadable levels instead of aborting.
