### PR TITLE
Keep effects across saves

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own (TRX1070)
 
 **Saves and settings**
+- Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)
 - Changed the save crystal behavior to give Lara a crystal when starting a game, if the mode is set to Saving (pickups), in line with the TR3 PS1 version (Gameplay → General → Crystal mode) (TRX1101)
 - Fixed save crystals activating even while Crystal mode is set to Disabled (Gameplay → General → Crystal mode) (regression from 1.10) (TRX1149)
 

--- a/src/trx/core/json/util/read_io.c
+++ b/src/trx/core/json/util/read_io.c
@@ -357,6 +357,25 @@ RESULT JSON_ReadIO_ReadXYZ32Current(
     return OK;
 }
 
+RESULT JSON_ReadIO_ReadXZ32Current(
+    JSON_READ_IO *const io, void *const target_void)
+{
+    XZ_32 *const target = target_void;
+    JSON_ARRAY *const tuple = JSON_ValueAsArray(io->current);
+    if (tuple != nullptr) {
+        const int32_t tuple_len = tuple->length;
+        if (tuple_len != 2) {
+            return M_Fail(io, "XZ tuple must have exactly 2 values");
+        }
+        MUST(JSON_READ_A(io, 0, &target->x));
+        MUST(JSON_READ_A(io, 1, &target->z));
+    } else {
+        MUST(JSON_READ(io, "x", &target->x));
+        MUST(JSON_READ(io, "z", &target->z));
+    }
+    return OK;
+}
+
 RESULT JSON_ReadIO_ReadXYZ16Current(
     JSON_READ_IO *const io, void *const target_void)
 {

--- a/src/trx/core/json/util/read_io.h
+++ b/src/trx/core/json/util/read_io.h
@@ -29,6 +29,7 @@ typedef struct {
     X(Double, double)                                                          \
     X(XYZ16, XYZ_16)                                                           \
     X(XYZ32, XYZ_32)                                                           \
+    X(XZ32, XZ_32)                                                             \
     X(RGB888, RGB_888)                                                         \
     X(RGBA8888, RGBA_8888)                                                     \
     X(String, const char *)

--- a/src/trx/core/json/util/write_io.c
+++ b/src/trx/core/json/util/write_io.c
@@ -130,6 +130,15 @@ void JSON_WriteIO_PushXYZ16(JSON_WRITE_IO *const io, const XYZ_16 value)
     JSON_WriteIO_PopAndSet(io, "z");
 }
 
+void JSON_WriteIO_PushXZ32(JSON_WRITE_IO *const io, const XZ_32 value)
+{
+    JSON_WriteIO_PushObject(io);
+    JSON_WriteIO_PushInt(io, value.x);
+    JSON_WriteIO_PopAndSet(io, "x");
+    JSON_WriteIO_PushInt(io, value.z);
+    JSON_WriteIO_PopAndSet(io, "z");
+}
+
 void JSON_WriteIO_PushXYZ32(JSON_WRITE_IO *const io, const XYZ_32 value)
 {
     JSON_WriteIO_PushObject(io);

--- a/src/trx/core/json/util/write_io.h
+++ b/src/trx/core/json/util/write_io.h
@@ -37,6 +37,7 @@ void JSON_WriteIO_PushDouble(JSON_WRITE_IO *io, double value);
 void JSON_WriteIO_PushRGB888(JSON_WRITE_IO *io, RGB_888 value);
 void JSON_WriteIO_PushXYZ16(JSON_WRITE_IO *io, XYZ_16 value);
 void JSON_WriteIO_PushXYZ32(JSON_WRITE_IO *io, XYZ_32 value);
+void JSON_WriteIO_PushXZ32(JSON_WRITE_IO *io, XZ_32 value);
 void JSON_WriteIO_PushString(JSON_WRITE_IO *io, const char *value);
 
 #define JSONW_PUSH_OBJECT(io) JSON_WriteIO_PushObject((io))
@@ -62,6 +63,7 @@ void JSON_WriteIO_PushString(JSON_WRITE_IO *io, const char *value);
         RGB_888: JSON_WriteIO_PushRGB888,                                      \
         XYZ_16: JSON_WriteIO_PushXYZ16,                                        \
         XYZ_32: JSON_WriteIO_PushXYZ32,                                        \
+        XZ_32: JSON_WriteIO_PushXZ32,                                          \
         const char *: JSON_WriteIO_PushString,                                 \
         char *: JSON_WriteIO_PushString)(io, value)
 

--- a/src/trx/game/fx/common.c
+++ b/src/trx/game/fx/common.c
@@ -1,5 +1,6 @@
 #include <trx/game/fx/common.h>
 
+#include <trx/config.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/debug.h>
@@ -55,6 +56,10 @@ void FX_Reset(void)
 
 void FX_Save(JSON_WRITE_IO *const io)
 {
+    if (!g_Config.gameplay.enable_enhanced_saves) {
+        return;
+    }
+
     for (int32_t i = 0; i < m_ModuleCount; i++) {
         const FX_MODULE *const module = m_Modules[i];
         if (module->save_func == nullptr) {
@@ -68,6 +73,7 @@ void FX_Save(JSON_WRITE_IO *const io)
 
 RESULT FX_Load(JSON_READ_IO *const io)
 {
+    const bool enabled = g_Config.gameplay.enable_enhanced_saves;
     for (int32_t i = 0; i < m_ModuleCount; i++) {
         const FX_MODULE *const module = m_Modules[i];
         if (module->load_func == nullptr) {
@@ -76,7 +82,7 @@ RESULT FX_Load(JSON_READ_IO *const io)
         if (module->reset_func != nullptr) {
             module->reset_func();
         }
-        if (!JSON_ReadIO_HasKey(io, module->save_key)) {
+        if (!enabled || !JSON_ReadIO_HasKey(io, module->save_key)) {
             continue;
         }
         MUST(JSON_PUSH(io, module->save_key));

--- a/src/trx/game/fx/common.h
+++ b/src/trx/game/fx/common.h
@@ -5,9 +5,8 @@
 typedef struct JSON_READ_IO JSON_READ_IO;
 typedef struct JSON_WRITE_IO JSON_WRITE_IO;
 
-// Lifecycle hooks an effect module takes part in. Every hook is optional.
-// A module that persists across saves fills in save_key together with save
-// and load; its state is written as an object under that key.
+// Defines the optional lifecycle hooks for an effect module. A persistent
+// module sets save_key, save_func and load_func.
 typedef struct {
     void (*new_frame_func)(void);
     void (*control_func)(void);
@@ -32,6 +31,10 @@ void FX_NewFrame(void);
 void FX_Control(void);
 void FX_Draw(void);
 
+// Writes the state of each persistent module, or nothing while the effect
+// saving setting is off.
 void FX_Save(JSON_WRITE_IO *io);
-// Resets every persisting module before applying what the save holds.
+
+// Resets each persistent module before applying what the save holds. While
+// the effect saving setting is off, the reset stands and the save is ignored.
 RESULT FX_Load(JSON_READ_IO *io);

--- a/src/trx/game/fx/droplets.c
+++ b/src/trx/game/fx/droplets.c
@@ -5,6 +5,8 @@
 // fx/water_particles.c, which is the TR3 residue drifting around Lara
 // while she is submerged.
 #include <trx/config.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/game/fx/common.h>
 #include <trx/game/interpolation.h>
@@ -239,10 +241,67 @@ static void M_Draw(void)
     }
 }
 
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_DROPLETS; i++) {
+        const M_DROPLET *const droplet = &m_Droplets[i];
+        if (!droplet->on) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", droplet->pos);
+        JSONW_WRITE(io, "color", droplet->color);
+        JSONW_WRITE(io, "y_vel", droplet->y_vel);
+        JSONW_WRITE(io, "gravity", droplet->gravity);
+        JSONW_WRITE(io, "life", droplet->life);
+        JSONW_WRITE(io, "room_num", droplet->room_num);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "drops");
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    if (!JSON_ReadIO_HasKey(io, "drops")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "drops"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_DROPLETS) {
+            LOG_WARNING(
+                "Malformed save: too many droplets. Extra droplets will be "
+                "ignored.");
+            break;
+        }
+
+        M_DROPLET *const droplet = &m_Droplets[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(JSON_READ(io, "pos", &droplet->pos));
+        MUST(JSON_READ(io, "color", &droplet->color));
+        MUST(JSON_READ(io, "y_vel", &droplet->y_vel));
+        MUST(JSON_READ(io, "gravity", &droplet->gravity));
+        MUST(JSON_READ(io, "life", &droplet->life));
+        MUST(JSON_READ(io, "room_num", &droplet->room_num));
+        MUST(JSON_POP(io));
+        droplet->on = true;
+        droplet->prev_pos = droplet->pos;
+        m_NextDroplet = (i + 1) % M_MAX_DROPLETS;
+    }
+
+    MUST(JSON_POP(io));
+    return OK;
+}
+
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
     .reset_func = M_Reset,
+    .save_key = "droplets",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/fire.c
+++ b/src/trx/game/fx/fire.c
@@ -1,5 +1,7 @@
 #include <trx/game/fx/fire.h>
 
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
 #include <trx/game/fx/common.h>
@@ -382,6 +384,47 @@ static void M_Draw(void)
     }
 }
 
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
+        const SPARK *const spark = &m_Sparks[i];
+        if (!spark->on) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "idx", i);
+        Sparks_SaveSpark(io, spark);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "sparks");
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    if (!JSON_ReadIO_HasKey(io, "sparks")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "sparks"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        MUST(JSON_PUSH_INDEX(io, i));
+        int32_t idx = 0;
+        MUST(JSON_READ(io, "idx", &idx));
+        if (idx < 0 || idx >= M_MAX_SPARKS) {
+            return JSON_ReadIO_Fail(io, "spark slot #%d is not there", idx);
+        }
+        SPARK *const spark = &m_Sparks[idx];
+        MUST(Sparks_LoadSpark(io, spark));
+        MUST(JSON_POP(io));
+        spark->on = true;
+    }
+
+    MUST(JSON_POP(io));
+    return OK;
+}
+
 void FX_Fire_Add(
     const XYZ_32 pos, const int32_t size, const int16_t room_num,
     const int32_t fade)
