### PR TITLE
replay: stop a crash on a missing replay file

### DIFF
--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -203,12 +203,12 @@ static RESULT M_PrepareSystem(void)
         // embedded info (created with the old directory layout).
         g_TRVersion = s->args->startup.engine_version;
         SHELL_ARGS *const tmp_args = TestReplay_Open(test_replay_path);
-        if (tmp_args != nullptr) {
-            tmp_args->headless = s->args->headless;
-            tmp_args->debug_render_performance =
-                s->args->debug_render_performance;
-            ShellSession_UseArgs(s, tmp_args);
-        }
+        FAIL_IF(
+            tmp_args == nullptr, "the replay file '%s' could not be read",
+            test_replay_path);
+        tmp_args->headless = s->args->headless;
+        tmp_args->debug_render_performance = s->args->debug_render_performance;
+        ShellSession_UseArgs(s, tmp_args);
     } else if (s->args->headless) {
         return FAIL("--headless can only be given with --test-replay");
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the game crashed when --test-replay named a file that does not exist. Before this, the missing file only made a warning and the game went on to read the recording it never loaded.