### PR TITLE
Report the cause when audio, video and images fail

### DIFF
--- a/src/tests/fakes/music.c
+++ b/src/tests/fakes/music.c
@@ -112,13 +112,13 @@ void Music_UnpauseStream(const int32_t slot)
     FAKE_RECORD("stream_unpause", FV(slot));
 }
 
-bool Music_SeekStream(const int32_t slot, const double timestamp)
+RESULT Music_SeekStream(const int32_t slot, const double timestamp)
 {
     FAKE_RECORD("stream_seek", FV(slot), FV(timestamp));
-    if (slot < 0 || slot >= FAKE_MUSIC_SLOT_COUNT || !m_Slots[slot].active) {
-        return false;
-    }
-    return true;
+    FAIL_IF(
+        slot < 0 || slot >= FAKE_MUSIC_SLOT_COUNT || !m_Slots[slot].active,
+        "slot %d holds no music", slot);
+    return OK;
 }
 
 void Music_Pause(void)

--- a/src/trx/av/audio.c
+++ b/src/trx/av/audio.c
@@ -80,21 +80,20 @@ static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
     memcpy(stream_data, m_MixBuffer, len);
 }
 
-bool Audio_Init(void)
+RESULT Audio_Init(void)
 {
     m_RefCount++;
     if (g_AudioDeviceID) {
         // already initialized
-        return true;
+        return OK;
     }
 
     m_CallbackSeen = false;
     m_ShouldSkipSDLQuitAudio = false;
     int32_t result = SDL_InitSubSystem(SDL_INIT_AUDIO);
-    if (result < 0) {
-        LOG_ERROR("Error while calling SDL_Init: 0x%lx", result);
-        return false;
-    }
+    FAIL_IF(
+        result < 0, "the audio subsystem could not be brought up: %s",
+        SDL_GetError());
 
     SDL_AudioSpec desired;
     SDL_memset(&desired, 0, sizeof(desired));
@@ -108,10 +107,9 @@ bool Audio_Init(void)
     SDL_AudioSpec delivered;
     g_AudioDeviceID = SDL_OpenAudioDevice(nullptr, 0, &desired, &delivered, 0);
 
-    if (!g_AudioDeviceID) {
-        LOG_ERROR("Failed to open audio device: %s", SDL_GetError());
-        return false;
-    }
+    FAIL_IF(
+        g_AudioDeviceID == 0, "the audio device could not be opened: %s",
+        SDL_GetError());
 
     m_Silence = desired.silence;
     m_MixBufferCapacity = desired.samples * desired.channels
@@ -127,14 +125,20 @@ bool Audio_Init(void)
     Audio_Reverb_Init(AUDIO_WORKING_RATE, AUDIO_WORKING_CHANNELS);
     M_StartWorker();
 
-    return true;
+    return OK;
 }
 
-bool Audio_Shutdown(void)
+RESULT Audio_CheckDevice(void)
+{
+    FAIL_IF(g_AudioDeviceID == 0, "the audio device is not open");
+    return OK;
+}
+
+RESULT Audio_Shutdown(void)
 {
     m_RefCount--;
     if (m_RefCount > 0) {
-        return false;
+        return OK;
     }
 
     M_StopWorker();
@@ -162,7 +166,7 @@ bool Audio_Shutdown(void)
     if (!m_ShouldSkipSDLQuitAudio) {
         SDL_QuitSubSystem(SDL_INIT_AUDIO);
     }
-    return true;
+    return OK;
 }
 
 bool Audio_ShouldSkipSDLQuitAudio(void)

--- a/src/trx/av/audio.h
+++ b/src/trx/av/audio.h
@@ -59,6 +59,9 @@ RESULT Audio_Stream_SetStopTimestamp(int32_t sound_id, double timestamp);
 // Stores the data of a sample for later playback, reporting data it cannot
 // use and a slot that is already in use.
 RESULT Audio_Sample_Load(int32_t sample_num, const char *content, size_t size);
+
+// Returns whether a sample slot holds audio to play.
+bool Audio_Sample_IsLoaded(int32_t sample_num);
 RESULT Audio_Sample_Unload(int32_t sample_id);
 RESULT Audio_Sample_UnloadAll(void);
 

--- a/src/trx/av/audio.h
+++ b/src/trx/av/audio.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <SDL2/SDL_audio.h>
 #include <libavutil/samplefmt.h>
 #include <stddef.h>
@@ -11,60 +13,68 @@
 #define AUDIO_DRIFT_THRESHOLD 0.2
 #define AUDIO_NO_SOUND (-1)
 
-bool Audio_Init(void);
-bool Audio_Shutdown(void);
+// Opens the audio device and starts the mixer, reporting a device that will
+// not open. A second call while the device is open only adds a reference.
+RESULT Audio_Init(void);
+RESULT Audio_Shutdown(void);
 bool Audio_ShouldSkipSDLQuitAudio(void);
 
 void Audio_Mute(void);
 void Audio_Unmute(void);
 bool Audio_IsMuted(void);
 
-bool Audio_Stream_Pause(int32_t sound_id);
-bool Audio_Stream_Unpause(int32_t sound_id);
-bool Audio_Stream_SetPaused(int32_t sound_id, bool is_paused);
-// Create a stream. The stream is paused, so that the caller can seek it and
-// set its volume before anything is heard; call Audio_Stream_Unpause to start
-// it.
-int32_t Audio_Stream_CreateFromFile(const char *path);
-int32_t Audio_Stream_CreateFromMemory(uint8_t *data, size_t size);
-bool Audio_Stream_Close(int32_t sound_id);
+RESULT Audio_Stream_Pause(int32_t sound_id);
+RESULT Audio_Stream_Unpause(int32_t sound_id);
+RESULT Audio_Stream_SetPaused(int32_t sound_id, bool is_paused);
+// Creates a stream and returns its id, reporting audio that cannot be read
+// and a state where every stream is already in use. The stream is paused, so
+// that the caller can seek it and set its volume before anything is heard; call
+// Audio_Stream_Unpause to start it.
+RESULT Audio_Stream_CreateFromFile(const char *path, int32_t *out_sound_id);
+RESULT Audio_Stream_CreateFromMemory(
+    uint8_t *data, size_t size, int32_t *out_sound_id);
+RESULT Audio_Stream_Close(int32_t sound_id);
 bool Audio_Stream_IsLooped(int32_t sound_id);
-bool Audio_Stream_SetVolume(int32_t sound_id, float volume);
+RESULT Audio_Stream_SetVolume(int32_t sound_id, float volume);
 
 // Play the stream faster or slower, pitching it with the rate the way a tape
 // does. Timestamps stay in the source timeline.
-bool Audio_Stream_SetSpeed(int32_t sound_id, double speed);
-bool Audio_Stream_SetIsLooped(int32_t sound_id, bool is_looped);
+RESULT Audio_Stream_SetSpeed(int32_t sound_id, double speed);
+RESULT Audio_Stream_SetIsLooped(int32_t sound_id, bool is_looped);
 
-// Sync the audio against specific timestamp (seek if the drift is too large).
-bool Audio_Stream_SyncTimestamp(int32_t sound_id, double timestamp);
+// Synchronizes the stream to the given timestamp, and seeks it where the
+// drift is too large. A stream that is already synchronized is no fault and
+// does not move.
+RESULT Audio_Stream_SyncTimestamp(int32_t sound_id, double timestamp);
 
-bool Audio_Stream_SetFinishCallback(
+RESULT Audio_Stream_SetFinishCallback(
     int32_t sound_id, void (*callback)(int32_t sound_id, void *user_data),
     void *user_data);
 double Audio_Stream_GetTimestamp(int32_t sound_id);
 double Audio_Stream_GetDuration(int32_t sound_id);
-bool Audio_Stream_SeekTimestamp(int32_t sound_id, double timestamp);
-bool Audio_Stream_SetStartTimestamp(int32_t sound_id, double timestamp);
-bool Audio_Stream_SetStopTimestamp(int32_t sound_id, double timestamp);
+RESULT Audio_Stream_SeekTimestamp(int32_t sound_id, double timestamp);
+RESULT Audio_Stream_SetStartTimestamp(int32_t sound_id, double timestamp);
+RESULT Audio_Stream_SetStopTimestamp(int32_t sound_id, double timestamp);
 
-bool Audio_Sample_Load(int32_t sample_num, const char *content, size_t size);
-bool Audio_Sample_Unload(int32_t sample_id);
-bool Audio_Sample_UnloadAll(void);
+// Stores the data of a sample for later playback, reporting data it cannot
+// use and a slot that is already in use.
+RESULT Audio_Sample_Load(int32_t sample_num, const char *content, size_t size);
+RESULT Audio_Sample_Unload(int32_t sample_id);
+RESULT Audio_Sample_UnloadAll(void);
 
 int32_t Audio_Sample_Play(
     int32_t sample_id, int32_t volume, float pitch, int32_t pan,
     bool is_looped);
 bool Audio_Sample_IsPlaying(int32_t sound_id);
-bool Audio_Sample_Pause(int32_t sound_id);
-bool Audio_Sample_PauseAll(void);
-bool Audio_Sample_Unpause(int32_t sound_id);
-bool Audio_Sample_UnpauseAll(void);
-bool Audio_Sample_Close(int32_t sound_id);
-bool Audio_Sample_CloseAll(void);
-bool Audio_Sample_SetPan(int32_t sound_id, int32_t pan);
-bool Audio_Sample_SetVolume(int32_t sound_id, int32_t volume);
-bool Audio_Sample_SetPitch(int32_t sound_id, float pan);
+RESULT Audio_Sample_Pause(int32_t sound_id);
+RESULT Audio_Sample_PauseAll(void);
+RESULT Audio_Sample_Unpause(int32_t sound_id);
+RESULT Audio_Sample_UnpauseAll(void);
+RESULT Audio_Sample_Close(int32_t sound_id);
+RESULT Audio_Sample_CloseAll(void);
+RESULT Audio_Sample_SetPan(int32_t sound_id, int32_t pan);
+RESULT Audio_Sample_SetVolume(int32_t sound_id, int32_t volume);
+RESULT Audio_Sample_SetPitch(int32_t sound_id, float pan);
 
 void Audio_SetReverbType(uint8_t reverb_type);
 uint8_t Audio_GetReverbType(void);

--- a/src/trx/av/audio_decoder.c
+++ b/src/trx/av/audio_decoder.c
@@ -111,7 +111,7 @@ static int64_t M_MemorySeek(
     return new_pos;
 }
 
-static bool M_OpenCodec(AUDIO_DECODER *const decoder)
+static RESULT M_OpenCodec(AUDIO_DECODER *const decoder)
 {
     int32_t error_code =
         avformat_find_stream_info(decoder->format_ctx, nullptr);
@@ -179,11 +179,10 @@ static bool M_OpenCodec(AUDIO_DECODER *const decoder)
         goto fail;
     }
 
-    return true;
+    return OK;
 
 fail:
-    LOG_ERROR("Error while opening audio: %s", av_err2str(error_code));
-    return false;
+    return FAIL("the audio could not be opened: %s", av_err2str(error_code));
 }
 
 static void M_FreeFilterGraph(AUDIO_DECODER *const decoder)
@@ -201,15 +200,15 @@ static void M_FreeFilterGraph(AUDIO_DECODER *const decoder)
     decoder->filter_sink = nullptr;
 }
 
-static bool M_BuildFilterGraph(AUDIO_DECODER *const decoder)
+static RESULT M_BuildFilterGraph(AUDIO_DECODER *const decoder)
 {
     decoder->filter_graph = avfilter_graph_alloc();
     decoder->filter_in = av_frame_alloc();
     decoder->filter_out = av_frame_alloc();
-    if (decoder->filter_graph == nullptr || decoder->filter_in == nullptr
-        || decoder->filter_out == nullptr) {
-        return false;
-    }
+    FAIL_IF(
+        decoder->filter_graph == nullptr || decoder->filter_in == nullptr
+            || decoder->filter_out == nullptr,
+        "the filter graph could not be set up");
 
     AVChannelLayout layout;
     av_channel_layout_default(&layout, decoder->channels);
@@ -224,18 +223,15 @@ static bool M_BuildFilterGraph(AUDIO_DECODER *const decoder)
         &decoder->filter_src, avfilter_get_by_name("abuffer"), "in", args,
         nullptr, decoder->filter_graph);
     Memory_Free(args);