@@ -408,6 +451,9 @@ static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
     .reset_func = M_Reset,
+    .save_key = "fire",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/footprint.c
+++ b/src/trx/game/fx/footprint.c
@@ -79,25 +79,14 @@ static int32_t M_GetVertexYOffset(
     return dy;
 }
 
-static bool M_HasActivePrints(void)
-{
-    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
-        if (m_Priv.prints[i].life != 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
 static void M_Save(JSON_WRITE_IO *const io)
 {
-    if (!M_HasActivePrints()) {
-        return;
-    }
-
     JSONW_PUSH_ARRAY(io);
     for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
         const M_FOOTPRINT *const print = &m_Priv.prints[i];
+        if (print->life == 0) {
+            continue;
+        }
         JSONW_PUSH_OBJECT(io);
         JSONW_WRITE(io, "pos", print->pos);
         JSONW_WRITE(io, "room_num", print->room_num);
@@ -105,7 +94,7 @@ static void M_Save(JSON_WRITE_IO *const io)
         JSONW_WRITE(io, "life", print->life);
         JSONW_POP_AND_APPEND(io);
     }
-    JSONW_POP_AND_SET(io, "prints");
+    JSONW_POP_AND_SET_NZ(io, "prints");
 }
 
 static RESULT M_Load(JSON_READ_IO *const io)
@@ -131,6 +120,7 @@ static RESULT M_Load(JSON_READ_IO *const io)
         MUST(JSON_READ(io, "y_rot", &print->y_rot));
         MUST(JSON_READ(io, "life", &print->life));
         MUST(JSON_POP(io));
+        m_Priv.next_idx = (i + 1) % M_MAX_FOOTPRINTS;
     }
 
     MUST(JSON_POP(io));

--- a/src/trx/game/fx/gun_flash.c
+++ b/src/trx/game/fx/gun_flash.c
@@ -2,6 +2,8 @@
 
 #include <trx/config.h>
 #include <trx/core/colors.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/game/collision.h>
 #include <trx/game/fx/common.h>
@@ -173,6 +175,76 @@ static void M_Draw(void)
     }
 }
 
+static void M_Reset(void)
+{
+    m_Priv = (M_PRIV) {};
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_FLASHES; i++) {
+        const M_GUN_FLASH *const flash = &m_Priv.flashes[i];
+        if (!flash->active) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "owner_item_num", flash->owner_item_num);
+        JSONW_WRITE(io, "room_num", flash->room_num);
+        JSONW_WRITE(io, "lifetime", flash->lifetime);
+        JSONW_WRITE(io, "rot", ((XZ_32) { flash->rot.x, flash->rot.z }));
+        JSONW_WRITE(io, "bite_pos", flash->bite.pos);
+        JSONW_WRITE(io, "bite_mesh_num", flash->bite.mesh_num);
+        JSONW_WRITE(io, "light_pos", flash->light_pos);
+        JSONW_WRITE(
+            io, "flash_object_id", Object_ToGameID(flash->flash_object_id));
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "flashes");
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    if (!JSON_ReadIO_HasKey(io, "flashes")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "flashes"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_FLASHES) {
+            LOG_WARNING(
+                "Malformed save: too many gun flashes. Extra flashes will be "
+                "ignored.");
+            break;
+        }
+
+        M_GUN_FLASH *const flash = &m_Priv.flashes[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(JSON_READ(io, "owner_item_num", &flash->owner_item_num));
+        MUST(JSON_READ(io, "room_num", &flash->room_num));
+        MUST(JSON_READ(io, "lifetime", &flash->lifetime));
+        XZ_32 rot = {};
+        MUST(JSON_READ(io, "rot", &rot));
+        flash->rot = (XZ_16) { rot.x, rot.z };
+        MUST(JSON_READ(io, "bite_pos", &flash->bite.pos));
+        MUST(JSON_READ(io, "bite_mesh_num", &flash->bite.mesh_num));
+        MUST(JSON_READ(io, "light_pos", &flash->light_pos));
+        int32_t game_id = 0;
+        MUST(JSON_READ(io, "flash_object_id", &game_id));
+        flash->flash_object_id = Object_FromGameID(game_id);
+        if (flash->flash_object_id == NO_OBJECT) {
+            return JSON_ReadIO_Fail(io, "unsupported object #%d", game_id);
+        }
+        MUST(JSON_POP(io));
+        flash->active = true;
+        m_Priv.next_idx = (i + 1) % M_MAX_FLASHES;
+    }
+
+    MUST(JSON_POP(io));
+    return OK;
+}
+
 bool FX_GunFlash_Spawn(
     const ITEM *const owner_item, const CREATURE_GUN *const gun)
 {
@@ -198,6 +270,10 @@ bool FX_GunFlash_Spawn(
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
+    .reset_func = M_Reset,
+    .save_key = "gun_flashes",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/laser.c
+++ b/src/trx/game/fx/laser.c
@@ -1,5 +1,7 @@
 #include <trx/game/fx/laser.h>
 
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
 #include <trx/game/fx/common.h>
@@ -113,6 +115,72 @@ static void M_Draw(void)
     }
 }
 
