### PR TITLE
Fix water wobble weakening at higher supersampling

### DIFF
--- a/data/trx/ship/cfg/shaders/common.glsl
+++ b/data/trx/ship/cfg/shaders/common.glsl
@@ -56,6 +56,7 @@ layout(std140) uniform Globals {
     int uAffineMappingEnabled; // bool
     int uTRVersion;
     float uUVScrollTick;
+    int uSupersamplingFactor;
 };
 
 layout(std140) uniform Matrices {

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -64,8 +64,9 @@ vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)
     pixelPos.y += sin(phases) * adjustedWibble;
 #else
     float phases = (uTimeInGame + length(worldPosition.xyz)) * (2.0 * PI / WIBBLE_SIZE);
-    pixelPos.x += sin(phases) * MAX_WIBBLE;
-    pixelPos.y += cos(phases) * MAX_WIBBLE;
+    float amplitude = MAX_WIBBLE * float(uSupersamplingFactor);
+    pixelPos.x += sin(phases) * amplitude;
+    pixelPos.y += cos(phases) * amplitude;
 #endif
     // reverse transform
     ndc.xy = (pixelPos / uViewportSize - 0.5) * 2.0;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Changed the lighting contrast option to appear in TR1 and TR2 only, as the other games light dynamic sources their own way (Graphic Options → Rendering → Lighting contrast)
 - Changed TR3 to light geometry on the brighter curve its hardware renderer used (Graphic Options → Rendering → Lighting model)
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
+- Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -42,7 +42,8 @@
     X_DECLARE_MEMBER(int, affine_mapping_enabled)                              \
     X_DECLARE_MEMBER(int, tr_version)                                          \
     X_DECLARE_MEMBER(float, uv_scroll_tick)                                    \
-    X_DECLARE_MEMBER(float, _pad, [2])
+    X_DECLARE_MEMBER(int, supersampling_factor)                                \
+    X_DECLARE_MEMBER(float, _pad, [1])
 
 #pragma pack(push, 4)
 typedef struct {
@@ -173,6 +174,7 @@ void Output_Uniforms_UploadGeneral(const OUTPUT_UNIFORMS *const uniforms)
         .sunset_duration = Output_GetSunsetDuration(),
         .tr_version = g_TRVersion,
         .uv_scroll_tick = Output_GetUVScrollTick(),
+        .supersampling_factor = Viewport_GetSupersamplingFactor(),
         .viewport_size = {
             (float)Viewport_GetWidth(VIEWPORT_GAME),
             (float)Viewport_GetHeight(VIEWPORT_GAME),


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the underwater view wobbled less as the supersampling value increased. The wobble now looks the same at every supersampling value.

Resolves TRX1207