### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/actions/prepare_macos_tooling/action.yml
+++ b/.github/actions/prepare_macos_tooling/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Select latest stable Xcode
       if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
         xcode-version: latest-stable
 
@@ -197,7 +197,7 @@ runs:
 
     - name: "Save dependencies to cache"
       if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: ${{ runner.os }}-tooling-${{ hashFiles('.github/actions/prepare_macos_tooling/action.yml') }}
         path: |

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,16 +14,16 @@ jobs:
           - platform: linux
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Install dependencies
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@6d97d0d47ea06f0bb4e81bc7911476e7cc61b312 # just
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: 'true'
 

--- a/.github/workflows/build_lint_image.yml
+++ b/.github/workflows/build_lint_image.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
         run: echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push lint image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: .github/docker/lint.Dockerfile

--- a/.github/workflows/comment_build.yml
+++ b/.github/workflows/comment_build.yml
@@ -4,9 +4,12 @@ on:
     workflows: ['Create a test build']
     types: [completed]
 
+# This workflow runs in the privileged base-repo context with a read-write
+# token, so it holds no more than it needs: it reads the run's artifacts and
+# writes one PR comment. It never checks out or executes pull request code.
 permissions:
-  actions: write
-  contents: write
+  actions: read
+  contents: read
   pull-requests: write
 jobs:
   pr_comment:
@@ -150,12 +153,19 @@ jobs:
               handleError(error, 'fetch artifacts', prNumber);
             }
 
