### PR TITLE
Stop the log from stuttering the game

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -145,6 +145,7 @@
 - Fixed a false warning that the settings could not be saved (TRX1112)
 - Fixed the camera when using binoculars clipping into the ceiling if the ceiling around Lara is very low (#6352 / TRX1205)
 - Fixed the rocket launcher's animation object having no name
+- Fixed the game stuttering while it writes its log
 
 **Lua**
 - Added `trx.events.on_cutscene_frame()`, which reports every frame of a TR4 cutscene, so a script can act part-way through one (TRX1199)

--- a/src/trx/core/log.c
+++ b/src/trx/core/log.c
@@ -7,6 +7,11 @@
 
 #define M_FORMAT "%s | %s [%s:%d:%s] "
 
+// How much log text the file holds before it reaches the disk. Every write
+// that reaches the disk costs the thread that logs, and a virus scanner makes
+// it cost more, so the game must not pay it for each line.
+#define M_FILE_BUFFER_SIZE 65536
+
 static LOG_LEVEL m_LogLevel = LOG_LEVEL_MAX;
 static FILE *m_LogHandle = nullptr;
 static bool m_UseAnsiColors = true;
@@ -34,6 +39,9 @@ void Log_Init(const char *path, const LOG_LEVEL min_level)
     m_UseAnsiColors = Log_ShouldUseAnsiColors();
     if (path != nullptr) {
         m_LogHandle = fopen(path, "w");
+        if (m_LogHandle != nullptr) {
+            setvbuf(m_LogHandle, nullptr, _IOFBF, M_FILE_BUFFER_SIZE);
+        }
     }
     Log_Init_Extra(path);
 }
@@ -77,7 +85,6 @@ void Log_Message(
             m_LogHandle, M_FORMAT, log_str, timestamp_str, file, line, func);
         vfprintf(m_LogHandle, fmt, vb);
         fprintf(m_LogHandle, "\n");
-        fflush(m_LogHandle);
 
         va_end(vb);
     }
@@ -97,6 +104,13 @@ void Log_Message(
     }
 
     va_end(va);
+}
+
+void Log_Flush(void)
+{
+    if (m_LogHandle != nullptr) {
+        fflush(m_LogHandle);
+    }
 }
 
 void Log_Shutdown(void)

--- a/src/trx/core/log.h
+++ b/src/trx/core/log.h
@@ -44,6 +44,12 @@ void Log_Init(const char *path, LOG_LEVEL min_level);
 LOG_LEVEL Log_GetMinLevel(void);
 void Log_SetMinLevel(LOG_LEVEL min_level);
 void Log_Shutdown(void);
+
+// Writes out the log lines the file still holds. The file is buffered, so a
+// path that ends the game without a clean shutdown calls this to keep the
+// lines that name the cause.
+void Log_Flush(void);
+
 void Log_Message(
     LOG_LEVEL level, const char *file, int line, const char *func,
     const char *fmt, ...);

--- a/src/trx/core/log_linux.c
+++ b/src/trx/core/log_linux.c
@@ -39,6 +39,7 @@ static void M_SignalHandler(int sig)
     LOG_ERROR("SIGNAL: %d", sig);
     LOG_ERROR("STACK TRACE:");
     M_WalkStack();
+    Log_Flush();
     exit(EXIT_FAILURE);
 }
 

--- a/src/trx/core/log_windows.c
+++ b/src/trx/core/log_windows.c
@@ -103,6 +103,7 @@ LONG WINAPI Log_CrashHandler(EXCEPTION_POINTERS *ex)
     dwstOfException(ex->ContextRecord, &M_StackTrace, &count);
 
     M_CreateMiniDump(ex, m_MiniDumpPath);
