### PR TITLE
Stop the moving spikes at a pushed block

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Fixed Lara being able to turn too quickly when wading (regression from 1.0) (TRX1129)
 - Fixed Lara's sliding SFX continuing after she leaves a slope (#6294 / TRX1155, regression from 1.0)
 - Fixed underwater blood clouds appearing in the air when the security lasers hurt Lara at the water surface (OG bug) (#6323 / TRX1180)
+- Fixed the ceiling spikes not stopping on a pushable block until Lara finishes pushing it (OG bug) (#6308 / TRX1169)
 
 **TR4**
 - Added the ability to skip in-game cutscenes (TRX1051)

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -1109,6 +1109,49 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
 }
 
+static bool M_IsSameSquare(const XYZ_32 pos_1, const XYZ_32 pos_2)
+{
+    return (pos_1.x >> WALL_SHIFT) == (pos_2.x >> WALL_SHIFT)
+        && (pos_1.z >> WALL_SHIFT) == (pos_2.z >> WALL_SHIFT);
+}
+
+static bool M_HasStartedMoving(const ITEM *const item)
+{
+    const ANIM *const anim = Item_GetAnim(item);
+    const ANIM_FRAME *const current = Item_GetBestFrame(item);
+    if (anim == nullptr || anim->frame_ptr == nullptr || current == nullptr) {
+        return false;
+    }
+
+    return current->offset.x != anim->frame_ptr->offset.x
+        || current->offset.z != anim->frame_ptr->offset.z;
+}
+
+bool MovableBlock_TestSquareClaimed(const XYZ_32 pos)
+{
+    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
+        const ITEM *const item = Item_Get(i);
+        if (!Object_IsType(item->object_id, g_MovableBlockObjects)
+            || !item->is_visible || !M_IsPushPull(item)
+            || !M_HasStartedMoving(item)) {
+            continue;
+        }
+
+        if (item->pos.y - WALL_L > pos.y) {
+            continue;
+        }
+
+        const M_PRIV *const p = item->priv;
+        const XYZ_32 target =
+            XYZ_32_OffsetYaw(item->pos, p->interaction_rot, WALL_L);
+        if (M_IsSameSquare(item->pos, pos) || M_IsSameSquare(target, pos)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void MovableBlock_UpdateBox(const ITEM *const item, const bool blocked)
 {
     if (blocked

--- a/src/trx/game/objects/traps/movable_block.h
+++ b/src/trx/game/objects/traps/movable_block.h
@@ -3,6 +3,12 @@
 #include <trx/game/objects/types.h>
 #include <trx/game/rooms.h>
 
+// Reports whether a movable block stands on the square at pos, or has begun
+// to move onto it, with the top of the block at or above the height pos
+// gives. A block claims the square it enters from the moment its animation
+// shifts it, which the floor data reports only once the move ends.
+bool MovableBlock_TestSquareClaimed(XYZ_32 pos);
+
 // Block or unblock a block's box overlap index.
 void MovableBlock_UpdateBox(const ITEM *item, bool blocked);
 

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -2,6 +2,7 @@
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
+#include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
@@ -37,6 +38,13 @@ static void M_Move(const int16_t item_num)
     int16_t room_num = item->room_num;
     const XYZ_32 pos = { item->pos.x, item->pos.y + p->speed, item->pos.z };
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
+
+    if (MovableBlock_TestSquareClaimed(
+            (XYZ_32) { item->pos.x, item->pos.y + WALL_L, item->pos.z })) {
+        Sound_StopEffect(SFX_SPIKE_WALL);
+        return;
+    }
+
     if (Room_GetHeight(sector, pos) < pos.y + WALL_L) {
         Item_SetFinished(item, true);
         Sound_StopEffect(SFX_SPIKE_WALL);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes moving spikes ignoring a pushable block while Lara is pushing it. The spikes now stop while the block occupies the sector ahead and resume if the block moves elsewhere.

Resolves #6308 / TRX1169