-    if (error_code < 0) {
-        LOG_ERROR(
-            "Failed to create the filter source: %s", av_err2str(error_code));
-        return false;
-    }
+    FAIL_IF(
+        error_code < 0, "the filter source could not be created: %s",
+        av_err2str(error_code));
 
     decoder->filter_sink = avfilter_graph_alloc_filter(
         decoder->filter_graph, avfilter_get_by_name("abuffersink"), "out");
-    if (decoder->filter_sink == nullptr) {
-        LOG_ERROR("Failed to create the filter sink");
-        return false;
-    }
+    FAIL_IF(
+        decoder->filter_sink == nullptr,
+        "the filter sink could not be created");
 
     // the sink only takes its format before it is initialised
     static const enum AVSampleFormat sample_fmts[] = {
@@ -247,8 +243,7 @@ static bool M_BuildFilterGraph(AUDIO_DECODER *const decoder)
             sizeof(sample_fmts), AV_OPT_SEARCH_CHILDREN)
             < 0
         || avfilter_init_dict(decoder->filter_sink, nullptr) < 0) {
-        LOG_ERROR("Failed to pin the filter output format");
-        return false;
+        return FAIL("the filter output format would not hold");
     }
 
     char *const tempo_args = String_Format("tempo=%f", decoder->speed);
@@ -259,17 +254,15 @@ static bool M_BuildFilterGraph(AUDIO_DECODER *const decoder)
     Memory_Free(tempo_args);
     if (stretch_result < 0
         || avfilter_link(decoder->filter_src, 0, stretch, 0) < 0) {
-        LOG_ERROR("Failed to create the time stretch filter");
-        return false;
+        return FAIL("the time stretch filter could not be created");
     }
 
     if (avfilter_link(stretch, 0, decoder->filter_sink, 0) < 0
         || avfilter_graph_config(decoder->filter_graph, nullptr) < 0) {
-        LOG_ERROR("Failed to configure the filter graph");
-        return false;
+        return FAIL("the filter graph could not be configured");
     }
 
-    return true;
+    return OK;
 }
 
 // Drops the samples the stretcher holds, which a seek makes stale.
@@ -279,7 +272,7 @@ static void M_RebuildFilterGraph(AUDIO_DECODER *const decoder)
         return;
     }
     M_FreeFilterGraph(decoder);
-    if (!M_BuildFilterGraph(decoder)) {
+    if (!SHOULD(M_BuildFilterGraph(decoder))) {
         M_FreeFilterGraph(decoder);
         decoder->speed = 1.0;
     }
@@ -383,33 +376,37 @@ static AUDIO_DECODER *M_Create(const int32_t channels)
     return decoder;
 }
 
