### PR TITLE
Add the TR4 water effects

### DIFF
--- a/data/trx/ship/cfg/shaders/lights_common.glsl
+++ b/data/trx/ship/cfg/shaders/lights_common.glsl
@@ -31,19 +31,18 @@ struct LightingResult {
 
 float ogPhaseTurns(vec3 worldPos, int scheme)
 {
-    // bucket like OG: xyz * (1/64, 1/64, 1/128)
-    ivec3 q = ivec3(floor(vec3(worldPos.x / 64.0,
-                               worldPos.y / 64.0,
-                               worldPos.z / 128.0)));
+    // The lane is a sum of the position, not a hash of the three axes: it
+    // steps once every four units of that sum, so vertices near each other
+    // share a lane and the light runs in broad bands. Hashing each vertex on
+    // its own leaves neighbours unrelated, which reads as speckle.
+    float sum = floor(worldPos.x / 64.0) + floor(worldPos.y / 64.0)
+        + floor(worldPos.z / 128.0);
+    float lane = mod(floor(sum / 4.0), 16.0);
 
-    // cheap hash -> 0..1
-    float n = fract(sin(
-        dot(vec3(q), vec3(12.9898, 78.233, 37.719)) + float(scheme) * 19.19
-    ) * 43758.5453);
-
-    // OG-ish: random is multiples of 4, then &63 => 16 lanes
-    float lane = floor(n * 16.0);  // 0..15
-    float offTurns = lane / 16.0;  // 0,1/16,...15/16
+    // stands in for the random byte the OG table holds per lane
+    float n =
+        fract(sin(lane * 12.9898 + float(scheme) * 19.19) * 43758.5453);
+    float offTurns = floor(n * 16.0) / 16.0;
 
     // time base is uTimeInGame with period 64
     float tTurns = fract(uTimeInGame / 64.0);

--- a/data/trx/ship/cfg/shaders/lights_tr4.glsl
+++ b/data/trx/ship/cfg/shaders/lights_tr4.glsl
@@ -114,14 +114,24 @@ LightingResult light(
         result.add += lightDynamicStaticTR4(pos);
     }
 
-    // Water shimmer, in the 128-neutral scale: the OG adds
-    // (shimmer + abs) << 3 onto the raw room channels of both water (0x2000)
-    // and shore (0x4000) vertices. Choppy is a position offset only in TR4,
-    // never a color term.
-    if ((flags & (VERT_MOVE | VERT_GLOW)) != 0u) {
-        float add = effectShimmer(pos.xyz) / 128.0 + effectAbs() / 128.0;
-        result.add += vec3(add);
+    // Water shimmer, on the 0 to 255 scale of the room color. A water vertex
+    // (0x2000) darkens by the height the choppy table lifted it, and a shore
+    // vertex (0x4000) takes the shimmer and the absolute term together. The
+    // two classes never share a term.
+    float add = 0.0;
+    if ((flags & VERT_MOVE) != 0u) {
+        add += effectChoppy(pos.xyz) / 256.0;
     }
+    if ((flags & VERT_GLOW) != 0u) {
+        add += effectShimmer(pos.xyz) / 256.0 + effectAbs() / 256.0;
+    }
+    result.add += vec3(add);
+
+    // The added light stands on its own and never cuts into the room color.
+    // The OG sums the dynamic light and the shimmer, clamps that sum at zero,
+    // and only then adds the room color on top, so a shimmer that swings
+    // negative cancels the lights and stops there.
+    result.add = max(result.add, vec3(0.0));
 
     return result;
 }

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -53,6 +53,13 @@ vec3 gammaCurve(vec3 rgb, float gamma_exp)
     return pow(clamp(rgb, 0.0, 1.0), vec3(gamma_exp));
 }
 
+float wibbleTable(float phase, float pos, float scale)
+{
+    float idx =
+        mod(floor(phase / 8.0 + pos / (8.0 * scale)), float(WIBBLE_SIZE));
+    return float(MAX_WIBBLE) * scale * sin(idx * (2.0 * PI / float(WIBBLE_SIZE)));
+}
+
 vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)
 {
     vec3 ndc = screenPosition.xyz / screenPosition.w;
@@ -62,6 +69,12 @@ vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)
     float scale = length(uViewportSize) / length(vec2(640.0, 480.0));
     float adjustedWibble = scale;
     pixelPos.y += sin(phases) * adjustedWibble;
+#elif TR_VERSION == 4
+    float phase = uTimeInGame * 4.0;
+    float scale = length(uViewportSize) / length(vec2(640.0, 480.0));
+    vec2 srcPos = pixelPos;
+    pixelPos.x += wibbleTable(phase, srcPos.y, scale);
+    pixelPos.y += wibbleTable(phase, srcPos.x, scale);
 #else
     float phases = (uTimeInGame + length(worldPosition.xyz)) * (2.0 * PI / WIBBLE_SIZE);
     float amplitude = MAX_WIBBLE * float(uSupersamplingFactor);

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -16,6 +16,7 @@ uniform vec4 uTint;
     vec2 trapezoidRatios;         \
     vec4 color;                   \
     vec3 add;                     \
