### PR TITLE
savegame: fix black flares after a save is loaded

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -97,6 +97,7 @@
 - Fixed Von Croy's shadow floating at the height of his knees during the scenes he plays in Angkor Wat (TRX911)
 - Fixed Lara's shadow being too small to read as the jeep's during the cutscene that opens Karnak (TRX911)
 - Fixed the geometry in Karnak causing the opening cutscene camera to be in the void, and some rooms not rendering fully as a result (TRX1184)
+- Fixed a dropped flare turning black after a save is loaded (TRX904)
 
 **Miscellaneous**
 - Added an option to cast Lara in gold whatever she is wearing (Graphic Options → Visuals → Golden Lara) (TRX1070)

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -793,6 +793,7 @@ static RESULT M_ReadFlare(JSON_READ_IO *const io)
     MUST(JSON_READ(io, "rot", &item->rot));
     MUST(JSON_READ(io, "room_num", &item->room_num));
     Item_Initialise(item_num);
+    item->shade.value_1 = -1;
     MUST(JSON_READ(io, "speed", &item->speed));
     MUST(JSON_READ(io, "fall_speed", &item->fall_speed));
     int32_t flare_age;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where a flare on the ground turned black in TR4 levels when a save was loaded. The restored flare kept no light of its own, so the game lit it as a fixed shade of zero.

Resolves TRX904