-AUDIO_DECODER *AudioDecoder_CreateFromPath(
-    const char *const path, const int32_t channels)
+RESULT AudioDecoder_CreateFromPath(
+    const char *const path, const int32_t channels,
+    AUDIO_DECODER **const out_decoder)
 {
     ASSERT(path != nullptr);
+    *out_decoder = nullptr;
 
     AUDIO_DECODER *decoder = M_Create(channels);
     const int32_t error_code =
         avformat_open_input(&decoder->format_ctx, path, nullptr, nullptr);
     if (error_code != 0) {
-        LOG_ERROR(
-            "Error while opening audio %s: %s", path, av_err2str(error_code));
         AudioDecoder_Free(&decoder);
-        return nullptr;
+        return FAIL("%s: %s", path, av_err2str(error_code));
     }
 
-    if (!M_OpenCodec(decoder)) {
+    const RESULT result = Result_Prefix(M_OpenCodec(decoder), "%s", path);
+    if (!IS_OK(result)) {
         AudioDecoder_Free(&decoder);
-        return nullptr;
+        return result;
     }
-    return decoder;
+    *out_decoder = decoder;
+    return OK;
 }
 
-AUDIO_DECODER *AudioDecoder_CreateFromMemory(
-    const uint8_t *const data, const size_t size, const int32_t channels)
+RESULT AudioDecoder_CreateFromMemory(
+    const uint8_t *const data, const size_t size, const int32_t channels,
+    AUDIO_DECODER **const out_decoder)
 {
     ASSERT(data != nullptr);
     ASSERT(size != 0);
+    *out_decoder = nullptr;
 
     AUDIO_DECODER *decoder = M_Create(channels);
     decoder->memory = (M_MEMORY_SOURCE) {
@@ -423,13 +420,13 @@ AUDIO_DECODER *AudioDecoder_CreateFromMemory(
         M_MemoryRead, nullptr, M_MemorySeek);
     if (decoder->avio_ctx == nullptr) {
         AudioDecoder_Free(&decoder);
-        return nullptr;
+        return FAIL("the audio reader could not be set up");
     }
 
     decoder->format_ctx = avformat_alloc_context();
     if (decoder->format_ctx == nullptr) {
         AudioDecoder_Free(&decoder);
-        return nullptr;
+        return FAIL("the audio format context could not be set up");
     }
     decoder->format_ctx->pb = decoder->avio_ctx;
     decoder->format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
@@ -437,18 +434,19 @@ AUDIO_DECODER *AudioDecoder_CreateFromMemory(
     const int32_t error_code =
         avformat_open_input(&decoder->format_ctx, nullptr, nullptr, nullptr);
     if (error_code != 0) {
-        LOG_ERROR(
-            "Error while opening audio memory stream: %s",
-            av_err2str(error_code));
         AudioDecoder_Free(&decoder);
-        return nullptr;
+        return FAIL(
+            "the audio in memory could not be opened: %s",
+            av_err2str(error_code));
     }
 
-    if (!M_OpenCodec(decoder)) {
+    const RESULT result = M_OpenCodec(decoder);
+    if (!IS_OK(result)) {
         AudioDecoder_Free(&decoder);
-        return nullptr;
+        return result;
     }
-    return decoder;
+    *out_decoder = decoder;
+    return OK;
 }
 
 void AudioDecoder_Free(AUDIO_DECODER **const decoder_ref)
@@ -501,56 +499,53 @@ double AudioDecoder_GetTimestamp(const AUDIO_DECODER *const decoder)
     return decoder->timestamp;
 }
 
-bool AudioDecoder_SetSpeed(AUDIO_DECODER *const decoder, const double speed)
+RESULT AudioDecoder_SetSpeed(AUDIO_DECODER *const decoder, const double speed)
 {
     ASSERT(decoder != nullptr);
 
-    if (speed <= 0.0 || speed == decoder->speed) {
-        return speed > 0.0;
+    FAIL_IF(speed <= 0.0, "audio cannot decode at %f times its rate", speed);
+    if (speed == decoder->speed) {
+        return OK;
     }
 
     M_FreeFilterGraph(decoder);
     decoder->speed = speed;
     if (speed == 1.0) {
-        return true;
+        return OK;
     }
 
-    if (!M_BuildFilterGraph(decoder)) {
+    const RESULT result = M_BuildFilterGraph(decoder);
+    if (!IS_OK(result)) {
         M_FreeFilterGraph(decoder);
         decoder->speed = 1.0;
-        return false;
     }
-    return true;
+    return result;
 }
 
-bool AudioDecoder_Seek(AUDIO_DECODER *const decoder, const double timestamp)
+RESULT AudioDecoder_Seek(AUDIO_DECODER *const decoder, const double timestamp)
 {
     ASSERT(decoder != nullptr);
 
     const double time_base_sec = av_q2d(decoder->stream->time_base);
-    if (time_base_sec <= 0.0) {
-        LOG_ERROR("Invalid time base %f", time_base_sec);
-        return false;
-    }
+    FAIL_IF(
+        time_base_sec <= 0.0, "the audio names a time base of %f",
+        time_base_sec);
 
     const int32_t error_code = av_seek_frame(
         decoder->format_ctx, decoder->stream->index,
         (int64_t)(timestamp / time_base_sec), AVSEEK_FLAG_ANY);
-    if (error_code < 0) {
-        LOG_ERROR(
-            "seek failed for timestamp %f: %s", timestamp,
-            av_err2str(error_code));
-        return false;
-    }
+    FAIL_IF(
+        error_code < 0, "the audio could not seek to %f s: %s", timestamp,
+        av_err2str(error_code));
 
     avcodec_flush_buffers(decoder->codec_ctx);
     M_RebuildFilterGraph(decoder);
     decoder->timestamp = timestamp;
     decoder->is_drained = false;
-    return true;
+    return OK;
 }
 
-bool AudioDecoder_Rewind(AUDIO_DECODER *const decoder, const double start_at)
+RESULT AudioDecoder_Rewind(AUDIO_DECODER *const decoder, const double start_at)
 {
     ASSERT(decoder != nullptr);
 
@@ -570,18 +565,15 @@ bool AudioDecoder_Rewind(AUDIO_DECODER *const decoder, const double start_at)
         return AudioDecoder_Seek(decoder, start_at);
     }
 
-    if (error_code < 0) {
-        LOG_ERROR(
-            "seek failed for timestamp %f: %s", start_at,
-            av_err2str(error_code));
-        return false;
-    }
+    FAIL_IF(
+        error_code < 0, "the audio could not seek to %f s: %s", start_at,
+        av_err2str(error_code));
 
     avcodec_flush_buffers(decoder->codec_ctx);
     M_RebuildFilterGraph(decoder);
     decoder->timestamp = start_at;
     decoder->is_drained = false;
-    return true;
+    return OK;
 }
 
 int32_t AudioDecoder_Read(AUDIO_DECODER *const decoder, const float **const out)

--- a/src/trx/av/audio_decoder.h
+++ b/src/trx/av/audio_decoder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -7,9 +9,13 @@
 // keeps the memory a decoder was created over alive for as long as it lives.
 typedef struct AUDIO_DECODER AUDIO_DECODER;
 
-AUDIO_DECODER *AudioDecoder_CreateFromPath(const char *path, int32_t channels);
-AUDIO_DECODER *AudioDecoder_CreateFromMemory(
-    const uint8_t *data, size_t size, int32_t channels);
+// Opens audio for decoding, reporting the error that ffmpeg gives. Caller
+// frees it with AudioDecoder_Free().
+RESULT AudioDecoder_CreateFromPath(
+    const char *path, int32_t channels, AUDIO_DECODER **out_decoder);
+RESULT AudioDecoder_CreateFromMemory(
+    const uint8_t *data, size_t size, int32_t channels,
+    AUDIO_DECODER **out_decoder);
 void AudioDecoder_Free(AUDIO_DECODER **decoder);
 
 // How long the source is, in seconds, or a negative value where the container
@@ -19,11 +25,12 @@ double AudioDecoder_GetDuration(const AUDIO_DECODER *decoder);
 // Where in the source the last decoded frame came from, in seconds.
 double AudioDecoder_GetTimestamp(const AUDIO_DECODER *decoder);
 
-// Decode faster or slower without moving the pitch.
-bool AudioDecoder_SetSpeed(AUDIO_DECODER *decoder, double speed);
+// Decodes faster or slower without a change of pitch, reporting a rate the
+// filter cannot apply.
+RESULT AudioDecoder_SetSpeed(AUDIO_DECODER *decoder, double speed);
 
-bool AudioDecoder_Seek(AUDIO_DECODER *decoder, double timestamp);
-bool AudioDecoder_Rewind(AUDIO_DECODER *decoder, double start_at);
+RESULT AudioDecoder_Seek(AUDIO_DECODER *decoder, double timestamp);
+RESULT AudioDecoder_Rewind(AUDIO_DECODER *decoder, double start_at);
 
 // Decodes the next packet and points `out` at the samples it produced. Returns
 // how many samples per channel those are - zero where the packet carried none

--- a/src/trx/av/audio_internal.h
+++ b/src/trx/av/audio_internal.h
@@ -12,6 +12,9 @@
 
 extern SDL_AudioDeviceID g_AudioDeviceID;
 
+// Reports an audio device that is not open.
+RESULT Audio_CheckDevice(void);
+
 void Audio_LockDevice(void);
 void Audio_UnlockDevice(void);
 

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -154,10 +154,10 @@ static bool M_DecoderOpen(AUDIO_SAMPLE *const sample)
 {
     ASSERT(sample->decoder == nullptr);
 
-    AUDIO_DECODER *const source = AudioDecoder_CreateFromMemory(
-        (const uint8_t *)sample->original_data, sample->original_size,
-        SAMPLE_CHANNELS);
-    if (source == nullptr) {
+    AUDIO_DECODER *source = nullptr;
+    if (!SHOULD(AudioDecoder_CreateFromMemory(
+            (const uint8_t *)sample->original_data, sample->original_size,
+            SAMPLE_CHANNELS, &source))) {
         return false;
     }
 

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -337,6 +337,14 @@ void Audio_Sample_Pump(void)
     Audio_WorkerUnlock();
 }
 
+bool Audio_Sample_IsLoaded(const int32_t sample_id)
+{
+    if (sample_id < 0 || sample_id >= AUDIO_MAX_SAMPLES) {
+        return false;
+    }
+    return m_LoadedSamples[sample_id].original_data != nullptr;
+}
+
 RESULT Audio_Sample_Unload(const int32_t sample_id)
 {
     MUST(M_CheckSampleID(sample_id));

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -89,6 +89,24 @@ static AUDIO_SAMPLE_SOUND m_Samples[AUDIO_MAX_ACTIVE_SAMPLES] = {};
 static int32_t m_DecodeQueue[AUDIO_MAX_SAMPLES] = {};
 static int32_t m_DecodeQueueCount = 0;
 
+static RESULT M_CheckSampleID(const int32_t sample_id)
+{
+    FAIL_IF(
+        sample_id < 0 || sample_id >= AUDIO_MAX_SAMPLES,
+        "sample %d is outside the %d samples that fit", sample_id,
+        AUDIO_MAX_SAMPLES);
+    return OK;
+}
+
+static RESULT M_CheckSoundID(const int32_t sound_id)
+{
+    MUST(Audio_CheckDevice());
+    FAIL_IF(
+        sound_id < 0 || sound_id >= AUDIO_MAX_ACTIVE_SAMPLES,
+        "sound %d is not playing", sound_id);
+    return OK;
+}
+
 static double M_DecibelToMultiplier(double db_gain)
 {
     if (g_TRVersion < 3) {
@@ -292,8 +310,8 @@ void Audio_Sample_Init(void)
 
 void Audio_Sample_Shutdown(void)
 {
-    Audio_Sample_CloseAll();
-    Audio_Sample_UnloadAll();
+    IGNORE(Audio_Sample_CloseAll());
+    IGNORE(Audio_Sample_UnloadAll());
 }
 
 void Audio_Sample_Pump(void)
@@ -319,27 +337,23 @@ void Audio_Sample_Pump(void)
     Audio_WorkerUnlock();
 }
 
-bool Audio_Sample_Unload(const int32_t sample_id)
+RESULT Audio_Sample_Unload(const int32_t sample_id)
 {
-    if (sample_id < 0 || sample_id >= AUDIO_MAX_SAMPLES) {
-        LOG_ERROR("Maximum allowed samples: %d", AUDIO_MAX_SAMPLES);
-        return false;
-    }
+    MUST(M_CheckSampleID(sample_id));
 
     AUDIO_SAMPLE *const sample = &m_LoadedSamples[sample_id];
-    if (sample->original_data == nullptr) {
-        LOG_ERROR("Sample %d is already unloaded", sample_id);
-        return false;
-    }
+    FAIL_IF(
+        sample->original_data == nullptr, "sample %d is already unloaded",
+        sample_id);
 
     Audio_WorkerLock();
     M_UnloadSample(sample);
     Audio_WorkerUnlock();
     m_LoadedSamplesCount--;
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_UnloadAll(void)
+RESULT Audio_Sample_UnloadAll(void)
 {
     Audio_WorkerLock();
     m_LoadedSamplesCount = 0;
@@ -347,40 +361,28 @@ bool Audio_Sample_UnloadAll(void)
         M_UnloadSample(&m_LoadedSamples[i]);
     }
     Audio_WorkerUnlock();
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_Load(
+RESULT Audio_Sample_Load(
     const int32_t sample_id, const char *const data, const size_t size)
 {
-    if (data == nullptr || size == 0) {
-        LOG_ERROR("Missing sample data %d", sample_id);
-        return false;
-    }
-
-    if (!g_AudioDeviceID) {
-        LOG_ERROR("Unitialized audio device");
-        return false;
-    }
-
-    if (sample_id < 0 || sample_id >= AUDIO_MAX_SAMPLES) {
-        LOG_ERROR("Maximum allowed samples: %d", AUDIO_MAX_SAMPLES);
-        return false;
-    }
+    FAIL_IF(
+        data == nullptr || size == 0, "sample %d carries no data", sample_id);
+    MUST(Audio_CheckDevice());
+    MUST(M_CheckSampleID(sample_id));
 
     AUDIO_SAMPLE *const sample = &m_LoadedSamples[sample_id];
-    if (sample->original_data != nullptr) {
-        LOG_ERROR(
-            "Sample %d is already loaded (trying to overwrite with %d bytes)",
-            sample_id, size);
-        return false;
-    }
+    FAIL_IF(
+        sample->original_data != nullptr,
+        "sample %d is already loaded, and %zu bytes would overwrite it",
+        sample_id, size);
 
     sample->original_data = Memory_Alloc(size);
     sample->original_size = size;
     memcpy(sample->original_data, data, size);
     m_LoadedSamplesCount++;
-    return true;
+    return OK;
 }
 
 int32_t Audio_Sample_Play(
@@ -447,142 +449,108 @@ bool Audio_Sample_IsPlaying(int32_t sound_id)
     return m_Samples[sound_id].is_playing;
 }
 
-bool Audio_Sample_Pause(int32_t sound_id)
+RESULT Audio_Sample_Pause(int32_t sound_id)
 {
-    if (!g_AudioDeviceID) {
-        return false;
-    }
-
+    MUST(Audio_CheckDevice());
     if (m_Samples[sound_id].is_playing) {
         Audio_LockDevice();
         m_Samples[sound_id].is_playing = false;
         Audio_UnlockDevice();
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_PauseAll(void)
+RESULT Audio_Sample_PauseAll(void)
 {
-    if (!g_AudioDeviceID) {
-        return false;
-    }
-
+    MUST(Audio_CheckDevice());
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
          sound_id++) {
         if (m_Samples[sound_id].is_used) {
-            Audio_Sample_Pause(sound_id);
+            IGNORE(Audio_Sample_Pause(sound_id));
         }
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_Unpause(int32_t sound_id)
+RESULT Audio_Sample_Unpause(int32_t sound_id)
 {
-    if (!g_AudioDeviceID) {
-        return false;
-    }
-
+    MUST(Audio_CheckDevice());
     if (!m_Samples[sound_id].is_playing) {
         Audio_LockDevice();
         m_Samples[sound_id].is_playing = true;
         Audio_UnlockDevice();
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_UnpauseAll(void)
+RESULT Audio_Sample_UnpauseAll(void)
 {
-    if (!g_AudioDeviceID) {
-        return false;
-    }
-
+    MUST(Audio_CheckDevice());
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
          sound_id++) {
         if (m_Samples[sound_id].is_used) {
-            Audio_Sample_Unpause(sound_id);
+            IGNORE(Audio_Sample_Unpause(sound_id));
         }
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_Close(int32_t sound_id)
+RESULT Audio_Sample_Close(int32_t sound_id)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_SAMPLES) {
-        return false;
-    }
-
+    MUST(M_CheckSoundID(sound_id));
     Audio_LockDevice();
     m_Samples[sound_id].is_used = false;
     m_Samples[sound_id].is_playing = false;
     Audio_UnlockDevice();
-
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_CloseAll(void)
+RESULT Audio_Sample_CloseAll(void)
 {
-    if (!g_AudioDeviceID) {
-        return false;
-    }
-
+    MUST(Audio_CheckDevice());
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
          sound_id++) {
         if (m_Samples[sound_id].is_used) {
-            Audio_Sample_Close(sound_id);
+            IGNORE(Audio_Sample_Close(sound_id));
         }
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_SetPan(int32_t sound_id, int32_t pan)
+RESULT Audio_Sample_SetPan(int32_t sound_id, int32_t pan)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_SAMPLES) {
-        return false;
-    }
+    MUST(M_CheckSoundID(sound_id));
 
     Audio_LockDevice();
     m_Samples[sound_id].pan = pan;
     M_RecalculateChannelVolumes(sound_id);
     Audio_UnlockDevice();
 
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_SetVolume(int32_t sound_id, int32_t volume)
+RESULT Audio_Sample_SetVolume(int32_t sound_id, int32_t volume)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_SAMPLES) {
-        return false;
-    }
+    MUST(M_CheckSoundID(sound_id));
 
     Audio_LockDevice();
     m_Samples[sound_id].volume = volume;
     M_RecalculateChannelVolumes(sound_id);
     Audio_UnlockDevice();
 
-    return true;
+    return OK;
 }
 
-bool Audio_Sample_SetPitch(int32_t sound_id, float pitch)
+RESULT Audio_Sample_SetPitch(int32_t sound_id, float pitch)
 {
-    if (!g_AudioDeviceID || sound_id < 0
-        || sound_id >= AUDIO_MAX_ACTIVE_SAMPLES) {
-        return false;
-    }
+    MUST(M_CheckSoundID(sound_id));
 
     Audio_LockDevice();
     m_Samples[sound_id].pitch = pitch;
     M_RecalculateChannelVolumes(sound_id);
     Audio_UnlockDevice();
 
-    return true;
+    return OK;
 }
 
 void Audio_Sample_Mix(float *dst_buffer, size_t len)
@@ -633,7 +601,7 @@ void Audio_Sample_Mix(float *dst_buffer, size_t len)
         sound->current_sample = src_sample_idx;
         if (sample->is_decoded && !sound->is_looped
             && (int32_t)src_sample_idx >= ready) {
-            Audio_Sample_Close(sound_id);
+            IGNORE(Audio_Sample_Close(sound_id));
         }
     }
 }

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -126,11 +126,19 @@ static bool M_IsValidID(const int32_t sound_id)
         && sound_id < AUDIO_MAX_ACTIVE_STREAMS;
 }
 
+static RESULT M_CheckID(const int32_t sound_id)
+{
+    MUST(Audio_CheckDevice());
+    FAIL_IF(
+        sound_id < 0 || sound_id >= AUDIO_MAX_ACTIVE_STREAMS,
+        "stream %d is not playing", sound_id);
+    return OK;
+}
+
 static void M_ResetPlaybackState(
     AUDIO_STREAM_SOUND *const stream, const double relative_timestamp)
 {
     ASSERT(stream != nullptr);
-
     const double clamped = MAX(0.0, relative_timestamp);
     Audio_LockDevice();
     stream->played_samples =
@@ -141,12 +149,10 @@ static void M_ResetPlaybackState(
 static bool M_Rewind(AUDIO_STREAM_SOUND *const stream)
 {
     ASSERT(stream != nullptr);
-
     if (!stream->is_looped
         || !AudioDecoder_Rewind(stream->decoder, stream->start_at)) {
         return false;
     }
-
     stream->decode_timestamp = MAX(stream->start_at, 0.0);
     M_ResetPlaybackState(stream, 0.0);
     return true;
@@ -336,71 +342,61 @@ void Audio_Stream_Pump(void)
     }
 }
 
-bool Audio_Stream_SyncTimestamp(const int32_t sound_id, const double timestamp)
+RESULT Audio_Stream_SyncTimestamp(
+    const int32_t sound_id, const double timestamp)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     double drift = Audio_Stream_GetTimestamp(sound_id) - timestamp;
     if (drift < 0) {
         drift = -drift;
     }
     if (drift >= AUDIO_DRIFT_THRESHOLD) {
         LOG_DEBUG("Detected audio drift: %f s", drift);
-        Audio_Stream_SeekTimestamp(sound_id, timestamp);
-        return true;
+        MUST(Audio_Stream_SeekTimestamp(sound_id, timestamp));
     }
-    return false;
+    return OK;
 }
 
-bool Audio_Stream_Pause(const int32_t sound_id)
+RESULT Audio_Stream_Pause(const int32_t sound_id)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     if (stream->is_playing) {
         Audio_LockDevice();
         stream->is_playing = false;
         Audio_UnlockDevice();
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Stream_Unpause(const int32_t sound_id)
+RESULT Audio_Stream_Unpause(const int32_t sound_id)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     if (!stream->is_playing) {
         Audio_LockDevice();
         stream->is_playing = true;
         Audio_UnlockDevice();
     }
-
-    return true;
+    return OK;
 }
 
-bool Audio_Stream_SetPaused(const int32_t sound_id, const bool is_paused)
+RESULT Audio_Stream_SetPaused(const int32_t sound_id, const bool is_paused)
 {
     return is_paused ? Audio_Stream_Pause(sound_id)
                      : Audio_Stream_Unpause(sound_id);
 }
 
-int32_t Audio_Stream_CreateFromFile(const char *const file_path)
+RESULT Audio_Stream_CreateFromFile(
+    const char *const file_path, int32_t *const out_sound_id)
 {
-    if (g_AudioDeviceID == 0) {
-        return AUDIO_NO_SOUND;
-    }
+    *out_sound_id = AUDIO_NO_SOUND;
+    FAIL_IF(g_AudioDeviceID == 0, "the audio device is not open");
 
     ASSERT(file_path != nullptr);
 
-    int32_t result = AUDIO_NO_SOUND;
+    RESULT result = FAIL(
+        "%s: all %d streams are in use", file_path, AUDIO_MAX_ACTIVE_STREAMS);
     Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
@@ -410,7 +406,10 @@ int32_t Audio_Stream_CreateFromFile(const char *const file_path)
         AUDIO_DECODER *const decoder =
             AudioDecoder_CreateFromPath(file_path, AUDIO_WORKING_CHANNELS);
         if (M_Initialise(sound_id, decoder, nullptr)) {
-            result = sound_id;
+            *out_sound_id = sound_id;
+            result = OK;
+        } else {
+            result = FAIL("%s: the audio could not be read", file_path);
         }
         break;
     }
@@ -419,16 +418,16 @@ int32_t Audio_Stream_CreateFromFile(const char *const file_path)
     return result;
 }
 
-int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
+RESULT Audio_Stream_CreateFromMemory(
+    uint8_t *const data, const size_t size, int32_t *const out_sound_id)
 {
-    if (g_AudioDeviceID == 0) {
-        return AUDIO_NO_SOUND;
-    }
+    *out_sound_id = AUDIO_NO_SOUND;
+    FAIL_IF(g_AudioDeviceID == 0, "the audio device is not open");
 
     ASSERT(data != nullptr);
     ASSERT(size != 0);
 
-    int32_t result = AUDIO_NO_SOUND;
+    RESULT result = FAIL("all %d streams are in use", AUDIO_MAX_ACTIVE_STREAMS);
     Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
@@ -438,7 +437,10 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
         AUDIO_DECODER *const decoder =
             AudioDecoder_CreateFromMemory(data, size, AUDIO_WORKING_CHANNELS);
         if (M_Initialise(sound_id, decoder, data)) {
-            result = sound_id;
+            *out_sound_id = sound_id;
+            result = OK;
+        } else {
+            result = FAIL("the audio in memory could not be read");
         }
         break;
     }
@@ -447,11 +449,9 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
     return result;
 }
 
-bool Audio_Stream_Close(const int32_t sound_id)
+RESULT Audio_Stream_Close(const int32_t sound_id)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
+    MUST(M_CheckID(sound_id));
 
     Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
@@ -463,37 +463,35 @@ bool Audio_Stream_Close(const int32_t sound_id)
         notification.func(sound_id, notification.user_data);
     }
 
-    return true;
+    return OK;
 }
 
-bool Audio_Stream_SetVolume(const int32_t sound_id, const float volume)
+RESULT Audio_Stream_SetVolume(const int32_t sound_id, const float volume)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     m_Streams[sound_id].volume = volume;
-
-    return true;
+    return OK;
 }
 
-bool Audio_Stream_SetSpeed(const int32_t sound_id, const double speed)
+RESULT Audio_Stream_SetSpeed(const int32_t sound_id, const double speed)
 {
-    if (!M_IsValidID(sound_id) || speed <= 0.0) {
-        return false;
-    }
+    MUST(M_CheckID(sound_id));
+    FAIL_IF(speed <= 0.0, "a stream cannot play at %f times its rate", speed);
 
     Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    bool result = false;
+    bool reached = false;
     if (stream->is_used) {
-        result = AudioDecoder_SetSpeed(stream->decoder, speed);
+        reached = AudioDecoder_SetSpeed(stream->decoder, speed);
         // a rate the decoder cannot reach leaves it playing at its own
-        stream->speed = result ? speed : 1.0;
+        stream->speed = reached ? speed : 1.0;
     }
     Audio_WorkerUnlock();
 
-    return result;
+    FAIL_IF(
+        !reached, "stream %d cannot play at %f times its rate", sound_id,
+        speed);
+    return OK;
 }
 
 bool Audio_Stream_IsLooped(const int32_t sound_id)
@@ -501,36 +499,27 @@ bool Audio_Stream_IsLooped(const int32_t sound_id)
     if (!M_IsValidID(sound_id)) {
         return false;
     }
-
     return m_Streams[sound_id].is_looped;
 }
 
-bool Audio_Stream_SetIsLooped(const int32_t sound_id, const bool is_looped)
+RESULT Audio_Stream_SetIsLooped(const int32_t sound_id, const bool is_looped)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     m_Streams[sound_id].is_looped = is_looped;
-
-    return true;
+    return OK;
 }
 
-bool Audio_Stream_SetFinishCallback(
+RESULT Audio_Stream_SetFinishCallback(
     const int32_t sound_id,
     void (*const callback)(int32_t sound_id, void *user_data),
     void *const user_data)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     Audio_WorkerLock();
     m_Streams[sound_id].finish_callback = callback;
     m_Streams[sound_id].finish_callback_user_data = user_data;
     Audio_WorkerUnlock();
-
-    return true;
+    return OK;
 }
 
 void Audio_Stream_Mix(float *const dst_buffer, const size_t len)
@@ -587,21 +576,20 @@ double Audio_Stream_GetDuration(const int32_t sound_id)
     return duration;
 }
 
-bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
+RESULT Audio_Stream_SeekTimestamp(
+    const int32_t sound_id, const double timestamp)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
+    MUST(M_CheckID(sound_id));
 
     Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    bool result = false;
+    bool sought = false;
     if (stream->is_used) {
         const double target = MAX(stream->start_at, 0.0) + timestamp;
-        result = AudioDecoder_Seek(stream->decoder, target);
+        sought = AudioDecoder_Seek(stream->decoder, target);
     }
 
-    if (result) {
+    if (sought) {
         Audio_LockDevice();
         M_RingReset(&stream->ring);
         Audio_UnlockDevice();
@@ -613,27 +601,22 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
     }
     Audio_WorkerUnlock();
 
-    return result;
+    FAIL_IF(!sought, "stream %d could not seek to %f s", sound_id, timestamp);
+    return OK;
 }
 
-bool Audio_Stream_SetStartTimestamp(
+RESULT Audio_Stream_SetStartTimestamp(
     const int32_t sound_id, const double timestamp)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     m_Streams[sound_id].start_at = timestamp;
-    return true;
+    return OK;
 }
 
-bool Audio_Stream_SetStopTimestamp(
+RESULT Audio_Stream_SetStopTimestamp(
     const int32_t sound_id, const double timestamp)
 {
-    if (!M_IsValidID(sound_id)) {
-        return false;
-    }
-
+    MUST(M_CheckID(sound_id));
     m_Streams[sound_id].stop_at = timestamp;
-    return true;
+    return OK;
 }

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -150,7 +150,7 @@ static bool M_Rewind(AUDIO_STREAM_SOUND *const stream)
 {
     ASSERT(stream != nullptr);
     if (!stream->is_looped
-        || !AudioDecoder_Rewind(stream->decoder, stream->start_at)) {
+        || !SHOULD(AudioDecoder_Rewind(stream->decoder, stream->start_at))) {
         return false;
     }
     stream->decode_timestamp = MAX(stream->start_at, 0.0);
@@ -403,13 +403,13 @@ RESULT Audio_Stream_CreateFromFile(
         if (m_Streams[sound_id].is_used) {
             continue;
         }
-        AUDIO_DECODER *const decoder =
-            AudioDecoder_CreateFromPath(file_path, AUDIO_WORKING_CHANNELS);
-        if (M_Initialise(sound_id, decoder, nullptr)) {
+        AUDIO_DECODER *decoder = nullptr;
+        result = AudioDecoder_CreateFromPath(
+            file_path, AUDIO_WORKING_CHANNELS, &decoder);
+        if (IS_OK(result) && M_Initialise(sound_id, decoder, nullptr)) {
             *out_sound_id = sound_id;
-            result = OK;
-        } else {
-            result = FAIL("%s: the audio could not be read", file_path);
+        } else if (IS_OK(result)) {
+            result = FAIL("%s: the stream could not be set up", file_path);
         }
         break;
     }
@@ -434,13 +434,13 @@ RESULT Audio_Stream_CreateFromMemory(
         if (m_Streams[sound_id].is_used) {
             continue;
         }
-        AUDIO_DECODER *const decoder =
-            AudioDecoder_CreateFromMemory(data, size, AUDIO_WORKING_CHANNELS);
-        if (M_Initialise(sound_id, decoder, data)) {
+        AUDIO_DECODER *decoder = nullptr;
+        result = AudioDecoder_CreateFromMemory(
+            data, size, AUDIO_WORKING_CHANNELS, &decoder);
+        if (IS_OK(result) && M_Initialise(sound_id, decoder, data)) {
             *out_sound_id = sound_id;
-            result = OK;
-        } else {
-            result = FAIL("the audio in memory could not be read");
+        } else if (IS_OK(result)) {
+            result = FAIL("the stream could not be set up");
         }
         break;
     }
@@ -480,17 +480,15 @@ RESULT Audio_Stream_SetSpeed(const int32_t sound_id, const double speed)
 
     Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    bool reached = false;
+    RESULT result = OK;
     if (stream->is_used) {
-        reached = AudioDecoder_SetSpeed(stream->decoder, speed);
+        result = AudioDecoder_SetSpeed(stream->decoder, speed);
         // a rate the decoder cannot reach leaves it playing at its own
-        stream->speed = reached ? speed : 1.0;
+        stream->speed = IS_OK(result) ? speed : 1.0;
     }
     Audio_WorkerUnlock();
 
-    FAIL_IF(
-        !reached, "stream %d cannot play at %f times its rate", sound_id,
-        speed);
+    MUST(result, "stream %d", sound_id);
     return OK;
 }
 
@@ -583,13 +581,13 @@ RESULT Audio_Stream_SeekTimestamp(
 
     Audio_WorkerLock();
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    bool sought = false;
+    RESULT result = FAIL("stream %d holds no audio", sound_id);
     if (stream->is_used) {
         const double target = MAX(stream->start_at, 0.0) + timestamp;
-        sought = AudioDecoder_Seek(stream->decoder, target);
+        result = AudioDecoder_Seek(stream->decoder, target);
     }
 
-    if (sought) {
+    if (IS_OK(result)) {
         Audio_LockDevice();
         M_RingReset(&stream->ring);
         Audio_UnlockDevice();
@@ -601,7 +599,7 @@ RESULT Audio_Stream_SeekTimestamp(
     }
     Audio_WorkerUnlock();
 
-    FAIL_IF(!sought, "stream %d could not seek to %f s", sound_id, timestamp);
+    MUST(result, "stream %d", sound_id);
     return OK;
 }
 

--- a/src/trx/av/image.c
+++ b/src/trx/av/image.c
@@ -60,7 +60,7 @@ static void M_Free(IMAGE_READER_CONTEXT *const ctx)
     }
 }
 
-static bool M_Init(const char *const path, IMAGE_READER_CONTEXT *const ctx)
+static RESULT M_Init(const char *const path, IMAGE_READER_CONTEXT *const ctx)
 {
     ASSERT(ctx != nullptr);
     ctx->format_ctx = nullptr;
@@ -157,13 +157,11 @@ static bool M_Init(const char *const path, IMAGE_READER_CONTEXT *const ctx)
 
 finish:
     if (error_code != 0) {
-        LOG_ERROR(
-            "Error while opening image %s: %s", path, av_err2str(error_code));
         M_Free(ctx);
-        return false;
+        return FAIL("%s: %s", path, av_err2str(error_code));
     }
 
-    return true;
+    return OK;
 }
 
 static IMAGE_BLIT M_GetBlit(
@@ -300,48 +298,44 @@ IMAGE *Image_Create(const int width, const int height)
     return image;
 }
 
-IMAGE *Image_CreateFromFile(const char *const path)
+RESULT Image_CreateFromFile(const char *const path, IMAGE **const out_image)
 {
     ASSERT(path != nullptr);
+    *out_image = nullptr;
 
     IMAGE_READER_CONTEXT ctx;
-    if (!M_Init(path, &ctx)) {
-        return nullptr;
-    }
+    MUST(M_Init(path, &ctx));
 
-    IMAGE *target_image = M_ConstructImage(
+    *out_image = M_ConstructImage(
         &ctx, ctx.frame->width, ctx.frame->height, IMAGE_FIT_STRETCH);
 
     M_Free(&ctx);
-
-    return target_image;
+    return OK;
 }
 
-IMAGE *Image_CreateFromFileInto(
+RESULT Image_CreateFromFileInto(
     const char *const path, const int32_t target_width,
-    const int32_t target_height, const IMAGE_FIT_MODE fit_mode)
+    const int32_t target_height, const IMAGE_FIT_MODE fit_mode,
+    IMAGE **const out_image)
 {
     ASSERT(path != nullptr);
+    *out_image = nullptr;
 
     IMAGE_READER_CONTEXT ctx;
-    if (!M_Init(path, &ctx)) {
-        return nullptr;
-    }
+    MUST(M_Init(path, &ctx));
 
-    IMAGE *target_image =
-        M_ConstructImage(&ctx, target_width, target_height, fit_mode);
+    *out_image = M_ConstructImage(&ctx, target_width, target_height, fit_mode);
 
     M_Free(&ctx);
-
-    return target_image;
+    return OK;
 }
 
-bool Image_SaveToFile(const IMAGE *const image, const char *const path)
+RESULT Image_SaveToFile(const IMAGE *const image, const char *const path)
 {
     ASSERT(image != nullptr);
     ASSERT(path != nullptr);
 
-    bool result = false;
+    RESULT result = OK;
 
     int error_code = 0;
     const AVCodec *codec = nullptr;
@@ -362,14 +356,13 @@ bool Image_SaveToFile(const IMAGE *const image, const char *const path)
         dst_pix_fmt = AV_PIX_FMT_RGB24;
         codec_id = AV_CODEC_ID_PNG;
     } else {
-        LOG_ERROR("Cannot determine image format based on path '%s'", path);
+        result = FAIL("%s: the picture format is not one TRX writes", path);
         goto cleanup;
     }
 
-    if (!SHOULD(FS_EnsureParentDirectories(path))) {
-        goto cleanup;
-    }
-    if (!SHOULD(File_OpenPath(path, FILE_OPEN_WRITE, &fp))) {
+    MUST(FS_EnsureParentDirectories(path));
+    result = File_OpenPath(path, FILE_OPEN_WRITE, &fp);
+    if (!IS_OK(result)) {
         goto cleanup;
     }
 
@@ -461,11 +454,8 @@ bool Image_SaveToFile(const IMAGE *const image, const char *const path)
     }
 
 cleanup:
-    if (error_code) {
-        LOG_ERROR(
-            "Error while saving image %s: %s", path, av_err2str(error_code));
-    } else {
-        result = true;
+    if (error_code != 0) {
+        result = FAIL("%s: %s", path, av_err2str(error_code));
     }
 
     if (fp) {

--- a/src/trx/av/image.h
+++ b/src/trx/av/image.h
@@ -38,8 +38,6 @@ RESULT Image_CreateFromFileInto(
 
 void Image_Free(IMAGE *image);
 
-bool Image_GetFileInfo(const char *path, int32_t *width, int32_t *height);
-
 // Writes an image to disk, reporting a path it cannot write and a format with
 // no encoder.
 RESULT Image_SaveToFile(const IMAGE *image, const char *path);

--- a/src/trx/av/image.h
+++ b/src/trx/av/image.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,17 +26,23 @@ typedef enum {
 
 IMAGE *Image_Create(int width, int height);
 
-IMAGE *Image_CreateFromFile(const char *path);
+// Reads an image from disk, reporting a file that does not exist and one the
+// reader cannot decode. Caller frees it with Image_Free().
+RESULT Image_CreateFromFile(const char *path, IMAGE **out_image);
 
-IMAGE *Image_CreateFromFileInto(
+// As Image_CreateFromFile, but scales the image to the given size during the
+// read.
+RESULT Image_CreateFromFileInto(
     const char *path, int32_t target_width, int32_t target_height,
-    IMAGE_FIT_MODE fit_mode);
+    IMAGE_FIT_MODE fit_mode, IMAGE **out_image);
 
 void Image_Free(IMAGE *image);
 
 bool Image_GetFileInfo(const char *path, int32_t *width, int32_t *height);
 
-bool Image_SaveToFile(const IMAGE *image, const char *path);
+// Writes an image to disk, reporting a path it cannot write and a format with
+// no encoder.
+RESULT Image_SaveToFile(const IMAGE *image, const char *path);
 
 IMAGE *Image_Scale(
     const IMAGE *source_image, size_t target_width, size_t target_height,

--- a/src/trx/av/video.c
+++ b/src/trx/av/video.c
@@ -1930,19 +1930,18 @@ fail:
     return nullptr;
 }
 
-VIDEO *Video_Open(const char *const file_path)
+RESULT Video_Open(const char *const file_path, VIDEO **const out_video)
 {
-    if (file_path == nullptr || String_IsEmpty(file_path)) {
-        LOG_ERROR("Cannot open video: empty file path");
-        return nullptr;
-    }
+    *out_video = nullptr;
+    FAIL_IF(
+        file_path == nullptr || String_IsEmpty(file_path),
+        "the video has no path to play from");
 
     LOG_DEBUG("Playing video: %s", file_path);
     int flags = SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER;
-    if (SDL_Init(flags)) {
-        LOG_ERROR("Could not initialize SDL - %s", SDL_GetError());
-        return nullptr;
-    }
+    FAIL_IF(
+        SDL_Init(flags), "%s: SDL could not be brought up: %s", file_path,
+        SDL_GetError());
 
     SDL_EventState(SDL_SYSWMEVENT, SDL_IGNORE);
     SDL_EventState(SDL_USEREVENT, SDL_IGNORE);
@@ -1952,13 +1951,16 @@ VIDEO *Video_Open(const char *const file_path)
     result->priv = M_StreamOpen(file_path);
     if (result->priv == nullptr) {
         Memory_Free(result);
-        LOG_ERROR("Failed to initialize video!");
-        return nullptr;
+        return FAIL(
+            "%s: the video could not be opened, and the log says where the "
+            "reader stopped",
+            file_path);
     }
 
     result->path = Memory_DupStr(file_path);
     result->is_playing = true;
-    return result;
+    *out_video = result;
+    return OK;
 }
 
 void Video_PumpEvents(VIDEO *video)

--- a/src/trx/av/video.h
+++ b/src/trx/av/video.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <libavutil/pixfmt.h>
 #include <stdint.h>
 
@@ -12,7 +14,10 @@ typedef struct {
 typedef void *(*VIDEO_SURFACE_ALLOCATOR_FUNC)(
     int32_t width, int32_t height, void *user_data);
 
-VIDEO *Video_Open(const char *path);
+// Opens a video and prepares it for playback, reporting a path that does not
+// exist and a file the reader cannot decode. Caller closes it with
+// Video_Close().
+RESULT Video_Open(const char *path, VIDEO **out_video);
 void Video_SetAudioEnabled(VIDEO *video, bool enabled);
 void Video_SetVolume(VIDEO *video, double volume);
 void Video_SetSurfacePixelFormat(VIDEO *video, enum AVPixelFormat pixel_format);

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -383,8 +383,9 @@ void Cutscene_End(void)
 GF_COMMAND Cutscene_Control(void)
 {
     Interpolation_Remember();
-    Music_SetSpeed(Clock_GetSpeedMultiplier());
-    Music_SyncTimestamp(Camera_GetCineData()->frame_idx / (double)LOGIC_FPS);
+    IGNORE(Music_SetSpeed(Clock_GetSpeedMultiplier()));
+    IGNORE(Music_SyncTimestamp(
+        Camera_GetCineData()->frame_idx / (double)LOGIC_FPS));
 
     Input_Update();
     Shell_ProcessInput();

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -351,8 +351,8 @@ static void M_Step(void)
 
     if (info->audio_track != -1
         && Music_GetCurrentPlayingTrack() == (MUSIC_ID)info->audio_track) {
-        Music_SetSpeed(Clock_GetSpeedMultiplier());
-        Music_SyncTimestamp(m_State.frame / (double)LOGIC_FPS);
+        IGNORE(Music_SetSpeed(Clock_GetSpeedMultiplier()));
+        IGNORE(Music_SyncTimestamp(m_State.frame / (double)LOGIC_FPS));
     }
 
     m_State.frame++;

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -67,8 +67,8 @@ static OUTPUT_QUAD_SURFACE_DESC M_MakeSurfaceDesc(
 
 static int32_t M_OpenAudioStream(const char *const file_name)
 {
-    int32_t audio_id = Audio_Stream_CreateFromFile(file_name);
-    if (audio_id != AUDIO_NO_SOUND) {
+    int32_t audio_id = AUDIO_NO_SOUND;
+    if (IGNORE(Audio_Stream_CreateFromFile(file_name, &audio_id))) {
         return audio_id;
     }
 
@@ -84,9 +84,10 @@ static int32_t M_OpenAudioStream(const char *const file_name)
         char *const candidate =
             String_Format("%.*s%s", (int)base_len, file_name, *ext);
         if (FS_Exists(candidate)) {
-            audio_id = Audio_Stream_CreateFromFile(candidate);
+            const bool opened =
+                IGNORE(Audio_Stream_CreateFromFile(candidate, &audio_id));
             Memory_Free(candidate);
-            if (audio_id != AUDIO_NO_SOUND) {
+            if (opened) {
                 return audio_id;
             }
         } else {
@@ -257,8 +258,8 @@ static RESULT M_Play(const char *const file_name)
     M_SetPauseText(false);
     Video_Start(video);
 
-    Audio_Stream_SetVolume(audio_id, M_GetAudioVolume());
-    Audio_Stream_Unpause(audio_id);
+    IGNORE(Audio_Stream_SetVolume(audio_id, M_GetAudioVolume()));
+    IGNORE(Audio_Stream_Unpause(audio_id));
 
     while (video->is_playing) {
         Shell_ProcessEvents();
@@ -274,11 +275,11 @@ static RESULT M_Play(const char *const file_name)
         const bool should_pause = focus_paused || input_paused;
         if (should_pause != paused) {
             Video_SetPaused(video, should_pause);
-            Audio_Stream_SetPaused(audio_id, should_pause);
+            IGNORE(Audio_Stream_SetPaused(audio_id, should_pause));
             paused = should_pause;
         }
 
-        Audio_Stream_SetVolume(audio_id, M_GetAudioVolume());
+        IGNORE(Audio_Stream_SetVolume(audio_id, M_GetAudioVolume()));
         const double audio_ts = Audio_Stream_GetTimestamp(audio_id);
         if (audio_ts >= 0.0) {
             Video_SetExternalAudioClock(video, audio_ts);
@@ -309,7 +310,7 @@ static RESULT M_Play(const char *const file_name)
     }
 
     M_SetPauseText(false);
-    Audio_Stream_Close(audio_id);
+    IGNORE(Audio_Stream_Close(audio_id));
     Video_Close(video);
 
     Output_Quad_Destroy(render_ctx.renderer_2d);

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -229,24 +229,13 @@ static void M_RedrawFrame(M_RENDER_CONTEXT *const ctx)
     Output_FlipScreen();
 }
 
-static bool M_Play(const char *const file_name)
+static RESULT M_Play(const char *const file_name)
 {
-    if (file_name == nullptr || String_IsEmpty(file_name)) {
-        LOG_ERROR("Cannot play FMV: empty file path");
-        return false;
-    }
-
-    VIDEO *const video = Video_Open(file_name);
-    if (video == nullptr) {
-        return false;
-    }
+    VIDEO *video = nullptr;
+    MUST(Video_Open(file_name, &video));
 
     M_RENDER_CONTEXT render_ctx = {};
-    if (!SHOULD(
-            Output_Quad_Create(&render_ctx.renderer_2d),
-            "the video cannot be drawn")) {
-        return false;
-    }
+    MUST(Output_Quad_Create(&render_ctx.renderer_2d));
 
     Video_SetSurfaceAllocatorFunc(video, M_AllocateSurface, nullptr);
     Video_SetSurfaceDeallocatorFunc(video, M_DeallocateSurface, nullptr);
@@ -325,21 +314,21 @@ static bool M_Play(const char *const file_name)
 
     Output_Quad_Destroy(render_ctx.renderer_2d);
     Output_ApplyRenderSettings();
-    return true;
+    return OK;
 }
 
-bool FMV_Play(const char *const file_path)
+RESULT FMV_Play(const char *const file_path)
 {
     Music_Stop();
     Sound_StopAll();
 
     if (!g_Config.gameplay.enable_fmv) {
-        return false;
+        return OK;
     }
 
     m_IsPlaying = true;
     Output_SetSupersamplingEnabled(false);
-    const bool result = M_Play(file_path);
+    const RESULT result = M_Play(file_path);
     Output_SetSupersamplingEnabled(true);
     m_IsPlaying = false;
     return result;

--- a/src/trx/game/fmv.h
+++ b/src/trx/game/fmv.h
@@ -1,4 +1,8 @@
 #pragma once
 
-bool FMV_Play(const char *file_path);
+#include <trx/core/result.h>
+
+// Plays a video full screen. Returns when the video ends or when the player
+// skips it. A video that the settings disable is no fault and plays nothing.
+RESULT FMV_Play(const char *file_path);
 bool FMV_IsPlaying(void);

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -247,7 +247,7 @@ M_GF_HANDLER(M_HandlePlayFMV)
         *out_cmd = gf_cmd;
         return OK;
     }
-    FMV_Play(fmv->path);
+    SHOULD(FMV_Play(fmv->path));
     *out_cmd = gf_cmd;
     return OK;
 }

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -27,7 +27,7 @@ static void M_PlayIntroFMVs(void)
     for (int32_t i = 0; i < g_GameFlow.fmv_count; i++) {
         const GF_FMV *const fmv = &g_GameFlow.fmvs[i];
         if (fmv->is_intro) {
-            FMV_Play(fmv->path);
+            SHOULD(FMV_Play(fmv->path));
         }
     }
 }

--- a/src/trx/game/inject/data/sound.c
+++ b/src/trx/game/inject/data/sound.c
@@ -69,8 +69,8 @@ static void M_HandleSFXData(
                 const int32_t sample_length = File_ReadS32(chunk.injection->fp);
                 char *const data = Memory_Alloc(sample_length);
                 File_ReadData(chunk.injection->fp, data, sample_length);
-                Sound_LoadSampleData(
-                    sample_info->number + j, data, sample_length);
+                SHOULD(Sound_LoadSampleData(
+                    sample_info->number + j, data, sample_length));
                 Memory_Free(data);
             }
         } else if (g_TRVersion >= 2) {

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -273,8 +273,8 @@ static void M_EndHouse(ITEM *const item, COLL_INFO *const coll)
     if (Music_GetCurrentPlayingTrack() == Music_ToGameID(MX_CUTSCENE_BATH)) {
         const int32_t frame_num = Item_GetRelativeFrame(item);
         const double ts = (frame_num - M_LF_SHOWER_START) / (double)LOGIC_FPS;
-        Music_SetSpeed(Clock_GetSpeedMultiplier());
-        Music_SyncTimestamp(ts);
+        IGNORE(Music_SetSpeed(Clock_GetSpeedMultiplier()));
+        IGNORE(Music_SyncTimestamp(ts));
     }
 }
 

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -178,6 +178,7 @@ static void M_CompleteSetup(
     } else {
         M_InitialiseSamplesFromFile(ctx, level->settings.sfx_path);
     }
+    SHOULD(Sound_CheckSamples(), "those sounds stay silent");
 
     Benchmark_End(&benchmark, nullptr);
 }

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -84,7 +84,7 @@ static void M_InitialiseSamplesFromFile(
         char *sample_data = Memory_Alloc(size);
         memcpy(sample_data, header, header_size);
         File_ReadData(fp, sample_data + header_size, aligned_size);
-        Sound_LoadSampleData(entry->game_index, sample_data, size);
+        SHOULD(Sound_LoadSampleData(entry->game_index, sample_data, size));
         Memory_FreePointer(&sample_data);
 
         current_sample++;
@@ -115,7 +115,7 @@ static void M_InitialiseSamplesFromLevelInfo(LEVEL_CONTEXT *const ctx)
 
         const char *const sample_data = &info->samples.data[current_offset];
         const size_t sample_size = next_offset - current_offset;
-        Sound_LoadSampleData(i, sample_data, sample_size);
+        SHOULD(Sound_LoadSampleData(i, sample_data, sample_size));
     }
 
     Memory_FreePointer(&info->samples.offsets);

--- a/src/trx/game/lua/capi/music.c
+++ b/src/trx/game/lua/capi/music.c
@@ -107,7 +107,7 @@ static int M_L_MusicStreamSeek(lua_State *const L)
         LUA_Struct_CheckRef(L, 1, &TYPE_MUSIC_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
     const double timestamp = luaL_checknumber(L, 2);
-    lua_pushboolean(L, Music_SeekStream(ref->handle.id, timestamp));
+    lua_pushboolean(L, IGNORE(Music_SeekStream(ref->handle.id, timestamp)));
     return 1;
 }
 

--- a/src/trx/game/music/backend_cdaudio.c
+++ b/src/trx/game/music/backend_cdaudio.c
@@ -176,10 +176,14 @@ static int32_t M_Play(
         return -1;
     }
 
-    const int32_t audio_stream_id = Audio_Stream_CreateFromFile(data->path);
-    Audio_Stream_SetStartTimestamp(audio_stream_id, track->from / 1000.0);
-    Audio_Stream_SetStopTimestamp(audio_stream_id, track->to / 1000.0);
-    Audio_Stream_SeekTimestamp(audio_stream_id, 0.0f);
+    int32_t audio_stream_id = AUDIO_NO_SOUND;
+    if (!SHOULD(Audio_Stream_CreateFromFile(data->path, &audio_stream_id))) {
+        return -1;
+    }
+    SHOULD(
+        Audio_Stream_SetStartTimestamp(audio_stream_id, track->from / 1000.0));
+    SHOULD(Audio_Stream_SetStopTimestamp(audio_stream_id, track->to / 1000.0));
+    SHOULD(Audio_Stream_SeekTimestamp(audio_stream_id, 0.0f));
     return audio_stream_id;
 }
 

--- a/src/trx/game/music/backend_cdaudio_wad.c
+++ b/src/trx/game/music/backend_cdaudio_wad.c
@@ -197,9 +197,11 @@ static int32_t M_Play(
         return AUDIO_NO_SOUND;
     }
 
-    const int32_t stream_id = Audio_Stream_CreateFromMemory(wav_data, wav_size);
-    if (stream_id < 0) {
+    int32_t stream_id = AUDIO_NO_SOUND;
+    if (!SHOULD(
+            Audio_Stream_CreateFromMemory(wav_data, wav_size, &stream_id))) {
         Memory_Free(wav_data);
+        return AUDIO_NO_SOUND;
     }
     return stream_id;
 }

--- a/src/trx/game/music/backend_files.c
+++ b/src/trx/game/music/backend_files.c
@@ -400,9 +400,11 @@ static int32_t M_Play(
         return -1;
     }
 
-    const int32_t stream_id = Audio_Stream_CreateFromFile(file_path);
+    int32_t stream_id = AUDIO_NO_SOUND;
+    const bool opened =
+        SHOULD(Audio_Stream_CreateFromFile(file_path, &stream_id));
     Memory_Free(file_path);
-    return stream_id;
+    return opened ? stream_id : -1;
 }
 
 static void M_Shutdown(MUSIC_BACKEND *backend)

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -552,8 +552,8 @@ double Music_GetTrackDuration(const MUSIC_ID track)
     double duration = -1.0;
     char *const path = Music_GetTrackPath(track);
     if (path != nullptr) {
-        AUDIO_DECODER *decoder = AudioDecoder_CreateFromPath(path, 2);
-        if (decoder != nullptr) {
+        AUDIO_DECODER *decoder = nullptr;
+        if (SHOULD(AudioDecoder_CreateFromPath(path, 2, &decoder))) {
             duration = AudioDecoder_GetDuration(decoder);
             AudioDecoder_Free(&decoder);
         }

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -140,8 +140,9 @@ static void M_StreamClose(M_MUSIC_STREAM *const stream)
     // finished by itself. In cases where we end the streams early by hand,
     // we clear the finish callback in order to avoid resuming the BGM playback
     // just after we stop it.
-    Audio_Stream_SetFinishCallback(stream->audio_stream_id, nullptr, nullptr);
-    Audio_Stream_Close(stream->audio_stream_id);
+    SHOULD(Audio_Stream_SetFinishCallback(
+        stream->audio_stream_id, nullptr, nullptr));
+    SHOULD(Audio_Stream_Close(stream->audio_stream_id));
     M_StreamReset(stream);
 }
 
@@ -227,7 +228,7 @@ static void M_SyncVolume(const M_MUSIC_STREAM *const stream)
     const float volume = stream->mode == MPM_OVERLAY
         ? g_Config.audio.music_volume * g_Config.audio.master_volume
         : m_MusicVolume;
-    Audio_Stream_SetVolume(stream->audio_stream_id, volume);
+    SHOULD(Audio_Stream_SetVolume(stream->audio_stream_id, volume));
 }
 
 static void M_SyncVolumes(void)
@@ -284,13 +285,13 @@ static int32_t M_PlayOverlayTrack(
     m_OverlayStreams[slot].mode = MPM_OVERLAY;
     m_OverlayStreams[slot].active = true;
     M_SyncVolume(&m_OverlayStreams[slot]);
-    Audio_Stream_SetIsLooped(stream_id, false);
-    Audio_Stream_SetFinishCallback(
-        stream_id, M_StreamFinished, &m_OverlayStreams[slot]);
+    SHOULD(Audio_Stream_SetIsLooped(stream_id, false));
+    SHOULD(Audio_Stream_SetFinishCallback(
+        stream_id, M_StreamFinished, &m_OverlayStreams[slot]));
     if (timestamp > 0.0) {
-        Audio_Stream_SeekTimestamp(stream_id, timestamp);
+        SHOULD(Audio_Stream_SeekTimestamp(stream_id, timestamp));
     }
-    Audio_Stream_Unpause(stream_id);
+    SHOULD(Audio_Stream_Unpause(stream_id));
     return slot + 1;
 }
 
@@ -361,12 +362,12 @@ static void M_Shutdown(void)
         m_Backend->shutdown(m_Backend);
         m_Backend = nullptr;
     }
-    Audio_Shutdown();
+    IGNORE(Audio_Shutdown());
 }
 
 static void M_ApplyConfig(void)
 {
-    Music_Init();
+    SHOULD(Music_Init());
     Music_SetVolume(g_Config.audio.music_volume);
 }
 
@@ -437,13 +438,13 @@ static int32_t M_Play(
             m_MainStream.mode = is_looped ? MPM_LOOP : MPM_ONCE;
             m_MainStream.active = true;
             M_SyncVolume(&m_MainStream);
-            Audio_Stream_SetIsLooped(stream_id, is_looped);
-            Audio_Stream_SetFinishCallback(
-                stream_id, M_StreamFinished, &m_MainStream);
+            SHOULD(Audio_Stream_SetIsLooped(stream_id, is_looped));
+            SHOULD(Audio_Stream_SetFinishCallback(
+                stream_id, M_StreamFinished, &m_MainStream));
             if (timestamp > 0.0) {
-                Audio_Stream_SeekTimestamp(stream_id, timestamp);
+                SHOULD(Audio_Stream_SeekTimestamp(stream_id, timestamp));
             }
-            Audio_Stream_Unpause(stream_id);
+            SHOULD(Audio_Stream_Unpause(stream_id));
             played = true;
         }
     }
@@ -463,7 +464,7 @@ static int32_t M_Play(
     return played ? 0 : -1;
 }
 
-bool Music_Init(void)
+RESULT Music_Init(void)
 {
     m_Initialised = true;
     memset(m_TrackDurations, 0, sizeof(m_TrackDurations));
@@ -491,7 +492,7 @@ finish:
     // game still knows which track is playing and what a track resolves to.
     // What such a run has no use for is the audio device.
     if (Shell_GetArgs()->headless) {
-        return true;
+        return OK;
     }
     return Audio_Init();
 }
@@ -591,12 +592,12 @@ void Music_StopTrack_Direct(const MUSIC_ID track)
 void Music_Pause(void)
 {
     if (m_MainStream.active && m_MainStream.audio_stream_id >= 0) {
-        Audio_Stream_Pause(m_MainStream.audio_stream_id);
+        SHOULD(Audio_Stream_Pause(m_MainStream.audio_stream_id));
     }
     for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
         if (m_OverlayStreams[i].active
             && m_OverlayStreams[i].audio_stream_id >= 0) {
-            Audio_Stream_Pause(m_OverlayStreams[i].audio_stream_id);
+            SHOULD(Audio_Stream_Pause(m_OverlayStreams[i].audio_stream_id));
         }
     }
 }
@@ -604,12 +605,12 @@ void Music_Pause(void)
 void Music_Unpause(void)
 {
     if (m_MainStream.active && m_MainStream.audio_stream_id >= 0) {
-        Audio_Stream_Unpause(m_MainStream.audio_stream_id);
+        SHOULD(Audio_Stream_Unpause(m_MainStream.audio_stream_id));
     }
     for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
         if (m_OverlayStreams[i].active
             && m_OverlayStreams[i].audio_stream_id >= 0) {
-            Audio_Stream_Unpause(m_OverlayStreams[i].audio_stream_id);
+            SHOULD(Audio_Stream_Unpause(m_OverlayStreams[i].audio_stream_id));
         }
     }
 }
@@ -627,7 +628,8 @@ bool Music_SeekTimestamp(const double timestamp)
     if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
         return false;
     }
-    return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
+    return IGNORE(
+        Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp));
 }
 
 bool Music_SetSpeed(const double speed)
@@ -635,7 +637,7 @@ bool Music_SetSpeed(const double speed)
     if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
         return false;
     }
-    return Audio_Stream_SetSpeed(m_MainStream.audio_stream_id, speed);
+    return IGNORE(Audio_Stream_SetSpeed(m_MainStream.audio_stream_id, speed));
 }
 
 bool Music_SyncTimestamp(const double timestamp)
