### PR TITLE
Fix the save and load dialog placement

### DIFF
--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -667,16 +667,25 @@ void InvRing_DrawUI(INV_RING *const ring)
         .spacing = { .v = 20.0f },
     });
 
-    if (m_ButtonHintDrawFunc != nullptr) {
+    const bool has_hint = m_ButtonHintDrawFunc != nullptr;
+    const bool has_count = m_CountText != nullptr && m_CountText[0] != '\0';
+
+    if (has_hint) {
         m_ButtonHintDrawFunc(m_ButtonHintUserData);
     }
 
-    if (m_CountText != nullptr && m_CountText[0] != '\0') {
+    if (has_count) {
         UI_BeginOffset(64.0f, 0.0f);
         UI_Label(m_CountText);
         UI_EndOffset();
     }
-    UI_Spacer(0.0f, M_UI_COUNT_NAME_GAP);
+
+    // The gap separates the hint and the count from the item name below them.
+    // Without either, it only takes room away from the region.
+    if (has_hint || has_count) {
+        UI_Spacer(0.0f, M_UI_COUNT_NAME_GAP);
+    }
+
     UI_EndStack();
     UI_EndRegion();
 }

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -239,6 +239,7 @@ void UI_EndScene(void)
 {
     m_Priv.scene_root = m_Priv.root;
     M_MeasureNode(m_Priv.root);
+    UI_Region_Layout();
     M_LayoutNode(m_Priv.root, 0, 0, UI_GetCanvasWidth(), UI_GetCanvasHeight());
     if (m_PaintHook != nullptr) {
         m_PaintHook();

--- a/src/trx/game/ui/regions.c
+++ b/src/trx/game/ui/regions.c
@@ -59,7 +59,7 @@ static UI_NODE *m_Caller;
 // Scene counter for the nodes above.
 static uint32_t m_Generation;
 
-// Middle box from the last laid-out scene.
+// Middle box from the last call to UI_Region_Layout.
 static struct {
     float x;
     float y;
@@ -281,6 +281,18 @@ bool UI_Region_GetSlotBox(
     *w = node->w;
     *h = node->h;
     return true;
+}
+
+void UI_Region_Layout(void)
+{
+    M_ForgetStaleNodes();
+    if (m_Container == nullptr) {
+        m_CenterBox.w = 0.0f;
+        m_CenterBox.h = 0.0f;
+        return;
+    }
+    m_Container->ops.layout(
+        m_Container, 0.0f, 0.0f, UI_GetCanvasWidth(), UI_GetCanvasHeight());
 }
 
 void UI_Region_GetCenterBox(

--- a/src/trx/game/ui/regions.h
+++ b/src/trx/game/ui/regions.h
@@ -30,7 +30,12 @@ typedef enum {
 void UI_BeginRegion(UI_REGION region);
 void UI_EndRegion(void);
 
-// Returns the middle box from the last laid-out scene.
+// Lays the regions out and updates the middle box. Called once per scene,
+// after every widget is measured and before the scene is laid out, so that
+// the middle box describes the current scene.
+void UI_Region_Layout(void);
+
+// Returns the middle box from the last call to UI_Region_Layout.
 void UI_Region_GetCenterBox(float *x, float *y, float *w, float *h);
 
 // Reserves space in a region and returns its slot for the current scene.


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes the positioning of the save and load dialog.

The inventory ring now reserves space for hints and item counts only when they're visible, and layout regions are updated before the rest of the scene to prevent a one-frame jump.

Both issues are unreleased, so there is no changelog entry. Resolves TRX1278

#### Testing

##### Placement

- [x] TR1–3: Open the passport from the inventory ring; verify save/load dialog placement matches other passport dialogs.
- [x] Open the passport from the title screen; verify dialog placement.
- [x] Verify item counts and button hints still appear correctly at the bottom of the ring.

##### Instant save/load screen

- [x] Enable instant save/load, set negative turbo speed, then save/load; verify the dialog appears in place without jumping.