+    float tintWeight;             \
     flat float reflectivity;      \
     noperspective vec4 affineUV;
 
@@ -170,10 +171,19 @@ void main(void) {
 
     float gamma_exp = 1.0 / ((uGamma / 10.0) * 4.0);
 
+    float tintWeight = 1.0;
+#if TR_VERSION == 4
+    if ((inFlags & (VERT_MOVE | VERT_GLOW)) != 0u) {
+        tintWeight = 0.0;
+    }
+#endif
+    gOut.tintWeight = tintWeight;
+
     // Applies PlayStation water tint before the gamma curve and texture
     // modulation, where the GTE combines it with the light register.
-    vec3 tintReg =
-        uLightingCurve == LIGHTING_CURVE_SATURATE ? uTint.rgb : vec3(1.0);
+    vec3 tintReg = uLightingCurve == LIGHTING_CURVE_SATURATE
+        ? mix(vec3(1.0), uTint.rgb, tintWeight)
+        : vec3(1.0);
 
 #if TR_VERSION >= 4
     // The OG engine lights everything in the "128 = neutral" scale: the lit value is
@@ -385,6 +395,8 @@ void emitAt(vec3 w)
         + gIn[1].trapezoidRatios * w.y + gIn[2].trapezoidRatios * w.z;
     gOut.color = gIn[0].color * w.x + gIn[1].color * w.y + gIn[2].color * w.z;
     gOut.add = gIn[0].add * w.x + gIn[1].add * w.y + gIn[2].add * w.z;
+    gOut.tintWeight = gIn[0].tintWeight * w.x + gIn[1].tintWeight * w.y
+        + gIn[2].tintWeight * w.z;
     gOut.affineUV =
         gIn[0].affineUV * w.x + gIn[1].affineUV * w.y + gIn[2].affineUV * w.z;
 
@@ -598,7 +610,8 @@ void main(void) {
     if (uLightingCurve == LIGHTING_CURVE_SATURATE) {
         texColor.a *= uTint.a;
     } else {
-        texColor *= uTint;
+        texColor.rgb *= mix(vec3(1.0), uTint.rgb, gIn.tintWeight);
+        texColor.a *= uTint.a;
     }
     texColor.rgb *= uTint.a;
 

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -54,6 +54,17 @@ vec3 gammaCurve(vec3 rgb, float gamma_exp)
     return pow(clamp(rgb, 0.0, 1.0), vec3(gamma_exp));
 }
 
+// Grows the distortion with the display, so that it stays visible where the
+// original left it at the two pixels a 640x480 screen was given. A sharp
+// screen shows the same share of the picture as a stronger distortion, so the
+// growth tapers rather than tracking the height. Supersampling raises the
+// render target alone and must not change what reaches the screen.
+float wibbleScale(void)
+{
+    float ss = float(uSupersamplingFactor);
+    return sqrt((uViewportSize.y / ss) / 480.0) * ss;
+}
+
 float wibbleTable(float phase, float pos, float scale)
 {
     float idx =
@@ -67,12 +78,10 @@ vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)
     vec2 pixelPos = (ndc.xy * 0.5 + 0.5) * uViewportSize;
 #if TR_VERSION == 3
     float phases = (uTimeInGame * 0.5 + length(worldPosition.xyz)) * (2.0 * PI / WIBBLE_SIZE);
-    float scale = length(uViewportSize) / length(vec2(640.0, 480.0));
-    float adjustedWibble = scale;
-    pixelPos.y += sin(phases) * adjustedWibble;
+    pixelPos.y += sin(phases) * wibbleScale();
 #elif TR_VERSION == 4
     float phase = uTimeInGame * 4.0;
-    float scale = length(uViewportSize) / length(vec2(640.0, 480.0));
+    float scale = wibbleScale();
     vec2 srcPos = pixelPos;
     pixelPos.x += wibbleTable(phase, srcPos.y, scale);
     pixelPos.y += wibbleTable(phase, srcPos.x, scale);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Added Boar control (TRX1185)
 - Added level statistics scanning (TRX1201)
 - Added the timer Race for the Iris runs between its cutscenes (TRX1109)
+- Added the wobble effect the original shows while the camera is under water (TRX523)
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Added the timer Race for the Iris runs between its cutscenes (TRX1109)
 - Added the wobble effect the original shows while the camera is under water (TRX523)
 - Added the drifting specks the original shows in water rooms (TRX553)
+- Added the water ripples the original shows, in their size, their color and the speed they spread at (TRX590)
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Added the wobble effect the original shows while the camera is under water (TRX523)
 - Added the drifting specks the original shows in water rooms (TRX553)
 - Added the water ripples the original shows, in their size, their color and the speed they spread at (TRX590)
+- Added the water tint the original shows while the camera is under water, which leaves the water surface and the shoreline in the colors they have in the dry room (TRX560)
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 
 **TR3**
 - Added crystals to each of the levels in The Lost Artefact, and made the crystal mode option visible (Gameplay → General → Crystal mode) (TRX1111)
+- Changed the underwater light patterns to run in broad bands, as the original draws them, rather than fine speckle
 - Changed the underwater picture wobble to grow more gently on large screens, where it was too strong
 - Fixed z-fighting in rooms 21, 67 amd 122 in Jungle, and fixed incorrect lighting in room 87 (OG bugs) (TRX1088)
 - Fixed Vultures in The River Ganges and Nevada Desert having incorrect animation bounds (OG bug) (#6303 / TRX1163)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Changed TR3 to light geometry on the brighter curve its hardware renderer used (Graphic Options → Rendering → Lighting model)
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
+- Fixed static objects that reach through a doorway taking the water tint and the light of the room next door
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Fixed underwater blood clouds appearing in the air when the security lasers hurt Lara at the water surface (OG bug) (#6323 / TRX1180)
 - Fixed the ceiling spikes not stopping on a pushable block until Lara finishes pushing it (OG bug) (#6308 / TRX1169)
 - Fixed the piranhas in It's a Madhouse! being invisible if attacking Lara while she collects the Aviary Key (#6345 / TRX1200)
+- Fixed the specks drifting in water being too small and all one size
 
 **TR4**
 - Added the ability to skip in-game cutscenes (TRX1051)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed static objects that reach through a doorway taking the water tint and the light of the room next door
+- Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Added level statistics scanning (TRX1201)
 - Added the timer Race for the Iris runs between its cutscenes (TRX1109)
 - Added the wobble effect the original shows while the camera is under water (TRX523)
+- Added the drifting specks the original shows in water rooms (TRX553)
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 
 **TR3**
 - Added crystals to each of the levels in The Lost Artefact, and made the crystal mode option visible (Gameplay → General → Crystal mode) (TRX1111)
+- Changed the underwater picture wobble to grow more gently on large screens, where it was too strong
 - Fixed z-fighting in rooms 21, 67 amd 122 in Jungle, and fixed incorrect lighting in room 87 (OG bugs) (TRX1088)
 - Fixed Vultures in The River Ganges and Nevada Desert having incorrect animation bounds (OG bug) (#6303 / TRX1163)
 - Fixed missing alpha blending on the MP5 and M16 gun flare in the gym (regression from 1.7) (TRX1066)

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -243,7 +243,7 @@
         },
         "water_particles": {
           "type": "boolean",
-          "description": "Enables PSX-style underwater water particles in this level."
+          "description": "Enables PSX-style underwater water particles in this level. TR4 shows them in every water room and ignores this property."
         },
         "death_tile": {
           "type": "string",

--- a/docs/trx/WATER_COLORS.md
+++ b/docs/trx/WATER_COLORS.md
@@ -277,3 +277,23 @@ order: 8
     </tr>
 </tbody>
 </table>
+
+<h4 colspan="4">TR4</h4>
+<table>
+<thead>
+    <tr>
+        <th>Platform</th>
+        <th>Color</th>
+        <th>Color&nbsp;(array)</th>
+        <th>Usage</th>
+    </tr>
+</thead>
+<tbody>
+    <tr>
+        <td rowspan="1">PC</td>
+        <td><img src="https://dummyimage.com/20x20/80e0ff/80e0ff.png" width="20" height="20" alt="#80E0FF" valign="middle"/> <code>#80E0FF</code></td>
+        <td><code>[0.502, 0.878, 1]</code></td>
+        <td>default PC renderer color</td>
+    </tr>
+</tbody>
+</table>

--- a/docs/trx/game_flow/levels/REGULAR_LEVELS.md
+++ b/docs/trx/game_flow/levels/REGULAR_LEVELS.md
@@ -145,7 +145,8 @@ Following are each of the properties available within a level.
     <td>Boolean</td>
     <td colspan="2">
       Enables PSX-style underwater water particles for this level. These follow
-      the weather effects toggle. Requires `O_SPARKS_GFX`.
+      the weather effects toggle. Requires `O_SPARKS_GFX`. TR4 shows the
+      particles in every water room and ignores this property.
     </td>
   </tr>
   <tr valign="top">

--- a/docs/trx/water_colors.yml
+++ b/docs/trx/water_colors.yml
@@ -102,3 +102,7 @@ TR3 PS1:
     color: "#80E0FF"
   - name: All Hallows
     color: "#B2E6E6"
+
+TR4 PC:
+  - name: default PC renderer color
+    color: "#80E0FF"

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -176,22 +176,39 @@ static void M_DrawRipple(const FX_WATER_RIPPLE *r)
     int32_t sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_RIPPLE);
     RGBA_8888 color;
 
-    if ((r->flags & 0x10U) != 0U) {
-        if ((r->flags & 0x20U) != 0U) {
+    const int32_t fade = init != 0 ? init : life;
+    if (g_TRVersion == 4) {
+        if ((r->flags & FX_RIPPLE_BLOOD) != 0U) {
+            sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
+        }
+        if ((r->flags & FX_RIPPLE_DARK) != 0U) {
+            if ((r->flags & FX_RIPPLE_BLOOD) != 0U) {
+                color = (RGBA_8888) {
+                    .r = MIN((fade >> 1) << 1, 255),
+                    .g = 0,
+                    .b = MIN((fade >> 4) << 1, 255),
+                    .a = 255,
+                };
+            } else {
+                color = M_Gray(MIN(fade << 1, 255));
+            }
+        } else {
+            color = M_Gray(MIN(fade << 2, 255));
+        }
+    } else if ((r->flags & FX_RIPPLE_DARK) != 0U) {
+        if ((r->flags & FX_RIPPLE_BLOOD) != 0U) {
             sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
             const int32_t shade = g_TRVersion == 4 && init != 0 ? init : life;
             if (!M_GetUnderwaterBloodColor(&color, shade)) {
                 return;
             }
         } else {
-            int32_t c1 = init != 0 ? (init >> 2) : (life >> 2);
-            c1 <<= 3;
+            int32_t c1 = (fade >> 2) << 3;
             CLAMPG(c1, 255);
             color = M_Gray(c1);
         }
     } else {
-        int32_t c1 = init != 0 ? (init >> 1) : (life >> 1);
-        c1 <<= 3;
+        int32_t c1 = (fade >> 1) << 3;
         CLAMPG(c1, 255);
         color = M_Gray(c1);
     }
@@ -224,7 +241,7 @@ static void M_Draw(void)
 
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
         const FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
-        if ((ripple->flags & 1U) == 0U) {
+        if ((ripple->flags & FX_RIPPLE_ACTIVE) == 0U) {
             continue;
         }
         M_DrawRipple(ripple);
@@ -288,17 +305,17 @@ static void M_Control(void)
 
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
         FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
-        if ((ripple->flags & 1U) == 0U) {
+        if ((ripple->flags & FX_RIPPLE_ACTIVE) == 0U) {
             continue;
         }
 
         M_RememberRipple(ripple);
 
+        const bool is_slow = (ripple->flags & FX_RIPPLE_SLOW) != 0U;
         const bool is_tr4 = g_TRVersion == 4;
-        const bool is_gentle = (ripple->flags & 2U) != 0U;
 
         if (ripple->size < (is_tr4 ? 252U : 254U)) {
-            ripple->size += is_tr4 && !is_gentle ? 4U : 2U;
+            ripple->size += is_tr4 && !is_slow ? 4U : 2U;
         }
 
         if (ripple->init == 0U) {
@@ -307,7 +324,7 @@ static void M_Control(void)
                 ripple->flags = 0U;
             }
         } else if (ripple->init < ripple->life) {
-            ripple->init += is_tr4 && is_gentle ? 8U : 4U;
+            ripple->init += is_tr4 && is_slow ? 8U : 4U;
             if (ripple->init >= ripple->life) {
                 ripple->init = 0U;
             }
@@ -349,7 +366,7 @@ static void M_SaveRipples(JSON_WRITE_IO *const io)
     JSONW_PUSH_ARRAY(io);
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
         const FX_WATER_RIPPLE *const ripple = &m_Ripples[i];
-        if ((ripple->flags & 1U) == 0U) {
+        if ((ripple->flags & FX_RIPPLE_ACTIVE) == 0U) {
             continue;
         }
         JSONW_PUSH_OBJECT(io);
@@ -451,12 +468,11 @@ static RESULT M_Load(JSON_READ_IO *const io)
 }
 
 FX_WATER_RIPPLE *FX_Water_SetupRipple(
-    const int32_t x, const int32_t y, const int32_t z, int32_t size,
-    const bool is_still)
+    const XYZ_32 pos, const int32_t size, const uint32_t flags)
 {
     int32_t idx = -1;
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
-        if ((m_Ripples[i].flags & 1U) == 0U) {
+        if ((m_Ripples[i].flags & FX_RIPPLE_ACTIVE) == 0U) {
             idx = i;
             break;
         }
@@ -466,20 +482,15 @@ FX_WATER_RIPPLE *FX_Water_SetupRipple(
     }
 
     FX_WATER_RIPPLE *const ripple = &m_Ripples[idx];
-
-    if (size < 0) {
-        ripple->flags = is_still ? 19U : 3U;
-        size = -size;
-    } else {
-        ripple->flags = 1U;
-    }
-
+    ripple->flags = (uint8_t)(flags | FX_RIPPLE_ACTIVE);
     ripple->init = 1U;
     ripple->size = (uint8_t)size;
     ripple->life = (uint8_t)((Random_GetControl() & 0xF) + 48);
-    ripple->pos.x = (Random_GetControl() & 0x7F) + x - 64;
-    ripple->pos.y = y;
-    ripple->pos.z = (Random_GetControl() & 0x7F) + z - 64;
+    ripple->pos = pos;
+    if ((flags & FX_RIPPLE_JITTER) != 0U) {
+        ripple->pos.x += (Random_GetControl() & 0x7F) - 64;
+        ripple->pos.z += (Random_GetControl() & 0x7F) - 64;
+    }
     M_RememberRipple(ripple);
     return ripple;
 }
@@ -715,10 +726,18 @@ void FX_Water_WadeSplash(const ITEM *const item, const int32_t depth)
         (time4 & 0xF) == 0
         && (((Random_GetControl() & 0xF) == 0)
             || item->current_anim_state != LS(LS_STOP))) {
-        FX_Water_SetupRipple(
-            item->pos.x, water_height, item->pos.z,
-            -16 - (Random_GetControl() & 0xF),
-            item->current_anim_state == LS(LS_STOP));
+        const bool is_still = item->current_anim_state == LS(LS_STOP);
+        const XYZ_32 pos = { item->pos.x, water_height, item->pos.z };
+        if (g_TRVersion == 4) {
+            FX_Water_SetupRipple(
+                pos, (Random_GetControl() & 0xF) + 112,
+                is_still ? FX_RIPPLE_DARK : FX_RIPPLE_DARK | FX_RIPPLE_SLOW);
+        } else {
+            FX_Water_SetupRipple(
+                pos, 16 + (Random_GetControl() & 0xF),
+                is_still ? FX_RIPPLE_SLOW | FX_RIPPLE_DARK | FX_RIPPLE_JITTER
+                         : FX_RIPPLE_SLOW | FX_RIPPLE_JITTER);
+        }
     }
 }
 
@@ -726,7 +745,7 @@ void FX_Water_TriggerUnderwaterBlood(const XYZ_32 pos, const int32_t size)
 {
     int32_t idx = -1;
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
-        if ((m_Ripples[i].flags & 1U) == 0U) {
+        if ((m_Ripples[i].flags & FX_RIPPLE_ACTIVE) == 0U) {
             idx = i;
             break;
         }
@@ -736,7 +755,8 @@ void FX_Water_TriggerUnderwaterBlood(const XYZ_32 pos, const int32_t size)
     }
 
     FX_WATER_RIPPLE *const ripple = &m_Ripples[idx];
-    ripple->flags = g_TRVersion == 4 ? 0x31U : 0x33U;
+    ripple->flags = FX_RIPPLE_ACTIVE | FX_RIPPLE_DARK | FX_RIPPLE_BLOOD
+        | (g_TRVersion == 4 ? 0U : FX_RIPPLE_SLOW);
     ripple->init = 1U;
     ripple->life = (Random_GetControl() & 7) - 16;
     ripple->size = size;
@@ -750,7 +770,7 @@ void FX_Water_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
 {
     int32_t idx = -1;
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
-        if ((m_Ripples[i].flags & 1U) == 0U) {
+        if ((m_Ripples[i].flags & FX_RIPPLE_ACTIVE) == 0U) {
             idx = i;
             break;
         }
@@ -760,7 +780,8 @@ void FX_Water_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
     }
 
     FX_WATER_RIPPLE *const ripple = &m_Ripples[idx];
-    ripple->flags = 0x33U;
+    ripple->flags =
+        FX_RIPPLE_ACTIVE | FX_RIPPLE_SLOW | FX_RIPPLE_DARK | FX_RIPPLE_BLOOD;
     ripple->init = 1U;
     ripple->life = (Random_GetDraw() & 7) - 16;
     ripple->size = size;

--- a/src/trx/game/fx/water.h
+++ b/src/trx/game/fx/water.h
@@ -6,6 +6,12 @@
 
 #include <stdint.h>
 
+#define FX_RIPPLE_ACTIVE 0x01u
+#define FX_RIPPLE_SLOW 0x02u
+#define FX_RIPPLE_DARK 0x10u
+#define FX_RIPPLE_BLOOD 0x20u
+#define FX_RIPPLE_JITTER 0x40u
+
 typedef struct {
     XYZ_32 pos;
     int32_t prev_size;
@@ -58,8 +64,7 @@ typedef struct {
     int16_t outer_friction;
 } FX_WATER_SPLASH_SETUP;
 
-FX_WATER_RIPPLE *FX_Water_SetupRipple(
-    int32_t x, int32_t y, int32_t z, int32_t size, bool is_still);
+FX_WATER_RIPPLE *FX_Water_SetupRipple(XYZ_32 pos, int32_t size, uint32_t flags);
 void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *setup);
 void FX_Water_Splash(const ITEM *item);
 void FX_Water_WadeSplash(const ITEM *item, int32_t depth);

--- a/src/trx/game/fx/water_particles.c
+++ b/src/trx/game/fx/water_particles.c
@@ -1,6 +1,3 @@
-// TR3 underwater residue: faint specks drifting around Lara while she is
-// submerged. The droplets falling off her once she is out of the water are
-// fx/droplets.c.
 #include <trx/config.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
@@ -17,6 +14,7 @@
 #include <trx/game/output/vars.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
+#include <trx/version.h>
 
 #include <string.h>
 
@@ -43,6 +41,10 @@ static bool M_IsEnabled(void)
 {
     if (!g_Config.visuals.enable_weather) {
         return false;
+    }
+
+    if (g_TRVersion == 4) {
+        return true;
     }
 
     const GF_LEVEL *const level = GF_GetCurrentLevel();

--- a/src/trx/game/fx/water_particles.c
+++ b/src/trx/game/fx/water_particles.c
@@ -24,9 +24,9 @@
 #define M_SPAWN_ANGLE_MASK 0x1FFE
 #define M_SPAWN_Y_MASK 0x7FF
 #define M_BASE_Y_OFF (-1024)
-#define M_MIN_SIZE 4.0f
-#define M_MAX_SIZE 16.0f
-#define M_SIZE_DIV 6.0f
+#define M_SMALL_SIZE 6.0f
+#define M_MAX_SIZE 12.0f
+#define M_SIZE_DIV 3.0f
 
 typedef struct {
     XYZ_32 pos;
@@ -210,7 +210,11 @@ static void M_Draw(void)
         // into world units - a size in pixels of the rasterized picture would
         // follow the resolution and the supersampling factor.
         float size = (float)((REF_PERSP * (particle->vel.y >> 3)) / vpos_z);
-        CLAMP(size, M_MIN_SIZE, M_MAX_SIZE);
+        if (size < 1.0f) {
+            size = M_SMALL_SIZE;
+        } else {
+            CLAMPG(size, M_MAX_SIZE);
+        }
         size = (size * vpos_z) / (REF_PERSP * M_SIZE_DIV);
 
         uint32_t c;

--- a/src/trx/game/fx/water_particles.c
+++ b/src/trx/game/fx/water_particles.c
@@ -3,10 +3,10 @@
 #include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
+#include <trx/game/camera/vars.h>
 #include <trx/game/fx/common.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/interpolation.h>
-#include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/output/const.h>
 #include <trx/game/output/sources/poly_fx.h>
@@ -69,14 +69,9 @@ static int64_t M_GetViewDepth(const XYZ_32 pos)
 
 static void M_Spawn(M_WATER_PARTICLE *const particle)
 {
-    const ITEM *const lara_item = Lara_GetItem();
-    if (lara_item == nullptr) {
-        return;
-    }
-
     const int32_t dist = Random_GetDraw() & M_SPAWN_DIST_MASK;
     const int32_t angle = (Random_GetDraw() & M_SPAWN_ANGLE_MASK) * 8;
-    particle->pos = XYZ_32_OffsetYaw(lara_item->pos, angle, dist);
+    particle->pos = XYZ_32_OffsetYaw(g_Camera.pos.pos, angle, dist);
     particle->pos.y += (Random_GetDraw() & M_SPAWN_Y_MASK) + M_BASE_Y_OFF;
 
     int16_t room_num = NO_ROOM;

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -100,6 +100,7 @@ static void M_FixStaticsVisibility(void)
             if (Object_IsValidStatid3D(static_mesh->static_num)) {
                 ASSERT(draw_num < MAX_ITEMS);
                 static_mesh->draw_num = draw_num++;
+                static_mesh->room_num = i;
                 Vector_Add(room_stat_vecs[i], static_mesh);
             } else {
                 LOG_WARNING(

--- a/src/trx/game/objects/creatures/orca.c
+++ b/src/trx/game/objects/creatures/orca.c
@@ -131,7 +131,9 @@ static void M_Control(int16_t item_num)
 
         if (water_height != NO_HEIGHT && pos.y < water_height) {
             FX_WATER_RIPPLE *const ripple = FX_Water_SetupRipple(
-                pos.x, water_height, pos.z, -2 - (Random_GetControl() & 1), 0);
+                (XYZ_32) { pos.x, water_height, pos.z },
+                2 + (Random_GetControl() & 1),
+                FX_RIPPLE_SLOW | FX_RIPPLE_JITTER);
             if (ripple != nullptr) {
                 ripple->init = 0;
             }

--- a/src/trx/game/objects/effects/bubble.c
+++ b/src/trx/game/objects/effects/bubble.c
@@ -66,8 +66,9 @@ static void M_Control_TR3(const int16_t effect_num)
     if (!Room_Get(room_num)->flags.underwater) {
         const ROOM *const old_room = Room_Get(effect->room_num);
         FX_Water_SetupRipple(
-            effect->pos.x, old_room->max_ceiling, effect->pos.z,
-            -2 - (Random_GetControl() & 1), true);
+            (XYZ_32) { effect->pos.x, old_room->max_ceiling, effect->pos.z },
+            2 + (Random_GetControl() & 1),
+            FX_RIPPLE_SLOW | FX_RIPPLE_DARK | FX_RIPPLE_JITTER);
         Effect_Destroy(effect_num);
         return;
     }

--- a/src/trx/game/objects/effects/gun_shell.c
+++ b/src/trx/game/objects/effects/gun_shell.c
@@ -38,9 +38,15 @@ static void M_Control(const int16_t effect_num)
     if (room->flags.underwater) {
         Sparks_TriggerSmallSplash(
             (XYZ_32) { effect->pos.x, room->max_ceiling, effect->pos.z }, 8);
-        FX_Water_SetupRipple(
-            effect->pos.x, room->max_ceiling, effect->pos.z,
-            -8 - (Random_GetControl() & 3), true);
+        const XYZ_32 pos = { effect->pos.x, room->max_ceiling, effect->pos.z };
+        if (g_TRVersion == 4) {
+            FX_Water_SetupRipple(
+                pos, (Random_GetControl() & 3) + 8, FX_RIPPLE_SLOW);
+        } else {
+            FX_Water_SetupRipple(
+                pos, 8 + (Random_GetControl() & 3),
+                FX_RIPPLE_SLOW | FX_RIPPLE_DARK | FX_RIPPLE_JITTER);
+        }
         Effect_Destroy(effect_num);
         return;
     }

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -255,7 +255,7 @@ static void M_DoRipple(
     }
 
     FX_WATER_RIPPLE *const ripple = FX_Water_SetupRipple(
-        pos.x, pos.y, pos.z, -2 - (Random_GetControl() & 1), 0);
+        pos, 2 + (Random_GetControl() & 1), FX_RIPPLE_SLOW | FX_RIPPLE_JITTER);
     if (ripple != nullptr) {
         ripple->init = 0;
     }

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -350,17 +350,14 @@ static void M_DrawOpaqueInstance(
     }
 
     Output_MeshShader_UploadWaterEffect(batcher->shader, inst->water_effect);
-    if (inst->wibble) {
+    if (inst->wibble && inst->wibble_fill) {
         Output_MeshShader_UploadWibbleEffect(batcher->shader, false);
         glDepthMask(GL_FALSE);
         M_DrawOpaqueVertices(batcher, inst);
         glDepthMask(GL_TRUE);
-        Output_MeshShader_UploadWibbleEffect(batcher->shader, true);
-        M_DrawOpaqueVertices(batcher, inst);
-    } else {
-        Output_MeshShader_UploadWibbleEffect(batcher->shader, false);
-        M_DrawOpaqueVertices(batcher, inst);
     }
+    Output_MeshShader_UploadWibbleEffect(batcher->shader, inst->wibble);
+    M_DrawOpaqueVertices(batcher, inst);
 
     if (inst->enable_scissor) {
         Output_DisableScissor();

--- a/src/trx/game/output/mesh_batcher/batcher.h
+++ b/src/trx/game/output/mesh_batcher/batcher.h
@@ -18,6 +18,11 @@ typedef struct MESH_INSTANCE {
     const ROOM *room;
     RGBA_F tint;
     bool wibble;
+    // Draws the instance a second time without the distortion, under the
+    // distorted one and without writing depth. Faces that distort next to
+    // faces that do not crack apart at the seam, and the plain copy fills
+    // the cracks. An instance that distorts as a whole needs no fill.
+    bool wibble_fill;
     int32_t water_effect;
 
     // Where the instance sits among the sorted pass's layers, drawn low first

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -366,7 +366,7 @@ static void M_Stage(const OBJECT_MESH *const mesh)
         .cwmatrix = *g_MatrixPtr,
         .wmatrix = *g_WMatrixPtr,
         .tint = Output_GetTint(),
-        .wibble = false,
+        .wibble = Output_GetObjectWibbleEffect(),
         .water_effect =
             (mesh->enable_caustics && Output_GetWaterEffect()) ? 1 : 0,
         .light_info = light_info,

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -278,6 +278,7 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
         .wmatrix = *g_WMatrixPtr,
         .tint = Output_GetRoomTint(),
         .wibble = Output_GetWibbleEffect(),
+        .wibble_fill = g_TRVersion != 4,
         .water_effect = M_GetWaterEffect(room),
         .enable_scissor = Room_IsOverlapping(Room_GetIndex(room)),
         .scissor = {

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -276,7 +276,7 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
         .mesh = mesh,
         .cwmatrix = *g_MatrixPtr,
         .wmatrix = *g_WMatrixPtr,
-        .tint = Output_GetTint(),
+        .tint = Output_GetRoomTint(),
         .wibble = Output_GetWibbleEffect(),
         .water_effect = M_GetWaterEffect(room),
         .enable_scissor = Room_IsOverlapping(Room_GetIndex(room)),

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -116,7 +116,10 @@ static void M_AddRoomFace(
             &room->mesh.vertices[face->vertices[i]];
 
         uint16_t flags = 0;
-        if (room_vert->flags.disable_wibble) {
+        const bool disable_wibble = g_TRVersion == 4
+            ? room_vert->flags.move
+            : room_vert->flags.disable_wibble;
+        if (disable_wibble) {
             flags |= VERT_NO_WIBBLE;
         }
         if (room_vert->flags.move) {

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -52,6 +52,7 @@ static XYZ_32 m_TR3LightDirView[3] = {};
 static bool m_IsWibbleEffect = false;
 static bool m_IsWaterEffect = false;
 static bool m_IsShadeEffect = false;
+static bool m_IsRoomShadeEffect = false;
 static bool m_IsSkyboxEnabled = false;
 
 static int32_t m_TintOverrideDepth = 0;
@@ -141,7 +142,8 @@ void Output_SetupBelowWater(const bool underwater)
 {
     m_IsWaterEffect = true;
     m_IsWibbleEffect = g_TRVersion == 4 ? underwater : !underwater;
-    m_IsShadeEffect = true;
+    m_IsShadeEffect = g_TRVersion != 4;
+    m_IsRoomShadeEffect = g_TRVersion == 4 ? underwater : true;
 }
 
 void Output_SetupAboveWater(const bool underwater)
@@ -149,6 +151,7 @@ void Output_SetupAboveWater(const bool underwater)
     m_IsWaterEffect = false;
     m_IsWibbleEffect = underwater;
     m_IsShadeEffect = underwater;
+    m_IsRoomShadeEffect = underwater;
 }
 
 bool Output_GetWaterEffect(void)
@@ -192,6 +195,17 @@ RGBA_F Output_GetTint(void)
         return m_TintOverrideStack[m_TintOverrideDepth - 1];
     }
     if (m_IsShadeEffect) {
+        return Color_RGBToRGBA(m_WaterColor);
+    }
+    return COLOR_RGBA_F_WHITE;
+}
+
+RGBA_F Output_GetRoomTint(void)
+{
+    if (m_TintOverrideDepth != 0) {
+        return m_TintOverrideStack[m_TintOverrideDepth - 1];
+    }
+    if (m_IsRoomShadeEffect) {
         return Color_RGBToRGBA(m_WaterColor);
     }
     return COLOR_RGBA_F_WHITE;

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -140,7 +140,7 @@ void Output_SetFogEnd(const int32_t dist)
 void Output_SetupBelowWater(const bool underwater)
 {
     m_IsWaterEffect = true;
-    m_IsWibbleEffect = !underwater;
+    m_IsWibbleEffect = g_TRVersion == 4 ? underwater : !underwater;
     m_IsShadeEffect = true;
 }
 
@@ -159,6 +159,11 @@ bool Output_GetWaterEffect(void)
 bool Output_GetWibbleEffect(void)
 {
     return m_IsWibbleEffect;
+}
+
+bool Output_GetObjectWibbleEffect(void)
+{
+    return g_TRVersion == 4 && m_IsWibbleEffect;
 }
 
 void Output_SetFogColor(const RGBA_8888 color)

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -30,7 +30,12 @@ RGBA_F Output_GetTint(void);
 void Output_PushTintOverride(RGBA_F tint);
 void Output_PopTintOverride(void);
 bool Output_GetWaterEffect(void);
+// Reports whether room geometry distorts. TR1 to TR3 distort water seen from
+// above and dry rooms seen from below the surface. TR4 distorts every room
+// while the camera is below the surface.
 bool Output_GetWibbleEffect(void);
+// Reports whether objects and static meshes distort.
+bool Output_GetObjectWibbleEffect(void);
 
 RGBA_F Output_GetFogColor(void);
 int32_t Output_GetFogStart(void);

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -26,7 +26,13 @@ void Output_SetupAboveWater(bool is_underwater);
 RGB_F Output_GetWaterColor(void);
 void Output_SetWaterColor(RGB_888 color);
 
+// Returns the tint for objects and static meshes. TR1 to TR3 tint objects in
+// water and dry rooms seen from below the surface. TR4 tints only dry rooms
+// seen from below the surface.
 RGBA_F Output_GetTint(void);
+// Returns the tint for room geometry. TR4 tints wet and dry rooms while the
+// camera is below the surface.
+RGBA_F Output_GetRoomTint(void);
 void Output_PushTintOverride(RGBA_F tint);
 void Output_PopTintOverride(void);
 bool Output_GetWaterEffect(void);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -436,9 +436,12 @@ static void M_DrawSingleRoom(const ROOM *const room)
         Matrix_RotY(mesh->rot.y);
         const CLIP clip = Output_CheckBoundsClip(&obj->draw_bounds);
         if (clip != CLIP_NOT_VISIBLE) {
+            const ROOM *const owner = Room_Get(mesh->room_num);
             M_DrawSet_Add(&m_DrawnStatics, mesh->draw_num);
-            Output_CalculateStaticMeshLight(mesh->pos, mesh->shade, room);
+            M_SetupWaterStatus(owner);
+            Output_CalculateStaticMeshLight(mesh->pos, mesh->shade, owner);
             Object_DrawMesh(obj->mesh_idx, clip, false);
+            M_SetupWaterStatus(room);
             if (g_Config.debug.enable_debug_bounding_boxes) {
                 Output_DrawCuboid(&obj->draw_bounds);
             }

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -194,6 +194,10 @@ typedef struct {
     SHADE shade;
     int16_t static_num;
     int16_t draw_num;
+    // The room that holds the mesh. A mesh that reaches through a portal is
+    // lent to the room on the other side, so the room that draws it is not
+    // always the room it stands in.
+    int16_t room_num;
 } STATIC_MESH;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This gives TR4 the water effects the original shows, which TRX either drew the TR3 way or did not draw at all. The effects now follow the camera rather than the room a thing stands in, as the original does.

- The picture wobbles while the camera is below the surface, and rooms, objects and static meshes all take the distortion. Nothing wobbles while the camera is above the surface. The wave keeps its size and its speed at any resolution.
- Water rooms carry drifting specks, in every level.
- Ripples take the size, the color and the spread of the original, and the shell casings, the wading splashes and the underwater blood all draw them that way.
- The water tint covers wet and dry rooms alike while the camera is below the surface, and leaves the water surface and the shoreline in the colors they have in the dry room.

For mod authors, the `water_particles` level property has no effect in TR4. The particles show in every water room, as they do in the original.

Resolves TRX523 / TRX553 / TRX560 / TRX590