### PR TITLE
Report Lua errors in the console and quiet the startup logs

### DIFF
--- a/data/trx/ship/games/tr1-level/gameflow.json5
+++ b/data/trx/ship/games/tr1-level/gameflow.json5
@@ -5,7 +5,6 @@
     "extends": "tr1",
     "name": "TR1 Direct Level",
 
-    "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tmp_%02d.dat",
 
     "injections": [

--- a/data/trx/ship/games/tr2-level/gameflow.json5
+++ b/data/trx/ship/games/tr2-level/gameflow.json5
@@ -5,7 +5,6 @@
     "extends": "tr2",
     "name": "TR2 Direct Level",
 
-    "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_custom_%02d.dat",
 
     "enable_tr2_item_drops": true,

--- a/data/trx/ship/games/tr3-level/gameflow.json5
+++ b/data/trx/ship/games/tr3-level/gameflow.json5
@@ -5,7 +5,6 @@
     "extends": "tr3",
     "name": "TR3 Direct Level",
 
-    "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr3_custom_%02d.dat",
 
     "enable_tr2_item_drops": true,

--- a/data/trx/ship/games/tr4-level/gameflow.json5
+++ b/data/trx/ship/games/tr4-level/gameflow.json5
@@ -5,13 +5,11 @@
     "extends": "tr4",
     "name": "TR4 Direct Level",
 
-    "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr4_custom_%02d.dat",
 
     "enable_tr2_item_drops": true,
     "convert_dropped_guns": true,
 
-    "sfx_path": "main.sfx",
     "injections": [
         "font.bin",
         "lara_outfits.bin",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3472,7 +3472,7 @@
       "path": "config.declare"
     },
     {
-      "description": "Calls `fn(value)` whenever the setting changes, and once as the watcher is\nattached with the value it holds now - so a script applies the player's saved value rather than\nwaiting for them to touch it again.\n\nA watcher that changes a setting itself is heard by that setting's watchers too. One that raises\nis logged and the rest still run; it is called again on the next change.\n\nA watcher a level script attaches goes when the level ends, as a `trx.events` listener does. One a\ngame script attaches stays for as long as the game.",
+      "description": "Calls `fn(value)` whenever the setting changes, and once as the watcher is\nattached with the value it holds now - so a script applies the player's saved value rather than\nwaiting for them to touch it again.\n\nA watcher that changes a setting itself is heard by that setting's watchers too. One that raises\nis logged and the rest still run; it is called again on the next change.\n\nA watcher a level script attaches goes when the level ends, as a `trx.events` listener does. One a\ngame script attaches stays for as long as the game.\n\nA level script runs before the level is read, where a handler can reach nothing the level carries.\nThe call for the value in force therefore waits until the level has its objects. Every other\nwatcher is called as it is attached.",
       "examples": [
         "local watcher = trx.config.on_change(\"mod.scanlines\", function(value)\n  trx.log.info(\"scanlines are now \" .. tostring(value))\nend)\n-- ... and when the script is done with it:\nwatcher:detach()"
       ],

--- a/docs/trx/lua/reference/CONFIG.md
+++ b/docs/trx/lua/reference/CONFIG.md
@@ -224,6 +224,10 @@ game's `scripts/_game.lua` declares belongs to that game and goes when it does.
   A watcher a level script attaches goes when the level ends, as a [`trx.events`](EVENTS.md#events) listener does. One a
   game script attaches stays for as long as the game.
 
+  A level script runs before the level is read, where a handler can reach nothing the level carries.
+  The call for the value in force therefore waits until the level has its objects. Every other
+  watcher is called as it is attached.
+
   Parameters:
   - <a id="config.on_change.key" name="config.on_change.key"></a>**`key`** (string). Dotted path to watch.
   - <a id="config.on_change.fn" name="config.on_change.fn"></a>**`fn`** (function). Called with the setting's value.

--- a/src/lua/api/config.lua
+++ b/src/lua/api/config.lua
@@ -449,7 +449,11 @@ A watcher that changes a setting itself is heard by that setting's watchers too.
 is logged and the rest still run; it is called again on the next change.
 
 A watcher a level script attaches goes when the level ends, as a `trx.events` listener does. One a
-game script attaches stays for as long as the game.]],
+game script attaches stays for as long as the game.
+
+A level script runs before the level is read, where a handler can reach nothing the level carries.
+The call for the value in force therefore waits until the level has its objects. Every other
+watcher is called as it is attached.]],
   params = {
     { name = "key", type = "string", description = "Dotted path to watch." },
     {

--- a/src/tests/fakes/console.c
+++ b/src/tests/fakes/console.c
@@ -166,6 +166,18 @@ void Console_LogImpl(
     FAKE_RECORD("log", FV(level), FV_STR(message));
 }
 
+void Console_ShowImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+    char message[256];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+    FAKE_RECORD("show", FV(level), FV_STR(message));
+}
+
 void Console_Clear(void)
 {
     FAKE_RECORD("clear");

--- a/src/tests/fakes/console.c
+++ b/src/tests/fakes/console.c
@@ -154,7 +154,7 @@ static int M_L_IsVerbose(lua_State *const L)
     return 1;
 }
 
-void Console_LogEx(
+void Console_LogImpl(
     const LOG_LEVEL level, const char *const file, const int line,
     const char *const func, const char *const fmt, ...)
 {

--- a/src/tests/fakes/level.c
+++ b/src/tests/fakes/level.c
@@ -1,0 +1,15 @@
+#include <fakes/level.h>
+
+#include <trx/game/level/common.h>
+
+static bool m_WorldLoaded = true;
+
+void FakeLevel_SetWorldLoaded(const bool loaded)
+{
+    m_WorldLoaded = loaded;
+}
+
+bool Level_IsWorldLoaded(void)
+{
+    return m_WorldLoaded;
+}

--- a/src/tests/fakes/level.h
+++ b/src/tests/fakes/level.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// The level's world, which the engine reads once the level file is loaded.
+// Loaded is the default: a test that wants what happens before the level is
+// read says so.
+
+void FakeLevel_SetWorldLoaded(bool loaded);

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -193,7 +193,7 @@ void GameStringManager_UnsubscribeReload(const int32_t listener_id)
 {
 }
 
-void Console_LogEx(
+void Console_LogImpl(
     const LOG_LEVEL level, const char *const file, const int line,
     const char *const func, const char *const fmt, ...)
 {

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -199,6 +199,12 @@ void Console_LogImpl(
 {
 }
 
+void Console_ShowImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+}
+
 bool ClockTimer_CheckElapsedAndTake(CLOCK_TIMER *const timer, const double sec)
 {
     return false;

--- a/src/tests/harness/stubs_console.c
+++ b/src/tests/harness/stubs_console.c
@@ -1,0 +1,16 @@
+// The console, for a test that links a module which reports through it but is
+// not testing what the console does with the report.
+
+#include <trx/game/console/common.h>
+
+void Console_LogImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+}
+
+void Console_ShowImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+}

--- a/src/tests/lua/api/config.c
+++ b/src/tests/lua/api/config.c
@@ -2,6 +2,7 @@
 // this stands up the world they run against.
 
 #include <fakes/config.h>
+#include <fakes/level.h>
 #include <harness/lua_surface.h>
 
 #include <trx/game/lua/common.h>
@@ -22,6 +23,21 @@ static int M_FakeAsLevelScript(lua_State *const L)
     return 0;
 }
 
+// Whether the level has been read yet. A level script runs before it has.
+static int M_FakeSetWorldLoaded(lua_State *const L)
+{
+    FakeLevel_SetWorldLoaded(lua_toboolean(L, 1));
+    return 0;
+}
+
+// What Level_Initialise does once the level is read.
+static int M_FakeLoadWorld(lua_State *const L)
+{
+    FakeLevel_SetWorldLoaded(true);
+    LUA_Config_FlushPendingWatchers();
+    return 0;
+}
+
 static int M_FakeEndLevel(lua_State *const L)
 {
     LUA_Config_ClearLevelWatchers();
@@ -36,6 +52,10 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "as_level_script");
     lua_pushcfunction(L, M_FakeEndLevel);
     lua_setfield(L, -2, "end_level");
+    lua_pushcfunction(L, M_FakeSetWorldLoaded);
+    lua_setfield(L, -2, "set_world_loaded");
+    lua_pushcfunction(L, M_FakeLoadWorld);
+    lua_setfield(L, -2, "load_world");
 }
 
 int main(void)

--- a/src/tests/lua/api/config.lua
+++ b/src/tests/lua/api/config.lua
@@ -419,4 +419,68 @@ test("a level script's watcher goes when the level does", function()
   kept:detach()
 end)
 
+-- A level script runs before the level is read, so a handler that reaches for
+-- what the level carries would find nothing. The call it is owed waits for the
+-- world instead.
+test(
+  "a level script's watcher hears the value once the level is read",
+  function()
+    local heard = {}
+    fake.set_world_loaded(false)
+    fake.as_level_script(true)
+    local watcher = trx.config.on_change("visuals.fov", function(value)
+      heard[#heard + 1] = value
+    end)
+    fake.as_level_script(false)
+
+    assert(#heard == 0, "it was called before the level was read")
+    fake.load_world()
+    assert(#heard == 1, "it was not called once the level was read")
+
+    watcher:detach()
+    fake.end_level()
+  end
+)
+
+test("a watcher attached after the level is read hears it at once", function()
+  local heard = 0
+  fake.as_level_script(true)
+  local watcher = trx.config.on_change("visuals.fov", function()
+    heard = heard + 1
+  end)
+  fake.as_level_script(false)
+
+  assert(heard == 1, "the call did not come with the attach")
+  watcher:detach()
+  fake.end_level()
+end)
+
+test("a global script's watcher hears the value before any level", function()
+  local heard = 0
+  fake.set_world_loaded(false)
+  local watcher = trx.config.on_change("visuals.fov", function()
+    heard = heard + 1
+  end)
+  fake.set_world_loaded(true)
+
+  assert(heard == 1, "a global watcher was made to wait")
+  watcher:detach()
+end)
+
+-- A level that goes before it is ever read leaves its watchers owed a call
+-- that must not arrive against the next level.
+test("a watcher owed a call and dropped with its level stays quiet", function()
+  local heard = 0
+  fake.set_world_loaded(false)
+  fake.as_level_script(true)
+  trx.config.on_change("visuals.fov", function()
+    heard = heard + 1
+  end)
+  fake.as_level_script(false)
+
+  fake.end_level()
+  fake.load_world()
+  assert(heard == 0, "a dropped watcher was still called: " .. heard)
+end)
+
 return h.report()

--- a/src/tests/lua/api/events.c
+++ b/src/tests/lua/api/events.c
@@ -9,6 +9,7 @@
 #include <harness/fake_calls.h>
 #include <harness/lua_surface.h>
 
+#include <trx/game/console/common.h>
 #include <trx/game/items/actions.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/events.h>
@@ -16,6 +17,10 @@
 
 #include <lauxlib.h>
 #include <string.h>
+
+// What the console was told to show. A handler that raises reports through the
+// console, so the count is how the tests see that it did.
+static int32_t m_ConsoleShows = 0;
 
 // fake.fire(name, ...) - mirrors the engine's own fire sites, argument for
 // argument.
@@ -81,6 +86,13 @@ static int M_FakeEndLevel(lua_State *const L)
     return 0;
 }
 
+// fake.console_shows() -> integer
+static int M_FakeConsoleShows(lua_State *const L)
+{
+    lua_pushinteger(L, m_ConsoleShows);
+    return 1;
+}
+
 static void M_PushFake(lua_State *const L)
 {
     lua_pushcfunction(L, M_FakeFire);
@@ -89,6 +101,21 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "as_level_script");
     lua_pushcfunction(L, M_FakeEndLevel);
     lua_setfield(L, -2, "end_level");
+    lua_pushcfunction(L, M_FakeConsoleShows);
+    lua_setfield(L, -2, "console_shows");
+}
+
+void Console_LogImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+}
+
+void Console_ShowImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+    m_ConsoleShows++;
 }
 
 int main(void)

--- a/src/tests/lua/api/events.lua
+++ b/src/tests/lua/api/events.lua
@@ -386,4 +386,17 @@ test("an event carries four arguments, of the kinds it can hold", function()
   end, "carries no value of this type")
 end)
 
