### PR TITLE
lua/api: spell a name the way the console does

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -193,6 +193,7 @@
 - Added `trx.lara.speech_face`, for the face Lara talks with, which follows the outfit she is wearing rather than the one a level carries
 - Added `trx.cutscenes.set_lara_shadow_bounds()`, for the box a cutscene gives Lara's shadow, so a scene can make it read as something she rides in (TRX911)
 - Added `trx.mod.Mod.can_switch`, which says whether `trx.mod.switch` accepts the mod, so a single level loaded on its own is told apart from a mod a player picks
+- Added `trx.strings.dash_case()`, which spells a name the way the console shows one
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6267,6 +6267,24 @@
       }
     },
     {
+      "description": "Spells a name the way the console shows one: lower case, with underscores read as dashes. This is how an enum constant is offered for completion, and a catalog name resolves in either spelling.",
+      "examples": [
+        "trx.strings.dash_case(\"LARA_NO\") -- \"lara-no\""
+      ],
+      "params": [
+        {
+          "description": "The name to spell.",
+          "name": "text",
+          "type": "string"
+        }
+      ],
+      "path": "strings.dash_case",
+      "returns": {
+        "description": "The name in dashed lower case.",
+        "type": "string"
+      }
+    },
+    {
       "description": "Takes the shared indentation off a block of text, so that a long string\nwritten inside `[[ ]]` reads as what it says rather than as where it sat in\nthe file. Leading and trailing blank lines go too.\n\nThe deepest lines keep the rest of their indentation, since a block may lay\nsomething out, and four spaces of it is a code block in markdown. Text may\nopen on the line the brackets are on, and that line then sets nothing and\nkeeps what it has, however the ones under it are written.",
       "examples": [
         "local help = trx.strings.dedent([[\n      Usage: /give <what>\n        keys   every plot item the level has a place for\n    ]])"

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -99,6 +99,19 @@ Not to be confused with [`trx.locale`](LOCALE.md#locale), which is the text a pl
   if trx.strings.regex_match(args, "^\\d+$") then ... end
   ```
 
+- <a id="strings.dash_case" name="strings.dash_case"></a>[lua]`trx.strings.dash_case(text)`  
+  Spells a name the way the console shows one: lower case, with underscores read as dashes. This is how an enum constant is offered for completion, and a catalog name resolves in either spelling.
+
+  Parameters:
+  - <a id="strings.dash_case.text" name="strings.dash_case.text"></a>**`text`** (string). The name to spell.
+
+  Returns: string. The name in dashed lower case.
+
+  Example:
+  ```lua
+  trx.strings.dash_case("LARA_NO") -- "lara-no"
+  ```
+
 - <a id="strings.dedent" name="strings.dedent"></a>[lua]`trx.strings.dedent(text)`  
   Takes the shared indentation off a block of text, so that a long string
   written inside `[[ ]]` reads as what it says rather than as where it sat in

--- a/src/lua/api/strings.lua
+++ b/src/lua/api/strings.lua
@@ -174,6 +174,20 @@ api.define("strings.regex_match", {
   impl = raw.regex_match,
 })
 
+api.define("strings.dash_case", {
+  description = "Spells a name the way the console shows one: lower case, with underscores read "
+    .. "as dashes. This is how an enum constant is offered for completion, and a catalog name "
+    .. "resolves in either spelling.",
+  params = {
+    { name = "text", type = "string", description = "The name to spell." },
+  },
+  returns = { type = "string", description = "The name in dashed lower case." },
+  examples = { [[trx.strings.dash_case("LARA_NO") -- "lara-no"]] },
+  impl = function(text)
+    return (text:lower():gsub("_", "-"))
+  end,
+})
+
 api.define("strings.dedent", {
   description = [=[
     Takes the shared indentation off a block of text, so that a long string

--- a/src/lua/commands/debug.lua
+++ b/src/lua/commands/debug.lua
@@ -28,15 +28,11 @@ local KEYS = {
   "debug.enable_debug_status",
 }
 
-local function display(key)
-  return (key:gsub("_", "-"))
-end
-
 local function log_get(key)
   trx.console.log(
     trx.locale.format(
       "console/cmd/debug/option_get",
-      display(key),
+      trx.strings.dash_case(key),
       tostring(trx.config.get(key))
     )
   )
@@ -46,7 +42,7 @@ local function log_set(key)
   trx.console.log(
     trx.locale.format(
       "console/cmd/debug/option_set",
-      display(key),
+      trx.strings.dash_case(key),
       tostring(trx.config.get(key))
     )
   )
@@ -62,7 +58,8 @@ end
 local function match_keys(text)
   local sources = {}
   for _, key in ipairs(KEYS) do
-    sources[#sources + 1] = { key = display(key), value = key, weight = 1 }
+    sources[#sources + 1] =
+      { key = trx.strings.dash_case(key), value = key, weight = 1 }
   end
   local matched = {}
   for _, m in ipairs(trx.strings.fuzzy_match(text, sources)) do
@@ -74,7 +71,7 @@ end
 local function overlay_choices()
   local out = {}
   for _, key in ipairs(KEYS) do
-    out[#out + 1] = { key = display(key), value = key }
+    out[#out + 1] = { key = trx.strings.dash_case(key), value = key }
   end
   return out
 end

--- a/src/lua/commands/easy_config.lua
+++ b/src/lua/commands/easy_config.lua
@@ -50,11 +50,6 @@ local COMMANDS = {
   },
 }
 
--- The console shows an option key with dashes, not underscores.
-local function display(key)
-  return (key:gsub("_", "-"))
-end
-
 -- What the setting takes, for completion: on/off or the enum values, and the
 -- dash that puts the default back. A number has no list to offer, so nothing is
 -- advertised for it.
@@ -66,7 +61,10 @@ local function value_choices(key)
     out[#out + 1] = { key = "off", value = "off" }
   elseif desc.kind == "enum" or desc.kind == "dynamic_enum" then
     for _, value in ipairs(desc.values) do
-      out[#out + 1] = { key = display(value), value = display(value) }
+      out[#out + 1] = {
+        key = trx.strings.dash_case(value),
+        value = trx.strings.dash_case(value),
+      }
     end
   else
     return nil
@@ -80,7 +78,7 @@ local function run(key, args)
     trx.console.log(
       trx.locale.format(
         "console/cmd/set/option_get",
-        display(key),
+        trx.strings.dash_case(key),
         trx.config.format_value(key)
       )
     )
@@ -89,7 +87,10 @@ local function run(key, args)
 
   if trx.config.is_overridden(key) then
     return trx.console.Result.FAILURE,
-      trx.locale.format("console/cmd/set/option_enforced", display(key))
+      trx.locale.format(
+        "console/cmd/set/option_enforced",
+        trx.strings.dash_case(key)
+      )
   end
 
   local ok
@@ -115,7 +116,7 @@ local function run(key, args)
   trx.console.log(
     trx.locale.format(
       "console/cmd/set/option_set",
-      display(key),
+      trx.strings.dash_case(key),
       trx.config.format_value(key)
     )
   )

--- a/src/lua/commands/outfit.lua
+++ b/src/lua/commands/outfit.lua
@@ -16,15 +16,10 @@ trx.locale.declare({
   ["console/cmd/outfit/worn"] = "Lara changed into %s",
 })
 
--- The console spells outfit names with dashes, as it does every enum value.
-local function display(name)
-  return (name:gsub("_", "-"))
-end
-
 local function choices()
   local out = { { key = "-", value = "-" } }
   for _, name in ipairs(trx.config.describe(OPTION).values) do
-    out[#out + 1] = { key = display(name), value = name }
+    out[#out + 1] = { key = trx.strings.dash_case(name), value = name }
   end
   return out
 end
@@ -35,7 +30,10 @@ local function report()
     return trx.console.Result.OK, trx.locale.get("console/cmd/outfit/default")
   end
   return trx.console.Result.OK,
-    trx.locale.format("console/cmd/outfit/current", display(worn))
+    trx.locale.format(
+      "console/cmd/outfit/current",
+      trx.strings.dash_case(worn)
+    )
 end
 
 trx.console.register({
@@ -68,6 +66,9 @@ trx.console.register({
         trx.locale.format("console/cmd/outfit/unknown", args.outfit)
     end
     return trx.console.Result.OK,
-      trx.locale.format("console/cmd/outfit/worn", display(args.outfit))
+      trx.locale.format(
+        "console/cmd/outfit/worn",
+        trx.strings.dash_case(args.outfit)
+      )
   end,
 })

--- a/src/lua/commands/rule.lua
+++ b/src/lua/commands/rule.lua
@@ -19,15 +19,11 @@ trx.locale.declare({
   ["console/cmd/rule/unknown_rule"] = "Unknown rule: %s",
 })
 
--- The console shows keys with dashes, not underscores.
-local function display(text)
-  return (text:gsub("_", "-"))
-end
-
 local function rule_sources()
   local sources = {}
   for _, key in ipairs(trx.rules.list()) do
-    sources[#sources + 1] = { key = display(key), value = key, weight = 1 }
+    sources[#sources + 1] =
+      { key = trx.strings.dash_case(key), value = key, weight = 1 }
   end
   return sources
 end
@@ -35,7 +31,7 @@ end
 local function report(key)
   return trx.locale.format(
     "console/cmd/rule/rule_get",
-    display(key),
+    trx.strings.dash_case(key),
     trx.rules.format_value(key)
   )
 end
@@ -81,7 +77,7 @@ local function run(args)
   return trx.console.Result.OK,
     trx.locale.format(
       "console/cmd/rule/rule_set",
-      display(key),
+      trx.strings.dash_case(key),
       trx.rules.format_value(key)
     )
 end

--- a/src/lua/commands/set.lua
+++ b/src/lua/commands/set.lua
@@ -18,16 +18,12 @@ trx.locale.declare({
   ["console/cmd/set/valid_values"] = "Valid values: %s",
 })
 
--- The console shows keys and enum values with dashes, not underscores.
-local function display(text)
-  return (text:gsub("_", "-"))
-end
-
 -- Every setting, by its dashed name, for matching and completion.
 local function option_sources()
   local sources = {}
   for key in pairs(trx.config.list()) do
-    sources[#sources + 1] = { key = display(key), value = key, weight = 1 }
+    sources[#sources + 1] =
+      { key = trx.strings.dash_case(key), value = key, weight = 1 }
   end
   return sources
 end
@@ -54,7 +50,10 @@ local function value_choices(parsed)
     out[#out + 1] = { key = "off", value = "off" }
   elseif desc.kind == "enum" or desc.kind == "dynamic_enum" then
     for _, value in ipairs(desc.values) do
-      out[#out + 1] = { key = display(value), value = display(value) }
+      out[#out + 1] = {
+        key = trx.strings.dash_case(value),
+        value = trx.strings.dash_case(value),
+      }
     end
   else
     return nil
@@ -105,7 +104,7 @@ local function run(args)
     trx.console.log(
       trx.locale.format(
         "console/cmd/set/option_get",
-        display(key),
+        trx.strings.dash_case(key),
         trx.config.format_value(key)
       )
     )
@@ -114,7 +113,10 @@ local function run(args)
 
   if not args.force and trx.config.is_overridden(key) then
     return trx.console.Result.FAILURE,
-      trx.locale.format("console/cmd/set/option_enforced", display(key))
+      trx.locale.format(
+        "console/cmd/set/option_enforced",
+        trx.strings.dash_case(key)
+      )
   end
 
   local value = args.value
@@ -139,7 +141,7 @@ local function run(args)
   trx.console.log(
     trx.locale.format(
       "console/cmd/set/option_set",
-      display(key),
+      trx.strings.dash_case(key),
       trx.config.format_value(key)
     )
   )

--- a/src/lua/commands/weather.lua
+++ b/src/lua/commands/weather.lua
@@ -17,7 +17,7 @@ trx.locale.declare({
 local function type_names()
   local names = {}
   for name in pairs(trx.weather.Type) do
-    names[#names + 1] = name:lower()
+    names[#names + 1] = trx.strings.dash_case(name)
   end
   table.sort(names)
   return names
@@ -26,7 +26,7 @@ end
 local function name_of(value)
   for name, v in pairs(trx.weather.Type) do
     if v == value then
-      return name:lower()
+      return trx.strings.dash_case(name)
     end
   end
   return tostring(value)
@@ -70,10 +70,10 @@ trx.console.register({
     end
 
     if args.state ~= nil then
-      local want = args.state:lower()
+      local want = trx.strings.dash_case(args.state)
       local found = nil
       for name, value in pairs(trx.weather.Type) do
-        if name:lower() == want then
+        if trx.strings.dash_case(name) == want then
           found = value
         end
       end


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds `trx.strings.dash_case`, which the commands that offer a key or an enum value for completion now share. Before this, five of them spelled the same rule out apiece.