### PR TITLE
console/mod: complete mod names

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Added the `/outfit` console command, which shows or changes what Lara is wearing (TRX1070)
 - Added the `/golden` console command, which casts Lara in gold (TRX1070)
 - Changed the `/flip` console command to take a flip group, so `/flip 3` moves that group alone while `/flip` on its own moves them all (TRX173)
+- Changed the `/mod` console command to complete the names of the mods it can switch to
 - Changed the `/set` console command to complete the values a setting accepts, such as its enum values or on and off (TRX1174)
 - Changed the developer console to sort completions alphabetically, prioritizing those that start with the text typed (TRX1175)
 - Fixed TR1's moored boat sharing its name with TR2's speedboat, so a command that took `boat` could act on either
@@ -191,6 +192,7 @@
 - Added a new Lua module, `trx.waypoints`, for how far along a level's own progression Lara has got, which TR4 marks out and its guides follow; it is saved with the game and reports the furthest she has ever reached as well as where she is now
 - Added `trx.lara.speech_face`, for the face Lara talks with, which follows the outfit she is wearing rather than the one a level carries
 - Added `trx.cutscenes.set_lara_shadow_bounds()`, for the box a cutscene gives Lara's shadow, so a scene can make it read as something she rides in (TRX911)
+- Added `trx.mod.Mod.can_switch`, which says whether `trx.mod.switch` accepts the mod, so a single level loaded on its own is told apart from a mod a player picks
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -10318,6 +10318,12 @@
           "writable": false
         },
         {
+          "description": "Whether `trx.mod.switch` accepts the mod. A single level loaded on its own is valid, but is not a mod to switch to.",
+          "name": "can_switch",
+          "type": "boolean",
+          "writable": false
+        },
+        {
           "description": "Which Tomb Raider the mod runs on.",
           "name": "engine_version",
           "type": "integer",

--- a/docs/trx/lua/reference/MOD.md
+++ b/docs/trx/lua/reference/MOD.md
@@ -48,6 +48,7 @@ The mods the game was built with, and which one is loaded.
 
     Properties:
     - <a id="mod.Mod.base_mod" name="mod.Mod.base_mod"></a>**`base_mod`**: string. The mod this one builds on, or `nil` if it stands alone. *(read-only)*
+    - <a id="mod.Mod.can_switch" name="mod.Mod.can_switch"></a>**`can_switch`**: boolean. Whether [`trx.mod.switch`](#mod.switch) accepts the mod. A single level loaded on its own is valid, but is not a mod to switch to. *(read-only)*
     - <a id="mod.Mod.engine_version" name="mod.Mod.engine_version"></a>**`engine_version`**: integer. Which Tomb Raider the mod runs on. *(read-only)*
     - <a id="mod.Mod.is_available" name="mod.Mod.is_available"></a>**`is_available`**: boolean. Whether the mod's files are present. *(read-only)*
     - <a id="mod.Mod.is_valid" name="mod.Mod.is_valid"></a>**`is_valid`**: boolean. Whether the mod can be loaded. *(read-only)*

--- a/src/lua/api/mod.lua
+++ b/src/lua/api/mod.lua
@@ -65,6 +65,13 @@ api.type("mod.Mod", {
       writable = false,
       description = "Whether the mod can be loaded.",
     },
+    can_switch = {
+      from = "can_switch",
+      type = "boolean",
+      writable = false,
+      description = "Whether `trx.mod.switch` accepts the mod. A single level "
+        .. "loaded on its own is valid, but is not a mod to switch to.",
+    },
   },
 })
 

--- a/src/lua/commands/mod.lua
+++ b/src/lua/commands/mod.lua
@@ -6,11 +6,21 @@ trx.locale.declare({
   ["console/cmd/mod/invalid"] = "Invalid mod: %s",
 })
 
+local function mod_names()
+  local out = {}
+  for _, mod in ipairs(trx.mod.list) do
+    if mod.can_switch then
+      out[#out + 1] = mod.name
+    end
+  end
+  return out
+end
+
 trx.console.register({
   name = "mod",
   help = "console/cmd/mod/help",
   args = function(parser)
-    parser:rest("name", { optional = true })
+    parser:rest("name", { optional = true, suggest = mod_names })
   end,
   run = function(args)
     if args.name == nil then

--- a/src/tests/lua/api/mod.c
+++ b/src/tests/lua/api/mod.c
@@ -72,10 +72,11 @@ const SHELL_MOD *Shell_GetModByName(const char *const name)
     return nullptr;
 }
 
-// A mod stands in for one that can be switched to when it is valid.
+// A mod stands in for one that can be switched to when it is valid and is not
+// a single level loaded on its own.
 bool Shell_CanSwitchToMod(const SHELL_MOD *const mod)
 {
-    return mod != nullptr && mod->is_valid;
+    return mod != nullptr && mod->is_valid && mod->mod_type != MOD_DIRECT_LEVEL;
 }
 
 void Shell_RequestModSwitch(const char *const mod_name)

--- a/src/trx/game/lua/capi/mod.c
+++ b/src/trx/game/lua/capi/mod.c
@@ -14,6 +14,13 @@
 // handle to one never goes stale. It is addressed by its place in the list,
 // which the ref carries as the handle id.
 
+static bool M_GetCanSwitch(const void *const self, TRX_VALUE *const out)
+{
+    *out =
+        (TRX_VALUE) { .type = TVT_BOOL, .as_bool = Shell_CanSwitchToMod(self) };
+    return true;
+}
+
 // clang-format off
 static const FIELD_DESC m_Fields[] = {
     FIELD_RO(SHELL_MOD, name),
@@ -23,6 +30,7 @@ static const FIELD_DESC m_Fields[] = {
     FIELD_RO(SHELL_MOD, base_mod),
     FIELD_RO(SHELL_MOD, is_available),
     FIELD_RO(SHELL_MOD, is_valid),
+    FIELD_FN("can_switch", TVT_BOOL, M_GetCanSwitch, nullptr),
 };
 // clang-format on
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Lets the console complete the mod names for the mod command. Only the mods that are available and valid are offered.