### PR TITLE
Complete the values a setting takes in /set

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Added the `/outfit` console command, which shows or changes what Lara is wearing (TRX1070)
 - Added the `/golden` console command, which casts Lara in gold (TRX1070)
 - Changed the `/flip` console command to take a flip group, so `/flip 3` moves that group alone while `/flip` on its own moves them all (TRX173)
+- Changed the `/set` console command to complete the values a setting accepts, such as its enum values or on and off (TRX1174)
 
 **Weapons and ammunition**
 - Added an option to keep Lara firing the M16/MP5 from her hip while the action key is held, rather than shouldering the gun the moment she stops moving (Gameplay → Controls → M16/MP5 aiming variants) (#3861 / TRX1048)

--- a/src/lua/commands/set.lua
+++ b/src/lua/commands/set.lua
@@ -36,6 +36,33 @@ local function match_options(text)
   return trx.strings.fuzzy_match(text, option_sources())
 end
 
+-- The values the option takes, for completion: on and off for a boolean, the
+-- enum values, and the dash that puts the default back. A setting that holds a
+-- number or a color has no list to offer, so nothing is suggested for it.
+local function value_choices(parsed)
+  if parsed.option == nil then
+    return nil
+  end
+  local matches = match_options(parsed.option)
+  if #matches ~= 1 then
+    return nil
+  end
+  local desc = trx.config.describe(matches[1].value)
+  local out = {}
+  if desc.kind == "boolean" then
+    out[#out + 1] = { key = "on", value = "on" }
+    out[#out + 1] = { key = "off", value = "off" }
+  elseif desc.kind == "enum" or desc.kind == "dynamic_enum" then
+    for _, value in ipairs(desc.values) do
+      out[#out + 1] = { key = display(value), value = display(value) }
+    end
+  else
+    return nil
+  end
+  out[#out + 1] = { key = "-", value = "-" }
+  return out
+end
+
 -- What the option accepts, for the message after a value that would not parse.
 local function valid_values(key)
   local valid = trx.config.accepted_values(key)
@@ -125,9 +152,9 @@ trx.console.register({
   args = function(parser)
     parser:flag("force", { short = "-f", long = "--force" })
     -- The option is matched by run, forgivingly and with its own messages, so
-    -- the parser only suggests the keys for completion.
+    -- the parser suggests the keys and takes the token as it stands.
     parser:positional("option", { optional = true, suggest = option_sources })
-    parser:rest("value", { optional = true })
+    parser:rest("value", { optional = true, suggest = value_choices })
   end,
   run = run,
 })

--- a/src/tests/lua/commands/set.lua
+++ b/src/tests/lua/commands/set.lua
@@ -63,4 +63,25 @@ test("a held setting reports as enforced, and -f writes through", function()
   assert(trx.config.get("visuals.fov") == 90, "the forced write did not land")
 end)
 
+test("an enum option offers its values, spelled with dashes", function()
+  assert(
+    table.concat(fake.complete_args("set", "shadow-type "), ",")
+      == "circle,sprite,extra-dark,-"
+  )
+end)
+
+test("a boolean option offers on and off", function()
+  assert(
+    table.concat(fake.complete_args("set", "enable-music "), ",") == "on,off,-"
+  )
+end)
+
+test("an option with no list of values offers nothing", function()
+  assert(#fake.complete_args("set", "fov ") == 0)
+end)
+
+test("a name that could be several options offers nothing", function()
+  assert(#fake.complete_args("set", "visuals ") == 0)
+end)
+
 return h.report()


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

`/set` now suggests what the setting named on the line accepts: on and off for a boolean, the enum values spelled with dashes, and the dash that puts the default back. Before this, only the setting names completed, so a value had to be typed in full or read from the error message after a wrong guess.

```
/set shadow-type <tab>    circle, sprite, extra-dark, -
/set enable-music <tab>   on, off, -
```

A setting that holds a number or a color has no list to offer, so nothing is suggested for it. The suggestions follow the setting the player has typed, so they only appear once the name matches one setting.

Resolves TRX1174