+            // Artifact names come from the pull request's own tree, so escape
+            // them before they enter the comment. This keeps a crafted name from
+            // injecting markdown or breaking out of the link label.
+            function escapeLinkLabel(name) {
+              return String(name).replace(/[\\\[\]`<>\r\n]/g, '');
+            }
+
             // Construct the comment body
             let body = 'Download the built assets for this pull request:\n' +
               allArtifacts
                 .filter(item => item.name !== "assets")
                 .sort((a, b) => a.name.localeCompare(b.name))
-                .map(item => `* [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`)
+                .map(item => `* [${escapeLinkLabel(item.name)}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`)
                 .join('\n');
 
             // Upsert the comment on the PR

--- a/.github/workflows/comment_build.yml
+++ b/.github/workflows/comment_build.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           # This snippet is public-domain, combined from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Install dependencies
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@6d97d0d47ea06f0bb4e81bc7911476e7cc61b312 # just
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
       - name: Restore ccache
         id: ccache
         if: ${{ inputs.platform == 'linux' || inputs.platform == 'win' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/ccache
           key: ccache-v1-${{ runner.os }}-${{ inputs.platform }}-${{ inputs.target }}-${{ hashFiles('justfile', 'tools/shared/docker/game-linux/Dockerfile', 'tools/shared/docker/game-win/Dockerfile', 'tools/shared/docker/game-win/meson_linux_mingw32.txt') }}
@@ -81,7 +81,7 @@ jobs:
       # skip this step and stay restore-only.
       - name: Save ccache
         if: ${{ github.event_name != 'pull_request' && steps.ccache.outputs.cache-primary-key && (inputs.platform == 'linux' || inputs.platform == 'win') }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/ccache
           key: ${{ steps.ccache.outputs.cache-primary-key }}
@@ -100,7 +100,7 @@ jobs:
           just lua-api-check
 
       - name: Upload artifacts (combined)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.vars.outputs.trx_asset }}
           path: ${{ steps.vars.outputs.trx_dir }}

--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -49,9 +49,13 @@ jobs:
         if: ${{ inputs.target == 'release' }}
         run: just download-assets
 
+      # A pull request restores the shared ccache read-only and never writes it
+      # back (see the Save step). This stops a malicious branch from poisoning
+      # the compiler cache that a later develop or release build would consume.
       - name: Restore ccache
+        id: ccache
         if: ${{ inputs.platform == 'linux' || inputs.platform == 'win' }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .cache/ccache
           key: ccache-v1-${{ runner.os }}-${{ inputs.platform }}-${{ inputs.target }}-${{ hashFiles('justfile', 'tools/shared/docker/game-linux/Dockerfile', 'tools/shared/docker/game-win/Dockerfile', 'tools/shared/docker/game-win/meson_linux_mingw32.txt') }}
@@ -72,6 +76,15 @@ jobs:
           else
             just trx-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.trx_dir }}" --no-zip
           fi
+
+      # Only a push from a trusted branch writes the shared ccache. Pull requests
+      # skip this step and stay restore-only.
+      - name: Save ccache
+        if: ${{ github.event_name != 'pull_request' && steps.ccache.outputs.cache-primary-key && (inputs.platform == 'linux' || inputs.platform == 'win') }}
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/ccache
+          key: ${{ steps.ccache.outputs.cache-primary-key }}
 
       # The dump needs a binary to query, so it rides along with the Linux build
       # rather than paying for one of its own. The engine boots SDL before it

--- a/.github/workflows/job_build_macos.yml
+++ b/.github/workflows/job_build_macos.yml
@@ -45,7 +45,7 @@ jobs:
           security set-key-partition-list -S "apple-tool:,apple:,codesign:" -s -k $MACOS_KEYCHAIN_PWD $KEYCHAIN_PATH
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -66,7 +66,7 @@ jobs:
 
       - name: "Try restore dependencies from cache"
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           key: ${{ runner.os }}-tooling-${{ hashFiles('.github/actions/prepare_macos_tooling/action.yml') }}
           path: |
@@ -156,7 +156,7 @@ jobs:
           xcrun stapler staple -v "${DMG_NAME}"
 
       - name: Upload signed+notarized installer image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.vars.outputs.asset_name }}
           path: |

--- a/.github/workflows/job_build_te.yml
+++ b/.github/workflows/job_build_te.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Install dependencies
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@6d97d0d47ea06f0bb4e81bc7911476e7cc61b312 # just
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
           echo "te_dir=build/artifacts/te/" >> $GITHUB_OUTPUT
 
       - name: Download windows build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ steps.vars.outputs.win_asset }}
           path: build/artifacts/trx/
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Upload TE bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.vars.outputs.te_asset }}
           path: ${{ steps.vars.outputs.te_dir }}

--- a/.github/workflows/job_release.yml
+++ b/.github/workflows/job_release.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Install dependencies"
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@6d97d0d47ea06f0bb4e81bc7911476e7cc61b312 # just
 
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: 'true'
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: "Download built assets"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts/
           merge-multiple: true
@@ -60,18 +60,18 @@ jobs:
       - name: "Get information on the latest pre-release"
         if: ${{ inputs.prerelease == true || inputs.prerelease == 'true' }}
         id: last_release
-        uses: InsonusK/get-latest-release@v1.0.1
+        uses: InsonusK/get-latest-release@f8686e4d0b2be19a66677ad5fa2f22c38ef43b62 # v1.0.1
         with:
           myToken: ${{ github.token }}
           exclude_types: "draft|release"
 
       - name: 'Mark the pre-release as latest'
         if: ${{ inputs.prerelease == true || inputs.prerelease == 'true' }}
-        uses: EndBug/latest-tag@latest
+        uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67 # v1.6.3
 
       - name: "Delete old pre-release assets"
         if: ${{ inputs.prerelease == true || inputs.prerelease == 'true' }}
-        uses: mknejp/delete-release-assets@v1
+        uses: mknejp/delete-release-assets@94e5896e003fe67dcd81273e1ce45b90b5f1086d # v1
         continue-on-error: true
         with:
           token: ${{ github.token }}
@@ -79,7 +79,7 @@ jobs:
           assets: "*.*"
 
       - name: "Publish a release"
-        uses: softprops/action-gh-release@v2.2.2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       image: ghcr.io/lostartefacts/trx-lint:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -35,7 +35,7 @@ jobs:
       # later push consumes.
       - name: Restore prek cache
         id: prek_cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/prek
           key: prek-v1-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -66,7 +66,7 @@ jobs:
       # Only a push writes the prek cache back. Pull requests stay restore-only.
       - name: Save prek cache
         if: ${{ github.event_name != 'pull_request' && steps.prek_cache.outputs.cache-primary-key }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .cache/prek
           key: ${{ steps.prek_cache.outputs.cache-primary-key }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Ensure prek cache dir exists
         run: mkdir -p "${PREK_HOME}"
 
+      # A pull request restores the prek cache read-only and never writes it back
+      # (see the Save step), so a malicious branch cannot poison the cache that a
+      # later push consumes.
       - name: Restore prek cache
-        uses: actions/cache@v4
+        id: prek_cache
+        uses: actions/cache/restore@v4
         with:
           path: .cache/prek
           key: prek-v1-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -58,3 +62,11 @@ jobs:
             echo 'just lint failed.'
             exit "${lint_status}"
           fi
+
+      # Only a push writes the prek cache back. Pull requests stay restore-only.
+      - name: Save prek cache
+        if: ${{ github.event_name != 'pull_request' && steps.prek_cache.outputs.cache-primary-key }}
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/prek
+          key: ${{ steps.prek_cache.outputs.cache-primary-key }}

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -3,6 +3,12 @@ name: Create a test build
 permissions:
   contents: write
 
+# Keep the trigger on `pull_request`, never `pull_request_target`. On a fork PR
+# `pull_request` runs with a read-only token and withholds every repository
+# secret, so the `secrets: inherit` below resolves to nothing an attacker can
+# reach. Switching to `pull_request_target` would run this same untrusted code
+# in the base-repo context with those secrets exposed, turning a hostile PR into
+# a full secret leak.
 on:
   pull_request:
   push:

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload test log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unit-test-log
           path: build/tests/meson-logs/testlog.txt


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Hardens the CI workflows against untrusted pull request code and supply chain attacks. Every third-party action is now pinned to a full commit SHA, with its version kept in a trailing comment.

- Restore ccache and prek caches read-only on pull requests; write them only on trusted pushes
- Limit permissions for the build-link comment workflow and escape artifact names before adding them to comments
- Document why the test-build trigger uses pull_request instead of pull_request_target
