### PR TITLE
rooms/draw: fix the misplaced room clip frames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Changed the game to run on the dedicated graphics card on laptops that have two
 - Fixed a headless run drawing none of the title screen's objects, such as the passport
 - Fixed a visible seam across the sky in TR4 levels (TRX563, regression from 1.9)
+- Fixed the debug room clip frames being drawn in the wrong place and size when the upscaling factor is raised
 - Fixed the inventory background showing black, and objects around it going missing, in a headless run
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed static objects that reach through a doorway taking the water tint and the light of the room next door

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -13,6 +13,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/rope.h>
 #include <trx/game/sparks.h>
+#include <trx/game/viewport.h>
 
 #include <string.h>
 
@@ -402,9 +403,15 @@ static void M_DrawSingleRoom(const ROOM *const room)
     g_PhdBottom = bind->bound_bottom;
 
     if (g_Config.debug.enable_debug_room_clip) {
+        const VIEWPORT_RECT game = Viewport_GetRect(VIEWPORT_GAME);
+        const VIEWPORT_RECT ui = Viewport_GetRect(VIEWPORT_UI);
+        const float scale = ui.width / (float)game.width;
         Output_DrawScreenFrame(
-            g_PhdLeft, g_PhdTop, g_PhdRight - g_PhdLeft, g_PhdBottom - g_PhdTop,
-            (RGBA_8888) { 0, 255, 0, 128 }, (RGBA_8888) { 0, 255, 0, 128 }, 1);
+            ui.x + (g_PhdLeft - game.x) * scale,
+            ui.y + (g_PhdTop - game.y) * scale,
+            (g_PhdRight - g_PhdLeft) * scale, (g_PhdBottom - g_PhdTop) * scale,
+            (RGBA_8888) { 0, 255, 0, 128 }, (RGBA_8888) { 0, 255, 0, 128 },
+            scale);
     }
 
     Matrix_TranslateAbs32(room->pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the debug room clip frames were drawn in the wrong place and at the wrong size when the upscaling or supersampling factor was not 1. The frames are now mapped from the scene grid to the UI grid.