### PR TITLE
objects/movable_block: block split floor destinations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed static objects that reach through a doorway taking the water tint and the light of the room next door
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
+- Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -237,6 +237,15 @@ static bool M_TestCurrentSector(
     return true;
 }
 
+static bool M_IsFloorHeight(const XYZ_32 pos, int16_t room_num)
+{
+    XYZ_32 test_pos = pos;
+    test_pos.y = MAX_HEIGHT;
+    const SECTOR *const sector = Room_GetSector(test_pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, test_pos);
+    return height == pos.y;
+}
+
 static bool M_TestPush(
     const ITEM *const item, const int32_t block_height,
     const DIRECTION quadrant)
@@ -275,6 +284,10 @@ static bool M_TestPush(
     }
 
     if (Room_GetHeight(sector, base_pos) != base_pos.y) {
+        return false;
+    }
+
+    if (sector->floor.is_split && M_IsFloorHeight(base_pos, room_num)) {
         return false;
     }
 
@@ -337,6 +350,10 @@ static bool M_TestPull(
     }
 
     if (Room_GetHeight(sector, base_pos) != base_pos.y) {
+        return false;
+    }
+
+    if (sector->floor.is_split && M_IsFloorHeight(base_pos, room_num)) {
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes being able to push blocks onto split floors. Pushing one over a bridge, trapdoor etc which happens to be sitting over a triangular sector will still work, similar to normal slopes. Test level available for TR1.

Resolves TRX1228.
