### PR TITLE
Fix the debug portal overlay

### DIFF
--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -39,6 +39,11 @@ static const char *const m_VariantPaths[M_VARIANT_COUNT] = {
     "meshes_tr12.glsl", "meshes_tr3.glsl", "meshes_tr4.glsl",
 };
 
+// Suspends the geometry stage for the pass that asked for it. The subdividing
+// variant takes triangles, so a pass that draws lines cannot use it, and a
+// pass that draws flat debug geometry gains nothing from the split.
+static bool m_SubdivisionSuspended;
+
 static bool M_VariantSubdivides(const int32_t variant_idx)
 {
     return variant_idx >= M_LIGHTING_VARIANT_COUNT;
@@ -47,7 +52,7 @@ static bool M_VariantSubdivides(const int32_t variant_idx)
 static int32_t M_GetVariantIndex(void)
 {
     const int32_t lighting = Output_Lights_GetModel()->shader_variant;
-    return g_Config.rendering.enable_affine_mapping
+    return g_Config.rendering.enable_affine_mapping && !m_SubdivisionSuspended
         ? lighting + M_LIGHTING_VARIANT_COUNT
         : lighting;
 }
@@ -123,6 +128,13 @@ void Output_MeshShader_Bind(OUTPUT_MESH_SHADER *const shader)
     const int32_t variant_idx = M_GetVariantIndex();
     Output_Shader_Bind(M_GetVariantBase(shader, variant_idx));
     M_UploadEnvMapRect(shader, variant_idx);
+}
+
+void Output_MeshShader_SuspendSubdivision(
+    OUTPUT_MESH_SHADER *const shader, const bool is_suspended)
+{
+    m_SubdivisionSuspended = is_suspended;
+    Output_MeshShader_Bind(shader);
 }
 
 void Output_MeshShader_Free(OUTPUT_MESH_SHADER *const shader)

--- a/src/trx/game/output/shaders/mesh.h
+++ b/src/trx/game/output/shaders/mesh.h
@@ -44,6 +44,12 @@ RESULT Output_MeshShader_Create(OUTPUT_MESH_SHADER **out_shader);
 void Output_MeshShader_Free(OUTPUT_MESH_SHADER *shader);
 void Output_MeshShader_Bind(OUTPUT_MESH_SHADER *shader);
 
+// Binds the variant with no geometry stage, and returns to the variant the
+// settings ask for once the pass is done. The geometry stage takes triangles,
+// so a pass that draws lines fails on it.
+void Output_MeshShader_SuspendSubdivision(
+    OUTPUT_MESH_SHADER *shader, bool is_suspended);
+
 // TODO: these could could use UBOs
 void Output_MeshShader_UploadModelMatrix(
     OUTPUT_MESH_SHADER *shader, const MATRIX *source);

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -217,6 +217,7 @@ static void M_RenderPass(
         return;
     }
 
+    Output_MeshShader_SuspendSubdivision(p->shader, true);
     Output_MeshShader_UploadTint(p->shader, COLOR_RGBA_F_WHITE);
 
     glBindVertexArray(p->vao);
@@ -253,6 +254,8 @@ static void M_RenderPass(
             glEnable(GL_DEPTH_TEST);
         }
     }
+
+    Output_MeshShader_SuspendSubdivision(p->shader, false);
 }
 
 static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)

--- a/src/trx/gl/utils.c
+++ b/src/trx/gl/utils.c
@@ -26,9 +26,12 @@ const char *TRX_GL_GetErrorString(GLenum err)
     }
 }
 
-void TRX_GL_CheckError(void)
+void TRX_GL_CheckErrorAt(
+    const char *const file, const int line, const char *const func)
 {
     for (GLenum err; (err = glGetError()) != GL_NO_ERROR;) {
-        LOG_ERROR("glGetError: (%s)", TRX_GL_GetErrorString(err));
+        Log_Message(
+            LOG_LEVEL_ERROR, file, line, func, "glGetError: (%s)",
+            TRX_GL_GetErrorString(err));
     }
 }

--- a/src/trx/gl/utils.h
+++ b/src/trx/gl/utils.h
@@ -5,5 +5,6 @@
 
 #include <GL/glew.h>
 
-void TRX_GL_CheckError(void);
+void TRX_GL_CheckErrorAt(const char *file, int line, const char *func);
+#define TRX_GL_CheckError() TRX_GL_CheckErrorAt(__FILE__, __LINE__, __func__)
 const char *TRX_GL_GetErrorString(GLenum err);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The debug portal overlay broke with affine texture mapping enabled because the room shader's geometry stage only accepts triangles, while the overlay draws lines. The debug pass now uses the shader variant without a geometry stage, which is all the flat, untextured overlay needs.

The GL error check now reports the file, line, and function that triggered it. Previously, every error pointed to `gl/utils.c`, where the check itself lives, making bad GL calls harder to track down.

#### Testing

- [x] Enable affine texture mapping (Graphic Options → Rendering), then enable debug portals. The blue portal outlines should be visible.
- [x] Disable affine texture mapping with debug portals still enabled. The outlines should remain visible.
- [x] Enable debug triggers alongside debug portals. Both overlays should be visible, and the level should respect the affine texture mapping setting.
- [x] Check the log while the overlays are enabled. No `GL_INVALID_OPERATION` should be reported.