### PR TITLE
output/scene: fix thin debug lines

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Fixed static objects that reach through a doorway taking the water tint and the light of the room next door
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
+- Fixed the debug portal and bounding box lines becoming thinner at higher supersampling values (TRX1251)
 
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -110,12 +110,11 @@ static bool M_IsAnySourceDirty(const M_PRIV *const p)
 static void M_PrepareScene(const M_PRIV *const p)
 {
 #ifndef __APPLE__
-    if (g_Config.rendering.enable_wireframe) {
-        glLineWidth(
-            g_Config.rendering.wireframe_width
-            * Viewport_GetSupersamplingFactor());
-        TRX_GL_CheckError();
-    }
+    const float line_width = g_Config.rendering.enable_wireframe
+        ? g_Config.rendering.wireframe_width
+        : 1.0f;
+    glLineWidth(line_width * Viewport_GetSupersamplingFactor());
+    TRX_GL_CheckError();
 #endif
 
     glBindSampler(0, p->sampler_id);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the debug portal and bounding box lines got thinner as the supersampling factor went up. Before this, only the wireframe mode scaled its line width with the factor.

Resolves TRX1251