@@ -643,7 +645,8 @@ bool Music_SyncTimestamp(const double timestamp)
     if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
         return false;
     }
-    return Audio_Stream_SyncTimestamp(m_MainStream.audio_stream_id, timestamp);
+    return IGNORE(
+        Audio_Stream_SyncTimestamp(m_MainStream.audio_stream_id, timestamp));
 }
 
 int32_t Music_GetStreamCount(void)
@@ -744,7 +747,7 @@ void Music_PauseStream(const int32_t slot)
 {
     const M_MUSIC_STREAM *const stream = M_GetStreamBySlot(slot);
     if (stream != nullptr && stream->active && stream->audio_stream_id >= 0) {
-        Audio_Stream_Pause(stream->audio_stream_id);
+        SHOULD(Audio_Stream_Pause(stream->audio_stream_id));
     }
 }
 
@@ -752,7 +755,7 @@ void Music_UnpauseStream(const int32_t slot)
 {
     const M_MUSIC_STREAM *const stream = M_GetStreamBySlot(slot);
     if (stream != nullptr && stream->active && stream->audio_stream_id >= 0) {
-        Audio_Stream_Unpause(stream->audio_stream_id);
+        SHOULD(Audio_Stream_Unpause(stream->audio_stream_id));
     }
 }
 
