### PR TITLE
objects/von_croy: fix camera room overlap and Lara's busy hands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Fixed Lara's shadow being too small to read as the jeep's during the cutscene that opens Karnak (TRX911)
 - Fixed the geometry in Karnak causing the opening cutscene camera to be in the void, and some rooms not rendering fully as a result (TRX1184)
 - Fixed a dropped flare turning black after a save is loaded (TRX904)
+- Fixed the camera getting stuck during a Von Croy tutorial at the end of Angkor Wat, Route of the Virtuous (TRX1213)
 
 **Miscellaneous**
 - Added an option to cast Lara in gold whatever she is wearing (Graphic Options → Visuals → Golden Lara) (TRX1070)

--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -480,6 +480,7 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
             lara->speed = 0;
             lara->fall_speed = 0;
             lara->gravity = 0;
+            Lara_GetLaraInfo()->gun_status = LGS_ARMLESS;
         }
 
         break;

--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -321,7 +321,11 @@ static void M_SetCutCamera(const ITEM *const item)
         g_Camera.target.z = item->pos.z;
     }
 
-    const int16_t cam_room = Room_GetIndexFromPos(g_Camera.pos.pos);
+    int16_t cam_room =
+        Room_FindByTraversal(item->pos, g_Camera.pos.pos, item->room_num);
+    if (cam_room == NO_ROOM) {
+        cam_room = Room_GetIndexFromPos(g_Camera.pos.pos);
+    }
     if (cam_room == NO_ROOM || !M_IsValidPos(g_Camera.pos.pos, cam_room)) {
         g_Camera.pos = m_OldCamera.pos;
     } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The camera in Von Croy's cutscenes now tries to first get the room number by traversing from his location to the camera location, and if that fails it falls back to a room lookup by position. There are lots of overlapping rooms at the end of Angkor Wat so OG was picking the wrong room for the virtuous route result.

Lara's hands are also now freed after Von Croy talks to her.

Resolves TRX1212 / TRX1213.