+static void M_Reset(void)
+{
+    m_Priv = (M_PRIV) {};
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_LASERS; i++) {
+        const M_LASER *const laser = &m_Priv.lasers[i];
+        if (!laser->active) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "owner_item_num", laser->owner_item_num);
+        JSONW_WRITE(io, "lifetime", laser->lifetime);
+        JSONW_WRITE(io, "bite_pos", laser->bite.pos);
+        JSONW_WRITE(io, "bite_mesh_num", laser->bite.mesh_num);
+        JSONW_WRITE(
+            io, "color",
+            ((RGB_888) { laser->color.r, laser->color.g, laser->color.b }));
+        JSONW_WRITE(io, "alpha", laser->color.a);
+        JSONW_WRITE(io, "width", laser->width);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "lasers");
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    if (!JSON_ReadIO_HasKey(io, "lasers")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "lasers"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_LASERS) {
+            LOG_WARNING(
+                "Malformed save: too many lasers. Extra lasers will be "
+                "ignored.");
+            break;
+        }
+
+        M_LASER *const laser = &m_Priv.lasers[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(JSON_READ(io, "owner_item_num", &laser->owner_item_num));
+        MUST(JSON_READ(io, "lifetime", &laser->lifetime));
+        MUST(JSON_READ(io, "bite_pos", &laser->bite.pos));
+        MUST(JSON_READ(io, "bite_mesh_num", &laser->bite.mesh_num));
+        RGB_888 color = {};
+        MUST(JSON_READ(io, "color", &color));
+        MUST(JSON_READ(io, "alpha", &laser->color.a));
+        laser->color.r = color.r;
+        laser->color.g = color.g;
+        laser->color.b = color.b;
+        MUST(JSON_READ(io, "width", &laser->width));
+        MUST(JSON_POP(io));
+        laser->active = true;
+        m_Priv.next_idx = (i + 1) % M_MAX_LASERS;
+    }
+
+    MUST(JSON_POP(io));
+    return OK;
+}
+
 bool FX_Laser_Spawn(const ITEM *const owner_item, const CREATURE_GUN *const gun)
 {
     if (owner_item == nullptr || gun == nullptr || !gun->tr3_enemy_flash) {
@@ -134,6 +202,10 @@ bool FX_Laser_Spawn(const ITEM *const owner_item, const CREATURE_GUN *const gun)
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
+    .reset_func = M_Reset,
+    .save_key = "lasers",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/ring.c
+++ b/src/trx/game/fx/ring.c
@@ -378,6 +378,9 @@ static void M_SaveRings(
     JSONW_PUSH_ARRAY(io);
     for (int32_t i = 0; i < M_MAX_RINGS; i++) {
         const FX_RING *const ring = &m_Rings[type][i];
+        if (!ring->on) {
+            continue;
+        }
         JSONW_PUSH_OBJECT(io);
         JSONW_WRITE(io, "on", ring->on);
         JSONW_WRITE(io, "life", ring->life);

--- a/src/trx/game/fx/wake.c
+++ b/src/trx/game/fx/wake.c
@@ -1,5 +1,7 @@
 #include <trx/game/fx/wake.h>
 
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
@@ -58,6 +60,69 @@ static void M_Control(void)
     if (!any_active) {
         m_Active = false;
     }
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_WRITE_NZ(io, "shade", m_Shade);
+    JSONW_WRITE_NZ(io, "start_idx", m_StartIndex);
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_POINTS; i++) {
+        for (int32_t side = 0; side < 2; side++) {
+            const FX_WAKE_POINT *const pt = &m_Points[i][side];
+            if (pt->life == 0) {
+                continue;
+            }
+            JSONW_PUSH_OBJECT(io);
+            JSONW_WRITE(io, "idx", i);
+            JSONW_WRITE(io, "side", side);
+            JSONW_WRITE(io, "life", pt->life);
+            JSONW_WRITE(io, "pos_left", pt->pos[0]);
+            JSONW_WRITE(io, "pos_right", pt->pos[1]);
+            JSONW_WRITE(io, "vel_left", pt->vel[0]);
+            JSONW_WRITE(io, "vel_right", pt->vel[1]);
+            JSONW_POP_AND_APPEND(io);
+        }
+    }
+    JSONW_POP_AND_SET_NZ(io, "points");
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    MUST(JSON_READ_D(io, "shade", &m_Shade, 0));
+    MUST(JSON_READ_D(io, "start_idx", &m_StartIndex, 0));
+
+    if (!JSON_ReadIO_HasKey(io, "points")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "points"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        MUST(JSON_PUSH_INDEX(io, i));
+        int32_t idx = 0;
+        int32_t side = 0;
+        MUST(JSON_READ(io, "idx", &idx));
+        MUST(JSON_READ(io, "side", &side));
+        if (idx < 0 || idx >= M_MAX_POINTS || side < 0 || side > 1) {
+            return JSON_ReadIO_Fail(
+                io, "wake point %d/%d is not there", idx, side);
+        }
+        FX_WAKE_POINT *const pt = &m_Points[idx][side];
+        MUST(JSON_READ(io, "life", &pt->life));
+        MUST(JSON_READ(io, "pos_left", &pt->pos[0]));
+        MUST(JSON_READ(io, "pos_right", &pt->pos[1]));
+        MUST(JSON_READ(io, "vel_left", &pt->vel[0]));
+        MUST(JSON_READ(io, "vel_right", &pt->vel[1]));
+        MUST(JSON_POP(io));
+        pt->prev_pos[0] = pt->pos[0];
+        pt->prev_pos[1] = pt->pos[1];
+        m_Active = true;
+    }
+
+    MUST(JSON_POP(io));
+    return OK;
 }
 
 void FX_Wake_Reset(void)
@@ -220,6 +285,9 @@ void FX_Wake_Draw(const ITEM *const item)
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .reset_func = FX_Wake_Reset,
+    .save_key = "wake",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -1,6 +1,8 @@
 #include <trx/game/fx/water.h>
 
 #include <trx/config.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/utils.h>
 #include <trx/game/fx/common.h>
 #include <trx/game/interpolation.h>
@@ -56,9 +58,7 @@ static void M_RememberSplash(FX_WATER_SPLASH *const splash)
     splash->prev_life = splash->life;
     for (int32_t i = 0; i < 48; i++) {
         FX_WATER_SPLASH_VERT *const v = &splash->v[i];
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
     }
 }
 
@@ -104,13 +104,16 @@ static void M_DrawSplash(const FX_WATER_SPLASH *s)
     for (int32_t i = 0; i < 48; i++) {
         const FX_WATER_SPLASH_VERT *const v = &s->v[i];
         points[i] = (XYZ_32) {
-            .x = s->x
-                + ((do_interp ? (int16_t)LERP(v->prev_wx, v->wx, ratio) : v->wx)
+            .x = s->pos.x
+                + ((do_interp ? (int16_t)LERP(v->prev_pos.x, v->pos.x, ratio)
+                              : v->pos.x)
                    >> 4),
-            .y = s->y
-                + (do_interp ? (int16_t)LERP(v->prev_wy, v->wy, ratio) : v->wy),
-            .z = s->z
-                + ((do_interp ? (int16_t)LERP(v->prev_wz, v->wz, ratio) : v->wz)
+            .y = s->pos.y
+                + (do_interp ? (int16_t)LERP(v->prev_pos.y, v->pos.y, ratio)
+                             : v->pos.y),
+            .z = s->pos.z
+                + ((do_interp ? (int16_t)LERP(v->prev_pos.z, v->pos.z, ratio)
+                              : v->pos.z)
                    >> 4),
         };
     }
@@ -194,10 +197,10 @@ static void M_DrawRipple(const FX_WATER_RIPPLE *r)
     }
 
     const XYZ_32 quad_pos[4] = {
-        { r->x - n, r->y, r->z - n },
-        { r->x + n, r->y, r->z - n },
-        { r->x + n, r->y, r->z + n },
-        { r->x - n, r->y, r->z + n },
+        { r->pos.x - n, r->pos.y, r->pos.z - n },
+        { r->pos.x + n, r->pos.y, r->pos.z - n },
+        { r->pos.x + n, r->pos.y, r->pos.z + n },
+        { r->pos.x - n, r->pos.y, r->pos.z + n },
     };
     const RGBA_8888 quad_color[4] = { color, color, color, color };
     OutputSource_PolyFX_StageSpriteQuadWorldDepth(
@@ -241,32 +244,32 @@ static void M_Control(void)
         bool set = false;
         for (int32_t j = 0; j < 48; j++) {
             FX_WATER_SPLASH_VERT *const v = &splash->v[j];
-            v->wx += v->xv >> 2;
-            v->wy += (int16_t)(v->yv >> 6);
-            v->wz += v->zv >> 2;
-            v->xv -= v->xv >> v->friction;
-            v->zv -= v->zv >> v->friction;
+            v->pos.x += v->vel.x >> 2;
+            v->pos.y += (int16_t)(v->vel.y >> 6);
+            v->pos.z += v->vel.z >> 2;
+            v->vel.x -= v->vel.x >> v->friction;
+            v->vel.z -= v->vel.z >> v->friction;
 
-            if ((v->oxv < 0 && v->xv > v->oxv)
-                || (v->oxv > 0 && v->xv < v->oxv)) {
-                v->xv = v->oxv;
+            if ((v->min_vel.x < 0 && v->vel.x > v->min_vel.x)
+                || (v->min_vel.x > 0 && v->vel.x < v->min_vel.x)) {
+                v->vel.x = v->min_vel.x;
             } else if (
-                (v->ozv < 0 && v->zv > v->ozv)
-                || (v->ozv > 0 && v->zv < v->ozv)) {
-                v->zv = v->ozv;
+                (v->min_vel.z < 0 && v->vel.z > v->min_vel.z)
+                || (v->min_vel.z > 0 && v->vel.z < v->min_vel.z)) {
+                v->vel.z = v->min_vel.z;
             }
 
-            v->yv += (int32_t)v->gravity << 3;
-            CLAMPG(v->yv, 0x10000);
+            v->vel.y += (int32_t)v->gravity << 3;
+            CLAMPG(v->vel.y, 0x10000);
 
-            if (v->wy > 0) {
+            if (v->pos.y > 0) {
                 if (j < 16) {
                     splash->flags |= 4U;
                 } else if (j < 32) {
                     splash->flags |= 8U;
                 }
 
-                v->wy = 0;
+                v->pos.y = 0;
                 set = true;
             }
         }
@@ -305,6 +308,141 @@ static void M_Control(void)
     }
 }
 
+static void M_SaveSplashes(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Splashes); i++) {
+        const FX_WATER_SPLASH *const splash = &m_Splashes[i];
+        if ((splash->flags & 1U) == 0U) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", splash->pos);
+        JSONW_WRITE(io, "flags", splash->flags);
+        JSONW_WRITE(io, "life", splash->life);
+        JSONW_PUSH_ARRAY(io);
+        for (int32_t j = 0; j < (int32_t)ARRAY_SIZE(splash->v); j++) {
+            const FX_WATER_SPLASH_VERT *const v = &splash->v[j];
+            JSONW_PUSH_OBJECT(io);
+            JSONW_WRITE(io, "pos", v->pos);
+            JSONW_WRITE(io, "vel", v->vel);
+            JSONW_WRITE(io, "min_vel", v->min_vel);
+            JSONW_WRITE(io, "friction", v->friction);
+            JSONW_WRITE(io, "gravity", v->gravity);
+            JSONW_POP_AND_APPEND(io);
+        }
+        JSONW_POP_AND_SET(io, "verts");
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "splashes");
+}
+
+static void M_SaveRipples(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
+        const FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
+        if ((ripple->flags & 1U) == 0U) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", ripple->pos);
+        JSONW_WRITE(io, "flags", ripple->flags);
+        JSONW_WRITE(io, "life", ripple->life);
+        JSONW_WRITE(io, "size", ripple->size);
+        JSONW_WRITE(io, "init", ripple->init);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "ripples");
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_WRITE_NZ(io, "splash_count", m_SplashCount);
+    M_SaveSplashes(io);
+    M_SaveRipples(io);
+}
+
+static RESULT M_LoadSplashes(JSON_READ_IO *const io)
+{
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= (int32_t)ARRAY_SIZE(m_Splashes)) {
+            LOG_WARNING(
+                "Malformed save: too many splashes. Extra splashes will be "
+                "ignored.");
+            break;
+        }
+
+        FX_WATER_SPLASH *const splash = &m_Splashes[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(JSON_READ(io, "pos", &splash->pos));
+        MUST(JSON_READ(io, "flags", &splash->flags));
+        MUST(JSON_READ(io, "life", &splash->life));
+        MUST(JSON_PUSH(io, "verts"));
+        const int32_t vert_count = JSON_ARRAY_LEN(io);
+        if (vert_count != (int32_t)ARRAY_SIZE(splash->v)) {
+            return JSON_ReadIO_Fail(
+                io, "a splash holds %d points, not %d", vert_count,
+                (int32_t)ARRAY_SIZE(splash->v));
+        }
+        for (int32_t j = 0; j < vert_count; j++) {
+            FX_WATER_SPLASH_VERT *const v = &splash->v[j];
+            MUST(JSON_PUSH_INDEX(io, j));
+            MUST(JSON_READ(io, "pos", &v->pos));
+            MUST(JSON_READ(io, "vel", &v->vel));
+            MUST(JSON_READ(io, "min_vel", &v->min_vel));
+            MUST(JSON_READ(io, "friction", &v->friction));
+            MUST(JSON_READ(io, "gravity", &v->gravity));
+            MUST(JSON_POP(io));
+        }
+        MUST(JSON_POP(io));
+        MUST(JSON_POP(io));
+        M_RememberSplash(splash);
+    }
+    return OK;
+}
+
+static RESULT M_LoadRipples(JSON_READ_IO *const io)
+{
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= (int32_t)ARRAY_SIZE(m_Ripples)) {
+            LOG_WARNING(
+                "Malformed save: too many ripples. Extra ripples will be "
+                "ignored.");
+            break;
+        }
+
+        FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(JSON_READ(io, "pos", &ripple->pos));
+        MUST(JSON_READ(io, "flags", &ripple->flags));
+        MUST(JSON_READ(io, "life", &ripple->life));
+        MUST(JSON_READ(io, "size", &ripple->size));
+        MUST(JSON_READ(io, "init", &ripple->init));
+        MUST(JSON_POP(io));
+        M_RememberRipple(ripple);
+    }
+    return OK;
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    MUST(JSON_READ_D(io, "splash_count", &m_SplashCount, 0));
+    if (JSON_ReadIO_HasKey(io, "splashes")) {
+        MUST(JSON_PUSH(io, "splashes"));
+        MUST(M_LoadSplashes(io));
+        MUST(JSON_POP(io));
+    }
+    if (JSON_ReadIO_HasKey(io, "ripples")) {
+        MUST(JSON_PUSH(io, "ripples"));
+        MUST(M_LoadRipples(io));
+        MUST(JSON_POP(io));
+    }
+    return OK;
+}
+
 FX_WATER_RIPPLE *FX_Water_SetupRipple(
     const int32_t x, const int32_t y, const int32_t z, int32_t size,
     const bool is_still)
