### PR TITLE
Sort the developer console completions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added the `/golden` console command, which casts Lara in gold (TRX1070)
 - Changed the `/flip` console command to take a flip group, so `/flip 3` moves that group alone while `/flip` on its own moves them all (TRX173)
 - Changed the `/set` console command to complete the values a setting accepts, such as its enum values or on and off (TRX1174)
+- Changed the developer console to sort completions alphabetically, prioritizing those that start with the text typed (TRX1175)
 
 **Weapons and ammunition**
 - Added an option to keep Lara firing the M16/MP5 from her hip while the action key is held, rather than shouldering the gun the moment she stops moving (Gameplay → Controls → M16/MP5 aiming variants) (#3861 / TRX1048)

--- a/src/lua/api/argparse.lua
+++ b/src/lua/api/argparse.lua
@@ -459,9 +459,33 @@ function P:format_error(err)
   return msg
 end
 
--- The keys an argument offers for `active`, best first. An empty `active` offers
--- them all. Both the choices its matchers restrict to and its `suggest` list
--- contribute; a boolean offers on/off without being told to.
+-- Puts the keys in alphabetical order for the completion list. The keys that
+-- start with the typed text come first, and the `-` that puts the default back
+-- comes last. Upper case and lower case letters have the same order, and `Rain`
+-- stays together with `rain`.
+local function sort_candidates(keys, active)
+  local prefix = active:lower()
+  local function has_prefix(key)
+    return key:lower():sub(1, #prefix) == prefix
+  end
+  table.sort(keys, function(a, b)
+    if has_prefix(a) ~= has_prefix(b) then
+      return has_prefix(a)
+    end
+    if (a == "-") ~= (b == "-") then
+      return b == "-"
+    end
+    if a:lower() ~= b:lower() then
+      return a:lower() < b:lower()
+    end
+    return a < b
+  end)
+  return keys
+end
+
+-- The keys an argument offers for `active`, in alphabetical order. An empty
+-- `active` offers them all. Both the choices its matchers restrict to and its
+-- `suggest` list contribute; a boolean offers on/off without being told to.
 local function candidates_for(arg, parsed, active)
   local out = {}
   local seen = {}
@@ -498,7 +522,7 @@ local function candidates_for(arg, parsed, active)
     add(choices)
   end
   add(safe_choices(arg.suggest, parsed))
-  return out
+  return sort_candidates(out, active)
 end
 
 -- The candidates for the token the caret sits in within `text`, best first, and
@@ -551,7 +575,7 @@ function P:complete(text, caret)
         end
       end
     end
-    return out, rstart, rend
+    return sort_candidates(out, prefix), rstart, rend
   end
 
   -- The positionals filled before the active one: non-flag tokens ending at or

--- a/src/tests/lua/api/argparse.lua
+++ b/src/tests/lua/api/argparse.lua
@@ -438,7 +438,7 @@ test(
 
     local out, rstart, rend = p:complete("")
     assert(
-      #out == 2 and out[1] == "uzi",
+      table.concat(out, ",") == "shotgun,uzi",
       "the tail is what an empty line takes"
     )
     assert(rstart == 0 and rend == 0)
@@ -463,6 +463,29 @@ test("a greedy run reaches back over the words already typed", function()
   out, rstart, rend = p:complete("big med")
   assert(#out == 1 and out[1] == "big medipack")
   assert(rstart == 0 and rend == 7, "the whole tail, not the last word alone")
+end)
+
+test("completion sorts the keys the typed text opens to the front", function()
+  local p = trx.argparse.new()
+  p:positional("option", {
+    suggest = { "zzz.ui.zzz", "ui.cc", "aaa.ui.zzz", "ui.aa", "ui.bb" },
+  })
+  assert(
+    table.concat(p:complete("ui."), ",")
+      == "ui.aa,ui.bb,ui.cc,aaa.ui.zzz,zzz.ui.zzz"
+  )
+end)
+
+test("completion sorts a list nothing is typed into", function()
+  local p = trx.argparse.new()
+  p:positional("weather", { choices = { "snow", "rain", "fog" } })
+  assert(table.concat(p:complete(""), ",") == "fog,rain,snow")
+end)
+
+test("completion sorts without regard to case", function()
+  local p = trx.argparse.new()
+  p:positional("level", { suggest = { "bacon", "Angkor", "apple" } })
+  assert(table.concat(p:complete(""), ",") == "Angkor,apple,bacon")
 end)
 
 return h.report()

--- a/src/tests/lua/commands/set.lua
+++ b/src/tests/lua/commands/set.lua
@@ -66,13 +66,13 @@ end)
 test("an enum option offers its values, spelled with dashes", function()
   assert(
     table.concat(fake.complete_args("set", "shadow-type "), ",")
-      == "circle,sprite,extra-dark,-"
+      == "circle,extra-dark,sprite,-"
   )
 end)
 
 test("a boolean option offers on and off", function()
   assert(
-    table.concat(fake.complete_args("set", "enable-music "), ",") == "on,off,-"
+    table.concat(fake.complete_args("set", "enable-music "), ",") == "off,on,-"
   )
 end)
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The console offers completions in alphabetical order, placing those that begin with the typed text first. Case carries no weight.

Resolves TRX1175