### PR TITLE
lara/state/crouch: disable enemy hits on climb

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed Lara being able to vault or crawl through breakable walls that stand on the edge of a tile (Gameplay → Fixes → Fix breakable wall clipping) (OG bug) (TRX1024)
 - Fixed Lara's rope-grab reach being shorter from certain directions (OG bug) (TRX1143)
 - Fixed Lara being thrown across the room when she shimmies to the end of a ladder (Gameplay → Controls → Corner shimmying) (TRX1203)
+- Fixed Lara getting pushed by enemies while climbing into or out of crawlspaces (OG bug) (TRX1182)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -357,6 +357,12 @@ static void M_CrawlJumpDown(ITEM *const item, COLL_INFO *const coll)
     lara->gun_status = LGS_ARMLESS;
 }
 
+static void M_CrawlClimb(ITEM *const item, COLL_INFO *const coll)
+{
+    coll->enable_baddie_push = 0;
+    coll->enable_hit = 0;
+}
+
 // clang-format off
 REGISTER_LARA_STATE(LS_CROUCH_IDLE,       M_CrouchIdle)
 REGISTER_LARA_STATE(LS_CROUCH_ROLL,       M_CrouchRoll)
@@ -368,4 +374,6 @@ REGISTER_LARA_STATE(LS_CRAWL_TURN_LEFT,   M_CrawlTurn)
 REGISTER_LARA_STATE(LS_CRAWL_TURN_RIGHT,  M_CrawlTurn)
 REGISTER_LARA_STATE(LS_CRAWL_BACK,        M_CrawlBack)
 REGISTER_LARA_STATE(LS_CRAWL_JUMP_DOWN,   M_CrawlJumpDown)
+REGISTER_LARA_STATE(LS_CRAWL_TO_CLIMB,    M_CrawlClimb)
+REGISTER_LARA_STATE(LS_CLIMB_TO_CRAWL,    M_CrawlClimb)
 // clang-format on


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This prevents Lara getting pushed by enemies when climbing into or out of crawlspaces, similar to the `LS_PULL_UP` state for regular space.

Resolves TRX1182.