@@ -332,9 +470,9 @@ FX_WATER_RIPPLE *FX_Water_SetupRipple(
     ripple->init = 1U;
     ripple->size = (uint8_t)size;
     ripple->life = (uint8_t)((Random_GetControl() & 0xF) + 48);
-    ripple->x = (Random_GetControl() & 0x7F) + x - 64;
-    ripple->y = y;
-    ripple->z = (Random_GetControl() & 0x7F) + z - 64;
+    ripple->pos.x = (Random_GetControl() & 0x7F) + x - 64;
+    ripple->pos.y = y;
+    ripple->pos.z = (Random_GetControl() & 0x7F) + z - 64;
     M_RememberRipple(ripple);
     return ripple;
 }
@@ -353,8 +491,8 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
 
     if (idx < 0) {
         Sound_Effect(
-            SFX_LARA_SPLASH, &(XYZ_32) { setup.x, setup.y, setup.z },
-            SPM_NORMAL);
+            SFX_LARA_SPLASH,
+            &(XYZ_32) { setup.pos.x, setup.pos.y, setup.pos.z }, SPM_NORMAL);
         return;
     }
 
@@ -366,130 +504,119 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         setup.outer_friction = 9;
     }
 
-    splash->x = setup.x;
-    splash->y = setup.y;
-    splash->z = setup.z;
+    splash->pos.x = setup.pos.x;
+    splash->pos.y = setup.pos.y;
+    splash->pos.z = setup.pos.z;
     splash->life = 63U;
 
     FX_WATER_SPLASH_VERT *v = splash->v;
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx = (setup.inner_xz_off * m_SplashRings[i][0]) * 2;
-        v->wy = 0;
-        v->wz = (setup.inner_xz_off * m_SplashRings[i][1]) * 2;
-        v->xv = (setup.inner_xz_vel * m_SplashRings[i][0]) / 12;
-        v->yv = 0;
-        v->zv = (setup.inner_xz_vel * m_SplashRings[i][1]) / 12;
-        v->oxv = v->xv >> 3;
-        v->ozv = v->zv >> 3;
+        v->pos.x = (setup.inner_xz_off * m_SplashRings[i][0]) * 2;
+        v->pos.y = 0;
+        v->pos.z = (setup.inner_xz_off * m_SplashRings[i][1]) * 2;
+        v->vel.x = (setup.inner_xz_vel * m_SplashRings[i][0]) / 12;
+        v->vel.y = 0;
+        v->vel.z = (setup.inner_xz_vel * m_SplashRings[i][1]) / 12;
+        v->min_vel.x = v->vel.x >> 3;
+        v->min_vel.z = v->vel.z >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)(setup.inner_friction - 2);
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
         v++;
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx =
+        v->pos.x =
             ((setup.inner_xz_off + setup.inner_xz_size) * m_SplashRings[i][0])
             * 2;
-        v->wy = setup.inner_y_size;
-        v->wz =
+        v->pos.y = setup.inner_y_size;
+        v->pos.z =
             ((setup.inner_xz_off + setup.inner_xz_size) * m_SplashRings[i][1])
             * 2;
-        v->xv = (setup.inner_xz_vel * m_SplashRings[i][0]) >> 3;
-        v->yv = setup.inner_y_vel;
-        v->zv = (setup.inner_xz_vel * m_SplashRings[i][1]) >> 3;
-        v->oxv = v->xv >> 3;
-        v->ozv = v->zv >> 3;
+        v->vel.x = (setup.inner_xz_vel * m_SplashRings[i][0]) >> 3;
+        v->vel.y = setup.inner_y_vel;
+        v->vel.z = (setup.inner_xz_vel * m_SplashRings[i][1]) >> 3;
+        v->min_vel.x = v->vel.x >> 3;
+        v->min_vel.z = v->vel.z >> 3;
         v->gravity = (uint8_t)setup.inner_gravity;
         v->friction = (uint8_t)setup.inner_friction;
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
         v++;
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx = (setup.middle_xz_off * m_SplashRings[i][0]) * 2;
-        v->wy = 0;
-        v->wz = (setup.middle_xz_off * m_SplashRings[i][1]) * 2;
-        v->xv = (setup.middle_xz_vel * m_SplashRings[i][0]) / 12;
-        v->yv = 0;
-        v->zv = (setup.middle_xz_vel * m_SplashRings[i][1]) / 12;
-        v->oxv = v->xv >> 3;
-        v->ozv = v->zv >> 3;
+        v->pos.x = (setup.middle_xz_off * m_SplashRings[i][0]) * 2;
+        v->pos.y = 0;
+        v->pos.z = (setup.middle_xz_off * m_SplashRings[i][1]) * 2;
+        v->vel.x = (setup.middle_xz_vel * m_SplashRings[i][0]) / 12;
+        v->vel.y = 0;
+        v->vel.z = (setup.middle_xz_vel * m_SplashRings[i][1]) / 12;
+        v->min_vel.x = v->vel.x >> 3;
+        v->min_vel.z = v->vel.z >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)(setup.middle_friction - 2);
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
         v++;
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx =
+        v->pos.x =
             ((setup.middle_xz_off + setup.middle_xz_size) * m_SplashRings[i][0])
             * 2;
-        v->wy = setup.middle_y_size;
-        v->wz =
+        v->pos.y = setup.middle_y_size;
+        v->pos.z =
             ((setup.middle_xz_off + setup.middle_xz_size) * m_SplashRings[i][1])
             * 2;
-        v->xv = (setup.middle_xz_vel * m_SplashRings[i][0]) >> 3;
-        v->yv = setup.middle_y_vel;
-        v->zv = (setup.middle_xz_vel * m_SplashRings[i][1]) >> 3;
-        v->oxv = v->xv >> 3;
-        v->ozv = v->zv >> 3;
+        v->vel.x = (setup.middle_xz_vel * m_SplashRings[i][0]) >> 3;
+        v->vel.y = setup.middle_y_vel;
+        v->vel.z = (setup.middle_xz_vel * m_SplashRings[i][1]) >> 3;
+        v->min_vel.x = v->vel.x >> 3;
+        v->min_vel.z = v->vel.z >> 3;
         v->gravity = (uint8_t)setup.middle_gravity;
         v->friction = (uint8_t)setup.middle_friction;
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
         v++;
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx = (setup.outer_xz_off * m_SplashRings[i][0]) * 2;
-        v->wy = 0;
-        v->wz = (setup.outer_xz_off * m_SplashRings[i][1]) * 2;
-        v->xv = (setup.outer_xz_vel * m_SplashRings[i][0]) / 12;
-        v->yv = 0;
-        v->zv = (setup.outer_xz_vel * m_SplashRings[i][1]) / 12;
-        v->oxv = v->xv >> 3;
-        v->ozv = v->zv >> 3;
+        v->pos.x = (setup.outer_xz_off * m_SplashRings[i][0]) * 2;
+        v->pos.y = 0;
+        v->pos.z = (setup.outer_xz_off * m_SplashRings[i][1]) * 2;
+        v->vel.x = (setup.outer_xz_vel * m_SplashRings[i][0]) / 12;
+        v->vel.y = 0;
+        v->vel.z = (setup.outer_xz_vel * m_SplashRings[i][1]) / 12;
+        v->min_vel.x = v->vel.x >> 3;
+        v->min_vel.z = v->vel.z >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)(setup.outer_friction - 2);
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
         v++;
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx =
+        v->pos.x =
             ((setup.outer_xz_off + setup.outer_xz_size) * m_SplashRings[i][0])
             * 2;
-        v->wy = 0;
-        v->wz =
+        v->pos.y = 0;
+        v->pos.z =
             ((setup.outer_xz_off + setup.outer_xz_size) * m_SplashRings[i][1])
             * 2;
-        v->xv = (setup.outer_xz_vel * m_SplashRings[i][0]) >> 3;
-        v->yv = 0;
-        v->zv = (setup.outer_xz_vel * m_SplashRings[i][1]) >> 3;
-        v->oxv = v->xv >> 3;
-        v->ozv = v->zv >> 3;
+        v->vel.x = (setup.outer_xz_vel * m_SplashRings[i][0]) >> 3;
+        v->vel.y = 0;
+        v->vel.z = (setup.outer_xz_vel * m_SplashRings[i][1]) >> 3;
+        v->min_vel.x = v->vel.x >> 3;
+        v->min_vel.z = v->vel.z >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)setup.outer_friction;
-        v->prev_wx = v->wx;
-        v->prev_wy = v->wy;
-        v->prev_wz = v->wz;
+        v->prev_pos = v->pos;
         v++;
     }
     splash->prev_life = splash->life;
 
     Sound_Effect(
-        SFX_LARA_SPLASH, &(XYZ_32) { setup.x, setup.y, setup.z }, SPM_NORMAL);
+        SFX_LARA_SPLASH, &(XYZ_32) { setup.pos.x, setup.pos.y, setup.pos.z },
+        SPM_NORMAL);
 }
 
 void FX_Water_Splash(const ITEM *const item)
