### PR TITLE
Hold catalog identities in a registry

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -319,6 +319,7 @@ common_sources = [
   'trx/game/camera/spline.c',
   'trx/game/camera/vars.c',
   'trx/game/catalog/manager.c',
+  'trx/game/catalog/table.c',
   'trx/game/clock/common.c',
   'trx/game/clock/timer.c',
   'trx/game/clock/turbo.c',

--- a/src/tests/fakes/catalog.c
+++ b/src/tests/fakes/catalog.c
@@ -13,28 +13,24 @@
 
 #define FAKE_SLOT_OFFSET 13
 
-bool Catalog_EnumToGameID(
-    const CATALOG_CONTEXT context, const CATALOG_ID id,
-    int32_t *const out_game_id)
+int32_t Catalog_ToSlot(
+    const CATALOG_CONTEXT context, const CATALOG_ID id, const int32_t fallback)
 {
     if (context == CATALOG_SAMPLES) {
-        *out_game_id = FAKE_SAMPLE;
-        return true;
+        return FAKE_SAMPLE;
     }
     if (context != CATALOG_OBJECTS) {
-        return false;
+        return fallback;
     }
-    *out_game_id = id + FAKE_SLOT_OFFSET;
-    return true;
+    return id + FAKE_SLOT_OFFSET;
 }
 
-bool Catalog_GameIDToEnum(
-    const CATALOG_CONTEXT context, const int32_t game_id,
-    CATALOG_ID *const out_id)
+CATALOG_ID Catalog_FromSlot(
+    const CATALOG_CONTEXT context, const int32_t slot,
+    const CATALOG_ID fallback)
 {
-    if (context != CATALOG_OBJECTS || game_id < FAKE_SLOT_OFFSET) {
-        return false;
+    if (context != CATALOG_OBJECTS || slot < FAKE_SLOT_OFFSET) {
+        return fallback;
     }
-    *out_id = game_id - FAKE_SLOT_OFFSET;
-    return true;
+    return slot - FAKE_SLOT_OFFSET;
 }

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -369,11 +369,11 @@ RESULT GameStringManager_ReloadLanguage(const char *const lang)
     return OK;
 }
 
-bool Catalog_NameToEnum(
-    const CATALOG_CONTEXT context, const char *const name,
-    CATALOG_ID *const out_id)
+CATALOG_ID Catalog_FromKey(
+    const CATALOG_CONTEXT context, const char *const key,
+    const CATALOG_ID fallback)
 {
-    return false;
+    return fallback;
 }
 
 void Music_SetVolume(const float volume)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -310,7 +310,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'trx/game/items/actions',
-  'engine': ['game/items/actions/common.c'],
+  'engine': ['core/memory.c', 'game/catalog/table.c', 'game/items/actions/common.c'],
 }
 
 unit_tests += {
@@ -321,7 +321,7 @@ unit_tests += {
 
 unit_tests += {
   'name': 'trx/game/game_flow/inventory',
-  'engine': ['game/game_flow/inventory.c'],
+  'engine': ['core/memory.c', 'game/catalog/table.c', 'game/game_flow/inventory.c'],
 }
 
 unit_tests += {
@@ -1079,6 +1079,7 @@ unit_tests += {
     'core/subsystem.c',
     'core/value.c',
     'core/vector.c',
+    'game/catalog/table.c',
     'game/enum.c',
     'game/game_strings/entries.c',
     'game/gun/registry.c',

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -23,9 +23,10 @@ typedef struct {
     const char *name_str;
 } M_ENTRY;
 
-// Internal map from name to CATALOG_ID
+// Internal map from a name to the CATALOG_ID it resolves to. One identity has
+// one entry for its canonical key and one for each of its aliases.
 typedef struct {
-    const char *name_str;
+    char *name_str;
     int32_t enum_value;
     UT_hash_handle hh;
 } M_NAME_ENTRY;
@@ -88,6 +89,22 @@ static void M_ClearGameIDMap(M_GAME_ID_ENTRY **const map)
     }
 }
 
+static RESULT M_AddName(
+    const CATALOG_CONTEXT context, const CATALOG_ID id, const char *const name)
+{
+    FAIL_IF(
+        Catalog_FromKey(context, name, -1) >= 0,
+        "context %d already holds the name '%s'", context, name);
+
+    M_NAME_ENTRY *const entry = Memory_Alloc(sizeof(*entry));
+    entry->name_str = Memory_DupStr(name);
+    entry->enum_value = id;
+    HASH_ADD_KEYPTR(
+        hh, m_Name2EnumMap[context], entry->name_str,
+        (uint32_t)strlen(entry->name_str), entry);
+    return OK;
+}
+
 // Mint the built-ins, walking each .def in file order, so that the ID of a
 // built-in equals the enum constant it was declared with. This runs before
 // main because the mods are scanned before the subsystems come up, and that
@@ -113,15 +130,18 @@ static void M_Shutdown(void)
 {
     for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
         M_ClearGameIDMap(&m_GameID2EnumMap[ctx]);
-        while (m_Counts[ctx] > m_BuiltInCounts[ctx]) {
-            const int32_t id = --m_Counts[ctx];
-            M_NAME_ENTRY *entry = nullptr;
-            HASH_FIND_STR(m_Name2EnumMap[ctx], m_Keys[ctx][id], entry);
-            if (entry != nullptr) {
-                HASH_DEL(m_Name2EnumMap[ctx], entry);
-                Memory_Free(entry);
+        M_NAME_ENTRY *cur, *tmp;
+        HASH_ITER(hh, m_Name2EnumMap[ctx], cur, tmp)
+        {
+            if (cur->enum_value < m_BuiltInCounts[ctx]) {
+                continue;
             }
-            Memory_FreePointer(&m_Keys[ctx][id]);
+            HASH_DEL(m_Name2EnumMap[ctx], cur);
+            Memory_FreePointer(&cur->name_str);
+            Memory_Free(cur);
+        }
+        while (m_Counts[ctx] > m_BuiltInCounts[ctx]) {
+            Memory_FreePointer(&m_Keys[ctx][--m_Counts[ctx]]);
         }
         for (int32_t id = 0; id < m_Counts[ctx]; id++) {
             m_GameIDs[ctx][id] = -1;
@@ -133,11 +153,10 @@ RESULT Catalog_Mint(
     const CATALOG_CONTEXT context, const char *const key,
     CATALOG_ID *const out_id)
 {
-    FAIL_IF(
-        Catalog_FromKey(context, key, -1) >= 0,
-        "context %d already holds the key '%s'", context, key);
+    const CATALOG_ID id = m_Counts[context];
+    MUST(M_AddName(context, id, key));
 
-    const CATALOG_ID id = m_Counts[context]++;
+    m_Counts[context]++;
     m_Keys[context] =
         Memory_Realloc(m_Keys[context], sizeof(char *) * m_Counts[context]);
     m_GameIDs[context] =
@@ -145,15 +164,17 @@ RESULT Catalog_Mint(
     m_Keys[context][id] = Memory_DupStr(key);
     m_GameIDs[context][id] = -1;
 
-    M_NAME_ENTRY *const entry = Memory_Alloc(sizeof(*entry));
-    entry->name_str = m_Keys[context][id];
-    entry->enum_value = id;
-    HASH_ADD_KEYPTR(
-        hh, m_Name2EnumMap[context], entry->name_str,
-        (uint32_t)strlen(entry->name_str), entry);
-
     *out_id = id;
     return OK;
+}
+
+RESULT Catalog_AddAlias(
+    const CATALOG_CONTEXT context, const CATALOG_ID id, const char *const alias)
+{
+    FAIL_IF(
+        id < 0 || id >= m_Counts[context], "context %d holds no ID %d", context,
+        id);
+    return M_AddName(context, id, alias);
 }
 
 const char *Catalog_GetKey(const CATALOG_CONTEXT context, const CATALOG_ID id)

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -2,10 +2,10 @@
 
 #include <trx/core/csv.h>
 #include <trx/core/filesystem.h>
-#include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
+#include <trx/debug.h>
 #include <trx/game/items/actions/ids.h>
 #include <trx/game/lara/enum.h>
 #include <trx/game/music/ids.h>
@@ -68,14 +68,14 @@ static M_NAME_ENTRY *m_Name2EnumMap[CATALOG_CONTEXT_MAX] = { nullptr };
 
 static M_GAME_ID_ENTRY *m_GameID2EnumMap[CATALOG_CONTEXT_MAX] = { nullptr };
 
-// Parsed game IDs arrays, one per context, sized by that context's entries
-static int32_t **m_CatalogGameIDs = nullptr;
+// The identities of each context. A resolve reads m_GameIDs by ID, so this is
+// a flat array rather than anything with a lookup in it.
+static char **m_Keys[CATALOG_CONTEXT_MAX] = { nullptr };
+static int32_t *m_GameIDs[CATALOG_CONTEXT_MAX] = { nullptr };
+static int32_t m_Counts[CATALOG_CONTEXT_MAX] = {};
 
-// Entry count of each context
-static int32_t m_CatalogCounts[CATALOG_CONTEXT_MAX] = {};
-
-// State flag
-static bool m_Initialized = false;
+// How many identities of each context the exe has a constant for
+static int32_t m_BuiltInCounts[CATALOG_CONTEXT_MAX] = {};
 
 // Helper: clear game_id->enum map
 static void M_ClearGameIDMap(M_GAME_ID_ENTRY **const map)
@@ -88,67 +88,116 @@ static void M_ClearGameIDMap(M_GAME_ID_ENTRY **const map)
     }
 }
 
-// Helper: clear name->enum map
-static void M_ClearNameMap(M_NAME_ENTRY **const map)
-{
-    M_NAME_ENTRY *cur, *tmp;
-    HASH_ITER(hh, *map, cur, tmp)
-    {
-        HASH_DEL(*map, cur);
-        Memory_Free(cur);
-    }
-}
-
-// Build initial maps on first load
-static void M_Initialize(void)
+// Mint the built-ins, walking each .def in file order, so that the ID of a
+// built-in equals the enum constant it was declared with. This runs before
+// main because the mods are scanned before the subsystems come up, and that
+// scan already names objects.
+__attribute__((constructor)) static void M_MintBuiltIns(void)
 {
     for (size_t idx = 0; idx < m_CatalogEntryCount; idx++) {
         const CATALOG_CONTEXT ctx = m_CatalogEntryDefs[idx].context;
-        m_CatalogCounts[ctx] =
-            MAX(m_CatalogCounts[ctx], m_CatalogEntryDefs[idx].id + 1);
+        CATALOG_ID id;
+        EXIT_ON_FAIL(
+            Catalog_Mint(ctx, m_CatalogEntryDefs[idx].name_str, &id),
+            "cannot seed the catalog");
+        ASSERT(id == m_CatalogEntryDefs[idx].id);
     }
-    m_CatalogGameIDs =
-        Memory_Alloc(sizeof(*m_CatalogGameIDs) * CATALOG_CONTEXT_MAX);
     for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
-        m_CatalogGameIDs[ctx] =
-            Memory_Alloc(sizeof(*m_CatalogGameIDs[ctx]) * m_CatalogCounts[ctx]);
+        m_BuiltInCounts[ctx] = m_Counts[ctx];
     }
-    for (size_t idx = 0; idx < m_CatalogEntryCount; idx++) {
-        const CATALOG_CONTEXT ctx = m_CatalogEntryDefs[idx].context;
-        const CATALOG_ID id = m_CatalogEntryDefs[idx].id;
-        m_CatalogGameIDs[ctx][id] = -1;
-        M_NAME_ENTRY *const entry = Memory_Alloc(sizeof(*entry));
-        entry->name_str = m_CatalogEntryDefs[idx].name_str;
-        entry->enum_value = id;
-        HASH_ADD_KEYPTR(
-            hh, m_Name2EnumMap[ctx], entry->name_str,
-            (uint32_t)strlen(entry->name_str), entry);
-    }
-    m_Initialized = true;
 }
 
+// Drop what the session minted and unbind the built-ins, so that the next mod
+// starts from what the exe names.
 static void M_Shutdown(void)
 {
-    if (!m_Initialized) {
-        return;
-    }
     for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
         M_ClearGameIDMap(&m_GameID2EnumMap[ctx]);
-        M_ClearNameMap(&m_Name2EnumMap[ctx]);
-        Memory_Free(m_CatalogGameIDs[ctx]);
+        while (m_Counts[ctx] > m_BuiltInCounts[ctx]) {
+            const int32_t id = --m_Counts[ctx];
+            M_NAME_ENTRY *entry = nullptr;
+            HASH_FIND_STR(m_Name2EnumMap[ctx], m_Keys[ctx][id], entry);
+            if (entry != nullptr) {
+                HASH_DEL(m_Name2EnumMap[ctx], entry);
+                Memory_Free(entry);
+            }
+            Memory_FreePointer(&m_Keys[ctx][id]);
+        }
+        for (int32_t id = 0; id < m_Counts[ctx]; id++) {
+            m_GameIDs[ctx][id] = -1;
+        }
     }
-    Memory_Free(m_CatalogGameIDs);
-    m_CatalogGameIDs = nullptr;
-    m_Initialized = false;
+}
+
+RESULT Catalog_Mint(
+    const CATALOG_CONTEXT context, const char *const key,
+    CATALOG_ID *const out_id)
+{
+    CATALOG_ID existing;
+    FAIL_IF(
+        Catalog_NameToEnum(context, key, &existing),
+        "context %d already holds the key '%s'", context, key);
+
+    const CATALOG_ID id = m_Counts[context]++;
+    m_Keys[context] =
+        Memory_Realloc(m_Keys[context], sizeof(char *) * m_Counts[context]);
+    m_GameIDs[context] =
+        Memory_Realloc(m_GameIDs[context], sizeof(int32_t) * m_Counts[context]);
+    m_Keys[context][id] = Memory_DupStr(key);
+    m_GameIDs[context][id] = -1;
+
+    M_NAME_ENTRY *const entry = Memory_Alloc(sizeof(*entry));
+    entry->name_str = m_Keys[context][id];
+    entry->enum_value = id;
+    HASH_ADD_KEYPTR(
+        hh, m_Name2EnumMap[context], entry->name_str,
+        (uint32_t)strlen(entry->name_str), entry);
+
+    *out_id = id;
+    return OK;
+}
+
+const char *Catalog_GetKey(const CATALOG_CONTEXT context, const CATALOG_ID id)
+{
+    if (id < 0 || id >= m_Counts[context]) {
+        return nullptr;
+    }
+    return m_Keys[context][id];
+}
+
+int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
+{
+    return m_Counts[context];
+}
+
+RESULT Catalog_BindGameID(
+    const CATALOG_CONTEXT context, const CATALOG_ID id, const int32_t game_id)
+{
+    FAIL_IF(
+        id < 0 || id >= m_Counts[context], "context %d holds no ID %d", context,
+        id);
+    m_GameIDs[context][id] = game_id;
+    if (game_id < 0) {
+        return OK;
+    }
+
+    M_GAME_ID_ENTRY *existing = nullptr;
+    HASH_FIND_INT(m_GameID2EnumMap[context], &game_id, existing);
+    FAIL_IF(
+        existing != nullptr, "duplicate game ID %d for context %d", game_id,
+        context);
+
+    M_GAME_ID_ENTRY *const entry = Memory_Alloc(sizeof(*entry));
+    entry->game_id = game_id;
+    entry->enum_value = id;
+    HASH_ADD_INT(m_GameID2EnumMap[context], game_id, entry);
+    return OK;
 }
 
 RESULT Catalog_Load(
     const CATALOG_CONTEXT context, const char *const csv_path,
     const bool allow_duplicates)
 {
-    if (!m_Initialized) {
-        M_Initialize();
-    }
     char *file_data;
     size_t file_size;
     MUST(FS_Load(csv_path, &file_data, &file_size));
@@ -182,19 +231,11 @@ RESULT Catalog_Load(
             continue;
         }
 
-        m_CatalogGameIDs[context][id] = game_id;
-        if (game_id >= 0) {
-            M_GAME_ID_ENTRY *existing = nullptr;
-            HASH_FIND_INT(m_GameID2EnumMap[context], &game_id, existing);
-            if (existing == nullptr) {
-                M_GAME_ID_ENTRY *gentry = Memory_Alloc(sizeof(*gentry));
-                gentry->game_id = game_id;
-                gentry->enum_value = id;
-                HASH_ADD_INT(m_GameID2EnumMap[context], game_id, gentry);
-            } else if (!allow_duplicates) {
-                LOG_ERROR(
-                    "Duplicate game ID %d for context %d", game_id, context);
-            }
+        RESULT result = Catalog_BindGameID(context, id, game_id);
+        if (allow_duplicates) {
+            IGNORE(result);
+        } else {
+            SHOULD(result);
         }
     }
     Memory_FreePointer(&file_data);
@@ -217,14 +258,10 @@ bool Catalog_EnumToGameID(
     const CATALOG_CONTEXT context, const CATALOG_ID id,
     int32_t *const out_game_id)
 {
-    if (id < 0 || id >= m_CatalogCounts[context]) {
+    if (id < 0 || id >= m_Counts[context] || m_GameIDs[context][id] < 0) {
         return false;
     }
-    const int32_t gid = m_CatalogGameIDs[context][id];
-    if (gid < 0) {
-        return false;
-    }
-    *out_game_id = gid;
+    *out_game_id = m_GameIDs[context][id];
     return true;
 }
 

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -133,9 +133,8 @@ RESULT Catalog_Mint(
     const CATALOG_CONTEXT context, const char *const key,
     CATALOG_ID *const out_id)
 {
-    CATALOG_ID existing;
     FAIL_IF(
-        Catalog_NameToEnum(context, key, &existing),
+        Catalog_FromKey(context, key, -1) >= 0,
         "context %d already holds the key '%s'", context, key);
 
     const CATALOG_ID id = m_Counts[context]++;
@@ -170,7 +169,7 @@ int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
     return m_Counts[context];
 }
 
-RESULT Catalog_BindGameID(
+RESULT Catalog_BindSlot(
     const CATALOG_CONTEXT context, const CATALOG_ID id, const int32_t game_id)
 {
     FAIL_IF(
@@ -226,12 +225,12 @@ RESULT Catalog_Load(
         char *const name_str = CSV_Trim(name_buf);
         const int32_t game_id = (int32_t)strtol(id_str, nullptr, 10);
 
-        CATALOG_ID id;
-        if (!Catalog_NameToEnum(context, name_str, &id)) {
+        const CATALOG_ID id = Catalog_FromKey(context, name_str, -1);
+        if (id < 0) {
             continue;
         }
 
-        RESULT result = Catalog_BindGameID(context, id, game_id);
+        RESULT result = Catalog_BindSlot(context, id, game_id);
         if (allow_duplicates) {
             IGNORE(result);
         } else {
@@ -242,40 +241,31 @@ RESULT Catalog_Load(
     return OK;
 }
 
-bool Catalog_NameToEnum(
-    const CATALOG_CONTEXT context, const char *name, CATALOG_ID *const out_id)
+CATALOG_ID Catalog_FromKey(
+    const CATALOG_CONTEXT context, const char *const key,
+    const CATALOG_ID fallback)
 {
     M_NAME_ENTRY *entry = nullptr;
-    HASH_FIND_STR(m_Name2EnumMap[context], name, entry);
-    if (entry != nullptr) {
-        *out_id = (CATALOG_ID)entry->enum_value;
-        return true;
-    }
-    return false;
+    HASH_FIND_STR(m_Name2EnumMap[context], key, entry);
+    return entry != nullptr ? (CATALOG_ID)entry->enum_value : fallback;
 }
 
-bool Catalog_EnumToGameID(
-    const CATALOG_CONTEXT context, const CATALOG_ID id,
-    int32_t *const out_game_id)
+int32_t Catalog_ToSlot(
+    const CATALOG_CONTEXT context, const CATALOG_ID id, const int32_t fallback)
 {
     if (id < 0 || id >= m_Counts[context] || m_GameIDs[context][id] < 0) {
-        return false;
+        return fallback;
     }
-    *out_game_id = m_GameIDs[context][id];
-    return true;
+    return m_GameIDs[context][id];
 }
 
-bool Catalog_GameIDToEnum(
-    const CATALOG_CONTEXT context, const int32_t game_id,
-    CATALOG_ID *const out_id)
+CATALOG_ID Catalog_FromSlot(
+    const CATALOG_CONTEXT context, const int32_t slot,
+    const CATALOG_ID fallback)
 {
     M_GAME_ID_ENTRY *entry = nullptr;
-    HASH_FIND_INT(m_GameID2EnumMap[context], &game_id, entry);
-    if (entry != nullptr) {
-        *out_id = (CATALOG_ID)entry->enum_value;
-        return true;
-    }
-    return false;
+    HASH_FIND_INT(m_GameID2EnumMap[context], &slot, entry);
+    return entry != nullptr ? (CATALOG_ID)entry->enum_value : fallback;
 }
 
 REGISTER_BASE_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -30,10 +30,10 @@ const char *Catalog_GetKey(CATALOG_CONTEXT context, CATALOG_ID id);
 // How many identities the context holds, built-in and minted together.
 int32_t Catalog_GetCount(CATALOG_CONTEXT context);
 
-// Bind an identity to this game's ID. Reports failure when another identity
-// already holds that game ID; the identity keeps the binding either way.
-RESULT Catalog_BindGameID(
-    CATALOG_CONTEXT context, CATALOG_ID id, int32_t game_id);
+// Bind an identity to the slot this game's files use for it. Reports failure
+// when another identity already holds that slot; the binding is made either
+// way, because a context such as the samples shares a slot on purpose.
+RESULT Catalog_BindSlot(CATALOG_CONTEXT context, CATALOG_ID id, int32_t slot);
 
 // Load mappings for a specific context from a CSV file of the form:
 // game_id,name[,comment]
@@ -42,17 +42,15 @@ RESULT Catalog_BindGameID(
 RESULT Catalog_Load(
     CATALOG_CONTEXT context, const char *csv_path, bool allow_duplicates);
 
-// Convert an item name to its CATALOG_ID within a context.
-// Returns false if not found.
-bool Catalog_NameToEnum(
-    CATALOG_CONTEXT context, const char *name, CATALOG_ID *out_id);
+// The identity a key names, or fallback when the context holds no such key.
+CATALOG_ID Catalog_FromKey(
+    CATALOG_CONTEXT context, const char *key, CATALOG_ID fallback);
 
-// Convert a CATALOG_ID to its game-specific ID within a context.
-// Returns false if unmapped.
-bool Catalog_EnumToGameID(
-    CATALOG_CONTEXT context, CATALOG_ID id, int32_t *out_game_id);
+// The slot an identity is bound to here, or fallback when it has none.
+int32_t Catalog_ToSlot(
+    CATALOG_CONTEXT context, CATALOG_ID id, int32_t fallback);
 
-// Convert a game-specific ID to its CATALOG_ID within a context.
-// Returns false if not found.
-bool Catalog_GameIDToEnum(
-    CATALOG_CONTEXT context, int32_t game_id, CATALOG_ID *out_id);
+// The identity a slot names here, or fallback when none holds it. A slot that
+// two identities share answers with the first of them.
+CATALOG_ID Catalog_FromSlot(
+    CATALOG_CONTEXT context, int32_t slot, CATALOG_ID fallback);

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -23,8 +23,14 @@ typedef int32_t CATALOG_ID;
 RESULT Catalog_Mint(
     CATALOG_CONTEXT context, const char *key, CATALOG_ID *out_id);
 
-// The key an ID answers to, which is what a savegame stores. Null when the
-// context holds no such ID.
+// Give an identity another name to answer to. Fails where the context already
+// holds the name. An alias resolves like the canonical key, and is never
+// written back out.
+RESULT Catalog_AddAlias(
+    CATALOG_CONTEXT context, CATALOG_ID id, const char *alias);
+
+// The canonical key an ID answers to, which is what a savegame stores. Null
+// when the context holds no such ID.
 const char *Catalog_GetKey(CATALOG_CONTEXT context, CATALOG_ID id);
 
 // How many identities the context holds, built-in and minted together.

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -17,6 +17,24 @@ typedef enum CATALOG_CONTEXT {
 
 typedef int32_t CATALOG_ID;
 
+// Declare an identity and return its ID. Fails if the context already holds
+// the key. The context is the namespace, so the same key in two contexts is
+// two identities.
+RESULT Catalog_Mint(
+    CATALOG_CONTEXT context, const char *key, CATALOG_ID *out_id);
+
+// The key an ID answers to, which is what a savegame stores. Null when the
+// context holds no such ID.
+const char *Catalog_GetKey(CATALOG_CONTEXT context, CATALOG_ID id);
+
+// How many identities the context holds, built-in and minted together.
+int32_t Catalog_GetCount(CATALOG_CONTEXT context);
+
+// Bind an identity to this game's ID. Reports failure when another identity
+// already holds that game ID; the identity keeps the binding either way.
+RESULT Catalog_BindGameID(
+    CATALOG_CONTEXT context, CATALOG_ID id, int32_t game_id);
+
 // Load mappings for a specific context from a CSV file of the form:
 // game_id,name[,comment]
 // A game_id of -1 indicates no mapping for that entry.

--- a/src/trx/game/catalog/table.c
+++ b/src/trx/game/catalog/table.c
@@ -1,0 +1,37 @@
+#include <trx/game/catalog/table.h>
+
+#include <trx/core/memory.h>
+
+void *CatalogTable_Get(CATALOG_TABLE *const table, const CATALOG_ID id)
+{
+    if (id < 0) {
+        return nullptr;
+    }
+    if (id < table->builtin_count) {
+        return (char *)table->builtin + (size_t)id * table->elem_size;
+    }
+    const int32_t tail_idx = id - table->builtin_count;
+    if (tail_idx >= table->tail_count) {
+        return nullptr;
+    }
+    return table->tail[tail_idx];
+}
+
+void *CatalogTable_Append(CATALOG_TABLE *const table)
+{
+    table->tail_count++;
+    table->tail =
+        Memory_Realloc(table->tail, sizeof(void *) * table->tail_count);
+    void *const record = Memory_Alloc(table->elem_size);
+    table->tail[table->tail_count - 1] = record;
+    return record;
+}
+
+void CatalogTable_Free(CATALOG_TABLE *const table)
+{
+    for (int32_t i = 0; i < table->tail_count; i++) {
+        Memory_FreePointer(&table->tail[i]);
+    }
+    Memory_FreePointer(&table->tail);
+    table->tail_count = 0;
+}

--- a/src/trx/game/catalog/table.h
+++ b/src/trx/game/catalog/table.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <trx/game/catalog/manager.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Storage for values indexed by a catalog ID. The built-in block is a static
+// array sized by the context's sentinel, so a constructor can write to it
+// before main. Minted identities live in the tail, which holds one allocation
+// per record so that growing the table never moves what is already there.
+typedef struct {
+    CATALOG_CONTEXT context;
+    size_t elem_size;
+    void *builtin;
+    int32_t builtin_count;
+    void **tail;
+    int32_t tail_count;
+} CATALOG_TABLE;
+
+#define CATALOG_TABLE_DEFINE(name, ctx, type, count)                           \
+    static type name##_BuiltIn[count] = {};                                    \
+    static CATALOG_TABLE name = {                                              \
+        .context = (ctx),                                                      \
+        .elem_size = sizeof(type),                                             \
+        .builtin = name##_BuiltIn,                                             \
+        .builtin_count = (count),                                              \
+    }
+
+// Return the record an ID names, or null if the table holds none.
+void *CatalogTable_Get(CATALOG_TABLE *table, CATALOG_ID id);
+
+// Add a record for the next minted identity and return it, zeroed. The
+// records already handed out keep their addresses.
+void *CatalogTable_Append(CATALOG_TABLE *table);
+
+// Release the tail. The built-in block is static and stays.
+void CatalogTable_Free(CATALOG_TABLE *table);

--- a/src/trx/game/game_flow/inventory.c
+++ b/src/trx/game/game_flow/inventory.c
@@ -1,6 +1,7 @@
 #include <trx/game/game_flow/inventory.h>
 
 #include <trx/config.h>
+#include <trx/game/catalog/table.h>
 #include <trx/game/gun.h>
 #include <trx/game/gun/common.h>
 #include <trx/game/gun/registry.h>
@@ -12,8 +13,8 @@
 
 #include <string.h>
 
-static int8_t m_SecretInvItems[O_NUMBER_OF] = {};
-static int8_t m_Add2InvItems[O_NUMBER_OF] = {};
+CATALOG_TABLE_DEFINE(m_SecretInvItems, CATALOG_OBJECTS, int8_t, O_NUMBER_OF);
+CATALOG_TABLE_DEFINE(m_Add2InvItems, CATALOG_OBJECTS, int8_t, O_NUMBER_OF);
 static bool m_RemoveWeapons = false;
 static bool m_RemoveAmmo = false;
 static bool m_RemoveFlares = false;
@@ -27,6 +28,16 @@ static const OBJECT_ID m_ScionObjects[] = {
     O_SCION_ITEM_1, O_QUEST_ITEM_1, O_QUEST_ITEM_2,
     O_QUEST_ITEM_3, O_QUEST_ITEM_4, NO_OBJECT,
 };
+
+static int8_t *M_SecretInvItem(const OBJECT_ID object_id)
+{
+    return CatalogTable_Get(&m_SecretInvItems, object_id);
+}
+
+static int8_t *M_Add2InvItem(const OBJECT_ID object_id)
+{
+    return CatalogTable_Get(&m_Add2InvItems, object_id);
+}
 
 static bool M_CanHaveItem(const OBJECT_ID object_id)
 {
@@ -70,9 +81,9 @@ static void M_ModifyResumeInfo_GunOrAmmo(
 
     Inv_State_AddAmmo(
         &resume->inv, gun_type,
-        ammo_pickup_qty * m_Add2InvItems[ammo_object_id]);
+        ammo_pickup_qty * *M_Add2InvItem(ammo_object_id));
     if (!Inv_State_Has(&resume->inv, gun_object_id)
-        && m_Add2InvItems[gun_object_id] > 0) {
+        && *M_Add2InvItem(gun_object_id) > 0) {
         Inv_State_SetCount(&resume->inv, gun_object_id, 1);
         Inv_State_AddAmmo(&resume->inv, gun_type, ammo_initial_qty);
     }
@@ -85,7 +96,7 @@ static void M_ModifyResumeInfo_Item(
         return;
     }
 
-    M_ResumeInfo_AddItem(resume, object_id, m_Add2InvItems[object_id]);
+    M_ResumeInfo_AddItem(resume, object_id, *M_Add2InvItem(object_id));
 }
 
 static void M_CollectNewPickup(const OBJECT_ID object_id)
@@ -111,43 +122,43 @@ static void M_ModifyInventory_GunOrAmmo(
             // Convert already collected guns into ammo to maintain stats
             // accuracy.
             Inv_AddAmmo(
-                gun_type, ammo_pickup_qty * m_SecretInvItems[ammo_object_id]);
+                gun_type, ammo_pickup_qty * *M_SecretInvItem(ammo_object_id));
             Inv_AddAmmo(
-                gun_type, ammo_initial_qty * m_SecretInvItems[gun_object_id]);
-            for (int32_t i = 0; i < m_SecretInvItems[ammo_object_id]; i++) {
+                gun_type, ammo_initial_qty * *M_SecretInvItem(gun_object_id));
+            for (int32_t i = 0; i < *M_SecretInvItem(ammo_object_id); i++) {
                 M_CollectNewPickup(ammo_object_id);
             }
-            for (int32_t i = 0; i < m_SecretInvItems[gun_object_id]; i++) {
+            for (int32_t i = 0; i < *M_SecretInvItem(gun_object_id); i++) {
                 M_CollectNewPickup(ammo_object_id);
             }
         } else if (type == GF_INV_REGULAR) {
             Inv_AddAmmo(
-                gun_type, ammo_pickup_qty * m_Add2InvItems[ammo_object_id]);
+                gun_type, ammo_pickup_qty * *M_Add2InvItem(ammo_object_id));
         }
     } else if (
-        (type == GF_INV_REGULAR && m_Add2InvItems[gun_object_id] > 0)
-        || (type == GF_INV_SECRET && m_SecretInvItems[gun_object_id] > 0)) {
+        (type == GF_INV_REGULAR && *M_Add2InvItem(gun_object_id) > 0)
+        || (type == GF_INV_SECRET && *M_SecretInvItem(gun_object_id) > 0)) {
 
         Inv_AddItem(gun_object_id);
 
         if (type == GF_INV_SECRET) {
             Inv_AddAmmo(
-                gun_type, ammo_pickup_qty * m_SecretInvItems[ammo_object_id]);
+                gun_type, ammo_pickup_qty * *M_SecretInvItem(ammo_object_id));
             M_CollectNewPickup(gun_object_id);
-            for (int32_t i = 0; i < m_SecretInvItems[ammo_object_id]; i++) {
+            for (int32_t i = 0; i < *M_SecretInvItem(ammo_object_id); i++) {
                 M_CollectNewPickup(ammo_object_id);
             }
         } else if (type == GF_INV_REGULAR) {
             Inv_AddAmmo(
-                gun_type, ammo_pickup_qty * m_Add2InvItems[ammo_object_id]);
+                gun_type, ammo_pickup_qty * *M_Add2InvItem(ammo_object_id));
         }
     } else if (type == GF_INV_SECRET) {
-        for (int32_t i = 0; i < m_SecretInvItems[ammo_object_id]; i++) {
+        for (int32_t i = 0; i < *M_SecretInvItem(ammo_object_id); i++) {
             Inv_AddItem(ammo_object_id);
             M_CollectNewPickup(ammo_object_id);
         }
     } else if (type == GF_INV_REGULAR) {
-        for (int32_t i = 0; i < m_Add2InvItems[ammo_object_id]; i++) {
+        for (int32_t i = 0; i < *M_Add2InvItem(ammo_object_id); i++) {
             Inv_AddItem(ammo_object_id);
         }
     }
@@ -158,9 +169,9 @@ static void M_ModifyInventory_Item(
 {
     int32_t qty = 0;
     if (type == GF_INV_SECRET) {
-        qty = m_SecretInvItems[object_id];
+        qty = *M_SecretInvItem(object_id);
     } else if (type == GF_INV_REGULAR) {
-        qty = m_Add2InvItems[object_id];
+        qty = *M_Add2InvItem(object_id);
     }
 
     // Check for gameplay mods from secret rewards
@@ -178,8 +189,8 @@ static void M_ModifyInventory_Item(
 void GF_InventoryModifier_Scan(const GF_LEVEL *const level)
 {
     for (int32_t i = O_FIRST; i < O_NUMBER_OF; i++) {
-        m_SecretInvItems[i] = 0;
-        m_Add2InvItems[i] = 0;
+        *M_SecretInvItem(i) = 0;
+        *M_Add2InvItem(i) = 0;
     }
     m_RemoveWeapons = false;
     m_RemoveAmmo = false;
@@ -200,9 +211,9 @@ void GF_InventoryModifier_Scan(const GF_LEVEL *const level)
                 continue;
             }
             if (data->inv_type == GF_INV_SECRET) {
-                m_SecretInvItems[data->object_id] += data->quantity;
+                *M_SecretInvItem(data->object_id) += data->quantity;
             } else if (data->inv_type == GF_INV_REGULAR) {
-                m_Add2InvItems[data->object_id] += data->quantity;
+                *M_Add2InvItem(data->object_id) += data->quantity;
             }
         } else if (event->type == GFS_REMOVE_WEAPONS) {
             m_RemoveWeapons = true;
@@ -257,7 +268,7 @@ void GF_InventoryModifier_ApplyToResumeInfo(const GF_LEVEL *const level)
     const OBJECT_ID default_gun_object = Gun_GetGunObject(default_gun);
     const bool default_gun_given =
         !Inv_State_Has(&resume->inv, default_gun_object)
-        && m_Add2InvItems[default_gun_object] != 0;
+        && *M_Add2InvItem(default_gun_object) != 0;
     if (default_gun_given) {
         Inv_State_SetCount(&resume->inv, default_gun_object, 1);
         if (resume->equipped_gun_type == LGT_UNARMED) {
@@ -323,7 +334,7 @@ void GF_InventoryModifier_Apply(
 
     if (type == GF_INV_SECRET) {
         const LARA_GUN_TYPE default_gun = Gun_GetDefaultType();
-        if (m_Add2InvItems[Gun_GetGunObject(default_gun)]) {
+        if (*M_Add2InvItem(Gun_GetGunObject(default_gun))) {
             Inv_AddItem(Gun_GetGunObject(default_gun));
             if (resume->equipped_gun_type == LGT_UNARMED) {
                 resume->equipped_gun_type = default_gun;

--- a/src/trx/game/gun/data.c
+++ b/src/trx/game/gun/data.c
@@ -105,8 +105,9 @@ static SAMPLE_TRX_ID M_ReadSample(
     const char *const sample =
         JSON_ObjectGetString(obj, key, JSON_INVALID_STRING);
     if (sample != JSON_INVALID_STRING && sample[0] != '\0') {
-        CATALOG_ID sample_id;
-        if (!Catalog_NameToEnum(CATALOG_SAMPLES, sample, &sample_id)) {
+        const CATALOG_ID sample_id =
+            Catalog_FromKey(CATALOG_SAMPLES, sample, -1);
+        if (sample_id < 0) {
             LOG_WARNING(
                 "unknown sample '%s' for '%s' in %s", sample, name, path);
         } else {

--- a/src/trx/game/inventory_ring/vars.c
+++ b/src/trx/game/inventory_ring/vars.c
@@ -41,10 +41,8 @@ static RESULT M_ReadItems(JSON_ARRAY *const arr, const char *const path)
         JSON_OBJECT *const obj = JSON_ArrayGetObject(arr, i);
         const char *const name =
             JSON_ObjectGetString(obj, "object_id", JSON_INVALID_STRING);
-        CATALOG_ID id;
-        FAIL_IF(
-            !Catalog_NameToEnum(CATALOG_OBJECTS, name, &id),
-            "%s: unknown object_id '%s'", path, name);
+        const CATALOG_ID id = Catalog_FromKey(CATALOG_OBJECTS, name, NO_OBJECT);
+        FAIL_IF(id == NO_OBJECT, "%s: unknown object_id '%s'", path, name);
         INVENTORY_ITEM *const item = Memory_Alloc(sizeof(*item));
         item->object_id = id;
         L_READ_INT("frames_total", item->frames_total);

--- a/src/trx/game/items/actions/common.c
+++ b/src/trx/game/items/actions/common.c
@@ -1,9 +1,13 @@
+#include <trx/game/catalog/table.h>
 #include <trx/game/items/actions.h>
 #include <trx/game/items/const.h>
 #include <trx/game/items/manager.h>
 #include <trx/game/rooms.h>
 
-static void (*m_Routines[ITEM_ACTION_NUMBER_OF])(ITEM *item) = {};
+typedef void (*M_ACTION_ROUTINE)(ITEM *item);
+
+CATALOG_TABLE_DEFINE(
+    m_Routines, CATALOG_ITEM_ACTIONS, M_ACTION_ROUTINE, ITEM_ACTION_NUMBER_OF);
 static int16_t m_FXType = 0;
 static ITEM_ACTION_INTERCEPTOR m_Interceptor = nullptr;
 
@@ -32,14 +36,15 @@ int16_t ItemAction_GetFXType(void)
 void ItemAction_Register(
     const ITEM_TRX_ACTION action, void (*const action_func)(ITEM *item))
 {
-    m_Routines[action] = action_func;
+    *(M_ACTION_ROUTINE *)CatalogTable_Get(&m_Routines, action) = action_func;
 }
 
 void ItemAction_Run(const ITEM_TRX_ACTION action_id, ITEM *const item)
 {
-    if (action_id >= 0 && action_id < ITEM_ACTION_NUMBER_OF
-        && m_Routines[action_id] != nullptr) {
-        m_Routines[action_id](item);
+    const M_ACTION_ROUTINE *const routine =
+        CatalogTable_Get(&m_Routines, action_id);
+    if (routine != nullptr && *routine != nullptr) {
+        (*routine)(item);
     }
 }
 

--- a/src/trx/game/items/actions/ids.c
+++ b/src/trx/game/items/actions/ids.c
@@ -3,18 +3,11 @@
 
 ITEM_ACTION ItemAction_ToGameID(const ITEM_TRX_ACTION action)
 {
-    ITEM_ACTION out;
-    if (Catalog_EnumToGameID(CATALOG_ITEM_ACTIONS, action, &out)) {
-        return out;
-    }
-    return ITEM_ACTION_INVALID;
+    return Catalog_ToSlot(CATALOG_ITEM_ACTIONS, action, ITEM_ACTION_INVALID);
 }
 
 ITEM_TRX_ACTION ItemAction_FromGameID(const ITEM_ACTION action)
 {
-    ITEM_TRX_ACTION out;
-    if (Catalog_GameIDToEnum(CATALOG_ITEM_ACTIONS, action, &out)) {
-        return out;
-    }
-    return ITEM_TRX_ACTION_INVALID;
+    return Catalog_FromSlot(
+        CATALOG_ITEM_ACTIONS, action, ITEM_TRX_ACTION_INVALID);
 }

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/debug.h>
+#include <trx/game/catalog/table.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/vars.h>
 #include <trx/game/rooms.h>
@@ -10,8 +11,11 @@
 #define M_MONKEY_CEILING_SNAP 704
 #define M_PUSH_TIMEOUT 15
 
-static void (*m_CollisionRoutines[LS_NUMBER_OF])(
-    ITEM *item, COLL_INFO *coll) = {};
+typedef void (*M_COLLISION_ROUTINE)(ITEM *item, COLL_INFO *coll);
+
+CATALOG_TABLE_DEFINE(
+    m_CollisionRoutines, CATALOG_LARA_STATES, M_COLLISION_ROUTINE,
+    LS_NUMBER_OF);
 
 void Lara_Col_Push(
     const COLL_ITEM *const item, COLL_INFO *const coll, const bool hit_on,
@@ -103,15 +107,17 @@ void Lara_Col_Register(
     void (*const handle_func)(ITEM *item, COLL_INFO *coll))
 {
     ASSERT(state >= 0 && state < LS_NUMBER_OF);
-    m_CollisionRoutines[state] = handle_func;
+    *(M_COLLISION_ROUTINE *)CatalogTable_Get(&m_CollisionRoutines, state) =
+        handle_func;
 }
 
 void Lara_Col_Update(ITEM *const item, COLL_INFO *const coll)
 {
     const LARA_TRX_STATE state = LS_U(item->current_anim_state);
-    if (state >= 0 && state < LS_NUMBER_OF
-        && m_CollisionRoutines[state] != nullptr) {
-        m_CollisionRoutines[state](item, coll);
+    const M_COLLISION_ROUTINE *const routine =
+        CatalogTable_Get(&m_CollisionRoutines, state);
+    if (routine != nullptr && *routine != nullptr) {
+        (*routine)(item, coll);
     }
 }
 

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -873,36 +873,20 @@ bool Lara_MovePositionEx(
 
 LARA_ANIMATION Lara_AnimToGameID(const LARA_TRX_ANIMATION anim)
 {
-    int32_t out;
-    if (!Catalog_EnumToGameID(CATALOG_LARA_ANIMS, anim, &out)) {
-        out = -1;
-    }
-    return out;
+    return Catalog_ToSlot(CATALOG_LARA_ANIMS, anim, -1);
 }
 
 LARA_STATE Lara_StateToGameID(const LARA_TRX_STATE state)
 {
-    int32_t out;
-    if (!Catalog_EnumToGameID(CATALOG_LARA_STATES, state, &out)) {
-        out = -1;
-    }
-    return out;
+    return Catalog_ToSlot(CATALOG_LARA_STATES, state, -1);
 }
 
 LARA_TRX_ANIMATION Lara_AnimFromGameID(const LARA_ANIMATION anim)
 {
-    int32_t out;
-    if (!Catalog_GameIDToEnum(CATALOG_LARA_ANIMS, anim, &out)) {
-        out = -1;
-    }
-    return out;
+    return Catalog_FromSlot(CATALOG_LARA_ANIMS, anim, -1);
 }
 
 LARA_TRX_STATE Lara_StateFromGameID(const LARA_STATE state)
 {
-    int32_t out;
-    if (!Catalog_GameIDToEnum(CATALOG_LARA_STATES, state, &out)) {
-        out = -1;
-    }
-    return out;
+    return Catalog_FromSlot(CATALOG_LARA_STATES, state, -1);
 }

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -328,8 +328,9 @@ static RESULT M_LoadObjectID(
     const char *obj_name = nullptr;
     MUST(JSON_READ(io, key, &obj_name));
 
-    CATALOG_ID object_id;
-    if (!Catalog_NameToEnum(CATALOG_OBJECTS, obj_name, &object_id)) {
+    const CATALOG_ID object_id =
+        Catalog_FromKey(CATALOG_OBJECTS, obj_name, NO_OBJECT);
+    if (object_id == NO_OBJECT) {
         MUST(JSON_POP(io));
         return JSON_ReadIO_Fail(io, "unknown outfit object_id '%s'", obj_name);
     }

--- a/src/trx/game/lara/state.c
+++ b/src/trx/game/lara/state.c
@@ -1,7 +1,10 @@
 #include <trx/game/lara/state.h>
 
 #include <trx/debug.h>
+#include <trx/game/catalog/table.h>
 #include <trx/game/lara.h>
+
+typedef void (*M_STATE_ROUTINE)(ITEM *item, COLL_INFO *coll);
 
 static const LARA_TRX_ANIMATION m_TestResponsiveAnims[] = {
     // clang-format off
@@ -14,8 +17,9 @@ static const LARA_TRX_ANIMATION m_TestResponsiveAnims[] = {
     // clang-format on
 };
 
-static bool m_ResponsiveAnims[LA_NUMBER_OF] = {};
-static void (*m_StateRoutines[LS_NUMBER_OF])(ITEM *item, COLL_INFO *coll) = {};
+CATALOG_TABLE_DEFINE(m_ResponsiveAnims, CATALOG_LARA_ANIMS, bool, LA_NUMBER_OF);
+CATALOG_TABLE_DEFINE(
+    m_StateRoutines, CATALOG_LARA_STATES, M_STATE_ROUTINE, LS_NUMBER_OF);
 static void (*m_ExtraRoutines[LS_EXTRA_NUMBER_OF])(
     ITEM *item, COLL_INFO *coll) = {};
 
@@ -41,7 +45,7 @@ void Lara_State_Register(
     const LARA_TRX_STATE state,
     void (*const handle_func)(ITEM *item, COLL_INFO *coll))
 {
-    m_StateRoutines[state] = handle_func;
+    *(M_STATE_ROUTINE *)CatalogTable_Get(&m_StateRoutines, state) = handle_func;
 }
 
 void Lara_State_RegisterExtra(
@@ -56,13 +60,16 @@ void Lara_State_Initialise(void)
 {
     for (int32_t i = 0; m_TestResponsiveAnims[i] != LA_TRX_INVALID; i++) {
         const LARA_TRX_ANIMATION anim = m_TestResponsiveAnims[i];
-        m_ResponsiveAnims[anim] = M_HasResponsiveState(anim);
+        *(bool *)CatalogTable_Get(&m_ResponsiveAnims, anim) =
+            M_HasResponsiveState(anim);
     }
 }
 
 bool Lara_State_IsResponsive(const LARA_TRX_ANIMATION anim_idx)
 {
-    return m_ResponsiveAnims[anim_idx];
+    const bool *const responsive =
+        CatalogTable_Get(&m_ResponsiveAnims, anim_idx);
+    return responsive != nullptr && *responsive;
 }
 
 void Lara_State_Update(ITEM *const item, COLL_INFO *const coll)
@@ -76,10 +83,9 @@ void Lara_State_Update(ITEM *const item, COLL_INFO *const coll)
     }
 
     const LARA_TRX_STATE state = LS_U(item->current_anim_state);
-    if (state >= 0 && state < LS_NUMBER_OF) {
-        if (m_StateRoutines[state] != nullptr) {
-            m_StateRoutines[state](item, coll);
-        }
-        return;
+    const M_STATE_ROUTINE *const routine =
+        CatalogTable_Get(&m_StateRoutines, state);
+    if (routine != nullptr && *routine != nullptr) {
+        (*routine)(item, coll);
     }
 }

--- a/src/trx/game/lua/capi/catalog.c
+++ b/src/trx/game/lua/capi/catalog.c
@@ -13,8 +13,8 @@
 // same number as the TRX id: TRX names an object once, across all four games,
 // and each game's files number it differently.
 
-// Neither Catalog_EnumToGameID nor Catalog_GameIDToEnum checks the context
-// before indexing its table with it.
+// Neither Catalog_ToSlot nor Catalog_FromSlot checks the context before
+// indexing its table with it.
 static CATALOG_CONTEXT M_CheckContext(lua_State *const L, const int arg)
 {
     return (CATALOG_CONTEXT)LUA_CheckRange(
@@ -26,14 +26,17 @@ static int M_L_CatalogToSlot(lua_State *const L)
 {
     const CATALOG_CONTEXT context = M_CheckContext(L, 1);
     CATALOG_ID id;
-    int32_t game_id;
     // Whether the narrowed id is in the catalog at all is Catalog_*'s to say.
-    if (!LUA_CheckBoundedInt(L, 2, INT32_MIN, INT32_MAX, &id)
-        || !Catalog_EnumToGameID(context, id, &game_id)) {
+    if (!LUA_CheckBoundedInt(L, 2, INT32_MIN, INT32_MAX, &id)) {
         lua_pushnil(L);
         return 1;
     }
-    lua_pushinteger(L, game_id);
+    const int32_t slot = Catalog_ToSlot(context, id, -1);
+    if (slot < 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushinteger(L, slot);
     return 1;
 }
 
@@ -41,10 +44,13 @@ static int M_L_CatalogToSlot(lua_State *const L)
 static int M_L_CatalogFromSlot(lua_State *const L)
 {
     const CATALOG_CONTEXT context = M_CheckContext(L, 1);
-    int32_t game_id;
-    CATALOG_ID id;
-    if (!LUA_CheckBoundedInt(L, 2, INT32_MIN, INT32_MAX, &game_id)
-        || !Catalog_GameIDToEnum(context, game_id, &id)) {
+    int32_t slot;
+    if (!LUA_CheckBoundedInt(L, 2, INT32_MIN, INT32_MAX, &slot)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    const CATALOG_ID id = Catalog_FromSlot(context, slot, -1);
+    if (id < 0) {
         lua_pushnil(L);
         return 1;
     }

--- a/src/trx/game/music/ids.c
+++ b/src/trx/game/music/ids.c
@@ -3,18 +3,10 @@
 
 MUSIC_ID Music_ToGameID(const MUSIC_TRX_ID music_track)
 {
-    int32_t out;
-    if (Catalog_EnumToGameID(CATALOG_MUSIC, music_track, &out)) {
-        return out;
-    }
-    return MX_INACTIVE;
+    return Catalog_ToSlot(CATALOG_MUSIC, music_track, MX_INACTIVE);
 }
 
 MUSIC_TRX_ID Music_FromGameID(const MUSIC_ID track_id)
 {
-    CATALOG_ID out;
-    if (Catalog_GameIDToEnum(CATALOG_MUSIC, track_id, &out)) {
-        return out;
-    }
-    return MX_TRX_INVALID;
+    return Catalog_FromSlot(CATALOG_MUSIC, track_id, MX_TRX_INVALID);
 }

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -5,6 +5,7 @@
 #include <trx/debug.h>
 #include <trx/game/anims.h>
 #include <trx/game/catalog/manager.h>
+#include <trx/game/catalog/table.h>
 #include <trx/game/const.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/lara/common.h>
@@ -16,7 +17,7 @@ typedef struct {
     OBJECT obj;
 } M_UNCATALOGED_SLOT;
 
-static OBJECT m_Objects[O_NUMBER_OF] = {};
+CATALOG_TABLE_DEFINE(m_Objects, CATALOG_OBJECTS, OBJECT, O_NUMBER_OF);
 static STATIC_OBJECT_3D *m_StaticObjects3D = nullptr;
 static STATIC_OBJECT_2D *m_StaticObjects2D = nullptr;
 static int32_t m_StaticObjects3DCount = 0;
@@ -24,13 +25,13 @@ static int32_t m_StaticObjects2DCount = 0;
 static VECTOR *m_MeshPointers = nullptr;
 
 static VECTOR *m_UncatalogedSlots = nullptr;
-static VECTOR *m_MintedObjects = nullptr;
 
 void Object_Reset(void)
 {
     for (int32_t i = O_FIRST; i < O_NUMBER_OF; i++) {
-        ObjectProperty_ResetObject(&m_Objects[i]);
-        m_Objects[i].loaded = false;
+        OBJECT *const obj = Object_TryGet(i);
+        ObjectProperty_ResetObject(obj);
+        obj->loaded = false;
     }
 
     m_StaticObjects3D = nullptr;
@@ -47,14 +48,7 @@ void Object_Reset(void)
         m_UncatalogedSlots = nullptr;
     }
 
-    if (m_MintedObjects != nullptr) {
-        for (int32_t i = 0; i < m_MintedObjects->count; i++) {
-            OBJECT **const obj = Vector_Get(m_MintedObjects, i);
-            Memory_FreePointer(obj);
-        }
-        Vector_Free(m_MintedObjects);
-        m_MintedObjects = nullptr;
-    }
+    CatalogTable_Free(&m_Objects);
 }
 
 void Object_InitialiseStaticObjects3D(const int32_t count)
@@ -85,18 +79,10 @@ int32_t Object_GetStaticObjects2DCount(void)
 
 OBJECT *Object_TryGet(const OBJECT_ID object_id)
 {
-    if (object_id >= O_NUMBER_OF) {
-        const int32_t minted_idx = object_id - O_NUMBER_OF;
-        if (m_MintedObjects == nullptr
-            || minted_idx >= m_MintedObjects->count) {
-            return nullptr;
-        }
-        return *(OBJECT **)Vector_Get(m_MintedObjects, minted_idx);
-    }
     if (object_id < O_FIRST) {
         return nullptr;
     }
-    return &m_Objects[object_id];
+    return CatalogTable_Get(&m_Objects, object_id);
 }
 
 OBJECT *Object_Get(const OBJECT_ID object_id)
@@ -108,14 +94,8 @@ OBJECT *Object_Get(const OBJECT_ID object_id)
 
 OBJECT_ID Object_Mint(void)
 {
-    if (m_MintedObjects == nullptr) {
-        m_MintedObjects = Vector_Create(sizeof(OBJECT *));
-    }
-    // Each record is allocated on its own, so a pointer handed out earlier
-    // survives the next mint.
-    OBJECT *const obj = Memory_Alloc(sizeof(OBJECT));
-    Vector_Add(m_MintedObjects, (void *)&obj);
-    return O_NUMBER_OF + m_MintedObjects->count - 1;
+    CatalogTable_Append(&m_Objects);
+    return O_NUMBER_OF + m_Objects.tail_count - 1;
 }
 
 OBJECT *Object_GetByGameID(const int32_t game_id)
@@ -124,7 +104,7 @@ OBJECT *Object_GetByGameID(const int32_t game_id)
     if (object_id == NO_OBJECT) {
         return nullptr;
     }
-    return &m_Objects[object_id];
+    return Object_TryGet(object_id);
 }
 
 void Object_StoreUncatalogedSlot(const int32_t game_id, const OBJECT *const obj)

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -154,20 +154,12 @@ STATIC_OBJECT_2D *Object_Get2DStatic(const int32_t static_id)
 
 OBJECT_ID Object_FromGameID(const int32_t game_id)
 {
-    int32_t out;
-    if (Catalog_GameIDToEnum(CATALOG_OBJECTS, game_id, &out)) {
-        return out;
-    }
-    return NO_OBJECT;
+    return Catalog_FromSlot(CATALOG_OBJECTS, game_id, NO_OBJECT);
 }
 
 int32_t Object_ToGameID(const OBJECT_ID object_id)
 {
-    int32_t out;
-    if (Catalog_EnumToGameID(CATALOG_OBJECTS, object_id, &out)) {
-        return out;
-    }
-    return -1;
+    return Catalog_ToSlot(CATALOG_OBJECTS, object_id, -1);
 }
 
 bool Object_IsType(const OBJECT_ID object_id, const OBJECT_ID *test_arr)

--- a/src/trx/game/objects/names.c
+++ b/src/trx/game/objects/names.c
@@ -5,6 +5,7 @@
 #include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
+#include <trx/game/catalog/table.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/vars.h>
@@ -28,8 +29,8 @@ typedef struct {
     const char *slot; // stable first-name slot for this object
 } M_NAME_ENTRY;
 
-static M_NAME_ENTRY m_NamesTable[O_NUMBER_OF] = {};
-static OBJECT_ID m_AliasResolver[O_NUMBER_OF] = {};
+CATALOG_TABLE_DEFINE(m_NamesTable, CATALOG_OBJECTS, M_NAME_ENTRY, O_NUMBER_OF);
+CATALOG_TABLE_DEFINE(m_AliasResolver, CATALOG_OBJECTS, OBJECT_ID, O_NUMBER_OF);
 
 // Compile-time default names (ignoring key aliases)
 static const M_DEFAULT m_Defaults[] = {
@@ -60,9 +61,15 @@ static M_ALIAS m_ObjectAliases[] = {
     { .target_object_id = NO_OBJECT },
 };
 
+static OBJECT_ID M_ResolveAlias(const OBJECT_ID obj_id)
+{
+    const OBJECT_ID *const alias = CatalogTable_Get(&m_AliasResolver, obj_id);
+    return alias != nullptr ? *alias : obj_id;
+}
+
 static const M_DEFAULT *M_ResolveDefault(OBJECT_ID obj_id)
 {
-    obj_id = m_AliasResolver[obj_id];
+    obj_id = M_ResolveAlias(obj_id);
     for (int32_t i = 0; m_Defaults[i].object_id != NO_OBJECT; i++) {
         if (m_Defaults[i].object_id == obj_id) {
             return &m_Defaults[i];
@@ -73,13 +80,13 @@ static const M_DEFAULT *M_ResolveDefault(OBJECT_ID obj_id)
 
 static M_NAME_ENTRY *M_ResolveNameEntry(const OBJECT_ID obj_id)
 {
-    return &m_NamesTable[m_AliasResolver[obj_id]];
+    return CatalogTable_Get(&m_NamesTable, M_ResolveAlias(obj_id));
 }
 
 static void M_ClearAllNames(void)
 {
     for (OBJECT_ID obj_id = O_FIRST; obj_id < O_NUMBER_OF; obj_id++) {
-        M_NAME_ENTRY *const entry = &m_NamesTable[obj_id];
+        M_NAME_ENTRY *const entry = CatalogTable_Get(&m_NamesTable, obj_id);
         if (entry->names != nullptr) {
             for (int32_t i = 0; i < entry->names->count; i++) {
                 char *n = *(char **)Vector_Get(entry->names, i);
@@ -96,6 +103,8 @@ static void M_ClearAllNames(void)
 static void M_Shutdown(void)
 {
     M_ClearAllNames();
+    CatalogTable_Free(&m_NamesTable);
+    CatalogTable_Free(&m_AliasResolver);
 }
 
 OBJECT_ID Object_ResolveAlias(const OBJECT_ID obj_id)
@@ -103,7 +112,7 @@ OBJECT_ID Object_ResolveAlias(const OBJECT_ID obj_id)
     if (obj_id < O_FIRST || obj_id >= O_NUMBER_OF) {
         return obj_id;
     }
-    return m_AliasResolver[obj_id];
+    return M_ResolveAlias(obj_id);
 }
 
 void Object_ClearNames(const OBJECT_ID obj_id)
@@ -170,12 +179,13 @@ void Object_ResetAllNames(void)
 
     // Install compile-time aliases
     for (OBJECT_ID obj_id = O_FIRST; obj_id < O_NUMBER_OF; obj_id++) {
-        m_AliasResolver[obj_id] = obj_id;
+        *(OBJECT_ID *)CatalogTable_Get(&m_AliasResolver, obj_id) = obj_id;
     }
     for (int32_t i = 0; m_ObjectAliases[i].target_object_id != NO_OBJECT; i++) {
         const OBJECT_ID target_object_id = m_ObjectAliases[i].target_object_id;
         const OBJECT_ID source_object_id = m_ObjectAliases[i].source_object_id;
-        m_AliasResolver[target_object_id] = source_object_id;
+        *(OBJECT_ID *)CatalogTable_Get(&m_AliasResolver, target_object_id) =
+            source_object_id;
     }
 
     // Now apply default names

--- a/src/trx/game/sound/ids.c
+++ b/src/trx/game/sound/ids.c
@@ -3,18 +3,10 @@
 
 SAMPLE_ID Sound_ToGameID(const SAMPLE_TRX_ID trx_id)
 {
-    int32_t out;
-    if (Catalog_EnumToGameID(CATALOG_SAMPLES, trx_id, &out)) {
-        return out;
-    }
-    return SFX_INVALID;
+    return Catalog_ToSlot(CATALOG_SAMPLES, trx_id, SFX_INVALID);
 }
 
 SAMPLE_TRX_ID Sound_FromGameID(const SAMPLE_ID sample_id)
 {
-    CATALOG_ID out;
-    if (Catalog_GameIDToEnum(CATALOG_SAMPLES, sample_id, &out)) {
-        return out;
-    }
-    return SFX_TRX_INVALID;
+    return Catalog_FromSlot(CATALOG_SAMPLES, sample_id, SFX_TRX_INVALID);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The catalog used to store a fixed name and game ID for each identity, so every identity had to come from a `.def` file. It now supports growable identities. Built-ins are still created before `main` in `.def` order, so their IDs still match their enum constants.

- `CATALOG_TABLE` stores values by catalog ID, with built-ins in a static block and new identities in a growable tail that preserves existing addresses
- the nine arrays previously sized by a context sentinel now use this table
- identities can have multiple names, so C-friendly names can differ from the names mod authors use
- lookups now return the result directly, or a caller-provided fallback

Relevant new APIs:

```c
// Declare an identity and return its ID.
RESULT Catalog_Mint(CATALOG_CONTEXT context, const char *key, CATALOG_ID *out_id);

// Add another name for an identity.
RESULT Catalog_AddAlias(CATALOG_CONTEXT context, CATALOG_ID id, const char *alias);

// Return the identity for a key, or the fallback.
CATALOG_ID Catalog_FromKey(CATALOG_CONTEXT context, const char *key, CATALOG_ID fallback);

// Return the slot for an identity, or the fallback.
int32_t Catalog_ToSlot(CATALOG_CONTEXT context, CATALOG_ID id, int32_t fallback);

// Return the identity for a slot, or the fallback.
CATALOG_ID Catalog_FromSlot(CATALOG_CONTEXT context, int32_t slot, CATALOG_ID fallback);

// Return the canonical key for an identity.
const char *Catalog_GetKey(CATALOG_CONTEXT context, CATALOG_ID id);

// Return the number of identities in a context.
int32_t Catalog_GetCount(CATALOG_CONTEXT context);

// Bind an identity to a game slot.
RESULT Catalog_BindSlot(CATALOG_CONTEXT context, CATALOG_ID id, int32_t slot);
```

New table APIs:

```c
// Declare storage indexed by a catalog ID.
CATALOG_TABLE_DEFINE(name, context, type, count);

// Return the record for an ID, or null if none exists.
void *CatalogTable_Get(CATALOG_TABLE *table, CATALOG_ID id);

// Add a zeroed record for the next minted identity.
void *CatalogTable_Append(CATALOG_TABLE *table);

// Free the tail; the built-in block remains.
void CatalogTable_Free(CATALOG_TABLE *table);
```

Renamed APIs:

| Before                 | Now                |
| ---                    | ---                |
| `Catalog_NameToEnum`   | `Catalog_FromKey`  |
| `Catalog_EnumToGameID` | `Catalog_ToSlot`   |
| `Catalog_GameIDToEnum` | `Catalog_FromSlot` |