### PR TITLE
Fix headless runs drawing nothing to capture

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Changed the lighting contrast option to appear in TR1 and TR2 only, as the other games light dynamic sources their own way (Graphic Options → Rendering → Lighting contrast)
 - Changed TR3 to light geometry on the brighter curve its hardware renderer used (Graphic Options → Rendering → Lighting model)
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
+- Fixed the inventory background showing black, and objects around it going missing, in a headless run
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed static objects that reach through a doorway taking the water tint and the light of the room next door
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Added the PlayStation lighting model, which deepens bright surfaces into their own color rather than white (Graphic Options → Rendering → Lighting model)
 - Changed the lighting contrast option to appear in TR1 and TR2 only, as the other games light dynamic sources their own way (Graphic Options → Rendering → Lighting contrast)
 - Changed TR3 to light geometry on the brighter curve its hardware renderer used (Graphic Options → Rendering → Lighting model)
+- Fixed a headless run drawing none of the title screen's objects, such as the passport
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
 - Fixed the inventory background showing black, and objects around it going missing, in a headless run
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -29,6 +29,7 @@
 typedef struct {
     VECTOR *sources;
     GLuint sampler_id;
+    int32_t capture_depth;
 } M_PRIV;
 
 static M_PRIV m_Priv = {};
@@ -185,8 +186,20 @@ static void M_RenderScenePasses(const M_PRIV *const p)
 
 static bool M_IsActive(void)
 {
-    return !Output_IsHeadless() || Shell_GetArgs()->debug_render_performance
+    return !Output_IsHeadless() || m_Priv.capture_depth > 0
+        || Shell_GetArgs()->debug_render_performance
         || TRX_GL_Context_GetScheduledScreenshotPath() != nullptr;
+}
+
+void SceneCompositor_BeginCapture(void)
+{
+    m_Priv.capture_depth++;
+}
+
+void SceneCompositor_EndCapture(void)
+{
+    ASSERT(m_Priv.capture_depth > 0);
+    m_Priv.capture_depth--;
 }
 
 void SceneCompositor_Init(void)
@@ -228,6 +241,7 @@ void SceneCompositor_Flush(void)
 {
     M_PRIV *const p = &m_Priv;
     if (!M_IsActive()) {
+        M_PROCESS_SOURCES(p, render_begin);
         return;
     }
     M_RenderScenePasses(p);
@@ -240,6 +254,7 @@ void SceneCompositor_EndScene(void)
 {
     M_PRIV *const p = &m_Priv;
     if (!M_IsActive()) {
+        M_PROCESS_SOURCES(p, render_begin);
         return;
     }
     M_RenderScenePasses(p);

--- a/src/trx/game/output/scene_compositor.h
+++ b/src/trx/game/output/scene_compositor.h
@@ -9,5 +9,12 @@ void SceneCompositor_AddSource(const SCENE_SOURCE *source);
 void SceneCompositor_BeginScene(void);
 void SceneCompositor_EndScene(void);
 void SceneCompositor_Flush(void);
+
+// Renders the scene even where the frame would otherwise be skipped, so a
+// capture reads back real content instead of an empty frame. A headless run
+// draws nothing on its own.
+void SceneCompositor_BeginCapture(void);
+void SceneCompositor_EndCapture(void);
+
 void SceneCompositor_AnimateTextures(void);
 void SceneCompositor_SetSamplerFilter(TEXTURE_FILTER filter);

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -894,9 +894,11 @@ void Output_Overlay_CaptureGameSnapshot(void)
     Interpolation_Disable();
     Output_SwitchViewport(VIEWPORT_GAME);
 
+    SceneCompositor_BeginCapture();
     SceneCompositor_BeginScene();
     Game_Draw(false);
     SceneCompositor_EndScene();
+    SceneCompositor_EndCapture();
     Interpolation_Enable();
 
     M_CopyFboToTexture(

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -365,7 +365,9 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     EXIT_ON_FAIL(M_CreateGameWindow(), "TRX could not open a window");
     EXIT_ON_FAIL(M_CreateGLContext(), "TRX cannot draw the game");
     EXIT_ON_FAIL(Output_Init(), "TRX cannot draw the game");
-    if (!s->args->headless) {
+    if (s->args->headless) {
+        Shell_RefreshRendererViewport();
+    } else {
         M_ShowWindow();
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes headless captures missing scene content due to an uninitialized clip window.

- Restores title screen objects, such as the passport
- Renders a real frame behind inventory captures instead of black