### PR TITLE
Fix a crash when switching mods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Changed weather to follow flyby cameras (TRX1231)
 - Changed a missing or unknown `lara_outfit` in a level to fall back to the default outfit, rather than stopping the game from starting (TRX1087)
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own (TRX1070)
+- Fixed a crash when switching mods (TRX1239)
 
 **Saves and settings**
 - Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -395,14 +395,15 @@ RESULT Audio_Stream_CreateFromFile(
 
     ASSERT(file_path != nullptr);
 
-    RESULT result = FAIL(
-        "%s: all %d streams are in use", file_path, AUDIO_MAX_ACTIVE_STREAMS);
+    RESULT result = OK;
+    bool have_slot = false;
     Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
         if (m_Streams[sound_id].is_used) {
             continue;
         }
+        have_slot = true;
         AUDIO_DECODER *decoder = nullptr;
         result = AudioDecoder_CreateFromPath(
             file_path, AUDIO_WORKING_CHANNELS, &decoder);
@@ -415,6 +416,11 @@ RESULT Audio_Stream_CreateFromFile(
     }
     Audio_WorkerUnlock();
 
+    if (!have_slot) {
+        result = FAIL(
+            "%s: all %d streams are in use", file_path,
+            AUDIO_MAX_ACTIVE_STREAMS);
+    }
     return result;
 }
 
@@ -427,13 +433,15 @@ RESULT Audio_Stream_CreateFromMemory(
     ASSERT(data != nullptr);
     ASSERT(size != 0);
 
-    RESULT result = FAIL("all %d streams are in use", AUDIO_MAX_ACTIVE_STREAMS);
+    RESULT result = OK;
+    bool have_slot = false;
     Audio_WorkerLock();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
         if (m_Streams[sound_id].is_used) {
             continue;
         }
+        have_slot = true;
         AUDIO_DECODER *decoder = nullptr;
         result = AudioDecoder_CreateFromMemory(
             data, size, AUDIO_WORKING_CHANNELS, &decoder);
@@ -446,6 +454,9 @@ RESULT Audio_Stream_CreateFromMemory(
     }
     Audio_WorkerUnlock();
 
+    if (!have_slot) {
+        result = FAIL("all %d streams are in use", AUDIO_MAX_ACTIVE_STREAMS);
+    }
     return result;
 }
 

--- a/src/trx/game/game_flow/common.c
+++ b/src/trx/game/game_flow/common.c
@@ -6,6 +6,7 @@
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/vars.h>
+#include <trx/game/level/cache.h>
 
 static const GF_LEVEL *m_CurrentLevel = nullptr;
 static GF_COMMAND m_OverrideCommand = { .action = GF_NOOP };
@@ -78,6 +79,8 @@ void GF_Shutdown(void)
 {
     m_CurrentLevel = nullptr;
     m_OverrideCommand = (GF_COMMAND) { .action = GF_NOOP };
+
+    LevelCache_Reset();
 
     GAME_FLOW *const gf = &g_GameFlow;
     M_FreeInjections(&gf->injections);

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -212,6 +212,12 @@ static void M_TriggeredItem(const INJECTION *const injection)
     const INJECTION_OBJECT_INFO obj_info = Inject_ReadObjectPtr(injection);
     item->object_id = obj_info.id;
     item->room_num = File_ReadS16(injection->fp);
+    if (Room_Get(item->room_num) == nullptr) {
+        LOG_WARNING(
+            "Injected item names room %d, which the level does not have",
+            item->room_num);
+        item->room_num = NO_ROOM;
+    }
     item->pos.x = File_ReadS32(injection->fp);
     item->pos.y = File_ReadS32(injection->fp);
     item->pos.z = File_ReadS32(injection->fp);

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -1,6 +1,7 @@
 #include <trx/game/items/manager.h>
 
 #include <trx/core/handle.h>
+#include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
@@ -301,6 +302,12 @@ int16_t Item_Spawn(const ITEM *const item, const OBJECT_ID obj_id)
 void Item_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    if (Room_Get(item->room_num) == nullptr) {
+        LOG_WARNING(
+            "Item %d names room %d, which the level does not have", item_num,
+            item->room_num);
+        return;
+    }
     const OBJECT *const obj = Object_Get(item->object_id);
 
     Item_SwitchToAnim(item, 0, 0);

--- a/src/trx/game/level/cache.c
+++ b/src/trx/game/level/cache.c
@@ -122,6 +122,11 @@ static const char *M_GetPath(const char *const filename)
         "%s/%s/%s", Shell_GetCacheDir(), args->startup.mod->name, filename);
 }
 
+void LevelCache_Reset(void)
+{
+    M_ClearLevelHashMap();
+}
+
 uint64_t LevelCache_InitChecksum(
     const char *const scope, const uint32_t version)
 {

--- a/src/trx/game/level/cache.h
+++ b/src/trx/game/level/cache.h
@@ -9,6 +9,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Drops the level checksums held from earlier calls. The checksums are kept
+// against the address of each level, so they must be dropped before the game
+// flow frees its levels; otherwise a level allocated at a reused address
+// reads back the checksum of the level that stood there before it.
+void LevelCache_Reset(void);
+
 uint64_t LevelCache_InitChecksum(const char *scope, uint32_t version);
 uint64_t LevelCache_UpdateLevelChecksum(
     uint64_t checksum, const GF_LEVEL *level);

--- a/src/trx/game/level/format/format_tr4.c
+++ b/src/trx/game/level/format/format_tr4.c
@@ -318,10 +318,15 @@ static void M_ReadSampleData(LEVEL_CONTEXT *const ctx, TRX_FILE *const file)
 
 static RESULT M_ProbeImages(TRX_FILE *const file)
 {
+    const char *const chunk_names[] = {
+        "images32",
+        "images16",
+        "sky/font",
+    };
+
     LEVEL_FORMAT_SKIP_OR_FAIL(6); // page counts
-    for (int32_t i = 0; i < 3; i++) {
-        TRX_FILE *const images =
-            M_ReadChunk(file, String_Format("probe images %d", i));
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(chunk_names); i++) {
+        TRX_FILE *const images = M_ReadChunk(file, chunk_names[i]);
         if (images == nullptr) {
             return ERR;
         }

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -373,8 +373,10 @@ void Stats_CalculateMaxStats(void)
                         Item_Initialise(item_num);
                     } else {
                         ROOM *const room = Room_Get(item->room_num);
-                        item->next_item = room->item_num;
-                        room->item_num = item_num;
+                        if (room != nullptr) {
+                            item->next_item = room->item_num;
+                            room->item_num = item_num;
+                        }
                     }
                 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Cached level checksums are now cleared when the game flow frees its levels, rather than only at program exit. Previously, reusing a level's address could retain the checksum from a previously played mod, causing the statistics cache to match data from the wrong mod.

As a second fix, items that refer to rooms missing from the level are now left out of the world. Previously, such items would crash the game while loading the level.

As a third fix, the PR squishes two tiny memory leaks.

Resolves TRX1239
