### PR TITLE
Fix the cutscene that opens Karnak

### DIFF
--- a/data/trx/ship/games/tr4/modules/cutscenes.lua
+++ b/data/trx/ship/games/tr4/modules/cutscenes.lua
@@ -50,6 +50,13 @@ function M.hide_items(object)
   end
 end
 
+-- Shows or hides every item of an object.
+function M.set_items_visible(object, visible)
+  for _, item in ipairs(trx.items.query:of_object(object):matches()) do
+    item.is_visible = visible
+  end
+end
+
 -- Plays a cutscene as the level opens. Some scenes are named by no floor
 -- trigger at all: the original game starts them from the level's own entry in
 -- the game flow, and a level script is where TRX says so. One that has already

--- a/data/trx/ship/games/tr4/scripts/karnak1.lua
+++ b/data/trx/ship/games/tr4/scripts/karnak1.lua
@@ -1,8 +1,20 @@
 local cutscenes = require("tr4.cutscenes")
 
--- No floor trigger names this one; it opens the level. What happens during it
--- is not scripted yet.
-cutscenes.play_on_start(12)
+-- No floor trigger names this one; it opens the level.
+local ARRIVAL = 12
+
+cutscenes.play_on_start(ARRIVAL)
+
+-- The jeep Lara arrives in is a level item standing where the scene drives its
+-- own, so the level's one waits until the scene has run.
+cutscenes.register(ARRIVAL, {
+  on_start = function()
+    cutscenes.set_items_visible(trx.catalog.objects.animating_6, false)
+  end,
+  on_end = function()
+    cutscenes.set_items_visible(trx.catalog.objects.animating_6, true)
+  end,
+})
 
 trx.events.on_game_start(function()
   trx.items[66].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,8 @@
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)
 - Fixed rooms and their contents sometimes disappearing while an in-game cutscene plays (TRX1052)
+- Fixed parts of the level dropping out of the picture during the cutscene that opens Karnak (TRX1092)
+- Fixed the parked jeep showing in the temple during the cutscene that opens Karnak (TRX1092)
 - Fixed a crash while an in-game cutscene poses Lara (TRX1059)
 
 **Miscellaneous**

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -160,6 +160,12 @@ void Camera_ApplyBounce(void)
 
 void Camera_ClampInterpResult(void)
 {
+    // A cutscene camera can jump between places without sector walking,
+    // and its room is already known.
+    if (g_Camera.type == CAM_CINEMATIC) {
+        return;
+    }
+
     if (g_Camera.type == CAM_PHOTO_MODE || g_Camera.type == CAM_FLYBY_MODE
         || g_Camera.type == CAM_BINOCULARS) {
         Room_GetSector(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes Karnak's opening cutscene.

1. The camera room is now used for portal clipping, preventing missing level geometry
2. The parked jeep is hidden until the cutscene finishes

Resolves TRX1092