@@ -762,7 +765,8 @@ bool Music_SeekStream(const int32_t slot, const double timestamp)
     if (stream == nullptr || !stream->active || stream->audio_stream_id < 0) {
         return false;
     }
-    return Audio_Stream_SeekTimestamp(stream->audio_stream_id, timestamp);
+    return IGNORE(
+        Audio_Stream_SeekTimestamp(stream->audio_stream_id, timestamp));
 }
 
 bool Music_SeekTrackTimestamp(
@@ -774,8 +778,8 @@ bool Music_SeekTrackTimestamp(
                 || m_OverlayStreams[i].track_id != track_id) {
                 continue;
             }
-            return Audio_Stream_SeekTimestamp(
-                m_OverlayStreams[i].audio_stream_id, timestamp);
+            return IGNORE(Audio_Stream_SeekTimestamp(
+                m_OverlayStreams[i].audio_stream_id, timestamp));
         }
         return false;
     }
@@ -787,7 +791,8 @@ bool Music_SeekTrackTimestamp(
     if (state.track_id != track_id || state.mode != mode) {
         return false;
     }
-    return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
+    return IGNORE(
+        Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp));
 }
 
 MUSIC_ID Music_GetDelayedTrack(void)

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -295,6 +295,15 @@ static int32_t M_PlayOverlayTrack(
     return slot + 1;
 }
 
