### PR TITLE
Name a catalog identity by its key

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -320,6 +320,7 @@ common_sources = [
   'trx/game/camera/photo_mode.c',
   'trx/game/camera/spline.c',
   'trx/game/camera/vars.c',
+  'trx/game/catalog/keys.c',
   'trx/game/catalog/manager.c',
   'trx/game/catalog/table.c',
   'trx/game/clock/common.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1259,6 +1259,7 @@ unit_tests += {
     'game/enum.c',
     'game/game_strings/entries.c',
     'game/gun/registry.c',
+    'game/catalog/keys.c',
     'game/objects/names.c',
     'game/objects/vars.c',
     'game/rules.c',

--- a/src/trx/game/catalog/keys.c
+++ b/src/trx/game/catalog/keys.c
@@ -1,0 +1,31 @@
+#include <trx/debug.h>
+#include <trx/game/catalog/manager.h>
+
+#include <ctype.h>
+#include <string.h>
+
+// Map each context to the prefix used before names in its C spelling.
+static const char *const m_ContextPrefixes[CATALOG_CONTEXT_MAX] = {
+    [CATALOG_OBJECTS] = "O_",     [CATALOG_MUSIC] = "MX_",
+    [CATALOG_SAMPLES] = "SFX_",   [CATALOG_LARA_STATES] = "LS_",
+    [CATALOG_LARA_ANIMS] = "LA_", [CATALOG_ITEM_ACTIONS] = "ITEM_ACTION_",
+};
+
+const char *Catalog_KeyForEnum(
+    const CATALOG_CONTEXT context, const char *const enum_name)
+{
+    const char *const prefix = m_ContextPrefixes[context];
+    const char *name = enum_name;
+    if (strncmp(name, prefix, strlen(prefix)) == 0) {
+        name += strlen(prefix);
+    }
+
+    static char key[64];
+    ASSERT(strlen(name) < sizeof(key));
+    size_t i = 0;
+    for (; name[i] != '\0' && i < sizeof(key) - 1; i++) {
+        key[i] = (char)tolower((unsigned char)name[i]);
+    }
+    key[i] = '\0';
+    return key;
+}

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -114,10 +114,13 @@ __attribute__((constructor)) static void M_MintBuiltIns(void)
     for (size_t idx = 0; idx < m_CatalogEntryCount; idx++) {
         const CATALOG_CONTEXT ctx = m_CatalogEntryDefs[idx].context;
         CATALOG_ID id;
+        const char *const enum_name = m_CatalogEntryDefs[idx].name_str;
         EXIT_ON_FAIL(
-            Catalog_Mint(ctx, m_CatalogEntryDefs[idx].name_str, &id),
+            Catalog_Mint(ctx, Catalog_KeyForEnum(ctx, enum_name), &id),
             "cannot seed the catalog");
         ASSERT(id == m_CatalogEntryDefs[idx].id);
+        // Bind catalogue CSV entries that use the C spelling.
+        IGNORE(Catalog_AddAlias(ctx, id, enum_name));
     }
     for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
         m_BuiltInCounts[ctx] = m_Counts[ctx];

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -17,6 +17,11 @@ typedef enum CATALOG_CONTEXT {
 
 typedef int32_t CATALOG_ID;
 
+// Return the executable built-in key: the lower-case C spelling without the
+// context prefix. Use only compile-time data, so this works before registry
+// initialisation; the next call overwrites the result.
+const char *Catalog_KeyForEnum(CATALOG_CONTEXT context, const char *enum_name);
+
 // Declare an identity and return its ID. Fails if the context already holds
 // the key. The context is the namespace, so the same key in two contexts is
 // two identities.

--- a/src/trx/game/objects/names.c
+++ b/src/trx/game/objects/names.c
@@ -2,9 +2,9 @@
 
 #include <trx/core/strings.h>
 #include <trx/debug.h>
+#include <trx/game/catalog/manager.h>
 #include <trx/game/game_strings/entries.h>
 
-#include <ctype.h>
 #include <string.h>
 
 typedef struct {
@@ -36,14 +36,7 @@ static const M_KEY m_Keys[] = {
 
 static bool M_KeyMatches(const char *const enum_name, const char *const key)
 {
-    const char *const name = enum_name + strlen("O_");
-    size_t i = 0;
-    for (; name[i] != '\0' && key[i] != '\0'; i++) {
-        if ((char)tolower((unsigned char)name[i]) != key[i]) {
-            return false;
-        }
-    }
-    return name[i] == '\0' && key[i] == '\0';
+    return strcmp(Catalog_KeyForEnum(CATALOG_OBJECTS, enum_name), key) == 0;
 }
 
 static const M_DEFAULT *M_GetDefault(const OBJECT_ID obj_id)
@@ -60,7 +53,7 @@ static const char *M_KeyFromId(const OBJECT_ID obj_id)
 {
     for (int32_t i = 0; m_Keys[i].object_id != NO_OBJECT; i++) {
         if (m_Keys[i].object_id == obj_id) {
-            return m_Keys[i].enum_name + strlen("O_");
+            return m_Keys[i].enum_name;
         }
     }
     return nullptr;
@@ -74,14 +67,8 @@ static const char *M_StringPath(const OBJECT_ID obj_id, const char *const what)
     if (enum_name == nullptr) {
         return nullptr;
     }
-    char key[64];
-    ASSERT(strlen(enum_name) < sizeof(key));
-    size_t i = 0;
-    for (; enum_name[i] != '\0' && i < sizeof(key) - 1; i++) {
-        key[i] = (char)tolower((unsigned char)enum_name[i]);
-    }
-    key[i] = '\0';
-    return String_FormatStatic("objects/%s/%s", key, what);
+    return String_FormatStatic(
+        "objects/%s/%s", Catalog_KeyForEnum(CATALOG_OBJECTS, enum_name), what);
 }
 
 static const char *M_Get(const OBJECT_ID obj_id, const char *const what)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The shotgun had two names: the catalog called it `O_SHOTGUN_ITEM`, while objects called it `shotgun_item`, with its name at `objects/shotgun_item/name`. `Catalog_GetKey` now returns `shotgun_item`, so the same identity has the same spelling everywhere it is read or written.

- This works for every catalog: object, sample, music track, Lara state, Lara animation, and item action IDs all have prefixes that can be removed without collisions.
- Prefix stripping now lives in `catalog/keys.c`. `objects/names.c` already needed the same logic, so it now shares the implementation instead of keeping its own copy.
- The C spelling remains an alias, so `games/tr1/catalog_objects.csv` and files using names such as `O_WOLF` continue to bind as before.
- `ENUM_MAP` is deliberately untouched. Catalog identities are run-time data and the enum map reflects what the executable was built with, so the two are kept apart.

Nothing reads these keys yet, so this does not change anything on disk. It lands now because savegames and injection files are about to start storing them; after that, changing the spelling would become a file-format migration instead of an internal cleanup.

The Lua API is unchanged. Catalog enums already declare `strip = "O_"`, so Lua was already exposing the prefixless spelling. `just lua-api-dump` produces byte-identical output.

Supersedes #6429
