### PR TITLE
camera/binoculars: fix inverted look option

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 **Camera**
 - Added an option to have the photo mode camera collide with level geometry (Graphic Options → Visuals → Photo mode collision) (#5719 / TRX540)
 - Changed moving Lara in photo mode to follow the direction the camera looks, rather than the way she faces (TRX1153)
+- Fixed the Inverted look option not applying to the binoculars (#6431 / TRX1291)
 - Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down (TRX1142)
 - Fixed the photo mode camera flickering and refusing to turn over when it is pitched past straight up or down, and turning in coarse steps while aimed near vertical (TRX1152)
 

--- a/src/trx/game/camera/binoculars.c
+++ b/src/trx/game/camera/binoculars.c
@@ -1,5 +1,6 @@
 #include <trx/game/camera/binoculars.h>
 
+#include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/camera.h>
@@ -101,12 +102,15 @@ static void M_HandleLookInput(void)
         }
     }
 
-    if (g_Input.forward) {
+    const bool inverted = g_Config.gameplay.enable_inverted_look;
+    const bool tilt_up = inverted ? g_Input.back : g_Input.forward;
+    const bool tilt_down = inverted ? g_Input.forward : g_Input.back;
+    if (tilt_up) {
         const int16_t turn = M_HEAD_TURN * (1792 - m_Range) / 3072;
         if (lara_info->head_rot.x > M_MIN_HEAD_ROT_X) {
             lara_info->head_rot.x -= turn;
         }
-    } else if (g_Input.back) {
+    } else if (tilt_down) {
         const int16_t turn = M_HEAD_TURN * (1792 - m_Range) / 3072;
         if (lara_info->head_rot.x < M_MAX_HEAD_ROT_X) {
             lara_info->head_rot.x += turn;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the Inverted look option had no effect while the binoculars are up.

Resolves #6431 / TRX1291