### PR TITLE
Fix drawing weapons while wading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 **Weapons and ammunition**
 - Added an option to keep Lara firing the M16/MP5 from her hip while the action key is held, rather than shouldering the gun the moment she stops moving (Gameplay → Controls → M16/MP5 aiming variants) (#3861 / TRX1048)
+- Fixed Lara taking out a two-handed weapon in wading-depth water only to put it away at once (OG bug) (#6253 / TRX1120)
+- Fixed Lara taking out a weapon while she is fully submerged in a swamp (#6255 / TRX1122)
 
 **Level and game data**
 - Added Natla as an outfit for Lara, selectable in every game (Graphic Options → Visuals → Lara's outfit) (TRX1050)

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -119,7 +119,8 @@ static bool M_IsOnlyUnderwaterUsable(void)
         || lara->water_status == LWS_SURFACE;
 }
 
-static bool M_IsTooSubmerged(const LARA_GUN_TYPE gun_type)
+// Where the water stands below the muzzle, so that the weapon still fires.
+static bool M_IsAboveWaterLine(const LARA_GUN_TYPE gun_type)
 {
     const LARA_INFO *const lara = Lara_GetLaraInfo();
     return lara->water_surface_dist > -g_Weapons[gun_type].gun_height;
@@ -171,19 +172,12 @@ static bool M_CanEquip(void)
     case LWS_SURFACE:
     case LWS_UNDERWATER:
         return M_IsUsableUnderwater(lara->request_gun_type);
-    case LWS_WADE: {
-        if (M_IsUsableUnderwater(lara->request_gun_type)) {
-            return true;
-        }
-        if (lara->gun_status == LGS_ARMLESS
-            || M_IsTooSubmerged(lara->gun_type)) {
-            return true;
-        }
-        return false;
+    case LWS_WADE:
+        return M_IsUsableUnderwater(lara->request_gun_type)
+            || M_IsAboveWaterLine(lara->request_gun_type);
     default:
         ASSERT_FAIL();
         return false;
-    }
     }
 }
 
@@ -224,7 +218,7 @@ static bool M_NeedToUndraw(void)
         return false;
     case LWS_WADE:
         return !M_IsUsableUnderwater(lara->request_gun_type)
-            && !M_IsTooSubmerged(lara->gun_type);
+            && !M_IsAboveWaterLine(lara->gun_type);
     default:
         return false;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes Lara briefly drawing unusable weapons in deep water or while submerged in swamps. Weapons now stay holstered until the water is shallow enough for the selected weapon.

Resolves #6253, #6255 / TRX1120 / TRX1122