### PR TITLE
Fix TR4 Werner pathing

### DIFF
--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1051,7 +1051,8 @@ bool Creature_Animate(
 
     const int16_t *const zone = Box_GetLotZone(lot);
 
-    if (g_TRVersion >= 2 && !Object_IsType(item->object_id, g_WaterObjects)) {
+    if (g_TRVersion >= 2 && g_TRVersion < 4
+        && !Object_IsType(item->object_id, g_WaterObjects)) {
         int16_t room_num = item->room_num;
         Room_GetSector(item->pos, &room_num);
         Item_UpdateRoom(item_num, room_num);

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -25,6 +25,7 @@
 
 // clang-format off
 #define M_FLOAT_SPEED      32
+#define M_ROOM_PROBE       32
 #define M_MAX_DISTANCE     (g_TRVersion < 3 ? WALL_L * 30 : STEP_L * 125) // = 30720 (TR1/2), 32000 (TR3)
 #define M_ATTACK_RANGE     SQUARE(WALL_L * 3) // = 0x900000 = 9437184
 #define M_ESCAPE_CHANCE    2048
@@ -1366,7 +1367,7 @@ bool Creature_Animate(
         item->rot.x = 0;
     }
 
-    if (!Object_IsType(item->object_id, g_WaterObjects)) {
+    if (g_TRVersion <= 3 && !Object_IsType(item->object_id, g_WaterObjects)) {
         // Get the room just above the enemy so that if it is in one-click high
         // water, its effects behave still as though in a dry room.
         Room_GetSector(
@@ -1375,6 +1376,13 @@ bool Creature_Animate(
         if (M_TestDrowned(item, bounds, room_num)) {
             Item_TakeFatalDamage(item, nullptr);
         }
+    }
+
+    if (g_TRVersion >= 4) {
+        room_num = item->room_num;
+        Room_GetSector(
+            (XYZ_32) { item->pos.x, item->pos.y - M_ROOM_PROBE, item->pos.z },
+            &room_num);
     }
 
     Item_UpdateRoom(item_num, room_num);

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -396,6 +396,15 @@ static void M_AvoidStoppers(ITEM *const item, CREATURE *const creature)
     }
 }
 
+XYZ_32 Creature_GetAITargetPos(const ITEM *const item)
+{
+    if (g_TRVersion < 4 || !M_IsAIObject(item->object_id)
+        || (item->init_flags & AI_OBJECT_FLAGS_NO_OFFSET) != 0) {
+        return item->pos;
+    }
+    return XYZ_32_OffsetYaw(item->pos, item->rot.y, STEP_L);
+}
+
 void Creature_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -690,7 +699,7 @@ void Creature_ApplyMood(
     case MOOD_ATTACK: {
         const int32_t smartness = Object_Get(item->object_id)->smartness;
         if (smartness < 0 || Random_GetControl() < smartness) {
-            lot->target = enemy->pos;
+            lot->target = Creature_GetAITargetPos(enemy);
             lot->required_box = enemy->box_num;
             if (lot->setup.fly != 0
                 && Lara_GetLaraInfo()->water_status == LWS_ABOVE_WATER) {

--- a/src/trx/game/creature/common.h
+++ b/src/trx/game/creature/common.h
@@ -4,6 +4,9 @@
 #include <trx/game/creature/types.h>
 
 #define AI_OBJECT_FLAGS_SPENT 255
+// Marks an AI object that a creature walks to exactly, rather than one click
+// past. See Creature_GetAITargetPos.
+#define AI_OBJECT_FLAGS_NO_OFFSET 0x20
 
 void Creature_Initialise(int16_t item_num);
 bool Creature_Activate(int16_t item_num);
@@ -88,6 +91,14 @@ ITEM *Creature_FindAITargetObject(
 // item, and their flags mean something else entirely. A spent one answers 255,
 // the value the original writes over its flags with.
 int32_t Creature_GetAIObjectFlags(const ITEM *item);
+
+// Returns the position a creature paths towards for an item. For a TR4 AI
+// object, this is one click along the object's own facing, so that a marker
+// sends the creature past it rather than to a stop on top of it. Objects that
+// carry AI_OBJECT_FLAGS_NO_OFFSET, and everything that is not an AI object,
+// answer their own position. Arrival tests and position snaps use the item's
+// own position instead.
+XYZ_32 Creature_GetAITargetPos(const ITEM *item);
 
 // Whether an AI object has been used up, so the search passes over it. The
 // original says so by writing over the object's own flags word, which is level

--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -662,8 +662,7 @@ static void M_RaceControl(const int16_t item_num)
         Creature_AIInfo(item, &info);
     }
 
-    Creature_ApplyMood(item, &info, 1);
-    Creature_Mood(item, &info, 1);
+    Creature_Mood(item, &info, true);
 
     int32_t lara_angle;
     int32_t distance;
@@ -1238,8 +1237,7 @@ static void M_GuideControl(const int16_t item_num)
         Creature_AIInfo(item, &m_AI);
     }
 
-    Creature_ApplyMood(item, &m_AI, 1);
-    Creature_Mood(item, &m_AI, 1);
+    Creature_Mood(item, &m_AI, true);
 
     if (creature->enemy == lara) {
         m_LaraAI = m_AI;

--- a/src/trx/game/pathing/box.c
+++ b/src/trx/game/pathing/box.c
@@ -388,6 +388,10 @@ TARGET_TYPE Box_CalculateTarget(
     int32_t right = seed_clip ? own_box->right : 0;
     int32_t left = seed_clip ? own_box->left : 0;
 
+    // TR4 also leaves an axis alone where the running clip is the opposite
+    // side of that axis. TR1 to TR3 test only the near side.
+    const bool pair_clip = g_TRVersion >= 4;
+
     const BOX_INFO *box = nullptr;
     int32_t prime_free = BOX_CLIP_ALL;
     do {
@@ -415,7 +419,9 @@ TARGET_TYPE Box_CalculateTarget(
                     CLAMPL(top, box->top);
                     CLAMPG(bottom, box->bottom);
                     prime_free = BOX_CLIP_LEFT;
-                } else if (prime_free != BOX_CLIP_LEFT) {
+                } else if (
+                    prime_free != BOX_CLIP_LEFT
+                    && (!pair_clip || prime_free != BOX_CLIP_RIGHT)) {
                     target->z = right - BOX_BIFF;
                     if (prime_free != BOX_CLIP_ALL) {
                         return TARGET_SECONDARY;
@@ -432,7 +438,9 @@ TARGET_TYPE Box_CalculateTarget(
                     CLAMPL(top, box->top);
                     CLAMPG(bottom, box->bottom);
                     prime_free = BOX_CLIP_RIGHT;
-                } else if (prime_free != BOX_CLIP_RIGHT) {
+                } else if (
+                    prime_free != BOX_CLIP_RIGHT
+                    && (!pair_clip || prime_free != BOX_CLIP_LEFT)) {
                     target->z = left + BOX_BIFF;
                     if (prime_free != BOX_CLIP_ALL) {
                         return TARGET_SECONDARY;
@@ -451,7 +459,9 @@ TARGET_TYPE Box_CalculateTarget(
                     CLAMPL(left, box->left);
                     CLAMPG(right, box->right);
                     prime_free = BOX_CLIP_TOP;
-                } else if (prime_free != BOX_CLIP_TOP) {
+                } else if (
+                    prime_free != BOX_CLIP_TOP
+                    && (!pair_clip || prime_free != BOX_CLIP_BOTTOM)) {
                     target->x = bottom - BOX_BIFF;
                     if (prime_free != BOX_CLIP_ALL) {
                         return TARGET_SECONDARY;
@@ -468,7 +478,9 @@ TARGET_TYPE Box_CalculateTarget(
                     CLAMPL(left, box->left);
                     CLAMPG(right, box->right);
                     prime_free = BOX_CLIP_BOTTOM;
-                } else if (prime_free != BOX_CLIP_BOTTOM) {
+                } else if (
+                    prime_free != BOX_CLIP_BOTTOM
+                    && (!pair_clip || prime_free != BOX_CLIP_TOP)) {
                     target->x = top + BOX_BIFF;
                     if (prime_free != BOX_CLIP_ALL) {
                         return TARGET_SECONDARY;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -667,6 +667,11 @@ static RESULT M_ReadItem(JSON_READ_IO *const io, const int16_t read_index)
                         JSON_READ(io, "hurt_by_lara", &creature->hurt_by_lara));
                     MUST(JSON_READ(
                         io, "damage_from_lara", &creature->damage_from_lara));
+                    // Introduced in TRX 1.11
+                    int32_t enemy_num = NO_ITEM;
+                    SHOULD(JSON_READ_OPT(io, "enemy", &enemy_num));
+                    creature->enemy =
+                        enemy_num == NO_ITEM ? nullptr : Item_Get(enemy_num);
                     MUST(JSON_PUSH(io, "joint_rotations"));
                     for (int32_t i = 0; i < 4; i++) {
                         // Introduced in TRX 1.2

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -208,6 +208,10 @@ static void M_WriteItem(JSON_WRITE_IO *const io, const ITEM *const item)
             JSONW_WRITE(io, "patrol_2", creature->patrol_2);
             JSONW_WRITE(io, "hurt_by_lara", creature->hurt_by_lara);
             JSONW_WRITE(io, "damage_from_lara", creature->damage_from_lara);
+            JSONW_WRITE(
+                io, "enemy",
+                creature->enemy == nullptr ? NO_ITEM
+                                           : Item_GetIndex(creature->enemy));
             JSONW_PUSH_ARRAY(io);
             for (int32_t i = 0; i < 4; i++) {
                 JSONW_PUSH_VALUE(io, creature->joint_rotation[i]);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes several issues with Von Croy in the Cambodia levels. He now:

- Walks past AI markers instead of stopping directly on them.
- Steps down from ledges instead of leaping over them.
- Keeps his current target when loading a save.
- Updates his path and mood in the correct order.
- No longer dies when standing in shallow water. 😓

Resolves TRX1179 / TRX1217