### PR TITLE
objects/von_croy: fix escape not skipping scenes

### DIFF
--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -391,7 +391,7 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
     M_PRIV *const p = M_GetPriv(item);
     ITEM *const lara = Lara_GetItem();
 
-    const bool skip_requested = g_InputDB.option || g_InputDB.look;
+    const bool skip_requested = g_InputDB.menu_back || g_InputDB.look;
 
     if (!Lara_IsControllable()) {
         InputState_Clear(&g_Input);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

`6694ae4343` changed von Croy's skip input to `option || look`, but cinematic mode masks `option`. As a result, Escape stopped working while Look still worked.