@@ -502,9 +629,7 @@ void FX_Water_Splash(const ITEM *const item)
 
     const int32_t water_height = Room_GetWaterHeight(item->pos, room_num);
     FX_WATER_SPLASH_SETUP setup = {
-        .x = item->pos.x,
-        .y = water_height,
-        .z = item->pos.z,
+        .pos = { .x = item->pos.x, .y = water_height, .z = item->pos.z },
         .inner_xz_off = 32,
         .inner_xz_size = 8,
         .inner_y_size = -128,
@@ -557,9 +682,7 @@ void FX_Water_WadeSplash(const ITEM *const item, const int32_t depth)
     const int32_t time4 = Output_GetTimeInGame() * 4;
     if (item->fall_speed > 0 && depth < 474 && m_SplashCount == 0) {
         const FX_WATER_SPLASH_SETUP setup = {
-            .x = item->pos.x,
-            .y = water_height,
-            .z = item->pos.z,
+            .pos = { .x = item->pos.x, .y = water_height, .z = item->pos.z },
             .inner_xz_off = 16,
             .inner_xz_size = 12,
             .inner_y_size = -96,
@@ -610,9 +733,9 @@ void FX_Water_TriggerUnderwaterBlood(const XYZ_32 pos, const int32_t size)
     ripple->init = 1U;
     ripple->life = (Random_GetControl() & 7) - 16;
     ripple->size = size;
-    ripple->x = pos.x + (Random_GetControl() & 0x3F) - 32;
-    ripple->y = pos.y;
-    ripple->z = pos.z + (Random_GetControl() & 0x3F) - 32;
+    ripple->pos.x = pos.x + (Random_GetControl() & 0x3F) - 32;
+    ripple->pos.y = pos.y;
+    ripple->pos.z = pos.z + (Random_GetControl() & 0x3F) - 32;
     M_RememberRipple(ripple);
 }
 
@@ -634,9 +757,9 @@ void FX_Water_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
     ripple->init = 1U;
     ripple->life = (Random_GetDraw() & 7) - 16;
     ripple->size = size;
-    ripple->x = pos.x + (Random_GetDraw() & 0x3F) - 32;
-    ripple->y = pos.y;
-    ripple->z = pos.z + (Random_GetDraw() & 0x3F) - 32;
+    ripple->pos.x = pos.x + (Random_GetDraw() & 0x3F) - 32;
+    ripple->pos.y = pos.y;
+    ripple->pos.z = pos.z + (Random_GetDraw() & 0x3F) - 32;
     M_RememberRipple(ripple);
 }
 
@@ -644,6 +767,9 @@ static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
     .reset_func = M_Reset,
+    .save_key = "water",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/water.h
+++ b/src/trx/game/fx/water.h
@@ -1,14 +1,13 @@
 #pragma once
 
+#include <trx/core/math/types.h>
 #include <trx/game/items/types.h>
 #include <trx/game/types.h>
 
 #include <stdint.h>
 
 typedef struct {
-    int32_t x;
-    int32_t y;
-    int32_t z;
+    XYZ_32 pos;
     int32_t prev_size;
     int32_t prev_life;
     int32_t prev_init;
@@ -19,25 +18,17 @@ typedef struct {
 } FX_WATER_RIPPLE;
 
 typedef struct {
-    int16_t wx;
-    int16_t wy;
-    int16_t wz;
-    int16_t prev_wx;
-    int16_t prev_wy;
-    int16_t prev_wz;
-    int16_t xv;
-    int32_t yv;
-    int16_t zv;
-    int16_t oxv;
-    int16_t ozv;
+    XYZ_16 pos;
+    XYZ_16 prev_pos;
+    XYZ_32 vel;
+    // Gives the speed that friction decays the point toward.
+    XZ_32 min_vel;
     uint8_t friction;
     uint8_t gravity;
 } FX_WATER_SPLASH_VERT;
 
 typedef struct {
-    int32_t x;
-    int32_t y;
-    int32_t z;
+    XYZ_32 pos;
     int32_t prev_life;
     uint8_t flags;
     uint8_t life;
@@ -46,9 +37,7 @@ typedef struct {
 } FX_WATER_SPLASH;
 
 typedef struct {
-    int32_t x;
-    int32_t y;
-    int32_t z;
+    XYZ_32 pos;
     int16_t inner_xz_off;
     int16_t inner_xz_size;
     int16_t inner_y_size;

--- a/src/trx/game/fx/water_particles.c
+++ b/src/trx/game/fx/water_particles.c
@@ -2,6 +2,8 @@
 // submerged. The droplets falling off her once she is out of the water are
 // fx/droplets.c.
 #include <trx/config.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/fx/common.h>
@@ -32,9 +34,7 @@ typedef struct {
     XYZ_32 pos;
     XYZ_32 prev_pos;
     uint8_t life;
-    uint8_t yv;
-    int8_t xv;
-    int8_t zv;
+    XYZ_32 vel;
 } M_WATER_PARTICLE;
 
 static M_WATER_PARTICLE m_WaterParticles[M_MAX_WATER_PARTICLES];
@@ -85,15 +85,15 @@ static void M_Spawn(M_WATER_PARTICLE *const particle)
     }
 
     particle->life = (uint8_t)((Random_GetDraw() & 7) + 16);
-    particle->xv = (int8_t)(Random_GetDraw() & 3);
-    if (particle->xv == 2) {
-        particle->xv = -1;
+    particle->vel.x = Random_GetDraw() & 3;
+    if (particle->vel.x == 2) {
+        particle->vel.x = -1;
     }
 
-    particle->yv = (uint8_t)(((Random_GetDraw() & 7) + 8) << 3);
-    particle->zv = (int8_t)(Random_GetDraw() & 3);
-    if (particle->zv == 2) {
-        particle->zv = -1;
+    particle->vel.y = ((Random_GetDraw() & 7) + 8) << 3;
+    particle->vel.z = Random_GetDraw() & 3;
+    if (particle->vel.z == 2) {
+        particle->vel.z = -1;
     }
 
     particle->prev_pos = particle->pos;
@@ -125,9 +125,9 @@ static void M_Control(void)
         }
 
         particle->prev_pos = particle->pos;
-        particle->pos.x += particle->xv;
-        particle->pos.y += (particle->yv & 0xF8) >> 6;
-        particle->pos.z += particle->zv;
+        particle->pos.x += particle->vel.x;
+        particle->pos.y += (particle->vel.y & 0xF8) >> 6;
+        particle->pos.z += particle->vel.z;
 
         if (particle->life == 0) {
             particle->pos.x = 0;
@@ -135,8 +135,8 @@ static void M_Control(void)
         }
 
         particle->life--;
-        if ((particle->yv & 7) != 7) {
-            particle->yv++;
+        if ((particle->vel.y & 7) != 7) {
+            particle->vel.y++;
         }
     }
 }
@@ -207,13 +207,13 @@ static void M_Draw(void)
         // viewport, so the clamp is applied there and the result taken back
         // into world units - a size in pixels of the rasterized picture would
         // follow the resolution and the supersampling factor.
-        float size = (float)((REF_PERSP * (particle->yv >> 3)) / vpos_z);
+        float size = (float)((REF_PERSP * (particle->vel.y >> 3)) / vpos_z);
         CLAMP(size, M_MIN_SIZE, M_MAX_SIZE);
         size = (size * vpos_z) / (REF_PERSP * M_SIZE_DIV);
 
         uint32_t c;
-        if ((particle->yv & 7) < 7) {
-            c = (uint32_t)(particle->yv & 7);
+        if ((particle->vel.y & 7) < 7) {
+            c = (uint32_t)(particle->vel.y & 7);
         } else if (particle->life > 18) {
             c = 15;
         } else {
@@ -239,10 +239,59 @@ static void M_Draw(void)
     }
 }
 
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_WATER_PARTICLES; i++) {
+        const M_WATER_PARTICLE *const particle = &m_WaterParticles[i];
+        if (particle->life == 0) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", particle->pos);
+        JSONW_WRITE(io, "life", particle->life);
+        JSONW_WRITE(io, "vel", particle->vel);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "particles");
+}
+
+static RESULT M_Load(JSON_READ_IO *const io)
+{
+    if (!JSON_ReadIO_HasKey(io, "particles")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "particles"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_WATER_PARTICLES) {
+            LOG_WARNING(
+                "Malformed save: too many water particles. Extra particles "
+                "will be ignored.");
+            break;
+        }
+
+        M_WATER_PARTICLE *const particle = &m_WaterParticles[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(JSON_READ(io, "pos", &particle->pos));
+        MUST(JSON_READ(io, "life", &particle->life));
+        MUST(JSON_READ(io, "vel", &particle->vel));
+        MUST(JSON_POP(io));
+        particle->prev_pos = particle->pos;
+    }
+
+    MUST(JSON_POP(io));
+    return OK;
+}
+
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
     .reset_func = M_Reset,
+    .save_key = "water_particles",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -42,9 +42,7 @@ typedef struct {
     XYZ_32 pos;
     XYZ_32 prev_pos;
     int32_t prev_yv;
-    int8_t xv;
-    uint8_t yv;
-    int8_t zv;
+    XYZ_32 vel;
     uint8_t life;
 } M_RAINDROP;
 
@@ -54,9 +52,7 @@ typedef struct {
     bool stopped;
     int32_t prev_yv;
     int32_t prev_life;
-    int8_t xv;
-    uint8_t yv;
-    int8_t zv;
+    XYZ_32 vel;
     uint8_t life;
 } M_SNOWFLAKE;
 
@@ -135,13 +131,13 @@ static void M_SpawnRainDrop(M_RAINDROP *const drop)
         return;
     }
 
-    drop->yv =
+    drop->vel.y =
         (uint8_t)((Random_GetDraw() & M_RAIN_YV_RND_MASK) + M_RAIN_BASE_YV);
-    drop->xv = (int8_t)((Random_GetDraw() & 7) - 4);
-    drop->zv = (int8_t)((Random_GetDraw() & 7) - 4);
-    drop->life = (uint8_t)(M_RAIN_LIFE_BASE - ((int32_t)drop->yv << 1));
+    drop->vel.x = (int8_t)((Random_GetDraw() & 7) - 4);
+    drop->vel.z = (int8_t)((Random_GetDraw() & 7) - 4);
+    drop->life = (uint8_t)(M_RAIN_LIFE_BASE - ((int32_t)drop->vel.y << 1));
     drop->prev_pos = drop->pos;
-    drop->prev_yv = drop->yv;
+    drop->prev_yv = drop->vel.y;
 }
 
 static void M_UpdateRain(void)
@@ -164,7 +160,7 @@ static void M_UpdateRain(void)
         }
 
         drop->prev_pos = drop->pos;
-        drop->prev_yv = drop->yv;
+        drop->prev_yv = drop->vel.y;
 
         int16_t room_num = NO_ROOM;
         const int32_t outside =
@@ -178,27 +174,27 @@ static void M_UpdateRain(void)
             continue;
         }
 
