### PR TITLE
Show scroll arrows in every game's list dialogs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Changed settings dialogs to stay readable at large text sizes, with shorter setting names and tighter layouts where needed
 - Changed the Fix one-shot music triggers option to sit with the other music settings (Sound → Misc) (TRX1045)
 - Changed the PS1 poison healthbar to flat yellow, as the PS1 releases had it (#5227 / TRX1135)
+- Changed the Customize Controls dialog to show a scroll arrow when the key list runs longer than the dialog (TRX546)
 - Changed the TR3 breeze mode to read TR3/4, as it covers both games (Graphic Options → Visuals → Breeze) (TRX1133)
 - Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258 / TRX1126)
 - Changed the F9 key to cycle the lighting model in TR3 and TR4, and the lighting contrast in TR1 and TR2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter (TRX1136)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control (TRX1057)
 - Fixed several dialogs running past the screen edges or overlapping headings at large text sizes (#6293 / TRX1154)
+- Fixed the save and load dialogs covering the inventory headings at large text sizes
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10) (TRX1068)
 - Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects (TRX1040)
 - Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down (TRX1142)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Changed the TR3 breeze mode to read TR3/4, as it covers both games (Graphic Options → Visuals → Breeze) (TRX1133)
 - Changed the preset confirmation to offer Apply and Go back as choices, rather than leaving the keys unsaid (#6258 / TRX1126)
 - Changed the F9 key to cycle the lighting model in TR3 and TR4, and the lighting contrast in TR1 and TR2
+- Changed the save, load, level select and mod dialogs to show scroll arrows in every game, as TR1 does (TRX547)
 - Changed vertex snapping to offer Disabled, 320x240, and Upscale Res modes (#6278 / TRX1137)
 - Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter (TRX1136)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control (TRX1057)

--- a/src/tests/trx/game/ui.c
+++ b/src/tests/trx/game/ui.c
@@ -368,7 +368,7 @@ static bool M_IsNear(const float actual, const float expected)
     return fabsf(actual - expected) < 0.001f;
 }
 
-TEST(ui_screen_insets_come_from_the_last_scene)
+TEST(ui_screen_insets_cover_the_scene_being_built)
 {
     Subsystem_InitAll();
     M_SetLanguage(nullptr);
@@ -376,8 +376,9 @@ TEST(ui_screen_insets_come_from_the_last_scene)
 
     UI_BeginScene();
     UI_SetScreenInset(UI_SCREEN_INSET_OVERLAY, 20.0f, 10.0f);
+    CHECK_EQ_INT(UI_GetScreenInsetTop(), 20);
+    CHECK_EQ_INT(UI_GetScreenInsetBottom(), 10);
     UI_EndScene();
-    CHECK_EQ_INT(UI_GetScreenInsetTop(), 0);
 
     UI_BeginScene();
     UI_EndScene();

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -271,6 +271,7 @@ float UI_GetScreenInsetTop(void)
     float result = 0.0f;
     for (int32_t i = 0; i < UI_SCREEN_INSET_SOURCE_COUNT; i++) {
         result = MAX(result, m_Priv.inset_current[i].top);
+        result = MAX(result, m_Priv.inset_pending[i].top);
     }
     return result;
 }
@@ -280,6 +281,7 @@ float UI_GetScreenInsetBottom(void)
     float result = 0.0f;
     for (int32_t i = 0; i < UI_SCREEN_INSET_SOURCE_COUNT; i++) {
         result = MAX(result, m_Priv.inset_current[i].bottom);
+        result = MAX(result, m_Priv.inset_pending[i].bottom);
     }
     return result;
 }