+-- A handler that raises is reported where a script author can see it: the log
+-- alone leaves the game looking as if nothing happened.
+test("a handler that raises is reported through the console", function()
+  local before = fake.console_shows()
+  local listener = trx.events.before_control(function()
+    error("boom")
+  end)
+  fake.fire("before_control")
+  listener:detach()
+
+  assert(fake.console_shows() > before, "the console was told nothing")
+end)
+
 return h.report()

--- a/src/tests/lua/api/ui.c
+++ b/src/tests/lua/api/ui.c
@@ -201,6 +201,12 @@ void Console_LogImpl(
     const char *const func, const char *const fmt, ...)
 {
 }
+void Console_ShowImpl(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+}
+
 int32_t Viewport_GetWidth(const VIEWPORT_SPACE space)
 {
     return m_ViewportW;

--- a/src/tests/lua/api/ui.c
+++ b/src/tests/lua/api/ui.c
@@ -196,7 +196,7 @@ void UI_ShutdownText(void)
 {
 }
 
-void Console_LogEx(
+void Console_LogImpl(
     const LOG_LEVEL level, const char *const file, const int line,
     const char *const func, const char *const fmt, ...)
 {

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -533,7 +533,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/signal',
   'bundles': [b_lua_surface, b_config, b_lua_math, b_lua_strings],
-  'src': ['harness/stubs_console.c', 'fakes/locale.c', 'fakes/rooms.c'],
+  'src': ['fakes/level.c', 'harness/stubs_console.c', 'fakes/locale.c', 'fakes/rooms.c'],
   'engine': [
     'game/lua/capi/config.c',
     'game/lua/capi/events.c',
@@ -576,7 +576,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/ui',
   'bundles': [b_lua_surface, b_lua_math, b_config],
-  'src': ['lua/api/ui.c', 'fakes/ui_draw.c', 'fakes/locale.c', 'fakes/rooms.c'],
+  'src': ['fakes/level.c', 'lua/api/ui.c', 'fakes/ui_draw.c', 'fakes/locale.c', 'fakes/rooms.c'],
   'engine': [
     'config/enum.c',
     'core/event_manager.c',
@@ -688,7 +688,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/zones',
   'bundles': [b_lua_surface, b_lua_math],
-  'src': [
+  'src': ['fakes/level.c',
     'harness/stubs_console.c',
     'fakes/items.c',
     'fakes/rooms.c',
@@ -778,7 +778,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/lara',
   'bundles': [b_lua_surface, b_lua_math],
-  'src': ['fakes/lara.c', 'fakes/items.c', 'fakes/catalog.c'],
+  'src': ['fakes/level.c', 'fakes/lara.c', 'fakes/items.c', 'fakes/catalog.c'],
   'engine': [
     'game/lua/capi/catalog.c',
     'game/lua/capi/items.c',
@@ -798,7 +798,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/config',
   'bundles': [b_lua_surface, b_config, b_lua_math, b_lua_strings],
-  'src': ['harness/stubs_console.c', 'fakes/locale.c'],
+  'src': ['fakes/level.c', 'harness/stubs_console.c', 'fakes/locale.c'],
   'engine': [
     'game/lua/capi/config.c',
     'game/lua/capi/locale.c',
@@ -837,7 +837,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/commands/heal',
   'bundles': [b_lua_surface, b_console, b_lua_math],
-  'src': ['fakes/game.c', 'fakes/items.c', 'fakes/lara.c'],
+  'src': ['fakes/level.c', 'fakes/game.c', 'fakes/items.c', 'fakes/lara.c'],
   'engine': [
     'game/lua/capi/game.c',
     'game/lua/capi/items.c',
@@ -884,7 +884,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/commands/give',
   'bundles': [b_lua_surface, b_console, b_lua_math, b_lua_strings],
-  'src': [
+  'src': ['fakes/level.c',
     'fakes/game.c',
     'fakes/items.c',
     'fakes/lara.c',
@@ -906,7 +906,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/commands/teleport',
   'bundles': [b_lua_surface, b_console, b_lua_strings, b_lua_math],
-  'src': [
+  'src': ['fakes/level.c',
     'fakes/camera.c',
     'fakes/catalog.c',
     'fakes/game.c',
@@ -943,7 +943,8 @@ unit_tests += {
 
 unit_tests += {
   'name': 'lua/commands/set',
-  'bundles': [b_lua_surface, b_config, b_lua_math, b_lua_strings, b_console],
+
+  'src': ['fakes/level.c'],  'bundles': [b_lua_surface, b_config, b_lua_math, b_lua_strings, b_console],
   'engine': ['game/lua/capi/config.c'],
 }
 

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -450,6 +450,7 @@ unit_tests += {
     'game/lua/utils.c',
   ],
   'src': [
+    'harness/stubs_console.c',
     'harness/stubs_enum_map.c',
     'harness/stubs_game_script.c',
     'harness/stubs_result.c',
@@ -491,7 +492,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/rooms',
   'bundles': [b_lua_surface, b_lua_math],
-  'src': ['fakes/rooms.c', 'fakes/items.c'],
+  'src': ['harness/stubs_console.c', 'fakes/rooms.c', 'fakes/items.c'],
   'engine': [
     'game/lua/capi/events.c',
     'game/lua/capi/items.c',
@@ -502,7 +503,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/items',
   'bundles': [b_lua_surface, b_lua_strings, b_lua_math],
-  'src': ['fakes/items.c', 'fakes/catalog.c'],
+  'src': ['harness/stubs_console.c', 'fakes/items.c', 'fakes/catalog.c'],
   'engine': [
     'game/lua/capi/catalog.c',
     'game/lua/capi/events.c',
@@ -532,7 +533,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/signal',
   'bundles': [b_lua_surface, b_config, b_lua_math, b_lua_strings],
-  'src': ['fakes/locale.c', 'fakes/rooms.c'],
+  'src': ['harness/stubs_console.c', 'fakes/locale.c', 'fakes/rooms.c'],
   'engine': [
     'game/lua/capi/config.c',
     'game/lua/capi/events.c',
@@ -688,6 +689,7 @@ unit_tests += {
   'name': 'lua/api/zones',
   'bundles': [b_lua_surface, b_lua_math],
   'src': [
+    'harness/stubs_console.c',
     'fakes/items.c',
     'fakes/rooms.c',
     'fakes/lara.c',
@@ -796,7 +798,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/config',
   'bundles': [b_lua_surface, b_config, b_lua_math, b_lua_strings],
-  'src': ['fakes/locale.c'],
+  'src': ['harness/stubs_console.c', 'fakes/locale.c'],
   'engine': [
     'game/lua/capi/config.c',
     'game/lua/capi/locale.c',

--- a/src/trx/game/clock/turbo.c
+++ b/src/trx/game/clock/turbo.c
@@ -34,7 +34,7 @@ void Clock_SetTurboSpeed(int32_t value)
     }
     CONFIG_SET(g_Config.gameplay.turbo_speed, value);
     Config_Update();
-    Console_Log(GS("general/osd/speed_set"), value);
+    Console_Info(GS("general/osd/speed_set"), value);
     Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
 }
 

--- a/src/trx/game/console/common.c
+++ b/src/trx/game/console/common.c
@@ -36,6 +36,32 @@ static RESULT M_Load(void)
     return OK;
 }
 
+static void M_Emit(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const bool show, const char *const fmt, va_list va)
+{
+    va_list va_copy;
+    va_copy(va_copy, va);
+
+    const size_t text_length = vsnprintf(nullptr, 0, fmt, va);
+    char *text = Memory_Alloc(text_length + 1);
+
+    vsnprintf(text, text_length + 1, fmt, va_copy);
+    va_end(va_copy);
+
+    Log_Message(level, file, line, func, "%s", text);
+
+    if (show) {
+        UI_FireEvent((EVENT) {
+            .name = "console_log",
+            .sender = nullptr,
+            .data = text,
+        });
+    }
+
+    Memory_FreePointer(&text);
+}
+
 void Console_Open(void)
 {
     if (m_IsOpened) {
@@ -69,27 +95,20 @@ void Console_LogImpl(
 
     va_list va;
     va_start(va, fmt);
-    va_list va_copy;
-    va_copy(va_copy, va);
-
-    const size_t text_length = vsnprintf(nullptr, 0, fmt, va);
-    char *text = Memory_Alloc(text_length + 1);
+    M_Emit(level, file, line, func, m_Verbose, fmt, va);
     va_end(va);
+}
 
-    vsnprintf(text, text_length + 1, fmt, va_copy);
-    va_end(va_copy);
+void Console_ShowImpl(
+    const LOG_LEVEL level, const char *file, int line, const char *func,
+    const char *const fmt, ...)
+{
+    ASSERT(fmt != nullptr);
 
-    Log_Message(level, file, line, func, "%s", text);
-
-    if (m_Verbose) {
-        UI_FireEvent((EVENT) {
-            .name = "console_log",
-            .sender = nullptr,
-            .data = text,
-        });
-    }
-
-    Memory_FreePointer(&text);
+    va_list va;
+    va_start(va, fmt);
+    M_Emit(level, file, line, func, true, fmt, va);
+    va_end(va);
 }
 
 void Console_SetVerbose(const bool verbose)

--- a/src/trx/game/console/common.c
+++ b/src/trx/game/console/common.c
@@ -61,7 +61,7 @@ bool Console_IsOpened(void)
     return m_IsOpened;
 }
 
-void Console_LogEx(
+void Console_LogImpl(
     const LOG_LEVEL level, const char *file, int line, const char *func,
     const char *const fmt, ...)
 {
@@ -122,7 +122,7 @@ COMMAND_RESULT Console_Eval(const char *const cmdline)
 
     const CONSOLE_COMMAND *const matching_cmd = Console_Registry_Get(line);
     if (matching_cmd == nullptr) {
-        Console_LogError(GS("general/osd/unknown_command"), line);
+        Console_Error(GS("general/osd/unknown_command"), line);
         return CR_BAD_INVOCATION;
     }
 
@@ -145,11 +145,11 @@ COMMAND_RESULT Console_Eval(const char *const cmdline)
 
     switch (result) {
     case CR_BAD_INVOCATION:
-        Console_LogError(GS("general/osd/command_bad_invocation"), cmdline);
+        Console_Error(GS("general/osd/command_bad_invocation"), cmdline);
         break;
 
     case CR_UNAVAILABLE:
-        Console_LogError(GS("general/osd/command_unavailable"));
+        Console_Error(GS("general/osd/command_unavailable"));
         break;
 
     case CR_SUCCESS:

--- a/src/trx/game/console/common.h
+++ b/src/trx/game/console/common.h
@@ -13,11 +13,20 @@
 #define Console_Warn(...) Console_Log(LOG_LEVEL_WARNING, __VA_ARGS__)
 #define Console_Error(...) Console_Log(LOG_LEVEL_ERROR, __VA_ARGS__)
 
+// Logs and displays the message in the console, even when no command is
+// running. Use when nothing else shows the message to the player.
+// Other levels need their own macro.
+#define Console_ShowError(...)                                                 \
+    Console_ShowImpl(LOG_LEVEL_ERROR, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
 void Console_Open(void);
 void Console_Close(void);
 bool Console_IsOpened(void);
 
 void Console_LogImpl(
+    LOG_LEVEL level, const char *file, int line, const char *func,
+    const char *fmt, ...);
+void Console_ShowImpl(
     LOG_LEVEL level, const char *file, int line, const char *func,
     const char *fmt, ...);
 void Console_Clear(void);

--- a/src/trx/game/console/common.h
+++ b/src/trx/game/console/common.h
@@ -7,18 +7,17 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define Console_LogGeneric(level, ...)                                         \
-    Console_LogEx(level, __FILE__, __LINE__, __func__, __VA_ARGS__)
-#define Console_Log(...) Console_LogGeneric(LOG_LEVEL_INFO, __VA_ARGS__)
-#define Console_LogWarning(...)                                                \
-    Console_LogGeneric(LOG_LEVEL_WARNING, __VA_ARGS__)
-#define Console_LogError(...) Console_LogGeneric(LOG_LEVEL_ERROR, __VA_ARGS__)
+#define Console_Log(level, ...)                                                \
+    Console_LogImpl(level, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#define Console_Info(...) Console_Log(LOG_LEVEL_INFO, __VA_ARGS__)
+#define Console_Warn(...) Console_Log(LOG_LEVEL_WARNING, __VA_ARGS__)
+#define Console_Error(...) Console_Log(LOG_LEVEL_ERROR, __VA_ARGS__)
 
 void Console_Open(void);
 void Console_Close(void);
 bool Console_IsOpened(void);
 
-void Console_LogEx(
+void Console_LogImpl(
     LOG_LEVEL level, const char *file, int line, const char *func,
     const char *fmt, ...);
 void Console_Clear(void);

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -129,28 +129,28 @@ GF_COMMAND Game_Control(const bool demo_mode)
             && Savegame_IsManualSaveAllowed()) {
             const SAVEGAME_SLOT_REF slot = SG_Manager_GetNextQuickSlot();
             if (!SG_Manager_IsValidSlotRef(slot)) {
-                Console_LogError(
-                    "%s", GS("general/osd/quick_save_fail_no_slots"));
+                Console_Error("%s", GS("general/osd/quick_save_fail_no_slots"));
             } else if (Savegame_Save(slot)) {
-                Console_Log("%s", GS("general/osd/quick_save"));
+                Console_Info("%s", GS("general/osd/quick_save"));
             }
             quick_handled = true;
         } else if (g_InputDB.quick_load) {
             const SAVEGAME_SLOT_REF slot = SG_Manager_GetBoundSlot();
             if (!SG_Manager_IsValidSlotRef(slot)) {
-                Console_LogError(
+                Console_Error(
                     "%s", GS("general/osd/quick_load_fail_no_bound_slot"));
             } else if (SG_Manager_IsSlotFree(slot)) {
-                Console_LogError(
+                Console_Error(
                     "%s",
                     GS("general/osd/quick_load_fail_unavailable_bound_slot"));
             } else {
                 if (slot.pool == SAVEGAME_SLOT_POOL_QUICK) {
                     const int32_t visual_index =
                         SG_Manager_QuickToVisualIndex(slot);
-                    Console_Log(GS("general/osd/quick_load"), visual_index + 1);
+                    Console_Info(
+                        GS("general/osd/quick_load"), visual_index + 1);
                 } else {
-                    Console_Log(GS("general/osd/load_game"), slot.index + 1);
+                    Console_Info(GS("general/osd/load_game"), slot.index + 1);
                 }
                 return (GF_COMMAND) {
                     .action = GF_START_SAVED_GAME,

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -180,12 +180,12 @@ bool Lara_Cheat_OpenNearestDoor(void)
     }
 
     if (opened > 0 || closed > 0) {
-        Console_Log(
+        Console_Info(
             opened > 0 ? GS("general/osd/door_open")
                        : GS("general/osd/door_close"));
         return true;
     }
-    Console_LogError(GS("general/osd/door_open_fail"));
+    Console_Error(GS("general/osd/door_open_fail"));
     return false;
 }
 
@@ -258,7 +258,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     Lara_Skin_ApplyOutfit();
     g_Camera.type = CAM_CHASE;
 
-    Console_Log(GS("general/osd/fly_mode_on"));
+    Console_Info(GS("general/osd/fly_mode_on"));
     return true;
 }
 
@@ -308,7 +308,7 @@ bool Lara_Cheat_ExitFlyMode(void)
         Lara_Control();
     }
 
-    Console_Log(GS("general/osd/fly_mode_off"));
+    Console_Info(GS("general/osd/fly_mode_off"));
     return true;
 }
 

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -29,8 +29,12 @@
 #include <trx/game/stats.h>
 #include <trx/game/ui.h>
 
+static bool m_WorldLoaded = false;
+
 void Level_Unload(void)
 {
+    m_WorldLoaded = false;
+
     // First, so the end event a dropped cutscene fires reaches a script that
     // can still read the world it played in.
     CutSeq_Reset();
@@ -63,6 +67,11 @@ void Level_Unload(void)
 
     Sound_StopAll();
     Viewport_AlterFOV(-1, FOV_MODE_GAME);
+}
+
+bool Level_IsWorldLoaded(void)
+{
+    return m_WorldLoaded;
 }
 
 RESULT Level_Initialise(
@@ -108,6 +117,7 @@ RESULT Level_Initialise(
     LUA_RunLevelScript(level);
 
     MUST(Level_Pipeline_Load(level));
+    m_WorldLoaded = true;
 
     UI_LoadText();
     Output_SetSkyboxEnabled(Object_Get(O_SKYBOX)->loaded);

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -119,6 +119,10 @@ RESULT Level_Initialise(
     MUST(Level_Pipeline_Load(level));
     m_WorldLoaded = true;
 
+    // The level script ran before any of this was here, so the watchers it
+    // attached are still owed the call for the value in force.
+    LUA_Config_FlushPendingWatchers();
+
     UI_LoadText();
     Output_SetSkyboxEnabled(Object_Get(O_SKYBOX)->loaded);
     Output_DispatchLevelLoad();

--- a/src/trx/game/level/common.h
+++ b/src/trx/game/level/common.h
@@ -5,3 +5,9 @@
 
 void Level_Unload(void);
 RESULT Level_Initialise(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);
+
+// Whether the level has its objects, rooms and items in memory. False while a
+// level script runs, which happens before the level is read, and false again
+// once the level is unloaded. Not the same as Game_IsLoaded, which reports
+// which level is current rather than whether it is there to be read.
+bool Level_IsWorldLoaded(void);

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -2,6 +2,7 @@
 #include <trx/core/math/const.h>
 #include <trx/core/math/trig.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
@@ -12,6 +13,16 @@
 #include <trx/game/rooms.h>
 
 #include <string.h>
+
+// One placed static reaching one room. The placement is what bleeds, and what
+// the level author has to move; the static it is placed from only says what
+// the shape is.
+typedef struct {
+    int16_t draw_num;
+    int16_t static_num;
+    int16_t home_room;
+    int16_t room_num;
+} M_BLEED;
 
 static inline BOUNDS_32 M_GetStaticBounds(const STATIC_MESH *const mesh)
 {
@@ -85,6 +96,68 @@ static void M_ComputePortalBounds(void)
     }
 }
 
+// Reports every placed static that reaches past the room it stands in, as one
+// list. A placement is what the level author has to move; the static it is
+// placed from only says what the shape is.
+static void M_ReportBleeds(const VECTOR *const bleeds)
+{
+    if (bleeds->count == 0) {
+        return;
+    }
+
+    VECTOR *const named = Vector_Create(sizeof(int16_t));
+    VECTOR *const rooms = Vector_Create(sizeof(int16_t));
+    char *text = nullptr;
+
+    for (int32_t i = 0; i < bleeds->count; i++) {
+        const M_BLEED *const bleed = Vector_Get(bleeds, i);
+        if (Vector_Contains(named, &bleed->draw_num)) {
+            continue;
+        }
+        Vector_Add(named, &(int16_t) { bleed->draw_num });
+
+        Vector_Clear(rooms);
+        for (int32_t j = i; j < bleeds->count; j++) {
+            const M_BLEED *const other = Vector_Get(bleeds, j);
+            if (other->draw_num != bleed->draw_num
+                || Vector_Contains(rooms, &other->room_num)) {
+                continue;
+            }
+            // In room order, so the same placement reads the same way
+            // whichever portal happened to reach it first.
+            int32_t at = rooms->count;
+            while (at > 0
+                   && *(int16_t *)Vector_Get(rooms, at - 1) > other->room_num) {
+                at--;
+            }
+            Vector_Insert(rooms, at, &(int16_t) { other->room_num });
+        }
+
+        char *list = nullptr;
+        for (int32_t j = 0; j < rooms->count; j++) {
+            const int16_t room_num = *(int16_t *)Vector_Get(rooms, j);
+            char *const grown = list == nullptr
+                ? String_Format("#%d", room_num)
+                : String_Format("%s, #%d", list, room_num);
+            Memory_FreePointer(&list);
+            list = grown;
+        }
+
+        char *const grown = String_Format(
+            "%s\n  - mesh #%d of static #%d in room #%d extends into %s %s",
+            text != nullptr ? text : "", bleed->draw_num, bleed->static_num,
+            bleed->home_room, rooms->count == 1 ? "room" : "rooms", list);
+        Memory_FreePointer(&list);
+        Memory_FreePointer(&text);
+        text = grown;
+    }
+
+    LOG_WARNING("Statics found to extend beyond their room:%s", text);
+    Memory_FreePointer(&text);
+    Vector_Free(rooms);
+    Vector_Free(named);
+}
+
 static void M_FixStaticsVisibility(void)
 {
     int32_t total_rooms = Room_GetCount();
@@ -118,6 +191,7 @@ static void M_FixStaticsVisibility(void)
         own_counts[i] = room_stat_vecs[i]->count;
     }
 
+    VECTOR *const bleeds = Vector_Create(sizeof(M_BLEED));
     for (int32_t i = 0; i < total_rooms; i++) {
         ROOM *const room = Room_Get(i);
         PORTALS *const portals = room->portals;
@@ -141,12 +215,20 @@ static void M_FixStaticsVisibility(void)
                     continue;
                 }
                 Vector_Add(room_stat_vecs[portal->room_num], mesh);
-                LOG_WARNING(
-                    "Static #%d bleeds into room #%d", mesh->static_num,
-                    portal->room_num);
+                Vector_Add(
+                    bleeds,
+                    &(M_BLEED) {
+                        .draw_num = mesh->draw_num,
+                        .static_num = mesh->static_num,
+                        .home_room = mesh->room_num,
+                        .room_num = portal->room_num,
+                    });
             }
         }
     }
+
+    M_ReportBleeds(bleeds);
+    Vector_Free(bleeds);
 
     Memory_FreePointer(&own_counts);
 
@@ -181,6 +263,7 @@ static void M_FixStaticsVisibility(void)
 
 static void M_FixStaticsCollision(void)
 {
+    char *degenerate = nullptr;
     const int32_t count = Object_GetStaticObjects3DCount();
     for (int32_t i = 0; i < count; i++) {
         STATIC_OBJECT_3D *const obj = Object_Get3DStatic(i);
@@ -195,12 +278,22 @@ static void M_FixStaticsCollision(void)
         };
 
         if (hitbox.x <= 0 && hitbox.y <= 0 && hitbox.z <= 0) {
-            LOG_WARNING(
-                "Static %d is marked as collidable, but has degenerate "
-                "hitbox (%d x %d x %d)",
-                i, hitbox.x, hitbox.y, hitbox.z);
+            char *const grown = String_Format(
+                "%s\n  - static #%d (%d x %d x %d)",
+                degenerate != nullptr ? degenerate : "", i, hitbox.x, hitbox.y,
+                hitbox.z);
+            Memory_FreePointer(&degenerate);
+            degenerate = grown;
             obj->collidable = false;
         }
+    }
+
+    if (degenerate != nullptr) {
+        LOG_WARNING(
+            "Collidable statics found to have degenerate hitboxes (their "
+            "meshes will have no collision):%s",
+            degenerate);
+        Memory_FreePointer(&degenerate);
     }
 }
 

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -8,6 +8,7 @@
 #include <trx/core/strings.h>
 #include <trx/core/vector.h>
 #include <trx/game/console/common.h>
+#include <trx/game/level/common.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
@@ -39,6 +40,10 @@ typedef struct {
     // Set up by a level script, so it goes when the level does, as a
     // trx.events listener does.
     bool level_scoped;
+    // Still owed the call that every watcher gets for the value in force. A
+    // level script attaches before the level is read, where a handler can
+    // reach nothing the level carries, so the call waits for the world.
+    bool pending_initial;
     bool dead;
 } M_WATCHER;
 
@@ -444,9 +449,10 @@ static int M_L_ConfigDeclare(lua_State *const L)
 // the rest of them with it: the setting has moved either way, and the others
 // still have to hear about it.
 static void M_CallWatcher(
-    lua_State *const L, const M_WATCHER *const watcher,
+    lua_State *const L, M_WATCHER *const watcher,
     const CONFIG_OPTION *const option)
 {
+    watcher->pending_initial = false;
     lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->fn_ref);
     LUA_Config_PushOptionValue(L, option);
     if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
@@ -501,7 +507,7 @@ static void M_HandleChange(const EVENT *const event, void *const user_data)
     for (int32_t i = 0; i < change->count; i++) {
         const CONFIG_OPTION *const option = change->options[i];
         for (int32_t j = 0; j < count && j < m_Watchers->count; j++) {
-            const M_WATCHER *const watcher = Vector_Get(m_Watchers, j);
+            M_WATCHER *const watcher = Vector_Get(m_Watchers, j);
             if (watcher->dead || strcmp(watcher->key, option->name) != 0) {
                 continue;
             }
@@ -526,17 +532,22 @@ static int M_L_ConfigOnChange(lua_State *const L)
     // Taken before the call below, which may attach a watcher of its own and
     // leave the counter naming that one instead.
     const int32_t id = m_NextWatcherId++;
+    const bool level_scoped = LUA_GetScriptContext() == LUA_CONTEXT_LEVEL;
+    const bool wait_for_world = level_scoped && !Level_IsWorldLoaded();
     Vector_Add(
         m_Watchers,
         &(M_WATCHER) {
             .id = id,
             .key = Memory_DupStr(option->name),
             .fn_ref = luaL_ref(L, LUA_REGISTRYINDEX),
-            .level_scoped = LUA_GetScriptContext() == LUA_CONTEXT_LEVEL,
+            .level_scoped = level_scoped,
+            .pending_initial = wait_for_world,
         });
     // The setting already holds something, and a script asking to hear about it
     // is asking about the value in force as much as the ones to come.
-    M_CallWatcher(L, Vector_Get(m_Watchers, m_Watchers->count - 1), option);
+    if (!wait_for_world) {
+        M_CallWatcher(L, Vector_Get(m_Watchers, m_Watchers->count - 1), option);
+    }
     lua_pushinteger(L, id);
     return 1;
 }
@@ -617,6 +628,31 @@ void LUA_Config_PushOptionValue(
         return;
     }
     LUA_PushValue(L, &option->value);
+}
+
+void LUA_Config_FlushPendingWatchers(void)
+{
+    lua_State *const L = m_L;
+    if (L == nullptr || m_Watchers == nullptr) {
+        return;
+    }
+    m_DispatchDepth++;
+    for (int32_t i = 0; i < m_Watchers->count; i++) {
+        M_WATCHER *const watcher = Vector_Get(m_Watchers, i);
+        if (watcher->dead || !watcher->pending_initial) {
+            continue;
+        }
+        const CONFIG_OPTION *const option = Config_FindOption(watcher->key);
+        if (option == nullptr) {
+            watcher->pending_initial = false;
+            continue;
+        }
+        M_CallWatcher(L, watcher, option);
+    }
+    m_DispatchDepth--;
+    if (m_DispatchDepth == 0) {
+        M_CompactWatchers(L);
+    }
 }
 
 void LUA_Config_ClearLevelWatchers(void)

--- a/src/trx/game/lua/capi/config.c
+++ b/src/trx/game/lua/capi/config.c
@@ -7,6 +7,7 @@
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/vector.h>
+#include <trx/game/console/common.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
@@ -449,7 +450,7 @@ static void M_CallWatcher(
     lua_rawgeti(L, LUA_REGISTRYINDEX, watcher->fn_ref);
     LUA_Config_PushOptionValue(L, option);
     if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
-        LOG_ERROR(
+        Console_ShowError(
             "config watcher for %s failed: %s", option->name,
             lua_tostring(L, -1));
         lua_pop(L, 1);
@@ -485,7 +486,7 @@ static void M_HandleChange(const EVENT *const event, void *const user_data)
         return;
     }
     if (m_DispatchDepth >= M_MAX_DISPATCH_DEPTH) {
-        LOG_ERROR(
+        Console_ShowError(
             "config watchers are still changing settings %d calls deep; "
             "giving up on this change",
             m_DispatchDepth);

--- a/src/trx/game/lua/capi/console.c
+++ b/src/trx/game/lua/capi/console.c
@@ -25,7 +25,7 @@ static int M_L_ConsoleLog(lua_State *const L)
 {
     LUA_LOG_CALL call;
     LUA_CheckLogCall(L, &call);
-    Console_LogEx(call.level, call.src, call.line, call.func, "%s", call.msg);
+    Console_LogImpl(call.level, call.src, call.line, call.func, "%s", call.msg);
     return 0;
 }
 
@@ -88,7 +88,7 @@ static COMMAND_RESULT M_LuaCommandProc(const COMMAND_CONTEXT *const ctx)
 
     lua_pushstring(L, ctx->args != nullptr ? ctx->args : "");
     if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
-        Console_LogError("%s: %s", ctx->prefix, lua_tostring(L, -1));
+        Console_Error("%s: %s", ctx->prefix, lua_tostring(L, -1));
         lua_settop(L, base);
         return CR_FAILURE;
     }
@@ -103,7 +103,7 @@ static COMMAND_RESULT M_LuaCommandProc(const COMMAND_CONTEXT *const ctx)
             && ENUM_MAP_TO_STRING(COMMAND_RESULT, lua_tointeger(L, -1))
                 != nullptr;
         if (!is_result) {
-            Console_LogError(
+            Console_Error(
                 "%s: the handler must give back a console result, or nothing",
                 ctx->prefix);
             lua_settop(L, base);
@@ -138,7 +138,7 @@ static void M_LuaArgComplete(
     lua_pushstring(L, text != nullptr ? text : "");
     lua_pushinteger(L, caret);
     if (lua_pcall(L, 2, 3, 0) != LUA_OK) {
-        Console_LogError("%s: %s", cmd->prefix, lua_tostring(L, -1));
+        Console_Error("%s: %s", cmd->prefix, lua_tostring(L, -1));
         lua_settop(L, base);
         return;
     }

--- a/src/trx/game/lua/capi/cutscenes.c
+++ b/src/trx/game/lua/capi/cutscenes.c
@@ -1,4 +1,5 @@
 #include <trx/game/cutseq.h>
+#include <trx/game/level/common.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
@@ -134,6 +135,9 @@ static int M_L_CutscenesSetNodeMesh(lua_State *const L)
     const int32_t node = M_CheckNode(L, 2);
     const OBJECT_ID object_id = LUA_CheckObjectID(L, 3);
     const OBJECT *const obj = Object_Get(object_id);
+    if (!Level_IsWorldLoaded()) {
+        return luaL_error(L, "the level has not loaded its objects yet");
+    }
     if (!obj->loaded) {
         return luaL_error(L, "this level does not carry that object");
     }

--- a/src/trx/game/lua/capi/events.c
+++ b/src/trx/game/lua/capi/events.c
@@ -1,6 +1,7 @@
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/vector.h>
+#include <trx/game/console/common.h>
 #include <trx/game/items/actions.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/events.h>
@@ -429,7 +430,8 @@ static bool M_FireEvent(
     // up: from here to the matching decrement nothing may raise, or the
     // listeners would never be compacted again.
     if (lua_checkstack(L, 2) == 0) {
-        LOG_ERROR("Lua stack exhausted; event %d not dispatched", (int32_t)ev);
+        Console_ShowError(
+            "Lua stack exhausted; event %d not dispatched", (int32_t)ev);
         return false;
     }
 
@@ -460,7 +462,8 @@ static bool M_FireEvent(
         lua_pushcfunction(L, M_CallListener);
         lua_pushlightuserdata(L, &dispatch);
         if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
-            LOG_ERROR("Lua event handler error: %s", lua_tostring(L, -1));
+            Console_ShowError(
+                "Lua event handler error: %s", lua_tostring(L, -1));
             lua_pop(L, 1);
         }
         LUA_SetScriptContext(outer_context);

--- a/src/trx/game/lua/capi/lara.c
+++ b/src/trx/game/lua/capi/lara.c
@@ -9,6 +9,7 @@
 #include <trx/game/lara/poison.h>
 #include <trx/game/lara/skin/storage.h>
 #include <trx/game/lara/types.h>
+#include <trx/game/level/common.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
@@ -161,6 +162,9 @@ static int M_L_LaraSetMesh(lua_State *const L)
     const LARA_MESH lara_mesh = M_CheckLaraMesh(L, 1);
     const OBJECT_ID object_id = LUA_CheckObjectID(L, 2);
     const OBJECT *const obj = Object_Get(object_id);
+    if (!Level_IsWorldLoaded()) {
+        return luaL_error(L, "the level has not loaded its objects yet");
+    }
     if (!obj->loaded) {
         return luaL_error(L, "this level does not carry that object");
     }

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -6,6 +6,7 @@
 #include <trx/core/shell.h>
 #include <trx/core/strings.h>
 #include <trx/debug.h>
+#include <trx/game/console/common.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/lua/api.h>
 #include <trx/game/lua/embedded_scripts.h>
@@ -481,7 +482,7 @@ void LUA_RunGameScript(void)
     LOG_INFO("Loading game script: %s", path);
     LUA_RESULT res = LUA_EvalFile(path);
     if (res.code != LUA_OK) {
-        LOG_ERROR("Lua game script error: %s", res.message);
+        Console_ShowError("Lua game script error: %s", res.message);
     }
     LUA_FreeResult(&res);
 }
@@ -511,7 +512,7 @@ void LUA_RunLevelScript(const GF_LEVEL *const level)
     if (level->script_path != nullptr) {
         LUA_RESULT res = LUA_EvalFile(level->script_path);
         if (res.code != LUA_OK) {
-            LOG_ERROR("Lua level script error: %s", res.message);
+            Console_ShowError("Lua level script error: %s", res.message);
         }
         LUA_FreeResult(&res);
     }

--- a/src/trx/game/lua/common.h
+++ b/src/trx/game/lua/common.h
@@ -70,6 +70,10 @@ void LUA_Config_PushOptionValue(lua_State *L, const CONFIG_OPTION *option);
 // are dropped. A watcher a game script set up stays.
 void LUA_Config_ClearLevelWatchers(void);
 
+// Makes the calls a level script's watchers are still owed, now that the level
+// has its objects. Level_Initialise does this once the level is read.
+void LUA_Config_FlushPendingWatchers(void);
+
 // Let go of the outgoing level's script: what it set up hears about it, and
 // then its listeners go. Level_Unload does this for a level change; a path that
 // re-runs a script without unloading the level does it for itself. The event

--- a/src/trx/game/paths.c
+++ b/src/trx/game/paths.c
@@ -916,6 +916,11 @@ static bool M_ForEachResolveAttempt(
 
         for (const char **ext = &policy->extensions[0]; *ext != nullptr;
              ext++) {
+            // The candidate carries an extension of its own and has been tried
+            // already, so the one that matches it would name the same file.
+            if (String_Equivalent(dot, *ext)) {
+                continue;
+            }
             const size_t out_size =
                 (size_t)(dot - candidate) + strlen(*ext) + 1;
             char *out = Memory_Alloc(out_size);

--- a/src/trx/game/savegame/resume.c
+++ b/src/trx/game/savegame/resume.c
@@ -156,7 +156,6 @@ void SG_Resume_ResetAllEntries(void)
 
 void SG_Resume_ResetEntry(const GF_LEVEL *const level)
 {
-    LOG_INFO("Resetting resume info for level #%d", level->num);
     RESUME_INFO *const current = SG_Resume_GetEntry(level);
     *current = (RESUME_INFO) { .prev_level = -1, .level_completed = false };
 }
@@ -218,8 +217,6 @@ void SG_Resume_ApplyRulesToEntry(const GF_LEVEL *const level)
     if (resume == nullptr) {
         return;
     }
-
-    LOG_INFO("Applying game logic to level #%d", level->num);
 
     if (!g_Config.gameplay.disable_healing_between_levels
         || level == GF_GetGymLevel() || level == GF_GetFirstLevel()) {

--- a/src/trx/game/shell/input.c
+++ b/src/trx/game/shell/input.c
@@ -23,7 +23,7 @@ static void M_ToggleFPSCounter(void)
 {
     CONFIG_TOGGLE(g_Config.ui.enable_fps_counter);
     Config_Update();
-    Console_Log(
+    Console_Info(
         "%s",
         g_Config.ui.enable_fps_counter ? GS("general/osd/fps_counter_on")
                                        : GS("general/osd/fps_counter_off"));
@@ -34,7 +34,7 @@ static void M_ToggleBilinearFilter(void)
     CONFIG_CYCLE(
         g_Config.rendering.texture_filter, 1, TEXTURE_FILTER_NUMBER_OF);
     Config_Update();
-    Console_Log(
+    Console_Info(
         "%s",
         g_Config.rendering.texture_filter == TEXTURE_FILTER_BILINEAR
             ? GS("general/osd/bilinear_filter_on")
@@ -45,7 +45,7 @@ static void M_ToggleTrapezoidFilter(void)
 {
     CONFIG_TOGGLE(g_Config.rendering.enable_trapezoid_filter);
     Config_Update();
-    Console_Log(
+    Console_Info(
         "%s",
         g_Config.rendering.enable_trapezoid_filter
             ? GS("general/osd/trapezoid_filter_on")
@@ -56,7 +56,7 @@ static void M_ToggleWireframe(void)
 {
     CONFIG_TOGGLE(g_Config.rendering.enable_wireframe);
     Config_Update();
-    Console_Log(
+    Console_Info(
         "%s",
         g_Config.rendering.enable_wireframe
             ? GS("general/osd/wireframe_mode_on")
@@ -67,7 +67,7 @@ static void M_ToggleTextures(void)
 {
     CONFIG_TOGGLE(g_Config.rendering.enable_textures);
     Config_Update();
-    Console_Log(
+    Console_Info(
         "%s",
         g_Config.rendering.enable_textures ? GS("general/osd/textures_on")
                                            : GS("general/osd/textures_off"));
@@ -81,7 +81,7 @@ static void M_CycleLightingModel(void)
         CONFIG_CYCLE(
             g_Config.rendering.lighting_curve, dir, LIGHTING_CURVE_NUMBER_OF);
         Config_Update();
-        Console_Log(
+        Console_Info(
             GS("general/osd/lighting_curve_fmt"),
             ENUM_MAP_TO_STRING(
                 LIGHTING_CURVE, g_Config.rendering.lighting_curve));
@@ -92,7 +92,7 @@ static void M_CycleLightingModel(void)
             g_Config.rendering.lighting_contrast, dir,
             LIGHTING_CONTRAST_NUMBER_OF);
         Config_Update();
-        Console_Log(
+        Console_Info(
             GS("general/osd/lighting_contrast_fmt"),
             ENUM_MAP_TO_STRING(
                 LIGHTING_CONTRAST, g_Config.rendering.lighting_contrast));
@@ -105,7 +105,7 @@ static void M_CycleUpscalingFactor(void)
         g_Config.rendering.upscaling_factor,
         g_Config.rendering.upscaling_factor + (g_Input.slow ? -1 : 1));
     Config_Update();
-    Console_Log(
+    Console_Info(
         GS("general/osd/upscaling_factor"),
         g_Config.rendering.upscaling_factor);
 }

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -257,7 +257,7 @@ void UI_ToggleState(const bool *const config_setting)
     };
     Config_Option_Write(option, &value);
     Config_Update();
-    Console_Log(
+    Console_Info(
         *config_setting ? GS("general/osd/ui_on") : GS("general/osd/ui_off"));
 }
 

--- a/src/trx/game/ui/hud/console_logs.c
+++ b/src/trx/game/ui/hud/console_logs.c
@@ -45,6 +45,7 @@ static void M_ScrollLogs(UI_CONSOLE_LOGS *const s)
            && Clock_GetRealTime() >= s->logs[i].expire_at) {
         s->logs[i].expire_at = 0.0;
         Memory_FreePointer(&s->logs[i].text);
+        Memory_FreePointer(&s->logs[i].wrapped);
         need_layout = true;
         i--;
     }
@@ -59,13 +60,16 @@ static void M_HandleLog(const EVENT *const event, void *const user_data)
     const char *text = event->data;
     UI_CONSOLE_LOGS *const s = user_data;
     Memory_FreePointer(&s->logs[s->max_lines - 1].text);
+    Memory_FreePointer(&s->logs[s->max_lines - 1].wrapped);
     for (int32_t i = s->max_lines - 1; i > 0; i--) {
         s->logs[i] = s->logs[i - 1];
     }
 
     s->logs[0].expire_at =
         Clock_GetRealTime() + strlen(text) * M_DELAY_PER_CHAR;
-    s->logs[0].text = UI_Text_WordWrap(text, M_LOG_SCALE, M_GetWrapWidth());
+    s->logs[0].text = Memory_DupStr(text);
+    s->logs[0].wrapped = nullptr;
+    s->logs[0].wrap_width = 0.0f;
     M_UpdateLogCount(s);
 }
 
@@ -94,6 +98,7 @@ void UI_ConsoleLogs_Free(UI_CONSOLE_LOGS *const s)
     if (s->logs != nullptr) {
         for (int32_t i = 0; i < M_MAX_LOG_LINES; i++) {
             Memory_FreePointer(&s->logs[i].text);
+            Memory_FreePointer(&s->logs[i].wrapped);
         }
         Memory_FreePointer(&s->logs);
     }
@@ -112,9 +117,19 @@ void UI_ConsoleLogs(UI_CONSOLE_LOGS *const s)
             .v = UI_STACK_V_ALIGN_CENTER,
         },
     });
+    const float wrap_width = M_GetWrapWidth();
     for (int32_t i = s->vis_lines - 1; i >= 0; i--) {
+        UI_CONSOLE_LOG_LINE *const line = &s->logs[i];
+        if (line->wrapped == nullptr || line->wrap_width != wrap_width) {
+            Memory_FreePointer(&line->wrapped);
+            line->wrapped =
+                UI_Text_WordWrap(line->text, M_LOG_SCALE, wrap_width);
+            line->wrap_width = wrap_width;
+        }
+        // A canvas with no width to wrap to leaves the line as it came.
         UI_LabelEx(
-            s->logs[i].text, (UI_LABEL_SETTINGS) { .scale = M_LOG_SCALE });
+            line->wrapped != nullptr ? line->wrapped : line->text,
+            (UI_LABEL_SETTINGS) { .scale = M_LOG_SCALE });
     }
     UI_EndStack();
 }

--- a/src/trx/game/ui/hud/console_logs.h
+++ b/src/trx/game/ui/hud/console_logs.h
@@ -7,6 +7,11 @@
 
 typedef struct {
     char *text;
+    // The line as it is drawn, wrapped to the width below. Both are dropped
+    // when the canvas changes width, so a line follows the window it is shown
+    // in rather than the one it arrived in.
+    char *wrapped;
+    float wrap_width;
     double expire_at;
 } UI_CONSOLE_LOG_LINE;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A Lua script error now appears in the developer console as well as the log, so broken scripts are visible while the game runs rather than only afterwards.

This exposed two related faults: level config watchers ran before the level was read, and the resulting error named the wrong fault. Both are fixed, and uninformative startup logging has been removed.

#### Watchers

Level-script watchers now receive the current value _after_ the level's objects are loaded. Game-script watchers are still called immediately.

Specifically, this previously failed on every Angkor Wat start:

```lua
trx.config.on_change("visuals.lara_outfit", function(outfit)
  trx.lara.set_mesh(trx.lara.Mesh.TORSO, trx.catalog.objects.lara_skin, 7)
end)
```

The handler ran with the level script, before `lara_skin` was loaded, so it raised instead of dressing Lara. It is now deferred until the level objects are loaded, allowing the torso mesh to be applied without error while keeping the watcher active.

#### Renames

| Before                       | After             |
| ---                          | ---               |
| `Console_Log`                | `Console_Info`    |
| `Console_LogWarning`         | `Console_Warn`    |
| `Console_LogError`           | `Console_Error`   |
| `Console_LogEx`              | `Console_LogImpl` |
| the macro taking a log level | `Console_Log`     |

#### New APIs

The console gains one call, and the level one predicate:

```c
// logs and displays
Console_ShowError("Lua level script error: %s", message);

// whether the level's objects, rooms and items are read
Level_IsWorldLoaded();
```

#### QoL changes

- Long console messages now wrap instead of running past the screen edges.
- Direct-level launchers also no longer report the parent game's title picture or sound file as missing.
- Level startup logging is quieter too:
  - failed path lookups no longer repeat the same file extension twice,
  - invalid statics are reported as one list each instead of one line per placement,
  - the resume info reports are removed as they contributed very little.

#### Testing

- [x] A level script that raises reports in the developer console as well as the log
- [x] Angkor Wat starts with no error in the log, and Lara wears the young outfit torso
- [x] A console message longer than the screen wraps onto the next line
- [x] `--mod tr4 -l 1` starts with no missing title picture or sound file in the log
- [x] The menu of a direct-level launcher opens and works
