### PR TITLE
cutseq/playback: fix the level flashing on end

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -159,6 +159,7 @@
 - Fixed the parked jeep showing in the temple during the cutscene that opens Karnak (TRX1092)
 - Fixed a crash while an in-game cutscene poses Lara (TRX1059)
 - Fixed characters sliding across the room, and Lara's braid trailing behind her, when an in-game cutscene moves them to a new place (TRX1270)
+- Fixed the level showing for a moment when an in-game cutscene ends (TRX1252)
 - Fixed Lara's shadow and the flames around her when she burns staying where an in-game cutscene began, rather than following her (TRX911)
 - Fixed the light the flames cast staying where an in-game cutscene began while Lara burns, rather than following her (TRX1197)
 - Fixed Von Croy's shadow floating at the height of his knees during the scenes he plays in Angkor Wat (TRX911)

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -12,6 +12,7 @@
 #include <trx/game/cutseq/pak.h>
 #include <trx/game/fader.h>
 #include <trx/game/flyby_mode.h>
+#include <trx/game/game/state.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/input.h>
 #include <trx/game/interpolation.h>
@@ -365,11 +366,20 @@ static void M_Finish(void)
 
     m_State.phase = M_PHASE_INACTIVE;
     m_State.num = M_NO_CUTSCENE;
-    Fader_InitTo(&m_State.fader, 1.0f, 0.0f, M_FADE_DURATION);
+    Fader_InitTo(&m_State.fader, 1.0f, 1.0f, 0.0f);
 
     // Fired last, so a handler that starts the next thing - the title hands
     // over to a flyby here - sees the cutscene fully torn down.
     LUA_FireEventInt32(LUA_EVENT_CUTSCENE_END, num);
+
+    // The screen stays black where the handler took it over, with another
+    // scene, with the end of the level, or with any other place to go. The
+    // level is only faded back in where the player returns to it.
+    const bool is_taken_over = m_State.phase != M_PHASE_INACTIVE
+        || Game_IsLevelComplete() || GF_GetOverrideCommand().action != GF_NOOP;
+    if (!is_taken_over) {
+        Fader_InitTo(&m_State.fader, 1.0f, 0.0f, M_FADE_DURATION);
+    }
 }
 
 // One frame of the scene: decodes every track, poses the actors and Lara, and


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the level showed for a moment when an in-game cutscene ended. Before this, the screen started to fade back in as soon as the scene was torn down, so a scene that ended the level, or that ran into the next one, let a frame of the level through first. The screen now holds black where the end of a scene hands over to something else.

Resolves TRX1252