--- a/src/trx/game/ui/common.h
+++ b/src/trx/game/ui/common.h
@@ -70,7 +70,9 @@ typedef enum {
 // Reserves top and bottom space, in text units, for the scene being built.
 void UI_SetScreenInset(UI_SCREEN_INSET_SOURCE source, float top, float bottom);
 
-// Returns the largest top or bottom inset from the previous scene.
+// Returns the largest top or bottom inset, taking the scene being built and
+// the previous one together, so a dialog laid out before the overlay
+// declares its inset still keeps that space clear.
 float UI_GetScreenInsetTop(void);
 float UI_GetScreenInsetBottom(void);
 

--- a/src/trx/game/ui/dialogs/base_passport.c
+++ b/src/trx/game/ui/dialogs/base_passport.c
@@ -6,7 +6,6 @@
 #include <trx/game/ui/elements/modal.h>
 #include <trx/game/ui/elements/requester.h>
 #include <trx/game/ui/elements/resize.h>
-#include <trx/game/ui/hud/overlay.h>
 #include <trx/game/ui/scaler.h>
 #include <trx/version.h>
 
@@ -19,10 +18,7 @@
 
 static float M_GetAvailableHeight(void)
 {
-    // The ring writes its heading above the dialog and the name of the page
-    // below it, and the dialog belongs between the two.
-    return UI_GetCanvasHeight() / UI_Scaler_GetTextScale()
-        - 2.0f * UI_Overlay_GetTextInset();
+    return UI_GetSafeCanvasHeight() / UI_Scaler_GetTextScale();
 }
 
 static int32_t M_GetVisibleRows(const UI_REQUESTER_STATE *const req)
@@ -64,8 +60,8 @@ void UI_BasePassportDialog_Control(UI_REQUESTER_STATE *const req)
 
 void UI_BeginBasePassportDialog(const UI_REQUESTER_STATE *const req)
 {
-    const float modal_y = g_InvRing_Mode == INV_TITLE_MODE ? 0.81f : 0.62f;
-    UI_BeginModalEx(0.5f, modal_y, UI_Overlay_GetTextInset());
+    const float modal_y = g_InvRing_Mode == INV_TITLE_MODE ? 0.98f : 0.67f;
+    UI_BeginModal(0.5f, modal_y);
     UI_Scaler_PushTextScale(M_GetFitScale(req));
     UI_BeginResizeEx((UI_RESIZE_SETTINGS) {
         .w = 300.0f,

--- a/src/trx/game/ui/dialogs/base_passport.c
+++ b/src/trx/game/ui/dialogs/base_passport.c
@@ -51,7 +51,7 @@ void UI_BasePassportDialog_Init(
     UI_Requester_Init(req, 0, max_rows, true);
     req->row_pad = 4.0f;
     req->row_spacing = g_TRVersion == 1 ? 2.0f : 3.0f;
-    req->show_arrows = g_TRVersion == 1;
+    req->show_arrows = true;
     req->reserve_space = true;
     req->footer_height = footer_height;
     UI_BasePassportDialog_Control(req);

--- a/src/trx/game/ui/elements/anchor.c
+++ b/src/trx/game/ui/elements/anchor.c
@@ -1,5 +1,6 @@
 #include <trx/game/ui/elements/anchor.h>
 
+#include <trx/core/utils.h>
 #include <trx/game/ui/helpers.h>
 #include <trx/game/ui/text.h>
 
@@ -14,6 +15,14 @@ static void M_Measure(UI_NODE *const node)
     node->measure_h = UI_GetCanvasHeight() - UI_TEXT_HEIGHT;
 }
 
+static float M_Offset(const float slack, const float ratio)
+{
+    if (slack >= 0.0f || ratio < 0.0f || ratio > 1.0f) {
+        return slack * ratio;
+    }
+    return 0.0f;
+}
+
 static void M_Layout(
     UI_NODE *const node, const float x, const float y, const float w,
     const float h)
@@ -24,8 +33,8 @@ static void M_Layout(
     while (child != nullptr) {
         const float cw = child->measure_w;
         const float ch = child->measure_h;
-        const float cx = x + (w - cw) * data->x;
-        const float cy = y + (h - ch) * data->y;
+        const float cx = x + M_Offset(w - cw, data->x);
+        const float cy = y + M_Offset(h - ch, data->y);
         child->ops.layout(child, cx, cy, cw, ch);
         child = child->next_sibling;
     }

--- a/src/trx/game/ui/elements/anchor.h
+++ b/src/trx/game/ui/elements/anchor.h
@@ -3,7 +3,10 @@
 #include <trx/game/ui/common.h>
 
 // Used to align a top-level widget to the screen center or to the screen edges.
-// Uses ratio inputs.
+// Uses ratio inputs. A ratio from 0 to 1 keeps the widget inside the space it
+// is given, and pins it to the top left corner once it grows past that space.
+// A ratio outside that range places the widget beyond the edge, which a widget
+// that has to sit in the padding around its box relies on.
 
 void UI_BeginAnchor(const float x, const float y);
 void UI_EndAnchor(void);

--- a/src/trx/game/ui/elements/modal.c
+++ b/src/trx/game/ui/elements/modal.c
@@ -57,13 +57,8 @@ static void M_Begin(const float x, const float y, const bool whole_screen)
 
 void UI_BeginModal(const float x, const float y)
 {
-    UI_BeginModalEx(x, y, 0.0f);
-}
-
-void UI_BeginModalEx(const float x, const float y, const float inset_v)
-{
     M_Begin(x, y, false);
-    UI_BeginPad(0.0f, inset_v);
+    UI_BeginPad(0.0f, 0.0f);
     UI_BeginAnchor(x, y);
 }
 

--- a/src/trx/game/ui/elements/modal.h
+++ b/src/trx/game/ui/elements/modal.h
@@ -12,9 +12,4 @@ void UI_BeginModal(float x, float y);
 // screen edges and so state the area the dialogs get.
 void UI_BeginScreenModal(float x, float y);
 
-// A modal that keeps the given height clear at the top and the bottom of the
-// canvas, so that what it places lands within what is left rather than over the
-// text drawn at the screen edges.
-void UI_BeginModalEx(float x, float y, float inset_v);
-
 void UI_EndModal(void);

--- a/src/trx/game/ui/hud/overlay.c
+++ b/src/trx/game/ui/hud/overlay.c
@@ -432,9 +432,14 @@ static void M_BottomRightRegion(const UI_OVERLAY_STATE *const s)
     UI_EndOverlayRegion();
 }
 
+static float M_GetTextInset(void)
+{
+    return M_REGION_PAD_Y + UI_TEXT_HEIGHT;
+}
+
 static void M_StateInsets(const UI_OVERLAY_STATE *const s)
 {
-    const float inset = UI_Overlay_GetTextInset() + UI_TEXT_HEIGHT / 2.0f;
+    const float inset = M_GetTextInset() + UI_TEXT_HEIGHT / 2.0f;
     UI_SetScreenInset(
         UI_SCREEN_INSET_OVERLAY,
         M_ResolveOverlayText(&s->top_text) != nullptr ? inset : 0.0f,
@@ -513,11 +518,6 @@ void UI_EndOverlayRegion(void)
     UI_EndStack();
     UI_EndPad();
     UI_EndModal();
-}
-
-float UI_Overlay_GetTextInset(void)
-{
-    return M_REGION_PAD_Y + UI_TEXT_HEIGHT;
 }
 
 void UI_Overlay_ShowArrow(

--- a/src/trx/game/ui/hud/overlay.h
+++ b/src/trx/game/ui/hud/overlay.h
@@ -45,11 +45,6 @@ void UI_Overlay(UI_OVERLAY_STATE *s);
 void UI_BeginOverlayRegion(float x, float y);
 void UI_EndOverlayRegion(void);
 
-// How far a region's text reaches into the screen from the edge it sits at:
-// one line of text and the padding above it. A dialog that must not run into
-// the heading or the item name keeps this much clear at the top and bottom.
-float UI_Overlay_GetTextInset(void);
-
 void UI_Overlay_ForceHealthBar(UI_OVERLAY_STATE *s, bool show);
 void UI_Overlay_ShowArrow(
     UI_OVERLAY_STATE *s, UI_OVERLAY_ARROW arrow, bool show);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds scroll arrows to the save, load, level select, and mod dialogs in every game, matching TR1.

Also fixes dialog layout bugs exposed by the extra content:

- Keeps screen insets current with the scene being built
- Holds anchored content at its top-left corner once it outgrows its box
- Stops save and load lists from covering their headings at large text sizes

Resolves TRX547