+    Log_Flush();
 
     return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -110,9 +110,12 @@ static bool M_IsAnySourceDirty(const M_PRIV *const p)
 static void M_PrepareScene(const M_PRIV *const p)
 {
 #ifndef __APPLE__
-    glLineWidth(
-        g_Config.rendering.wireframe_width * Viewport_GetSupersamplingFactor());
-    TRX_GL_CheckError();
+    if (g_Config.rendering.enable_wireframe) {
+        glLineWidth(
+            g_Config.rendering.wireframe_width
+            * Viewport_GetSupersamplingFactor());
+        TRX_GL_CheckError();
+    }
 #endif
 
     glBindSampler(0, p->sampler_id);

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -36,6 +36,7 @@ static void M_ShowFatalError(
     const char *const log_message, const char *const dialog_message)
 {
     LOG_ERROR("%s", log_message);
+    Log_Flush();
     if (M_IsInteractive()) {
         // The dialog is placed over its parent window. Until the game window is
         // shown, it is still hidden at the position the config named, so the

--- a/src/trx/gl/context.c
+++ b/src/trx/gl/context.c
@@ -11,6 +11,7 @@
 
 #include <GL/glew.h>
 #include <SDL2/SDL_video.h>
+#include <stdint.h>
 #include <string.h>
 
 typedef struct {
@@ -32,6 +33,13 @@ extern RGBA_F Output_GetFogColor(void);
 
 static TRX_GL_CONTEXT m_Context = {};
 
+// The driver reports the same message once a frame, which the log has no room
+// for. Only the first of a run is logged. The count of the rest names the
+// message it belongs to, because other modules log between the two lines.
+static bool m_HasLastDebug = false;
+static GLuint m_LastDebugID = 0;
+static uint32_t m_LastDebugRepeats = 0;
+
 static bool M_IsExtensionSupported(const char *name)
 {
     int number_of_extensions;
@@ -50,6 +58,17 @@ static bool M_IsExtensionSupported(const char *name)
     return false;
 }
 
+static void M_ReportDebugRepeats(void)
+{
+    if (m_LastDebugRepeats == 0) {
+        return;
+    }
+    LOG_INFO(
+        "OpenGL message #%u repeated %u more times", m_LastDebugID,
+        m_LastDebugRepeats);
+    m_LastDebugRepeats = 0;
+}
+
 static GLvoid GLAPIENTRY M_GLDebug(
     const GLenum source, const GLenum type, const GLuint id,
     const GLenum severity, const GLsizei length, const GLchar *const message,
@@ -58,11 +77,20 @@ static GLvoid GLAPIENTRY M_GLDebug(
     if (severity == GL_DEBUG_SEVERITY_NOTIFICATION) {
         return;
     }
+
+    if (m_HasLastDebug && id == m_LastDebugID) {
+        m_LastDebugRepeats++;
+        return;
+    }
+    M_ReportDebugRepeats();
+    m_HasLastDebug = true;
+    m_LastDebugID = id;
+
     size_t len = strlen(message);
     if (len > 0 && message[len - 1] == '\n') {
         len--;
     }
-    LOG_INFO("%d %*s", source, len, message);
+    LOG_INFO("%d #%u %.*s", source, id, (int)len, message);
 }
 
 void TRX_GL_Context_SwitchToViewport(const VIEWPORT_SPACE space)
@@ -138,6 +166,11 @@ RESULT TRX_GL_Context_Attach(void *window_handle)
     if (glDebugMessageCallback != nullptr) {
         glDebugMessageCallback(M_GLDebug, nullptr);
     }
+    if (glDebugMessageControl != nullptr) {
+        glDebugMessageControl(
+            GL_DONT_CARE, GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR, GL_DONT_CARE, 0,
+            nullptr, GL_FALSE);
+    }
     glEnable(GL_DEBUG_OUTPUT);
 #endif
 
@@ -176,6 +209,8 @@ char *TRX_GL_Context_DescribeDriver(void *const window_handle)
 
 void TRX_GL_Context_Detach(void)
 {
+    M_ReportDebugRepeats();
+
     if (!m_Context.window_handle) {
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR reduces logging overhead and prevents driver warnings from causing stutter on older GPUs:

- Buffers log writes instead of flushing every line.
- Sets OpenGL line width only in wireframe mode.
- Filters deprecated driver warnings.
- Collapses repeated messages from OpenGL driver into a single entry with a count.

This only bites in develop builds.

#### Testing

- [x] Confirm `TRX.log` still holds content
- [x] Start the game with no game data present and confirm the message in the error dialog is already in `TRX.log` while the dialog is still open
- [x] Toggle wireframe mode and confirm the lines still take the width the wireframe width setting names
