### PR TITLE
Stop Lara flinching at Von Croy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)
+- Fixed Lara flinching when she bumps into Von Croy (TRX1095)
 - Fixed rooms and their contents sometimes disappearing while an in-game cutscene plays (TRX1052)
 - Fixed parts of the level dropping out of the picture during the cutscene that opens Karnak (TRX1092)
 - Fixed the parked jeep showing in the temple during the cutscene that opens Karnak (TRX1092)

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/debug.h>
 #include <trx/game/lara.h>
+#include <trx/game/objects/vars.h>
 #include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
 
@@ -145,7 +146,10 @@ void Lara_Col_ItemPush(
         .pos = item->pos,
         .rot = item->rot,
     };
-    Lara_Col_Push(&src_item, coll, hit_on, big_push);
+    Lara_Col_Push(
+        &src_item, coll,
+        hit_on && !Object_IsType(item->object_id, g_NoHitReactionObjects),
+        big_push);
 }
 
 void Lara_Col_Static3DPush(const STATIC_MESH *const mesh, COLL_INFO *const coll)

--- a/src/trx/game/objects/vars.c
+++ b/src/trx/game/objects/vars.c
@@ -171,6 +171,13 @@ const OBJECT_ID g_WaterObjects[] = {
     // clang-format on
 };
 
+const OBJECT_ID g_NoHitReactionObjects[] = {
+    // clang-format off
+    O_VON_CROY,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const OBJECT_ID g_LoyalObjects[] = {
     // clang-format off
     O_LARA,

--- a/src/trx/game/objects/vars.h
+++ b/src/trx/game/objects/vars.h
@@ -7,6 +7,7 @@ extern const OBJECT_ID g_CreatureObjects[];
 extern const OBJECT_ID g_ProjectileObjects[];
 extern const OBJECT_ID g_WaterObjects[];
 extern const OBJECT_ID g_LoyalObjects[];
+extern const OBJECT_ID g_NoHitReactionObjects[];
 extern const OBJECT_ID g_PickupObjects[];
 extern const OBJECT_ID g_ElevatedPickupObjects[];
 extern const OBJECT_ID g_SwitchObjects[];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where Lara flinched and cried out when she bumped into Von Croy. The original game excludes the guide, Von Croy and the enemy jeep from this reaction.

Resolves TRX1095