### PR TITLE
shell/platform: ask for the dedicated GPU

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Added the PlayStation lighting model, which deepens bright surfaces into their own color rather than white (Graphic Options → Rendering → Lighting model)
 - Changed the lighting contrast option to appear in TR1 and TR2 only, as the other games light dynamic sources their own way (Graphic Options → Rendering → Lighting contrast)
 - Changed TR3 to light geometry on the brighter curve its hardware renderer used (Graphic Options → Rendering → Lighting model)
+- Changed the game to run on the dedicated graphics card on laptops that have two
 - Fixed a headless run drawing none of the title screen's objects, such as the passport
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
 - Fixed the inventory background showing black, and objects around it going missing, in a headless run

--- a/src/trx/game/shell/platform.c
+++ b/src/trx/game/shell/platform.c
@@ -18,6 +18,14 @@
 #include <libavutil/log.h>
 
 #ifdef _WIN32
+// Asks the NVIDIA Optimus and AMD switchable graphics drivers for the discrete
+// GPU. The drivers read these exported symbols from the executable, so nothing
+// in the game refers to them.
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+#endif
+
+#ifdef _WIN32
 // NOTE – taken from SDL3:
 // From 8994878767cfb9403f525d12c0770c1e149a4d08 Mon Sep 17 00:00:00 2001
 // From: Sam Lantinga <slouken@libsdl.org>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Laptops with two graphics cards now use the dedicated one for the game, where the integrated card used to be the default.