### PR TITLE
lara/col/jump: fix ledge jump transition collision

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed Lara's rope-grab reach being shorter from certain directions (OG bug) (TRX1143)
 - Fixed Lara being thrown across the room when she shimmies to the end of a ladder (Gameplay → Controls → Corner shimmying) (TRX1203)
 - Fixed Lara getting pushed by enemies while climbing into or out of crawlspaces (OG bug) (TRX1182)
+- Fixed static meshes affecting ledge jumps when soft static collision is not enabled (#6366 / TRX1218)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -342,7 +342,10 @@ static void M_ForwardJump(ITEM *const item, COLL_INFO *const coll)
     coll->bad_ceiling = M_BAD_JUMP_CEILING;
 
     Lara_Col_GetInfo(item, coll);
-    Lara_Col_DeflectEdgeJump(item, coll);
+    if (!Item_TestAnimEqual(item, LA(LA_HANG_TO_JUMP_BACK_CONTINUE))) {
+        Lara_Col_DeflectEdgeJump(item, coll);
+    }
+
     if (item->speed < 0
         && g_Config.gameplay.wall_glitch_mode != WALL_GLITCH_TR1) {
         lara->move_angle = item->rot.y;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes static meshes forcing Lara out of ledge jumps in certain setups, specifically when soft static collision is disabled. `LA_HANG_TO_JUMP_BACK_CONTINUE` is a one frame transition animation needed only to rotate Lara, so normal collision will resume on the next animation.

Resolves #6366 / TRX1218.
