### PR TITLE
docs: fix typo overriden -> overridden

### DIFF
--- a/docs/trx/game_flow/GLOBAL_PROPERTIES.md
+++ b/docs/trx/game_flow/GLOBAL_PROPERTIES.md
@@ -163,7 +163,7 @@ remains distinct for each game.
     <code>enforced_config</code></td>
     <td>String-to-object map</td>
     <td>
-      This allows <em>any</em> regular game config setting to be overriden. See
+      This allows <em>any</em> regular game config setting to be overridden. See
       <a href="./USER_CONFIGURATION.md">User configuration</a> for full details.
     </td>
   </tr>


### PR DESCRIPTION
One-word typo fix in `docs/trx/game_flow/GLOBAL_PROPERTIES.md:166`.
