### PR TITLE
objects/lift: fix Lara clipping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Removed the golden outfits, which the engine now produces from any outfit, freeing their model slots for outfits of your own (TRX1070)
 - Fixed a crash when switching mods (TRX1239)
 - Fixed Lara's arms leaving their intended positions when looking around in the crouched stance (OG bug) (#6402)
+- Fixed Lara clipping into or underneath lifts if she tries to step on top of or into one from an exterior floor whose height matches the lift ceiling or floor (OG bug) (#3905 / TRX1014)
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 
 **Saves and settings**

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -183,9 +183,9 @@ static void M_FloorCeiling(
                 *out_ceiling = -UNDEFINED_HEIGHT;
             }
         } else if (point_in_shaft) {
-            if (lara_item->pos.y < lift_ceiling) {
+            if (lara_item->pos.y <= lift_ceiling) {
                 *out_floor = lift_top;
-            } else if (lara_item->pos.y < lift_bottom) {
+            } else if (lara_item->pos.y <= lift_bottom) {
                 *out_floor = lift_floor;
                 *out_ceiling = lift_ceiling;
             } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes Lara clipping into a lift if she steps on top of one from a floor at precisely the lift's interior ceiling height. Equally, if a floor lines up with the bottom of a lift, it fixes her clipping underneath it.

Test level available.
<img width="800" height="467" alt="liftclip" src="https://github.com/user-attachments/assets/9f261427-4669-4b65-aefc-9882348e1953" />


Resolves #3905 / TRX1014.