+// What every call that speaks to the music answers for first.
+static RESULT M_CheckMainStream(void)
+{
+    FAIL_IF(
+        !m_MainStream.active || m_MainStream.audio_stream_id < 0,
+        "no music is playing");
+    return OK;
+}
+
 static bool M_GetMainTrackState(MUSIC_STREAM_STATE *const state)
 {
     if (!m_MainStream.active || state == nullptr) {
@@ -320,7 +329,7 @@ static bool M_GetMainTrackState(MUSIC_STREAM_STATE *const state)
 static void M_SeekMainStream(const double timestamp)
 {
     if (timestamp > 0.0) {
-        Music_SeekTimestamp(timestamp);
+        SHOULD(Music_SeekTimestamp(timestamp));
     }
 }
 
@@ -623,30 +632,22 @@ double Music_GetTimestamp(void)
     return Audio_Stream_GetTimestamp(m_MainStream.audio_stream_id);
 }
 
-bool Music_SeekTimestamp(const double timestamp)
+RESULT Music_SeekTimestamp(const double timestamp)
 {
-    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
-        return false;
-    }
-    return IGNORE(
-        Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp));
+    MUST(M_CheckMainStream());
+    return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 
-bool Music_SetSpeed(const double speed)
+RESULT Music_SetSpeed(const double speed)
 {
-    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
-        return false;
-    }
-    return IGNORE(Audio_Stream_SetSpeed(m_MainStream.audio_stream_id, speed));
+    MUST(M_CheckMainStream());
+    return Audio_Stream_SetSpeed(m_MainStream.audio_stream_id, speed);
 }
 
