### PR TITLE
lara/state/crouch: reset torso angle when crouched

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Changed a missing or unknown `lara_outfit` in a level to fall back to the default outfit, rather than stopping the game from starting (TRX1087)
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own (TRX1070)
 - Fixed a crash when switching mods (TRX1239)
+- Fixed Lara's arms leaving their intended positions when looking around in the crouched stance (OG bug) (#6402)
 
 **Saves and settings**
 - Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -120,13 +120,6 @@ static void M_CrouchIdle(ITEM *const item, COLL_INFO *const coll)
     coll->enable_hit = 1;
     coll->enable_baddie_push = 1;
 
-    LARA_INFO *const lara = Lara_GetLaraInfo();
-    const bool crouch_active = g_Config.gameplay.enable_toggle_crouch
-        ? lara->crouching || lara->keep_crouched
-        : g_Input.crouch || lara->keep_crouched;
-    lara->sprinting = false;
-    lara->is_crouched = true;
-
     if (item->hit_points <= 0) {
         item->goal_anim_state = LS(LS_CRAWL_IDLE);
         return;
@@ -139,6 +132,15 @@ static void M_CrouchIdle(ITEM *const item, COLL_INFO *const coll)
     if (g_Input.look) {
         Lara_Look_UpDown();
     }
+
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->torso_rot.x = 0;
+    lara->torso_rot.y = 0;
+    const bool crouch_active = g_Config.gameplay.enable_toggle_crouch
+        ? lara->crouching || lara->keep_crouched
+        : g_Input.crouch || lara->keep_crouched;
+    lara->sprinting = false;
+    lara->is_crouched = true;
 
     if ((g_Input.forward || g_Input.back) && crouch_active
         && lara->gun_status == LGS_ARMLESS && M_CanEnterCrawlFromCrouch(item)) {
@@ -166,6 +168,8 @@ static void M_CrouchRoll(ITEM *const item, COLL_INFO *const coll)
     g_Camera.target_elevation = -3640;
     item->goal_anim_state = LS(LS_CROUCH_IDLE);
     LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->torso_rot.x = 0;
+    lara->torso_rot.y = 0;
     lara->is_crouched = true;
 }
 
@@ -179,6 +183,8 @@ static void M_CrouchTurn(ITEM *const item, COLL_INFO *const coll)
     coll->enable_hit = 0;
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->torso_rot.x = 0;
+    lara->torso_rot.y = 0;
     const bool crouch_active = g_Config.gameplay.enable_toggle_crouch
         ? lara->crouching || lara->keep_crouched
         : g_Input.crouch || lara->keep_crouched;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Prevents Lara's torso from rotating with the view when looking around while crouched. Previously this caused her arms to leave their intended positions while in the crouch animation.

Fixes #6402