### PR TITLE
objects/shoal: use enemy room during attack

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Fixed Lara's sliding SFX continuing after she leaves a slope (#6294 / TRX1155, regression from 1.0)
 - Fixed underwater blood clouds appearing in the air when the security lasers hurt Lara at the water surface (OG bug) (#6323 / TRX1180)
 - Fixed the ceiling spikes not stopping on a pushable block until Lara finishes pushing it (OG bug) (#6308 / TRX1169)
+- Fixed the piranhas in It's a Madhouse! being invisible if attacking Lara while she collects the Aviary Key (#6345 / TRX1200)
 
 **TR4**
 - Added the ability to skip in-game cutscenes (TRX1051)

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -506,7 +506,9 @@ static void M_Control(const int16_t item_num)
         .y = p->anchor.y + leader_fish->pos.y,
         .z = p->anchor.z + leader_fish->pos.z,
     };
-    int16_t room_num = item->room_num;
+    int16_t room_num = (piranha_attack != 0 && enemy != nullptr)
+        ? enemy->room_num
+        : item->room_num;
     Room_GetSector(item->pos, &room_num);
     if (room_num != item->room_num) {
         Item_UpdateRoom(item_num, room_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This updates piranhas to use their enemy's room number when attacking, solving the case in It's a Madhouse! where there is no sector traversal possible when Lara collects the Aviary Key.

Resolves #6345 / TRX1200.
