### PR TITLE
objects/traps: make underwater propeller untriggerable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,9 @@
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)
 - Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand (TRX1073)
 
+**TR2**
+- Fixed Underwater Propeller that doesn't untrigger
+
 **TR3**
 - Added crystals to each of the levels in The Lost Artefact, and made the crystal mode option visible (Gameplay → General → Crystal mode) (TRX1111)
 - Changed the underwater light patterns to run in broad bands, as the original draws them, rather than fine speckle

--- a/src/trx/game/items/trigger.c
+++ b/src/trx/game/items/trigger.c
@@ -35,6 +35,10 @@ static void M_FireTriggerEvent(
 static bool M_IsOneShotSpent(
     const ITEM_TRIGGER *const trigger, const ITEM *const item)
 {
+    if (item->object_id == O_PROPELLER_1 || item->object_id == O_PROPELLER_2) {
+        return false;
+    }
+
     if (g_TRVersion == 3) {
         switch (trigger->kind) {
         case ITEM_TRIGGER_SWITCH:
@@ -92,7 +96,7 @@ void Item_Trigger(const int16_t item_num, const ITEM_TRIGGER *const trigger)
             break;
         }
 
-        if (item->trigger.mask == TRIGGER_MASK_ALL) {
+        if (Item_IsTriggerActiveRO(item)) {
             if (trigger->one_shot) {
                 item->trigger.spent = true;
             }

--- a/src/trx/game/objects/traps/propeller.c
+++ b/src/trx/game/objects/traps/propeller.c
@@ -27,9 +27,25 @@ static void M_Collision(
     }
 }
 
+static void M_Activate(ITEM *const item)
+{
+    const int16_t item_num = Item_GetIndex(item);
+
+    Item_SetFinished(item, false);
+    Item_SwitchToAnim(item, 0, 0);
+    const ANIM *const anim = Item_GetAnim(item);
+    item->current_anim_state = anim->current_anim_state;
+    item->goal_anim_state = M_STATE_ON;
+    item->required_anim_state = 0;
+    item->touch_bits = 0;
+    item->is_collidable = true;
+    Item_AddSimulated(item_num);
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     obj->priv_size = sizeof(PROPELLER_PRIV);
+    obj->activate_func = M_Activate;
     obj->control_func = Propeller_Control;
     obj->collision_func = M_Collision;
     obj->save_flags = true;
@@ -55,8 +71,14 @@ void Propeller_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     const PROPELLER_PRIV *const p = item->priv;
 
-    if (Item_IsTriggerActive(item) && !item->trigger.spent) {
+    if (Item_IsTriggerActive(item)
+        && (item->object_id == O_PROPELLER_1 || item->object_id == O_PROPELLER_2
+            || !item->trigger.spent)) {
         item->goal_anim_state = M_STATE_ON;
+        if (item->object_id == O_PROPELLER_1
+            || item->object_id == O_PROPELLER_2) {
+            item->is_collidable = true;
+        }
 
         if ((item->touch_bits & 6) != 0) {
             const ITEM *const lara_item = Lara_GetItem();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR adds the possibility to untrigger underwarter propellers in TR2, since before wasn't possible before with 
turning off a switch or using antitriggers. 
This is also a feature requested from a TRX custom level builder