### PR TITLE
objects/spikes: avoid teleporting Lara on death

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed Lara getting pushed by enemies while climbing into or out of crawlspaces (OG bug) (TRX1182)
 - Fixed static meshes affecting ledge jumps when soft static collision is not enabled (#6366 / TRX1218)
 - Fixed Lara sliding on walkable items (trapdoors, bridges etc) when there is a steep slope directly below and touching the item (OG bug)
+- Fixed Lara teleporting to the floor when killed by spikes that are to her side rather than directly below her (OG bug) (#6351 / TRX1204)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/objects/traps/spikes.c
+++ b/src/trx/game/objects/traps/spikes.c
@@ -2,6 +2,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects/property.h>
 #include <trx/game/random.h>
+#include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
 #include <trx/version.h>
@@ -12,6 +13,24 @@
 typedef struct {
     int32_t damage;
 } M_PRIV;
+
+static bool M_ShouldImpaleLara(
+    const ITEM *const item, const ITEM *const lara_item)
+{
+    if (lara_item->hit_points > 0) {
+        return false;
+    }
+
+    int16_t room_num = lara_item->room_num;
+    const SECTOR *sector = Room_GetSector(lara_item->pos, &room_num);
+    const int32_t height_at_lara = Room_GetHeight(sector, lara_item->pos);
+
+    room_num = item->room_num;
+    sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height_at_item = Room_GetHeight(sector, item->pos);
+
+    return ABS(height_at_lara - height_at_item) <= WALL_L;
+}
 
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
@@ -51,7 +70,7 @@ static void M_Collision(
             pos.x, pos.y, pos.z, 20, Random_GetControl(), item->room_num);
     }
 
-    if (lara_item->hit_points <= 0) {
+    if (M_ShouldImpaleLara(item, lara_item)) {
         Item_SwitchToAnim(lara_item, LA(LA_SPIKE_DEATH), 0);
         lara_item->current_anim_state = LS(LS_DEATH);
         lara_item->goal_anim_state = LS(LS_DEATH);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids Lara teleporting to the floor if she is killed by spikes while falling to the side of them. The spikes continue to kill her, but her default death animation will take place.

I think this also resolves the odd scenario in Coastal Village room 128 where she gets pushed into the water if she grazes the spikes there.

Resolves #6351 / TRX1204.
