### PR TITLE
cutseq+von_croy: handle Lara in fly cheat

### DIFF
--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -324,6 +324,10 @@ static void M_Finish(void)
     M_ReleaseNodes();
     Lara_Pose_SetOverride(nullptr);
     M_TeleportLara(m_State.lara_return.pos, m_State.lara_return.rot);
+    if (Lara_GetLaraInfo()->water_status == LWS_CHEAT) {
+        Lara_Cheat_ExitFlyMode();
+        Lara_Cheat_EnterFlyMode();
+    }
     m_State.lara_return.is_present = false;
     m_State.lara_shadow_bounds.is_present = false;
     Lara_Hair_Initialise();

--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -404,8 +404,9 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
         p->waypoint = Waypoint_GetPad();
     }
 
-    if (Waypoint_GetPad() == 20
-        && lara->current_anim_state != LS(LS_SURF_TREAD)) {
+    const bool fly_cheat_active = Lara_GetLaraInfo()->water_status == LWS_CHEAT;
+    if (Waypoint_GetPad() == 20 && lara->current_anim_state != LS(LS_SURF_TREAD)
+        && !fly_cheat_active) {
         return;
     }
 
@@ -467,7 +468,10 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
 
         lara->rot.y = angle + 0x8000;
 
-        if (lara->current_anim_state != LS(LS_SURF_TREAD)) {
+        if (fly_cheat_active) {
+            lara->speed = 0;
+            lara->fall_speed = 0;
+        } else if (lara->current_anim_state != LS(LS_SURF_TREAD)) {
             int16_t room_num = lara->room_num;
             const SECTOR *const sector = Room_GetSector(lara->pos, &room_num);
             lara->pos.y = Room_GetHeight(sector, lara->pos);
@@ -613,7 +617,7 @@ static void M_RaceControl(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     CREATURE *const creature = item->creature_data;
     M_PRIV *const p = M_GetPriv(item);
-    const ITEM *const lara = Lara_GetItem();
+    ITEM *const lara = Lara_GetItem();
 
     int16_t tilt = 0;
     int16_t angle = 0;
@@ -675,6 +679,10 @@ static void M_RaceControl(const int16_t item_num)
 
     if (FlybyMode_IsActive()
         && Music_GetCurrentPlayingTrack() == M_FLYBY_TALK_TRACK) {
+        if (Lara_GetLaraInfo()->water_status == LWS_CHEAT) {
+            lara->speed = 0;
+            lara->fall_speed = 0;
+        }
         IGNORE(Music_SetSpeed(Clock_GetSpeedMultiplier()));
         p->flyby.talk_timer++;
 

--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -400,10 +400,6 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
         Input_HoldOffSkip();
     }
 
-    const SECTOR *sector;
-    int32_t height;
-    int16_t ang, room_num;
-
     if (Waypoint_GetPad() != 8 && Waypoint_GetPad() != 15) {
         p->waypoint = Waypoint_GetPad();
     }
@@ -448,10 +444,8 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
         }
 
         M_GetAIEnemy(info, Waypoint_GetPad());
-        item->pos.x = info->enemy->pos.x;
-        item->pos.y = info->enemy->pos.y;
-        item->pos.z = info->enemy->pos.z;
-        ang = (int16_t)Math_Atan(
+        item->pos = info->enemy->pos;
+        const int16_t angle = (int16_t)Math_Atan(
             lara->pos.z - item->pos.z, lara->pos.x - item->pos.x);
 
         if (p->waypoint == 14 || p->waypoint == 3) {
@@ -462,7 +456,7 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
             info->maximum_turn = 0;
             item->rot.y = -0x6000;
         } else {
-            item->rot.y = ang;
+            item->rot.y = angle;
         }
         const int16_t probe_room = Room_GetIndexFromPos((XYZ_32) {
             .x = item->pos.x, .y = item->pos.y - 64, .z = item->pos.z });
@@ -471,13 +465,12 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
             Item_UpdateRoom(Item_GetIndex(item), probe_room);
         }
 
-        lara->rot.y = ang + 0x8000;
+        lara->rot.y = angle + 0x8000;
 
         if (lara->current_anim_state != LS(LS_SURF_TREAD)) {
-            room_num = lara->room_num;
-            sector = Room_GetSector(lara->pos, &room_num);
-            height = Room_GetHeight(sector, lara->pos);
-            lara->pos.y = height;
+            int16_t room_num = lara->room_num;
+            const SECTOR *const sector = Room_GetSector(lara->pos, &room_num);
+            lara->pos.y = Room_GetHeight(sector, lara->pos);
             Item_SwitchToAnim(lara, LA(LA_STAND_STILL), 0);
             lara->current_anim_state = LS(LS_STOP);
             lara->goal_anim_state = LS(LS_STOP);
@@ -545,11 +538,11 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
         p->swap_bits &= ~M_SWAP_BOOK;
         p->cut_phase = 0;
         M_SetCutPlayed(p, p->waypoint);
-        ang = info->enemy->rot.y - item->rot.y;
+        const int16_t angle_delta = info->enemy->rot.y - item->rot.y;
 
-        if (ang > 1024) {
+        if (angle_delta > 1024) {
             item->required_anim_state = M_STATE_TURN_LEFT;
-        } else if (ang < -1024) {
+        } else if (angle_delta < -1024) {
             item->required_anim_state = M_STATE_TURN_RIGHT;
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes Lara's state after entering a cutscene in the fly cheat. If it's a Von Croy tutorial she will remain in the flying pose during the scene, but her speed is reset to stop her drifting. Scripted cutscenes (backpack, Alexandria, Citadel etc) will reset her animation as before, but she will return to the flying state afterwards.

Resolves TRX1194.
