### PR TITLE
lua/game: fix reading a level's inventory or stats

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -182,6 +182,7 @@
 - Changed a color setting to read as a `trx.math.Color` rather than as hex text, and to be written with either (TRX1091)
 - Changed the `trx.weapons` functions that take a weapon id to be deprecated, the weapon itself now answering what it is available as, what it is carried as, and what it is fed (TRX1091)
 - Fixed creatures taking wrong routes where crossing to the next square needs a jump or a monkey swing (TRX1061)
+- Fixed reading a level's `inventory` or `stats` raising an error
 
 
 

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -1,4 +1,6 @@
 local raw = trxc.game
+local raw_inventory = trxc.inventory
+local raw_stats = trxc.stats
 local api = trx.api
 
 api.module("game", {
@@ -171,7 +173,7 @@ this install.]],
         .. "she will arrive there with rather than what she is carrying now, which is "
         .. "`trx.inventory` itself.",
       impl = function(level)
-        return trxc.inventory.get(level.num)
+        return raw_inventory.get(level.num)
       end,
     },
     stats = {
@@ -180,7 +182,7 @@ this install.]],
         .. "that counts nothing: the title screen and the cutscenes. The level being played is "
         .. "also `trx.stats` itself.",
       impl = function(level)
-        return trxc.stats.get(level.num)
+        return raw_stats.get(level.num)
       end,
     },
   },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where reading `trx.game.levels[n].inventory` or the matching `stats` raised an error rather than reporting what the level keeps. The engine takes `trxc` off the globals once the API is sealed, and these two properties read it when a script calls in rather than when the module loads.