### PR TITLE
objects/von_croy: fix path split logic

### DIFF
--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -1272,12 +1272,11 @@ static void M_GuideControl(const int16_t item_num)
         enemy = target;
     }
 
-    if (p->waypoint == 43 && Stats_CheckAllLevelSecretsPickedUp()) {
+    if (p->waypoint == 43 && Stats_CheckAllLevelSecretsCollected()) {
         creature->reached_goal = false;
         creature->enemy = nullptr;
         item->ai_bits = AI_FOLLOW;
         p->waypoint = 53;
-        Waypoint_Set(53);
     }
 
     if ((Waypoint_GetPad() == 9 || Waypoint_GetPad() == 10)
@@ -1295,9 +1294,7 @@ static void M_GuideControl(const int16_t item_num)
         Waypoint_SetPad((int16_t)p->waypoint);
         Waypoint_Set(Waypoint_GetPad());
     } else if (
-        Waypoint_Get() == 43
-        && (p->waypoint == 44 || p->waypoint == 54 || p->waypoint == 44
-            || p->waypoint == 54)) {
+        Waypoint_Get() == 43 && (p->waypoint == 44 || p->waypoint == 54)) {
         Waypoint_Set((int16_t)p->waypoint);
     }
 

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -394,7 +394,7 @@ static void M_DoPickup(const int16_t item_num)
     Overlay_AddDisplayPickup(item->object_id);
     if (Object_IsType(item->object_id, g_SecretObjects)) {
         Stats_MarkSecretCollected(item);
-        if (Stats_CheckAllLevelSecretsPickedUp()) {
+        if (Stats_CheckAllLevelSecretsCollected()) {
             GF_InventoryModifier_Apply(Game_GetCurrentLevel(), GF_INV_SECRET);
         }
     } else {

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -176,18 +176,13 @@ void Stats_MarkSecretCollected(const ITEM *const item)
     Stats_UpdateSecrets(stats);
 }
 
-bool Stats_CheckAllLevelSecretsPickedUp(void)
+bool Stats_CheckAllLevelSecretsCollected(void)
 {
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
     const LEVEL_STATS *const stats = Stats_GetLevelStats(level);
-    int32_t flags = stats->secret_flags;
-    size_t count = 0;
-    while (flags != 0) {
-        count += flags & 1;
-        flags >>= 1;
-    }
-    return count >= max_stats->max_pickup_secret_count;
+    return stats->counts[STATS_CAT_SECRETS]
+        >= max_stats->maxes[STATS_CAT_SECRETS];
 }
 
 bool Stats_CheckAllSecretsCollected(void)

--- a/src/trx/game/stats/common.h
+++ b/src/trx/game/stats/common.h
@@ -33,7 +33,7 @@ uint32_t Stats_GetSecretMaskForItem(const GF_LEVEL *level, int16_t item_num);
 void Stats_UpdateSecrets(LEVEL_STATS *stats);
 void Stats_MarkSecretCollected(const ITEM *item);
 bool Stats_CheckAllSecretsCollected(void);
-bool Stats_CheckAllLevelSecretsPickedUp(void);
+bool Stats_CheckAllLevelSecretsCollected(void);
 
 void Stats_UpdateTimer(void);
 void Stats_AddKill(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes the logic for Von Croy deciding which path to take towards the end of Angkor Wat. A change related to this is that checking if all secrets in a level are collected is now type-agnostic. While the secrets are pickups in this level, they're essentially still floor triggers.

The path decision now seems to work, but I'm not sure about Lara's location during his speech here. Setting the waypoint too early made her stop a sector behind where she does on this build, and she was then out of view from the camera.

We'll need to double check collecting all secrets in a TR2 level gives the rewards normally.

Resolves TRX1107.
