### PR TITLE
Fix blood clouds appearing in the air

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Fixed the kayak at times not being drawn in certain rooms (regression from 1.10.1) (TRX1145)
 - Fixed some of Lara's skin joints incorrectly being drawn when riding the kayak (regression from 1.10) (TRX1146)
 - Fixed Lara's sliding SFX continuing after she leaves a slope (#6294 / TRX1155, regression from 1.0)
+- Fixed underwater blood clouds appearing in the air when the security lasers hurt Lara at the water surface (OG bug) (#6323 / TRX1180)
 
 **TR4**
 - Added the ability to skip in-game cutscenes (TRX1051)

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -17,6 +17,12 @@
 #include <trx/game/sparks/spawners.h>
 #include <trx/version.h>
 
+static bool M_IsUnderwaterAt(const XYZ_32 pos, int16_t room_num)
+{
+    Room_GetSector(pos, &room_num);
+    return Room_Get(room_num)->flags.underwater;
+}
+
 static void M_ShootAtLara(EFFECT *const effect)
 {
     const ITEM *const lara_item = Lara_GetItem();
@@ -182,7 +188,7 @@ int16_t Spawn_Blood(
     const int16_t y_rot, const int16_t room_num)
 {
     if (g_TRVersion == 3) {
-        if (Room_Get(room_num)->flags.underwater) {
+        if (M_IsUnderwaterAt((XYZ_32) { x, y, z }, room_num)) {
             FX_Water_TriggerUnderwaterBlood(
                 (XYZ_32) { x, y, z }, Random_GetControl() & 7);
         } else {
@@ -230,7 +236,7 @@ int16_t Spawn_BloodD(
     const int16_t y_rot, const int16_t room_num)
 {
     if (g_TRVersion == 3) {
-        if (Room_Get(room_num)->flags.underwater) {
+        if (M_IsUnderwaterAt((XYZ_32) { x, y, z }, room_num)) {
             FX_Water_TriggerUnderwaterBloodD(
                 (XYZ_32) { x, y + 64, z }, Random_GetDraw() & 7);
         } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where underwater blood clouds spawned in the air when the security lasers hurt Lara at the water surface. Before this, the blood effect was chosen from the room the caller gave, which was Lara's room while the blood landed in the air room above.

Resolves #6323 / TRX1180