-        drop->pos.x += (int32_t)drop->xv + 4 * wind.x;
-        drop->pos.y += (int32_t)drop->yv * 8;
-        drop->pos.z += (int32_t)drop->zv + 4 * wind.z;
+        drop->pos.x += (int32_t)drop->vel.x + 4 * wind.x;
+        drop->pos.y += (int32_t)drop->vel.y * 8;
+        drop->pos.z += (int32_t)drop->vel.z + 4 * wind.z;
 
         int32_t rnd = Random_GetDraw();
         if ((rnd & 3) != 3) {
-            drop->xv += (int8_t)((rnd & 3) - 1);
-            if (drop->xv < -4) {
-                drop->xv = -4;
-            } else if (drop->xv > 4) {
-                drop->xv = 4;
+            drop->vel.x += (int8_t)((rnd & 3) - 1);
+            if (drop->vel.x < -4) {
+                drop->vel.x = -4;
+            } else if (drop->vel.x > 4) {
+                drop->vel.x = 4;
             }
         }
 
         rnd = (rnd >> 2) & 3;
         if (rnd != 3) {
-            drop->zv += (int8_t)(rnd - 1);
-            if (drop->zv < -4) {
-                drop->zv = -4;
-            } else if (drop->zv > 4) {
-                drop->zv = 4;
+            drop->vel.z += (int8_t)(rnd - 1);
+            if (drop->vel.z < -4) {
+                drop->vel.z = -4;
+            } else if (drop->vel.z > 4) {
+                drop->vel.z = 4;
             }
         }
 
@@ -232,8 +228,8 @@ static void M_DrawRain(void)
         }
 
         const int32_t yv = do_interp
-            ? (int32_t)LERP(drop->prev_yv, drop->yv, ratio)
-            : (int32_t)drop->yv;
+            ? (int32_t)LERP(drop->prev_yv, drop->vel.y, ratio)
+            : (int32_t)drop->vel.y;
         const XYZ_32 to = do_interp
             ? (XYZ_32) {
                   .x = (int32_t)LERP(drop->prev_pos.x, drop->pos.x, ratio),
@@ -259,13 +255,13 @@ static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
     }
 
     snow->stopped = false;
-    snow->xv = (int8_t)((Random_GetDraw() & 7) - 4);
-    snow->yv =
+    snow->vel.x = (int8_t)((Random_GetDraw() & 7) - 4);
+    snow->vel.y =
         (uint8_t)(((Random_GetDraw() % M_SNOW_YV_RANGE) + M_SNOW_YV_MIN) * 8);
-    snow->zv = (int8_t)((Random_GetDraw() & 7) - 4);
-    snow->life = (uint8_t)(M_SNOW_LIFE_BASE - ((int32_t)snow->yv << 1));
+    snow->vel.z = (int8_t)((Random_GetDraw() & 7) - 4);
+    snow->life = (uint8_t)(M_SNOW_LIFE_BASE - ((int32_t)snow->vel.y << 1));
     snow->prev_pos = snow->pos;
-    snow->prev_yv = snow->yv;
+    snow->prev_yv = snow->vel.y;
     snow->prev_life = snow->life;
 }
 
@@ -288,7 +284,7 @@ static void M_UpdateSnow(void)
         }
 
         snow->prev_pos = snow->pos;
-        snow->prev_yv = snow->yv;
+        snow->prev_yv = snow->vel.y;
         snow->prev_life = snow->life;
 
         const XYZ_32 old_pos = snow->pos;
@@ -296,9 +292,9 @@ static void M_UpdateSnow(void)
         int16_t room_num = NO_ROOM;
         int32_t outside = 1;
         if (!snow->stopped) {
-            snow->pos.x += snow->xv;
-            snow->pos.y += (snow->yv & 0xF8) >> 2;
-            snow->pos.z += snow->zv;
+            snow->pos.x += snow->vel.x;
+            snow->pos.y += (snow->vel.y & 0xF8) >> 2;
+            snow->pos.z += snow->vel.z;
 
             outside = Room_GetOutsideStatus(snow->pos, &room_num, nullptr);
             if (outside == -3) {
@@ -315,8 +311,8 @@ static void M_UpdateSnow(void)
                 if (snow->life > 16) {
                     snow->life = 16;
                 }
-                if (snow->yv > 16) {
-                    snow->yv -= 16;
+                if (snow->vel.y > 16) {
+                    snow->vel.y -= 16;
                 }
             }
         }
@@ -334,21 +330,21 @@ static void M_UpdateSnow(void)
 
         const XZ_32 wind = Sparks_GetSmokeWind();
 
-        if (snow->xv < (wind.x * 2)) {
-            snow->xv++;
-        } else if (snow->xv > (wind.x * 2)) {
-            snow->xv--;
+        if (snow->vel.x < (wind.x * 2)) {
+            snow->vel.x++;
+        } else if (snow->vel.x > (wind.x * 2)) {
+            snow->vel.x--;
         }
 
-        if (snow->zv < (wind.z * 2)) {
-            snow->zv++;
-        } else if (snow->zv > (wind.z * 2)) {
-            snow->zv--;
+        if (snow->vel.z < (wind.z * 2)) {
+            snow->vel.z++;
+        } else if (snow->vel.z > (wind.z * 2)) {
+            snow->vel.z--;
         }
 
         snow->life -= 2;
-        if ((snow->yv & 7) != 7) {
-            snow->yv++;
+        if ((snow->vel.y & 7) != 7) {
+            snow->vel.y++;
         }
     }
 }
@@ -395,8 +391,8 @@ static void M_DrawSnow(void)
         }
 
         const int32_t yv = do_interp
-            ? (int32_t)LERP(snow->prev_yv, snow->yv, ratio)
-            : (int32_t)snow->yv;
+            ? (int32_t)LERP(snow->prev_yv, snow->vel.y, ratio)
+            : (int32_t)snow->vel.y;
         const int32_t life = do_interp
             ? (int32_t)LERP(snow->prev_life, snow->life, ratio)
             : (int32_t)snow->life;
@@ -455,9 +451,7 @@ static void M_SaveRain(JSON_WRITE_IO *const io)
 
         JSONW_PUSH_OBJECT(io);
         JSONW_WRITE(io, "pos", drop->pos);
-        JSONW_WRITE(io, "xv", drop->xv);
-        JSONW_WRITE(io, "yv", drop->yv);
-        JSONW_WRITE(io, "zv", drop->zv);
+        JSONW_WRITE(io, "vel", drop->vel);
         JSONW_WRITE(io, "life", drop->life);
         JSONW_POP_AND_APPEND(io);
     }
@@ -475,9 +469,7 @@ static void M_SaveSnow(JSON_WRITE_IO *const io)
 
         JSONW_PUSH_OBJECT(io);
         JSONW_WRITE(io, "pos", snow->pos);
-        JSONW_WRITE(io, "xv", snow->xv);
-        JSONW_WRITE(io, "yv", snow->yv);
-        JSONW_WRITE(io, "zv", snow->zv);
+        JSONW_WRITE(io, "vel", snow->vel);
         JSONW_WRITE(io, "life", snow->life);
         JSONW_WRITE(io, "stopped", snow->stopped);
         JSONW_POP_AND_APPEND(io);
@@ -497,6 +489,17 @@ static void M_Save(JSON_WRITE_IO *const io)
     }
 }
 
+static RESULT M_LoadVelocity(JSON_READ_IO *const io, XYZ_32 *const vel)
+{
+    if (JSON_ReadIO_HasKey(io, "vel")) {
+        return JSON_READ(io, "vel", vel);
+    }
+    MUST(JSON_READ(io, "xv", &vel->x));
+    MUST(JSON_READ(io, "yv", &vel->y));
+    MUST(JSON_READ(io, "zv", &vel->z));
+    return OK;
+}
+
 static RESULT M_LoadRain(JSON_READ_IO *const io)
 {
     const int32_t count = JSON_ARRAY_LEN(io);
@@ -511,13 +514,11 @@ static RESULT M_LoadRain(JSON_READ_IO *const io)
         M_RAINDROP *const drop = &m_Raindrops[i];
         MUST(JSON_PUSH_INDEX(io, i));
         MUST(JSON_READ(io, "pos", &drop->pos));
-        MUST(JSON_READ(io, "xv", &drop->xv));
-        MUST(JSON_READ(io, "yv", &drop->yv));
-        MUST(JSON_READ(io, "zv", &drop->zv));
+        MUST(M_LoadVelocity(io, &drop->vel));
         MUST(JSON_READ(io, "life", &drop->life));
         MUST(JSON_POP(io));
         drop->prev_pos = drop->pos;
-        drop->prev_yv = drop->yv;
+        drop->prev_yv = drop->vel.y;
     }
     return OK;
 }
@@ -536,14 +537,12 @@ static RESULT M_LoadSnow(JSON_READ_IO *const io)
         M_SNOWFLAKE *const snow = &m_Snowflakes[i];
         MUST(JSON_PUSH_INDEX(io, i));
         MUST(JSON_READ(io, "pos", &snow->pos));
-        MUST(JSON_READ(io, "xv", &snow->xv));
-        MUST(JSON_READ(io, "yv", &snow->yv));
-        MUST(JSON_READ(io, "zv", &snow->zv));
+        MUST(M_LoadVelocity(io, &snow->vel));
         MUST(JSON_READ(io, "life", &snow->life));
         MUST(JSON_READ(io, "stopped", &snow->stopped));
         MUST(JSON_POP(io));
         snow->prev_pos = snow->pos;
-        snow->prev_yv = snow->yv;
+        snow->prev_yv = snow->vel.y;
         snow->prev_life = snow->life;
     }
     return OK;

