### PR TITLE
objects/flame: light Lara where she burns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Fixed the parked jeep showing in the temple during the cutscene that opens Karnak (TRX1092)
 - Fixed a crash while an in-game cutscene poses Lara (TRX1059)
 - Fixed Lara's shadow and the flames around her when she burns staying where an in-game cutscene began, rather than following her (TRX911)
+- Fixed the light the flames cast staying where an in-game cutscene began while Lara burns, rather than following her (TRX1197)
 - Fixed Von Croy's shadow floating at the height of his knees during the scenes he plays in Angkor Wat (TRX911)
 - Fixed Lara's shadow being too small to read as the jeep's during the cutscene that opens Karnak (TRX911)
 - Fixed the geometry in Karnak causing the opening cutscene camera to be in the void, and some rooms not rendering fully as a result (TRX1184)

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -5,6 +5,7 @@
 #include <trx/core/utils.h>
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
+#include <trx/game/lara/pose.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -24,6 +25,19 @@ static const uint8_t m_TR3_XZOffsets[16][2] = {
     { 40, 24 }, { 55, 24 }, { 9, 40 },  { 24, 40 }, { 40, 40 }, { 55, 40 },
     { 9, 55 },  { 24, 55 }, { 40, 55 }, { 55, 55 },
 };
+
+// Where the light of the flames around Lara belongs. A cutscene leaves her item
+// at the scene's origin and poses her from there, so the light hangs off the
+// same joint the flames hang off rather than off the item.
+static XYZ_32 M_GetLaraFireLightPos(const ITEM *const lara_item)
+{
+    if (Lara_Pose_Get() == nullptr) {
+        return lara_item->pos;
+    }
+    XYZ_32 pos = {};
+    Collide_GetJointAbsPosition(lara_item, &pos, LM_HIPS);
+    return pos;
+}
 
 static bool M_IsGreenAttachedFlame(const EFFECT *const effect)
 {
@@ -189,7 +203,7 @@ static void M_TR3_ControlSmall(
             color.g = ((rnd >> 4) & 0x1F) + 96;
             color.b = 0;
         }
-        Output_AddDynamicLightRGB(lara_item->pos, 13, color);
+        Output_AddDynamicLightRGB(M_GetLaraFireLightPos(lara_item), 13, color);
     }
 
     if (lara_item->room_num != effect->room_num) {
@@ -485,7 +499,7 @@ static void M_TR4_Control(const int16_t effect_num)
             color.g = (Random_GetControl() & 0x1F) + 96;
             color.b = 0;
         }
-        Output_AddDynamicLightRGB(lara_item->pos, 13, color);
+        Output_AddDynamicLightRGB(M_GetLaraFireLightPos(lara_item), 13, color);
     }
 
     if (lara_item->room_num != effect->room_num) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the light of the flames around a burning Lara stayed where an in-game cutscene began, falling on whoever stood there instead of on her. Her shadow and the flames themselves already follow her.

Resolves TRX1197