### PR TITLE
output: fix the first frame size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Changed TR3 to light geometry on the brighter curve its hardware renderer used (Graphic Options → Rendering → Lighting model)
 - Changed the game to run on the dedicated graphics card on laptops that have two
 - Fixed a headless run drawing none of the title screen's objects, such as the passport
+- Fixed the first frame of a level being drawn small and in the corner of the screen when the game renders below the window size
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
 - Fixed the inventory background showing black, and objects around it going missing, in a headless run
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -120,6 +120,8 @@ OUTPUT_UI_SHADER *Output_GetUIShader(void)
 void Output_BeginScene(void)
 {
     Output_ApplyFOV();
+    // Resize framebuffers before the first frame draws into them.
+    TRX_GL_Renderer_SyncFboSizes();
     // The frame that was presented is still in the framebuffers until this
     // point, so that a snapshot can be composited from it between frames.
     TRX_GL_Renderer_BindGeometryFbo();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes the first frame rendering small in the corner when using a resolution below the window size. Framebuffers are now resized before drawing, so the player's settings are applied immediately.