-bool Music_SyncTimestamp(const double timestamp)
+RESULT Music_SyncTimestamp(const double timestamp)
 {
-    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
-        return false;
-    }
-    return IGNORE(
-        Audio_Stream_SyncTimestamp(m_MainStream.audio_stream_id, timestamp));
+    MUST(M_CheckMainStream());
+    return Audio_Stream_SyncTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 
 int32_t Music_GetStreamCount(void)
@@ -759,17 +760,16 @@ void Music_UnpauseStream(const int32_t slot)
     }
 }
 
-bool Music_SeekStream(const int32_t slot, const double timestamp)
+RESULT Music_SeekStream(const int32_t slot, const double timestamp)
 {
     const M_MUSIC_STREAM *const stream = M_GetStreamBySlot(slot);
-    if (stream == nullptr || !stream->active || stream->audio_stream_id < 0) {
-        return false;
-    }
-    return IGNORE(
-        Audio_Stream_SeekTimestamp(stream->audio_stream_id, timestamp));
+    FAIL_IF(
+        stream == nullptr || !stream->active || stream->audio_stream_id < 0,
+        "slot %d holds no music", slot);
+    return Audio_Stream_SeekTimestamp(stream->audio_stream_id, timestamp);
 }
 
-bool Music_SeekTrackTimestamp(
+RESULT Music_SeekTrackTimestamp(
     const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode, const double timestamp)
 {
     if (mode == MPM_OVERLAY) {
@@ -778,21 +778,18 @@ bool Music_SeekTrackTimestamp(
                 || m_OverlayStreams[i].track_id != track_id) {
                 continue;
             }
-            return IGNORE(Audio_Stream_SeekTimestamp(
-                m_OverlayStreams[i].audio_stream_id, timestamp));
+            return Audio_Stream_SeekTimestamp(
+                m_OverlayStreams[i].audio_stream_id, timestamp);
         }
-        return false;
+        return FAIL("track %d is not playing as an overlay", track_id);
     }
 
     MUSIC_STREAM_STATE state = {};
-    if (!M_GetMainTrackState(&state)) {
-        return false;
-    }
-    if (state.track_id != track_id || state.mode != mode) {
-        return false;
-    }
-    return IGNORE(
-        Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp));
+    FAIL_IF(!M_GetMainTrackState(&state), "no music is playing");
+    FAIL_IF(
+        state.track_id != track_id || state.mode != mode,
+        "track %d is not what the music is playing", track_id);
+    return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 
 MUSIC_ID Music_GetDelayedTrack(void)

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/music/enum.h>
 #include <trx/game/music/ids.h>
 #include <trx/game/music/types.h>
@@ -14,7 +15,9 @@ typedef struct {
     double timestamp;
 } MUSIC_STREAM_STATE;
 
-bool Music_Init(void);
+// Selects a backend and opens the audio device, reporting a device that will
+// not open. A headless run creates the backend without a device.
+RESULT Music_Init(void);
 
 // Stops playing current track and plays a single track.
 //

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -83,15 +83,16 @@ void Music_Unpause(void);
 // Get the current timestamp of the current stream in seconds.
 double Music_GetTimestamp(void);
 
-// Seek to timestamp of current stream.
-bool Music_SeekTimestamp(double timestamp);
+// Seeks the current stream to the given timestamp, reporting a state where no
+// music plays.
+RESULT Music_SeekTimestamp(double timestamp);
 
 // Seeks to the given timestamp if the drift is too big.
-bool Music_SyncTimestamp(double timestamp);
+RESULT Music_SyncTimestamp(double timestamp);
 
 // Play the current track at the given rate, so a sped-up cutscene carries its
 // music with it instead of seeking away from it.
-bool Music_SetSpeed(double speed);
+RESULT Music_SetSpeed(double speed);
 
 // Returns the number of currently active serializable streams.
 int32_t Music_GetStreamCount(void);
@@ -115,12 +116,12 @@ void Music_StopStream(int32_t slot);
 void Music_PauseStream(int32_t slot);
 void Music_UnpauseStream(int32_t slot);
 
-// Seeks the stream in a slot to a timestamp. Returns false when the slot is
-// inactive.
-bool Music_SeekStream(int32_t slot, double timestamp);
+// Seeks the stream in a slot to the given timestamp, reporting a slot that
+// holds no music.
+RESULT Music_SeekStream(int32_t slot, double timestamp);
 
 // Seeks timestamp for the active stream that matches track and mode.