--- a/src/trx/game/objects/general/carcass.c
+++ b/src/trx/game/objects/general/carcass.c
@@ -18,9 +18,7 @@ static void M_SpawnSplash(const ITEM *const item)
 {
     const ROOM *const room = Room_Get(item->room_num);
     const FX_WATER_SPLASH_SETUP setup = {
-        .x = item->pos.x,
-        .y = room->max_ceiling,
-        .z = item->pos.z,
+        .pos = { .x = item->pos.x, .y = room->max_ceiling, .z = item->pos.z },
         .inner_xz_off = 16,
         .inner_xz_size = 16,
         .inner_y_size = -96,

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -269,9 +269,9 @@ static void M_Control(const int16_t item_num)
             const int32_t middle_y_vel =
                 -1024 - ((int32_t)item->fall_speed << 4);
             FX_Water_SetupSplash(&(FX_WATER_SPLASH_SETUP) {
-                .x = item->pos.x,
-                .y = new_room->max_ceiling,
-                .z = item->pos.z,
+                .pos = { .x = item->pos.x,
+                         .y = new_room->max_ceiling,
+                         .z = item->pos.z },
                 .inner_xz_off = 16,
                 .inner_xz_size = 12,
                 .inner_y_size = -96,

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -251,9 +251,9 @@ static void M_Control(const int16_t item_num)
             new_room != nullptr && new_room->flags.underwater;
         if (is_underwater && !was_underwater) {
             FX_Water_SetupSplash(&(FX_WATER_SPLASH_SETUP) {
-                .x = item->pos.x,
-                .y = new_room->max_ceiling,
-                .z = item->pos.z,
+                .pos = { .x = item->pos.x,
+                         .y = new_room->max_ceiling,
+                         .z = item->pos.z },
                 .inner_xz_off = 16,
                 .inner_xz_size = 12,
                 .inner_y_size = -96,

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -939,9 +939,7 @@ static void M_KayakSplash(
         return;
     }
     FX_WATER_SPLASH_SETUP splash_setup = {
-        .x = item->pos.x,
-        .y = item->pos.y,
-        .z = item->pos.z,
+        .pos = { .x = item->pos.x, .y = item->pos.y, .z = item->pos.z },
         .inner_xz_off = 128,
         .inner_xz_size = 48,
         .inner_y_size = -384,

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -624,9 +624,7 @@ static void M_Splash(
     const int32_t water_height)
 {
     FX_WATER_SPLASH_SETUP splash_setup = {
-        .x = item->pos.x,
-        .y = water_height,
-        .z = item->pos.z,
+        .pos = { .x = item->pos.x, .y = water_height, .z = item->pos.z },
         .inner_xz_off = 64,
         .inner_xz_size = 48,
         .inner_y_size = -384,

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -8,6 +8,7 @@
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/savegame.h>
+#include <trx/game/sparks/manager.h>
 #include <trx/version.h>
 
 #include <string.h>
@@ -128,6 +129,7 @@ static RESULT M_Load(JSON_READ_IO *const io)
     MUST(SG_File_LoadItems(io));
     MUST(SG_File_LoadEffects(io));
     MUST(SG_File_LoadFX(io));
+    MUST(Sparks_Load(io));
     MUST(SG_File_LoadFlares(io));
     MUST(SG_File_LoadMusic(io));
     MUST(SG_File_LoadLara(io));
@@ -176,6 +178,7 @@ RESULT SG_File_SaveToFile(TRX_FILE *const fp, SAVEGAME_INFO *const info)
     SG_File_DumpItems(io);
     SG_File_DumpEffects(io);
     SG_File_DumpFX(io);
+    Sparks_Save(io);
     SG_File_DumpLara(io);
     SG_File_DumpMusic(io);
     SG_File_DumpFlares(io);

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -25,11 +25,6 @@
 #include <trx/game/savegame/file.h>
 #include <trx/version.h>
 
-typedef struct {
-    int16_t count;
-    int16_t id_map[MAX_EFFECTS];
-} M_FX_ORDER;
-
 static void M_WriteXYZ32(
     JSON_WRITE_IO *const io, const char *const key, const XYZ_32 source)
 {
@@ -94,20 +89,6 @@ static void M_WriteRopeState(JSON_WRITE_IO *const io)
     JSONW_POP_AND_SET(io, "rope_state");
 }
 
-static void M_GetFXOrder(M_FX_ORDER *const order)
-{
-    order->count = 0;
-    for (int32_t i = 0; i < MAX_EFFECTS; i++) {
-        order->id_map[i] = -1;
-    }
-
-    for (int16_t link_num = Effect_GetActiveNum(); link_num != NO_ITEM;
-         link_num = Effect_Get(link_num)->next_active) {
-        order->id_map[link_num] = order->count;
-        order->count++;
-    }
-}
-
 // Global anim indices shift as injections append anims, so persist the owning
 // object and an index relative to it.
 static void M_WriteAnimNum(JSON_WRITE_IO *const io, const int16_t anim_num)
@@ -161,9 +142,7 @@ static uint16_t M_PackItemFlags(const ITEM *const item)
         | (item->is_destroyed ? IF_DESTROYED : 0);
 }
 
-static void M_WriteItem(
-    JSON_WRITE_IO *const io, const ITEM *const item,
-    const M_FX_ORDER *const fx_order)
+static void M_WriteItem(JSON_WRITE_IO *const io, const ITEM *const item)
 {
     JSONW_WRITE(io, "index", Item_GetIndex(item));
     if (item->name != nullptr) {
@@ -404,9 +383,6 @@ void SG_File_DumpFlares(JSON_WRITE_IO *const io)
 
 void SG_File_DumpEffects(JSON_WRITE_IO *const io)
 {
-    M_FX_ORDER fx_order;
-    M_GetFXOrder(&fx_order);
-
     JSONW_PUSH_ARRAY(io);
     for (int16_t link_num = Effect_GetActiveNum(); link_num != NO_ITEM;
          link_num = Effect_Get(link_num)->next_active) {
@@ -529,13 +505,11 @@ void SG_File_DumpMusic(JSON_WRITE_IO *const io)
 void SG_File_DumpItems(JSON_WRITE_IO *const io)
 {
     Savegame_ProcessItemsBeforeSave();
-    M_FX_ORDER fx_order;
-    M_GetFXOrder(&fx_order);
 
     JSONW_PUSH_ARRAY(io);
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         JSONW_PUSH_OBJECT(io);
-        M_WriteItem(io, Item_Get(i), &fx_order);
+        M_WriteItem(io, Item_Get(i));
         JSONW_POP_AND_APPEND(io);
     }
     JSONW_POP_AND_SET(io, "items");

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -1,9 +1,13 @@
 #include <trx/game/sparks/manager.h>
 
 #include <trx/config.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
+#include <trx/game/objects.h>
 #include <trx/game/output/lights.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/random.h>
@@ -139,6 +143,115 @@ static void M_UpdateWind(void)
     m_HairWindZ = 0;
 }
 
+void Sparks_SaveSpark(JSON_WRITE_IO *const io, const SPARK *const spark)
+{
+    JSONW_WRITE(io, "s_life", spark->s_life);
+    JSONW_WRITE(io, "life", spark->life);
+    JSONW_WRITE(io, "pos", spark->pos);
+    JSONW_WRITE(io, "vel", spark->vel);
+    JSONW_WRITE(io, "src_width", spark->src_size.width);
+    JSONW_WRITE(io, "src_height", spark->src_size.height);
+    JSONW_WRITE(io, "dst_width", spark->dst_size.width);
+    JSONW_WRITE(io, "dst_height", spark->dst_size.height);
+    JSONW_WRITE(io, "width", spark->size.width);
+    JSONW_WRITE(io, "height", spark->size.height);
+    JSONW_WRITE(io, "src_color", spark->src_color);
+    JSONW_WRITE(io, "dst_color", spark->dst_color);
+    JSONW_WRITE(io, "color", spark->color);
+    JSONW_WRITE(io, "scalar", spark->scalar);
+    JSONW_WRITE(io, "col_fade_speed", spark->col_fade_speed);
+    JSONW_WRITE(io, "fade_to_black", spark->fade_to_black);
+    JSONW_WRITE(io, "gravity", spark->gravity);
+    JSONW_WRITE(io, "max_y_vel", spark->max_y_vel);
+    JSONW_WRITE(io, "friction", spark->friction);
+    JSONW_WRITE(io, "flags", spark->flags);
+    JSONW_WRITE(io, "room_num", spark->room_num);
+    JSONW_WRITE(io, "node_num", spark->node_num);
+    JSONW_WRITE(io, "extras", spark->extras);
+    JSONW_WRITE(io, "dynamic", spark->dynamic);
+    JSONW_WRITE(io, "rot_angle", spark->rot_angle);
+    JSONW_WRITE(io, "rot_add", spark->rot_add);
+    JSONW_WRITE(io, "draw_type", (int32_t)spark->draw_type);
+
+    if ((spark->flags & SPARK_F_SPRITE) != 0U) {
+        const OBJECT *const obj = Object_Get(spark->sprite_obj_id);
+        JSONW_WRITE(io, "sprite_obj_id", Object_ToGameID(spark->sprite_obj_id));
+        JSONW_WRITE(io, "sprite_offset", spark->sprite_idx - obj->mesh_idx);
+    }
+
+    if ((spark->flags & SPARK_F_ITEM) != 0U) {
+        JSONW_WRITE(io, "item_num", spark->item_num);
+    } else if ((spark->flags & SPARK_F_FX) != 0U) {
+        JSONW_WRITE(io, "effect_num", Effect_GetInOrderNum(spark->effect_num));
+    }
+}
+
+RESULT Sparks_LoadSpark(JSON_READ_IO *const io, SPARK *const spark)
+{
+    MUST(JSON_READ(io, "s_life", &spark->s_life));
+    MUST(JSON_READ(io, "life", &spark->life));
+    MUST(JSON_READ(io, "pos", &spark->pos));
+    MUST(JSON_READ(io, "vel", &spark->vel));
+    MUST(JSON_READ(io, "src_width", &spark->src_size.width));
+    MUST(JSON_READ(io, "src_height", &spark->src_size.height));
+    MUST(JSON_READ(io, "dst_width", &spark->dst_size.width));
+    MUST(JSON_READ(io, "dst_height", &spark->dst_size.height));
+    MUST(JSON_READ(io, "width", &spark->size.width));
+    MUST(JSON_READ(io, "height", &spark->size.height));
+    MUST(JSON_READ(io, "src_color", &spark->src_color));
+    MUST(JSON_READ(io, "dst_color", &spark->dst_color));
+    MUST(JSON_READ(io, "color", &spark->color));
+    MUST(JSON_READ(io, "scalar", &spark->scalar));
+    MUST(JSON_READ(io, "col_fade_speed", &spark->col_fade_speed));
+    MUST(JSON_READ(io, "fade_to_black", &spark->fade_to_black));
+    MUST(JSON_READ(io, "gravity", &spark->gravity));
+    MUST(JSON_READ(io, "max_y_vel", &spark->max_y_vel));
+    MUST(JSON_READ(io, "friction", &spark->friction));
+    MUST(JSON_READ(io, "flags", &spark->flags));
+    MUST(JSON_READ(io, "room_num", &spark->room_num));
+    MUST(JSON_READ(io, "node_num", &spark->node_num));
+    MUST(JSON_READ(io, "extras", &spark->extras));
+    MUST(JSON_READ(io, "dynamic", &spark->dynamic));
+    MUST(JSON_READ(io, "rot_angle", &spark->rot_angle));
+    MUST(JSON_READ(io, "rot_add", &spark->rot_add));
+
+    int32_t draw_type = 0;
+    MUST(JSON_READ(io, "draw_type", &draw_type));
+    spark->draw_type = (DRAW_TYPE)draw_type;
+
+    spark->sprite_obj_id = NO_OBJECT;
+    spark->sprite_idx = 0;
+    if ((spark->flags & SPARK_F_SPRITE) != 0U) {
+        int32_t game_id = 0;
+        int32_t sprite_offset = 0;
+        MUST(JSON_READ(io, "sprite_obj_id", &game_id));
+        MUST(JSON_READ(io, "sprite_offset", &sprite_offset));
+        spark->sprite_obj_id = Object_FromGameID(game_id);
+        if (spark->sprite_obj_id == NO_OBJECT) {
+            return JSON_ReadIO_Fail(io, "unsupported object #%d", game_id);
+        }
+        const OBJECT *const obj = Object_Get(spark->sprite_obj_id);
+        if (!obj->loaded || sprite_offset < 0
+            || sprite_offset >= ABS(obj->mesh_count)) {
+            return JSON_ReadIO_Fail(
+                io, "sprite #%d is not in object #%d", sprite_offset, game_id);
+        }
+        spark->sprite_idx = obj->mesh_idx + sprite_offset;
+    }
+
+    if ((spark->flags & SPARK_F_ITEM) != 0U) {
+        MUST(JSON_READ(io, "item_num", &spark->item_num));
+    } else if ((spark->flags & SPARK_F_FX) != 0U) {
+        MUST(JSON_READ(io, "effect_num", &spark->effect_num));
+        if (Effect_GetInOrderNum(spark->effect_num) == NO_EFFECT) {
+            return JSON_ReadIO_Fail(
+                io, "no effect #%d to attach to", spark->effect_num);
+        }
+    }
+
+    return OK;
+}
+
 XYZ_32 Sparks_GetWorldPos(const SPARK *const spark)
 {
     if (spark == nullptr) {
@@ -207,6 +320,7 @@ SPARK *Sparks_InitialiseSpriteSpark(const SPARK_SPRITE_TYPE type)
     SPARK *const spark = Sparks_GetFreeSpark();
     spark->on = true;
     spark->sprite_idx = sprite_idx;
+    spark->sprite_obj_id = O_SPARKS_GFX;
     return spark;
 }
 
@@ -220,6 +334,61 @@ int32_t Sparks_GetSpriteIndex(const SPARK_SPRITE_TYPE type)
         return NO_ITEM;
     }
     return obj->mesh_idx + type;
+}
+
+void Sparks_Save(JSON_WRITE_IO *const io)
+{
+    if (!g_Config.gameplay.enable_enhanced_saves) {
+        return;
+    }
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
+        const SPARK *const spark = &m_Sparks[i];
+        if (!spark->on) {
+            continue;
+        }
+        if ((spark->flags & SPARK_F_FX) != 0U
+            && Effect_GetInOrderNum(spark->effect_num) == NO_EFFECT) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        Sparks_SaveSpark(io, spark);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET(io, "sparks");
+}
+
+RESULT Sparks_Load(JSON_READ_IO *const io)
+{
+    if (!g_Config.gameplay.enable_enhanced_saves) {
+        return OK;
+    }
+
+    if (!JSON_ReadIO_HasKey(io, "sparks")) {
+        return OK;
+    }
+    MUST(JSON_PUSH(io, "sparks"));
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_SPARKS) {
+            LOG_WARNING(
+                "Malformed save: too many sparks. Extra sparks will be "
+                "ignored.");
+            break;
+        }
+        SPARK *const spark = &m_Sparks[i];
+        MUST(JSON_PUSH_INDEX(io, i));
+        MUST(Sparks_LoadSpark(io, spark));
+        MUST(JSON_POP(io));
+        spark->on = true;
+        Sparks_Sync(spark);
+    }
+    m_NextSpark = count < M_MAX_SPARKS ? count : 0;
+
+    MUST(JSON_POP(io));
+    return OK;
 }
 
 void Sparks_Sync(SPARK *const spark)
@@ -367,6 +536,7 @@ void Sparks_Control(void)
         if ((spark->flags & SPARK_F_ALT_SPRITE) != 0U) {
             const int32_t base = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
             if (base != NO_ITEM) {
+                spark->sprite_obj_id = O_SPARKS_GFX;
                 if (spark->color.r < 16 && spark->color.g < 16
                     && spark->color.b < 16) {
                     spark->sprite_idx = base + 3;

--- a/src/trx/game/sparks/manager.h
+++ b/src/trx/game/sparks/manager.h
@@ -1,10 +1,26 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/sparks/types.h>
+
+typedef struct JSON_READ_IO JSON_READ_IO;
+typedef struct JSON_WRITE_IO JSON_WRITE_IO;
 
 void Sparks_Reset(void);
 void Sparks_Control(void);
 void Sparks_Draw(void);
+
+// Writes and reads one spark. A sprite spark stores its object and sprite
+// offset. The owning pool stores the on flag and attachment.
+void Sparks_SaveSpark(JSON_WRITE_IO *io, const SPARK *spark);
+RESULT Sparks_LoadSpark(JSON_READ_IO *io, SPARK *spark);
+
+// Writes each live spark, or nothing while enhanced saves are off.
+void Sparks_Save(JSON_WRITE_IO *io);
+
+// Reads saved sparks. Reports failure if the save names a sprite the level does
+// not carry. Leaves unnamed slots as Sparks_Reset set them.
+RESULT Sparks_Load(JSON_READ_IO *io);
 
 void Sparks_DetachEffect(int16_t effect_num);
 void Sparks_DetachItem(int16_t item_num);

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -59,6 +59,7 @@ void Sparks_TriggerBubble(
             SPARK_F_ATTACHED_POS | SPARK_F_FX | SPARK_F_SPRITE | SPARK_F_SCALE,
         .effect_num = effect_num,
         .sprite_idx = bubble_obj->mesh_idx,
+        .sprite_obj_id = O_BUBBLE_1,
         .pos = { .x = 0, .y = 0, .z = 0 },
         .vel = { .x = 0, .y = 0, .z = 0 },
         .gravity = 0,
@@ -111,6 +112,7 @@ void Sparks_TriggerWaterfallMist(
             .life = (uint8_t)((Random_GetControl() & 3) + 6),
             .dynamic = -1,
             .sprite_idx = sprite_idx,
+            .sprite_obj_id = O_SPARKS_GFX,
             .pos = {
                 .x = x + (Random_GetControl() % 16) - 8 + spread.x,
                 .y = y + (Random_GetControl() % 16) - 8,
@@ -218,6 +220,7 @@ void Sparks_TriggerBreath(
         .life = (uint8_t)((Random_GetControl() & 3) + 37),
         .dynamic = -1,
         .sprite_idx = sprite_idx,
+        .sprite_obj_id = O_SPARKS_GFX,
         .pos = {
             .x = pos.x + jitter_x,
             .y = pos.y + jitter_y,
@@ -727,9 +730,7 @@ void Sparks_TriggerUnderwaterExplosion(const ITEM *item)
 
     const ROOM *const room = Room_Get(item->room_num);
     FX_Water_SetupSplash(&(FX_WATER_SPLASH_SETUP) {
-        .x = item->pos.x,
-        .y = room->max_ceiling,
-        .z = item->pos.z,
+        .pos = { .x = item->pos.x, .y = room->max_ceiling, .z = item->pos.z },
         .inner_y_size = -96,
         .inner_xz_vel = 160,
         .inner_gravity = 96,
@@ -784,6 +785,7 @@ void Sparks_TriggerExplosionSparks(
         .life = 0,
         .dynamic = (int8_t)dynamic,
         .sprite_idx = sprite_idx,
+        .sprite_obj_id = O_SPARKS_GFX,
         .pos = pos,
         .vel = {
             .x = (Random_GetControl() & 0xFFF) - 2048,
@@ -899,6 +901,7 @@ void Sparks_TriggerExplosionBubble(const XYZ_32 pos, const int16_t room_num)
         .extras = 0,
         .dynamic = -1,
         .sprite_idx = sprite_idx,
+        .sprite_obj_id = O_SPARKS_GFX,
         .pos = pos,
         .vel = { .x = 0, .y = 0, .z = 0 },
         .gravity = 0,
@@ -1225,6 +1228,7 @@ void Sparks_TriggerPickupAid(const XYZ_32 pos, const XZ_32 vel)
     const OBJECT *const obj = Object_Get(O_PICKUP_AID);
     const int32_t mesh_count = ABS(obj->mesh_count) - 1;
     spark->sprite_idx = obj->mesh_idx + (Random_GetControl() & mesh_count);
+    spark->sprite_obj_id = O_PICKUP_AID;
 
     spark->scalar = 1;
     int32_t rnd = (Random_GetControl() & 0x3F) + 36;

--- a/src/trx/game/sparks/types.h
+++ b/src/trx/game/sparks/types.h
@@ -2,6 +2,7 @@
 
 #include <trx/core/colors.h>
 #include <trx/core/math/types.h>
+#include <trx/game/objects/ids.h>
 #include <trx/game/output/types.h>
 #include <trx/game/sparks/enum.h>
 
@@ -53,5 +54,6 @@ typedef struct SPARK {
     int8_t rot_add;
 
     int32_t sprite_idx;
+    OBJECT_ID sprite_obj_id;
     DRAW_TYPE draw_type;
 } SPARK;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A save now preserves sparks and the full set of FX, expanding on the fire, weather, and explosion rings it already kept:

- smoke, bubbles and other sparks
- water droplets (wet Lara)
- water trails (kayak, rib)
- underwater particles
- muzzle flashes
- lasers
- splashes
- ripples

All additions are gated under the Save effects setting.
A save that references a sprite not present in the level now fails to load.

Resolves #6231 / TRX1089