-bool Music_SeekTrackTimestamp(
+RESULT Music_SeekTrackTimestamp(
     MUSIC_ID track, MUSIC_PLAY_MODE mode, double timestamp);
 
 // Returns the delayed track. Ignores looped tracks.

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -362,8 +362,8 @@ static bool M_Image_LoadIntoTexture(
     ASSERT(e != nullptr);
     ASSERT(path != nullptr);
 
-    IMAGE *const img = Image_CreateFromFile(path);
-    if (img == nullptr) {
+    IMAGE *img = nullptr;
+    if (!SHOULD(Image_CreateFromFile(path, &img))) {
         return false;
     }
 

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -234,7 +234,7 @@ static void M_ClearAllActiveSounds(void)
 
 static void M_CloseActiveSound(M_ACTIVE_SOUND *const sound)
 {
-    Audio_Sample_Close(sound->handle);
+    IGNORE(Audio_Sample_Close(sound->handle));
     M_ClearActiveSound(sound);
 }
 
@@ -266,10 +266,11 @@ static void M_ClearSampleMaps(void)
 
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
 {
-    Audio_Sample_SetPan(sound->handle, M_ConvertPanToDecibel(sound->pan));
-    Audio_Sample_SetPitch(sound->handle, M_ConvertPitch(sound->pitch));
-    Audio_Sample_SetVolume(
-        sound->handle, M_ConvertVolumeToDecibel(sound->volume));
+    IGNORE(
+        Audio_Sample_SetPan(sound->handle, M_ConvertPanToDecibel(sound->pan)));
+    IGNORE(Audio_Sample_SetPitch(sound->handle, M_ConvertPitch(sound->pitch)));
+    IGNORE(Audio_Sample_SetVolume(
+        sound->handle, M_ConvertVolumeToDecibel(sound->volume)));
 }
 
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
@@ -303,7 +304,7 @@ static M_ACTIVE_SOUND *M_GetActiveSlot(const int32_t slot)
 static void M_Shutdown(void)
 {
     m_Initialised = false;
-    Audio_Shutdown();
+    IGNORE(Audio_Shutdown());
     M_ClearSampleMaps();
 }
 
@@ -312,11 +313,11 @@ static void M_ApplyConfig(void)
     if (Shell_GetArgs()->headless) {
         return;
     }
-    Sound_Init();
+    SHOULD(Sound_Init());
     Sound_SetMasterVolume(g_Config.audio.sound_volume);
 }
 
-bool Sound_Init(void)
+RESULT Sound_Init(void)
 {
     m_MasterVolume = g_Config.audio.sound_volume;
     m_DecibelLUT[0] = -10000;
@@ -336,17 +337,14 @@ bool Sound_Init(void)
         }
     }
 
-    if (!Audio_Init()) {
-        LOG_ERROR("Failed to initialize libtrx sound system");
-        return false;
-    }
+    MUST(Audio_Init());
 
     m_Initialised = true;
     if (m_SlotHandles.gens == nullptr) {
         Handle_RegistryInit(&m_SlotHandles, m_SlotGens, M_MAX_ACTIVE_SOUNDS);
     }
     M_ClearAllActiveSounds();
-    return true;
+    return OK;
 }
 
 bool Sound_IsInitialised(void)
@@ -374,19 +372,17 @@ void Sound_ResetSamples(void)
     if (!Sound_IsInitialised()) {
         return;
     }
-    Audio_Sample_CloseAll();
-    Audio_Sample_UnloadAll();
+    IGNORE(Audio_Sample_CloseAll());
+    IGNORE(Audio_Sample_UnloadAll());
     M_ClearAllActiveSounds();
     M_ClearSampleMaps();
 }
 
-bool Sound_LoadSampleData(
+RESULT Sound_LoadSampleData(
     const int32_t sample_data_id, const char *const sample_data,
     const size_t size)
 {
-    if (!Sound_IsInitialised()) {
-        return false;
-    }
+    FAIL_IF(!Sound_IsInitialised(), "the sound system is not up");
     return Audio_Sample_Load(sample_data_id, sample_data, size);
 }
 
@@ -702,12 +698,12 @@ void Sound_UpdateEffects(void)
 
 void Sound_PauseAll(void)
 {
-    Audio_Sample_PauseAll();
+    IGNORE(Audio_Sample_PauseAll());
 }
 
 void Sound_UnpauseAll(void)
 {
-    Audio_Sample_UnpauseAll();
+    IGNORE(Audio_Sample_UnpauseAll());
 }
 
 void Sound_StopAll(void)
@@ -715,7 +711,7 @@ void Sound_StopAll(void)
     if (!Sound_IsInitialised()) {
         return;
     }
-    Audio_Sample_CloseAll();
+    IGNORE(Audio_Sample_CloseAll());
     M_ClearAllActiveSounds();
 }
 
@@ -762,7 +758,7 @@ void Sound_PauseActiveSlot(const int32_t slot)
 {
     const M_ACTIVE_SOUND *const sound = M_GetActiveSlot(slot);
     if (sound != nullptr) {
-        Audio_Sample_Pause(sound->handle);
+        IGNORE(Audio_Sample_Pause(sound->handle));
     }
 }
 
@@ -770,7 +766,7 @@ void Sound_UnpauseActiveSlot(const int32_t slot)
 {
     const M_ACTIVE_SOUND *const sound = M_GetActiveSlot(slot);
     if (sound != nullptr) {
-        Audio_Sample_Unpause(sound->handle);
+        IGNORE(Audio_Sample_Unpause(sound->handle));
     }
 }
 

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -6,6 +6,7 @@
 #include <trx/core/math/geom.h>
 #include <trx/core/memory.h>
 #include <trx/core/subsystem.h>
+#include <trx/core/utils.h>
 #include <trx/game/camera.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/lara.h>
@@ -460,6 +461,34 @@ bool Sound_IsAvailable(const SAMPLE_TRX_ID sample_id)
 
 // Get the maximum direct SAMPLE_ID loaded for playback.
 // Returns SFX_INVALID if no samples are available.
+RESULT Sound_CheckSamples(void)
+{
+    RESULT result = OK;
+    const SAMPLE_ID max_id = Sound_GetMaxDirectSampleID();
+    for (SAMPLE_ID sample_id = 0; sample_id <= max_id; sample_id++) {
+        const SAMPLE_INFO *const sample = Sound_GetSample(sample_id);
+        if (sample == nullptr) {
+            continue;
+        }
+        if (sample->number < 0) {
+            result = Result_Merge(
+                result, FAIL("sample %d names no audio", sample_id));
+            continue;
+        }
+        for (int32_t i = 0; i < MAX(sample->flags.num_samples, 1); i++) {
+            if (!Audio_Sample_IsLoaded(sample->number + i)) {
+                result = Result_Merge(
+                    result,
+                    FAIL(
+                        "sample %d names audio %d, which the level does not "
+                        "carry",
+                        sample_id, sample->number + i));
+            }
+        }
+    }
+    return result;
+}
+
 SAMPLE_ID Sound_GetMaxDirectSampleID(void)
 {
     M_SAMPLE_ENTRY *entry, *tmp;

--- a/src/trx/game/sound/common.h
+++ b/src/trx/game/sound/common.h
@@ -50,6 +50,11 @@ bool Sound_IsAvailable(SAMPLE_TRX_ID sample_id);
 // Returns SFX_INVALID if no samples are available.
 SAMPLE_ID Sound_GetMaxDirectSampleID(void);
 
+// Reports each sample that the level declares without audio. Such samples
+// play silently, and the play call cannot report them because it runs every
+// frame, so this function reports them at the end of the level load.
+RESULT Sound_CheckSamples(void);
+
 // Play a sample with the given number. pos is an optional world position to
 // play the sound at, and can be nullptr. Returns the active-sound slot the
 // sample plays in, or -1 when it does not play.

--- a/src/trx/game/sound/common.h
+++ b/src/trx/game/sound/common.h
@@ -2,6 +2,7 @@
 
 #include <trx/core/handle.h>
 #include <trx/core/math.h>
+#include <trx/core/result.h>
 #include <trx/game/sound/enum.h>
 #include <trx/game/sound/ids.h>
 #include <trx/game/sound/types.h>
@@ -11,7 +12,9 @@
 
 #define SOUND_DEFAULT_PITCH 0x10000
 
-bool Sound_Init(void);
+// Starts the sound system and opens the audio device, reporting a device that
+// will not open.
+RESULT Sound_Init(void);
 bool Sound_IsInitialised(void);
 
 void Sound_SetMasterVolume(float volume);
@@ -20,7 +23,7 @@ void Sound_SetReverbType(uint8_t reverb_type);
 
 void Sound_ResetSamples(void);
 
-bool Sound_LoadSampleData(
+RESULT Sound_LoadSampleData(
     int32_t sample_data_id, const char *sample_data, size_t size);
 
 void Sound_InitialiseSources(int32_t num_sources);

--- a/src/trx/gl/renderer.c
+++ b/src/trx/gl/renderer.c
@@ -185,8 +185,8 @@ static void M_Render(TRX_GL_RENDERER *renderer)
 
     if (TRX_GL_Context_GetScheduledScreenshotPath() != nullptr) {
         TRX_GL_Context_SwitchToViewport(VIEWPORT_TARGET);
-        TRX_GL_Screenshot_CaptureToFile(
-            TRX_GL_Context_GetScheduledScreenshotPath());
+        SHOULD(TRX_GL_Screenshot_CaptureToFile(
+            TRX_GL_Context_GetScheduledScreenshotPath()));
         TRX_GL_Context_ClearScheduledScreenshotPath();
     }
 }

--- a/src/trx/gl/screenshot.c
+++ b/src/trx/gl/screenshot.c
@@ -7,10 +7,8 @@
 
 #include <string.h>
 
-bool TRX_GL_Screenshot_CaptureToFile(const char *path)
+RESULT TRX_GL_Screenshot_CaptureToFile(const char *path)
 {
-    bool ret = false;
-
     GLint width;
     GLint height;
     TRX_GL_Screenshot_CaptureToBuffer(
@@ -23,12 +21,12 @@ bool TRX_GL_Screenshot_CaptureToFile(const char *path)
         (uint8_t *)image->data, &width, &height, 3, GL_RGB, GL_UNSIGNED_BYTE,
         true);
 
-    ret = Image_SaveToFile(image, path);
+    const RESULT result = Image_SaveToFile(image, path);
 
     if (image) {
         Image_Free(image);
     }
-    return ret;
+    return result;
 }
 
 void TRX_GL_Screenshot_CaptureToBuffer(

--- a/src/trx/gl/screenshot.h
+++ b/src/trx/gl/screenshot.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <trx/core/result.h>
+
 #include <GL/glew.h>
 #include <stdint.h>
 
-bool TRX_GL_Screenshot_CaptureToFile(const char *path);
+// Writes the contents of the viewport to an image file, reporting a path it
+// cannot write.
+RESULT TRX_GL_Screenshot_CaptureToFile(const char *path);
 
 void TRX_GL_Screenshot_CaptureToBuffer(
     uint8_t *out_buffer, GLint *out_width, GLint *out_height, GLint depth,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The av layer and the music and sound modules above it now return a `RESULT` instead of a bool, so a failure carries its cause to the caller rather than leaving it in the log. A music track that did not start, an FMV that did not play, a level background that is missing, and a screenshot that was not written now each say why, and the reason names the file or the track it belongs to.

```c
RESULT Audio_Stream_CreateFromFile(const char *path, int32_t *out_sound_id);
RESULT Image_CreateFromFile(const char *path, IMAGE **out_image);
RESULT Video_Open(const char *path, VIDEO **out_video);
RESULT Music_SeekTimestamp(double timestamp);
RESULT Sound_CheckSamples(void);
```

Queries keep their bool, because they state a fact: whether the audio is muted, whether a stream loops, whether a sample plays. Creation calls that returned a bare pointer now return it through an out parameter.

For mod authors, a level that completes its load reports which of its declared sounds have no audio, and names each sample. Those sounds stay silent and the level plays as before. Nothing changes for players, and Lua still gets a boolean from the music seek functions.
