### PR TITLE
Enable registering catalog identities at runtime

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -215,6 +215,7 @@
 - Added `trx.mod.Mod.can_switch`, which says whether `trx.mod.switch` accepts the mod, so a single level loaded on its own is told apart from a mod a player picks
 - Added `trx.strings.dash_case()`, which spells a name the way the console shows one
 - Added `trx.game.fmvs` and `trx.game.play_fmv()`, so a script can read the movies the game flow declares and play one where the player stands
+- Added `trx.catalog.key()`, which gives back the name an id answers to, and made a catalog report the names a mod minted beside the ones the engine carries
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -215,7 +215,8 @@
 - Added `trx.mod.Mod.can_switch`, which says whether `trx.mod.switch` accepts the mod, so a single level loaded on its own is told apart from a mod a player picks
 - Added `trx.strings.dash_case()`, which spells a name the way the console shows one
 - Added `trx.game.fmvs` and `trx.game.play_fmv()`, so a script can read the movies the game flow declares and play one where the player stands
-- Added `trx.catalog.key()`, which gives back the name an id answers to, and made a catalog report the names a mod minted beside the ones the engine carries
+- Added `trx.catalog.mint()`, so a mod that ships only a script can declare an object of its own
+- Added `trx.catalog.key()`, which gives back the name an id answers to
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3362,6 +3362,30 @@
       "path": "camera.cancel_flyby"
     },
     {
+      "description": "Declares an identity the engine has no constant for, and gives back its id. This is how a mod that ships only a script introduces an object of its own, without touching the catalog the game owns.\n\nThe identity carries no slot, because nothing in the game's own files refers to it. It lasts until the mod is unloaded.\n\nA savegame records an object by the slot this game's files use, so an item of a minted object is not written to one and does not come back on load. Spawn it from a script until savegames record a name.",
+      "examples": [
+        "local drum = trx.catalog.mint(trx.catalog.Context.OBJECTS, \"oil_drum\")"
+      ],
+      "params": [
+        {
+          "description": "Which catalog.",
+          "name": "context",
+          "type": "catalog.Context"
+        },
+        {
+          "description": "The name to declare. Letters, digits and `:_-`, so a mod can put its own prefix in front of what it brings.",
+          "name": "name",
+          "type": "string"
+        }
+      ],
+      "path": "catalog.mint",
+      "returns": {
+        "description": "`nil` if the name is not one an identity may take, or the catalog already holds it.",
+        "nullable": true,
+        "type": "catalog.Id"
+      }
+    },
+    {
       "description": "Gives back the name an id answers to, which is the name a savegame stores and the name a mod writes. An id a script read out of the engine is a number, and this is what says which thing it names.",
       "examples": [
         "local name = trx.catalog.key(trx.catalog.Context.OBJECTS, item.object_id)"

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3362,6 +3362,29 @@
       "path": "camera.cancel_flyby"
     },
     {
+      "description": "Gives back the name an id answers to, which is the name a savegame stores and the name a mod writes. An id a script read out of the engine is a number, and this is what says which thing it names.",
+      "examples": [
+        "local name = trx.catalog.key(trx.catalog.Context.OBJECTS, item.object_id)"
+      ],
+      "params": [
+        {
+          "description": "Which catalog.",
+          "name": "context",
+          "type": "catalog.Context"
+        },
+        {
+          "name": "id",
+          "type": "catalog.Id"
+        }
+      ],
+      "path": "catalog.key",
+      "returns": {
+        "description": "`nil` if the catalog holds no such id.",
+        "nullable": true,
+        "type": "string"
+      }
+    },
+    {
       "description": "Converts a `trx.catalog.Id` into the `trx.catalog.Slot` this game's own files use for it.",
       "examples": [
         "local slot = trx.catalog.to_slot(trx.catalog.Context.OBJECTS, trx.catalog.objects.WOLF)"

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -635,6 +635,24 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
 ### Functions
 
+- <a id="catalog.mint" name="catalog.mint"></a>[lua]`trx.catalog.mint(context, name)`  
+  Declares an identity the engine has no constant for, and gives back its id. This is how a mod that ships only a script introduces an object of its own, without touching the catalog the game owns.
+
+  The identity carries no slot, because nothing in the game's own files refers to it. It lasts until the mod is unloaded.
+
+  A savegame records an object by the slot this game's files use, so an item of a minted object is not written to one and does not come back on load. Spawn it from a script until savegames record a name.
+
+  Parameters:
+  - <a id="catalog.mint.context" name="catalog.mint.context"></a>**`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
+  - <a id="catalog.mint.name" name="catalog.mint.name"></a>**`name`** (string). The name to declare. Letters, digits and `:_-`, so a mod can put its own prefix in front of what it brings.
+
+  Returns: [trx.catalog.Id](#catalog.Id) or `nil`. `nil` if the name is not one an identity may take, or the catalog already holds it.
+
+  Example:
+  ```lua
+  local drum = trx.catalog.mint(trx.catalog.Context.OBJECTS, "oil_drum")
+  ```
+
 - <a id="catalog.key" name="catalog.key"></a>[lua]`trx.catalog.key(context, id)`  
   Gives back the name an id answers to, which is the name a savegame stores and the name a mod writes. An id a script read out of the engine is a number, and this is what says which thing it names.
 

--- a/docs/trx/lua/reference/CATALOG.md
+++ b/docs/trx/lua/reference/CATALOG.md
@@ -635,6 +635,20 @@ The ids in a catalog are TRX's own, and they are the same in all four games. The
 
 ### Functions
 
+- <a id="catalog.key" name="catalog.key"></a>[lua]`trx.catalog.key(context, id)`  
+  Gives back the name an id answers to, which is the name a savegame stores and the name a mod writes. An id a script read out of the engine is a number, and this is what says which thing it names.
+
+  Parameters:
+  - <a id="catalog.key.context" name="catalog.key.context"></a>**`context`** ([trx.catalog.Context](#catalog.Context)). Which catalog.
+  - <a id="catalog.key.id" name="catalog.key.id"></a>**`id`** ([trx.catalog.Id](#catalog.Id)).
+
+  Returns: string or `nil`. `nil` if the catalog holds no such id.
+
+  Example:
+  ```lua
+  local name = trx.catalog.key(trx.catalog.Context.OBJECTS, item.object_id)
+  ```
+
 - <a id="catalog.to_slot" name="catalog.to_slot"></a>[lua]`trx.catalog.to_slot(context, id)`  
   Converts a [`trx.catalog.Id`](#catalog.Id) into the [`trx.catalog.Slot`](#catalog.Slot) this game's own files use for it.
 

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -15,6 +15,7 @@
 local struct = trxc.struct
 
 local enum = trxc.enum
+local catalog = trxc.catalog
 
 local capi = trxc.api
 
@@ -1192,6 +1193,11 @@ end
 -- the data files are keyed by and cannot move, but
 -- trx.lara.ExtraMesh.EXTRA_MESH_OAR only says EXTRA_MESH twice.
 function api.enum_name(spec, reflected_name)
+  -- A catalog reports its keys in lower case, and upper case is what a
+  -- constant reads as everywhere else.
+  if spec.context ~= nil then
+    return reflected_name:upper()
+  end
   local strip = spec.strip
   if strip ~= nil and reflected_name:sub(1, #strip) == strip then
     return reflected_name:sub(#strip + 1)
@@ -1210,9 +1216,15 @@ api.enum = declarator("enum", "enums", {
     local bulk = spec.bulk == true
     need(bulk or type(spec.values) == "table", "values must be a table")
 
+    -- A catalog reports what it holds itself. It is the one enum whose values
+    -- are not fixed at build time, because a mod mints identities of its own.
+    local from_catalog = spec.context ~= nil
+    local constants = from_catalog and catalog.values(spec.context)
+      or enum.values(spec.backing)
+
     local public = {}
     local reflected = {}
-    for _, constant in ipairs(enum.values(spec.backing)) do
+    for _, constant in ipairs(constants) do
       local value_name = api.enum_name(spec, constant.name)
       -- Stripping a prefix can collide two C constants onto one Lua name, and the
       -- second would quietly take the first one's place.
@@ -1266,7 +1278,14 @@ api.enum = declarator("enum", "enums", {
         if type(key) ~= "string" then
           return nil
         end
-        return public[key] or public[key:upper()]
+        local value = public[key] or public[key:upper()]
+        if value ~= nil or not from_catalog then
+          return value
+        end
+        -- A name minted after the enum was declared is not in public, so the
+        -- catalog is asked for it.
+        return catalog.from_key(spec.context, key)
+          or catalog.from_key(spec.context, key:lower())
       end,
       __newindex = function(_, key)
         error(
@@ -1314,14 +1333,16 @@ api.enum = declarator("enum", "enums", {
     }
     -- A bulk enum reads as names only, and no values: the ids are TRX's own, and
     -- a script refers to them by name.
+    local constants = spec.context ~= nil and catalog.values(spec.context)
+      or enum.values(spec.backing)
     if out.bulk then
       out.names = {}
-      for _, constant in ipairs(enum.values(spec.backing)) do
+      for _, constant in ipairs(constants) do
         table.insert(out.names, api.enum_name(spec, constant.name))
       end
       table.sort(out.names)
     else
-      for _, constant in ipairs(enum.values(spec.backing)) do
+      for _, constant in ipairs(constants) do
         local value_name = api.enum_name(spec, constant.name)
         table.insert(out.values, {
           name = value_name,

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -23,7 +23,7 @@ api.number("catalog.Slot", {
     .. "Editor. It differs from game to game.",
 })
 
-api.enum("catalog.Context", {
+local Context = api.enum("catalog.Context", {
   backing = "CATALOG_CONTEXT",
   strip = "CATALOG_",
   description = "Which catalog a slot belongs to.",
@@ -39,7 +39,7 @@ api.enum("catalog.Context", {
 
 api.enum("catalog.objects", {
   backing = "OBJECT_ID",
-  strip = "O_",
+  context = Context.OBJECTS,
   bulk = true,
   description = "Every object TRX has a name for.",
   examples = { [[if item.object_id == trx.catalog.objects.WOLF then ... end]] },
@@ -47,7 +47,7 @@ api.enum("catalog.objects", {
 
 api.enum("catalog.samples", {
   backing = "SAMPLE_TRX_ID",
-  strip = "SFX_",
+  context = Context.SAMPLES,
   bulk = true,
   description = "Every sound sample TRX has a name for.",
   examples = { [[trx.sound.play(trx.catalog.samples.LARA_NO)]] },
@@ -55,7 +55,7 @@ api.enum("catalog.samples", {
 
 api.enum("catalog.music", {
   backing = "MUSIC_TRX_ID",
-  strip = "MX_",
+  context = Context.MUSIC,
   bulk = true,
   description = "Every music track TRX has a name for.",
   examples = { [[trx.music.play(trx.catalog.music.SECRET)]] },
@@ -63,7 +63,7 @@ api.enum("catalog.music", {
 
 api.enum("catalog.lara_states", {
   backing = "LARA_TRX_STATE",
-  strip = "LS_",
+  context = Context.LARA_STATES,
   bulk = true,
   description = "Every state Lara can be in.",
   examples = {
@@ -73,14 +73,14 @@ api.enum("catalog.lara_states", {
 
 api.enum("catalog.lara_anims", {
   backing = "LARA_TRX_ANIMATION",
-  strip = "LA_",
+  context = Context.LARA_ANIMS,
   bulk = true,
   description = "Every animation Lara has.",
 })
 
 api.enum("catalog.flip_effects", {
   backing = "ITEM_TRX_ACTION",
-  strip = "ITEM_ACTION_",
+  context = Context.ITEM_ACTIONS,
   bulk = true,
   description = "Every item action a flip effect can trigger.",
   examples = {

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -98,6 +98,40 @@ api.enum("catalog.weapons", {
   },
 })
 
+api.define("catalog.mint", {
+  description = "Declares an identity the engine has no constant for, and gives back its id. "
+    .. "This is how a mod that ships only a script introduces an object of its own, without "
+    .. "touching the catalog the game owns.\n\n"
+    .. "The identity carries no slot, because nothing in the game's own files refers to it. "
+    .. "It lasts until the mod is unloaded.\n\n"
+    .. "A savegame records an object by the slot this game's files use, so an item of a minted "
+    .. "object is not written to one and does not come back on load. Spawn it from a script "
+    .. "until savegames record a name.",
+  params = {
+    {
+      name = "context",
+      type = "catalog.Context",
+      description = "Which catalog.",
+    },
+    {
+      name = "name",
+      type = "string",
+      description = "The name to declare. Letters, digits and `:_-`, so a mod can put its own "
+        .. "prefix in front of what it brings.",
+    },
+  },
+  returns = {
+    type = "catalog.Id",
+    nullable = true,
+    description = "`nil` if the name is not one an identity may take, or the catalog already "
+      .. "holds it.",
+  },
+  examples = {
+    [[local drum = trx.catalog.mint(trx.catalog.Context.OBJECTS, "oil_drum")]],
+  },
+  impl = raw.mint,
+})
+
 api.define("catalog.key", {
   description = "Gives back the name an id answers to, which is the name a savegame stores "
     .. "and the name a mod writes. An id a script read out of the engine is a number, and this "

--- a/src/lua/api/catalog.lua
+++ b/src/lua/api/catalog.lua
@@ -98,6 +98,29 @@ api.enum("catalog.weapons", {
   },
 })
 
+api.define("catalog.key", {
+  description = "Gives back the name an id answers to, which is the name a savegame stores "
+    .. "and the name a mod writes. An id a script read out of the engine is a number, and this "
+    .. "is what says which thing it names.",
+  params = {
+    {
+      name = "context",
+      type = "catalog.Context",
+      description = "Which catalog.",
+    },
+    { name = "id", type = "catalog.Id" },
+  },
+  returns = {
+    type = "string",
+    nullable = true,
+    description = "`nil` if the catalog holds no such id.",
+  },
+  examples = {
+    [[local name = trx.catalog.key(trx.catalog.Context.OBJECTS, item.object_id)]],
+  },
+  impl = raw.key,
+})
+
 api.define("catalog.to_slot", {
   description = "Converts a `trx.catalog.Id` into the `trx.catalog.Slot` this game's own files "
     .. "use for it.",

--- a/src/tests/fakes/catalog.c
+++ b/src/tests/fakes/catalog.c
@@ -9,12 +9,19 @@
 
 #include <fakes/sound.h>
 
+#include <trx/core/result.h>
 #include <trx/core/utils.h>
 #include <trx/game/catalog/manager.h>
 
 #include <string.h>
 
 #define FAKE_SLOT_OFFSET 13
+
+// Mint mod IDs after the built-in IDs in each test context to match the real
+// registry.
+#define FAKE_MINTED_MAX 8
+static char m_Minted[CATALOG_CONTEXT_MAX][FAKE_MINTED_MAX][64];
+static int32_t m_MintedCount[CATALOG_CONTEXT_MAX] = {};
 
 // Preserve each identity because its position in the context's numerically
 // ordered .def names is its ID.
@@ -71,15 +78,36 @@ int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
 {
     int32_t count;
     M_Names(context, &count);
-    return count;
+    return count + m_MintedCount[context];
+}
+
+RESULT Catalog_Mint(
+    const CATALOG_CONTEXT context, const char *const key,
+    CATALOG_ID *const out_id)
+{
+    FAIL_IF(
+        !Catalog_IsValidKey(key), "'%s' is not a name an identity may take",
+        key);
+    FAIL_IF(
+        Catalog_FromKey(context, key, -1) >= 0, "'%s' is already held", key);
+    FAIL_IF(m_MintedCount[context] >= FAKE_MINTED_MAX, "no room left to mint");
+    const int32_t idx = m_MintedCount[context]++;
+    strncpy(m_Minted[context][idx], key, sizeof(m_Minted[0][0]) - 1);
+    int32_t builtins;
+    M_Names(context, &builtins);
+    *out_id = builtins + idx;
+    return OK;
 }
 
 const char *Catalog_GetKey(const CATALOG_CONTEXT context, const CATALOG_ID id)
 {
     int32_t count;
     const char *const *const names = M_Names(context, &count);
-    if (names == nullptr || id < 0 || id >= count) {
+    if (id < 0 || id >= count + m_MintedCount[context]) {
         return nullptr;
+    }
+    if (id >= count) {
+        return m_Minted[context][id - count];
     }
     return Catalog_KeyForEnum(context, names[id]);
 }
@@ -93,6 +121,11 @@ CATALOG_ID Catalog_FromKey(
     for (CATALOG_ID id = 0; id < count; id++) {
         if (strcmp(Catalog_KeyForEnum(context, names[id]), key) == 0) {
             return id;
+        }
+    }
+    for (int32_t i = 0; i < m_MintedCount[context]; i++) {
+        if (strcmp(m_Minted[context][i], key) == 0) {
+            return count + i;
         }
     }
     return fallback;

--- a/src/tests/fakes/catalog.c
+++ b/src/tests/fakes/catalog.c
@@ -9,9 +9,94 @@
 
 #include <fakes/sound.h>
 
+#include <trx/core/utils.h>
 #include <trx/game/catalog/manager.h>
 
+#include <string.h>
+
 #define FAKE_SLOT_OFFSET 13
+
+// Preserve each identity because its position in the context's numerically
+// ordered .def names is its ID.
+#define X_CATALOG_ID(enum_value) #enum_value,
+static const char *const m_Objects[] = {
+#include <trx/game/catalog/objects.def>
+};
+static const char *const m_Samples[] = {
+#include <trx/game/catalog/samples.def>
+};
+static const char *const m_Music[] = {
+#include <trx/game/catalog/music.def>
+};
+static const char *const m_LaraStates[] = {
+#include <trx/game/catalog/lara_states.def>
+};
+static const char *const m_LaraAnims[] = {
+#include <trx/game/catalog/lara_anims.def>
+};
+static const char *const m_ItemActions[] = {
+#include <trx/game/catalog/item_actions.def>
+};
+#undef X_CATALOG_ID
+
+static const char *const *M_Names(
+    const CATALOG_CONTEXT context, int32_t *const out_count)
+{
+    switch (context) {
+    case CATALOG_OBJECTS:
+        *out_count = ARRAY_SIZE(m_Objects);
+        return m_Objects;
+    case CATALOG_SAMPLES:
+        *out_count = ARRAY_SIZE(m_Samples);
+        return m_Samples;
+    case CATALOG_MUSIC:
+        *out_count = ARRAY_SIZE(m_Music);
+        return m_Music;
+    case CATALOG_LARA_STATES:
+        *out_count = ARRAY_SIZE(m_LaraStates);
+        return m_LaraStates;
+    case CATALOG_LARA_ANIMS:
+        *out_count = ARRAY_SIZE(m_LaraAnims);
+        return m_LaraAnims;
+    case CATALOG_ITEM_ACTIONS:
+        *out_count = ARRAY_SIZE(m_ItemActions);
+        return m_ItemActions;
+    default:
+        *out_count = 0;
+        return nullptr;
+    }
+}
+
+int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
+{
+    int32_t count;
+    M_Names(context, &count);
+    return count;
+}
+
+const char *Catalog_GetKey(const CATALOG_CONTEXT context, const CATALOG_ID id)
+{
+    int32_t count;
+    const char *const *const names = M_Names(context, &count);
+    if (names == nullptr || id < 0 || id >= count) {
+        return nullptr;
+    }
+    return Catalog_KeyForEnum(context, names[id]);
+}
+
+CATALOG_ID Catalog_FromKey(
+    const CATALOG_CONTEXT context, const char *const key,
+    const CATALOG_ID fallback)
+{
+    int32_t count;
+    const char *const *const names = M_Names(context, &count);
+    for (CATALOG_ID id = 0; id < count; id++) {
+        if (strcmp(Catalog_KeyForEnum(context, names[id]), key) == 0) {
+            return id;
+        }
+    }
+    return fallback;
+}
 
 int32_t Catalog_ToSlot(
     const CATALOG_CONTEXT context, const CATALOG_ID id, const int32_t fallback)

--- a/src/tests/fakes/settings.c
+++ b/src/tests/fakes/settings.c
@@ -369,13 +369,6 @@ RESULT GameStringManager_ReloadLanguage(const char *const lang)
     return OK;
 }
 
-CATALOG_ID Catalog_FromKey(
-    const CATALOG_CONTEXT context, const char *const key,
-    const CATALOG_ID fallback)
-{
-    return fallback;
-}
-
 void Music_SetVolume(const float volume)
 {
 }

--- a/src/tests/harness/stubs_catalog.c
+++ b/src/tests/harness/stubs_catalog.c
@@ -9,3 +9,9 @@ int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
 {
     return context == CATALOG_OBJECTS ? O_NUMBER_OF : 0;
 }
+
+const char *Catalog_GetKey(const CATALOG_CONTEXT context, const CATALOG_ID id)
+{
+    // Every id the stub reports is one the exe names, so none is anonymous.
+    return id >= 0 && id < Catalog_GetCount(context) ? "" : nullptr;
+}

--- a/src/tests/harness/stubs_catalog.c
+++ b/src/tests/harness/stubs_catalog.c
@@ -1,0 +1,11 @@
+// A table indexed by a catalog id asks how many identities a context holds,
+// which is what bounds the id. Standing that up here keeps the unit tests
+// engine-free, the same reason the other stubs here exist.
+
+#include <trx/game/catalog/manager.h>
+#include <trx/game/objects/ids.h>
+
+int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
+{
+    return context == CATALOG_OBJECTS ? O_NUMBER_OF : 0;
+}

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -18,6 +18,9 @@ local function test(name, fn)
   end
 end
 
+-- The context the catalog fake answers for.
+local FAKE_CONTEXT = 3
+
 -- Records what api.type() asked the C binder to expose, so the tests can assert
 -- on the declaration rather than on a real metatable.
 local function fresh_env()
@@ -73,6 +76,28 @@ local function fresh_env()
           { name = "OFF", value = 0 },
           { name = "ON", value = 1 },
         }
+      end,
+    },
+    -- Stands in for a catalog. It reports what it holds rather than what the
+    -- exe was built with, so a name minted while the game runs is reachable
+    -- without appearing in the constant list.
+    catalog = {
+      values = function(context)
+        assert(
+          context == FAKE_CONTEXT,
+          "unknown context: " .. tostring(context)
+        )
+        return {
+          { name = "off", value = 0 },
+          { name = "on", value = 1 },
+        }
+      end,
+      from_key = function(context, key)
+        assert(
+          context == FAKE_CONTEXT,
+          "unknown context: " .. tostring(context)
+        )
+        return key == "oil_drum" and 9 or nil
       end,
     },
     -- Where the registry hands C the entrypoints it keeps after the seal.
@@ -649,6 +674,40 @@ test(
     assert(e.ON == 1, "and the write must not have landed")
   end
 )
+
+-- A catalog reports what it holds, so its constants are whatever it names when
+-- the enum is declared, and a name minted after that still resolves.
+test("a catalog enum reads its constants from the catalog", function()
+  local api = fresh_env()
+  api.module("things", {})
+
+  local e = api.enum("things.Kind", {
+    backing = "WIDGET_STATE",
+    context = FAKE_CONTEXT,
+    bulk = true,
+  })
+
+  assert(e.OFF == 0, "a catalog name reads as a constant")
+  assert(e.ON == 1)
+  assert(e.on == 1, "in any case")
+
+  local names = {}
+  for name in pairs(e) do
+    names[#names + 1] = name
+  end
+  table.sort(names)
+  assert(
+    table.concat(names, ",") == "OFF,ON",
+    "and the constant list is what the catalog held"
+  )
+
+  assert(
+    e["oil_drum"] == 9,
+    "a name minted after the enum was declared must resolve"
+  )
+  assert(e["OIL_DRUM"] == 9, "in any case")
+  assert(e.WOMBAT == nil, "and a name nothing holds is still nil")
+end)
 
 test(
   "a bulk enum is described as a whole, not a constant at a time",

--- a/src/tests/lua/api/catalog.lua
+++ b/src/tests/lua/api/catalog.lua
@@ -92,4 +92,37 @@ test("the contexts are named", function()
   )
 end)
 
+-- A mod that ships only a script has no catalog file of its own, and must not
+-- edit the one the game owns, so it declares what it brings while the game runs.
+test("a script mints an identity of its own", function()
+  local id = trx.catalog.mint(trx.catalog.Context.OBJECTS, "oil_drum")
+  assert(id ~= nil, "minting gives back an id")
+  assert(
+    trx.catalog.objects["oil_drum"] == id,
+    "and the catalog answers to the name from then on"
+  )
+  assert(
+    trx.catalog.key(trx.catalog.Context.OBJECTS, id) == "oil_drum",
+    "and gives the name back for the id"
+  )
+end)
+
+test("a name the catalog already holds is not minted twice", function()
+  local id = trx.catalog.mint(trx.catalog.Context.OBJECTS, "oil_drum_twice")
+  assert(id ~= nil)
+  assert(
+    trx.catalog.mint(trx.catalog.Context.OBJECTS, "oil_drum_twice") == nil,
+    "the second mint says no rather than taking the name again"
+  )
+  assert(
+    trx.catalog.mint(trx.catalog.Context.OBJECTS, "wolf") == nil,
+    "and a name the engine carries is held as well"
+  )
+end)
+
+test("a name an identity may not take is refused", function()
+  assert(trx.catalog.mint(trx.catalog.Context.OBJECTS, "") == nil)
+  assert(trx.catalog.mint(trx.catalog.Context.OBJECTS, "has space") == nil)
+end)
+
 return h.report()

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1221,7 +1221,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/ui',
   'src': [
-    'harness/stubs_catalog.c',
+    'fakes/catalog.c',
     'harness/stubs_result.c',
     'fakes/settings.c',
     'fakes/ui.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -71,6 +71,7 @@ b_lua_surface = {
   'engine': [
     'core/dynamic_enum.c',
     'core/enum_map.c',
+    'game/catalog/keys.c',
     'core/handle.c',
     'core/memory.c',
     'core/result.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -330,6 +330,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/items/actions',
   'engine': ['core/memory.c', 'game/catalog/table.c', 'game/items/actions/common.c'],
+  'src': ['harness/stubs_catalog.c'],
 }
 
 unit_tests += {
@@ -341,6 +342,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/game_flow/inventory',
   'engine': ['core/memory.c', 'game/catalog/table.c', 'game/game_flow/inventory.c'],
+  'src': ['harness/stubs_catalog.c'],
 }
 
 unit_tests += {
@@ -1221,6 +1223,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/ui',
   'src': [
+    'harness/stubs_catalog.c',
     'harness/stubs_result.c',
     'fakes/settings.c',
     'fakes/ui.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -88,6 +88,7 @@ b_lua_surface = {
     'game/lua/utils.c',
   ],
   'src': [
+    'fakes/catalog.c',
     'harness/fake_calls.c',
     'harness/lua_surface.c',
     'harness/stubs_enum_map.c',
@@ -449,6 +450,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/lua/capi/enum',
   'bundles': [b_value],
+  'src': ['harness/stubs_catalog.c'],
   'engine': [
     'game/lua/capi/enum.c',
     'game/lua/registry.c',
@@ -472,6 +474,7 @@ unit_tests += {
     'game/lua/utils.c',
   ],
   'src': [
+    'harness/stubs_catalog.c',
     'harness/stubs_console.c',
     'harness/stubs_enum_map.c',
     'harness/stubs_game_script.c',
@@ -501,6 +504,7 @@ unit_tests += {
 unit_tests += {
   'name': 'trx/game/lua/capi/struct',
   'bundles': [b_value],
+  'src': ['harness/stubs_catalog.c'],
   'engine': [
     'core/handle.c',
     'game/lua/capi/struct.c',
@@ -525,7 +529,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/items',
   'bundles': [b_lua_surface, b_lua_strings, b_lua_math],
-  'src': ['harness/stubs_console.c', 'fakes/items.c', 'fakes/catalog.c'],
+  'src': ['harness/stubs_console.c', 'fakes/items.c'],
   'engine': [
     'game/lua/capi/catalog.c',
     'game/lua/capi/events.c',
@@ -723,7 +727,6 @@ unit_tests += {
     'fakes/items.c',
     'fakes/rooms.c',
     'fakes/lara.c',
-    'fakes/catalog.c',
     'fakes/camera.c',
   ],
   'engine': [
@@ -775,7 +778,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/objects',
   'bundles': [b_lua_surface, b_lua_strings],
-  'src': ['fakes/items.c', 'fakes/catalog.c'],
+  'src': ['fakes/items.c'],
   'engine': ['game/lua/capi/catalog.c', 'game/lua/capi/objects.c'],
 }
 
@@ -783,7 +786,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/inventory',
   'bundles': [b_lua_surface, b_lua_math],
-  'src': ['fakes/game.c', 'fakes/lara.c', 'fakes/items.c', 'fakes/catalog.c'],
+  'src': ['fakes/game.c', 'fakes/lara.c', 'fakes/items.c'],
   'engine': [
     'game/lua/capi/catalog.c',
     'game/lua/capi/inventory.c',
@@ -797,7 +800,7 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/weapons',
   'bundles': [b_lua_surface, b_lua_math],
-  'src': ['fakes/lara.c', 'fakes/items.c', 'fakes/catalog.c'],
+  'src': ['fakes/lara.c', 'fakes/items.c'],
   'engine': [
     'game/lua/capi/catalog.c',
     'game/lua/capi/items.c',
@@ -813,7 +816,6 @@ unit_tests += {
     'fakes/level.c',
     'fakes/lara.c',
     'fakes/items.c',
-    'fakes/catalog.c',
   ],
   'engine': [
     'game/lua/capi/catalog.c',
@@ -827,7 +829,6 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/catalog',
   'bundles': [b_lua_surface],
-  'src': ['fakes/catalog.c'],
   'engine': ['game/lua/capi/catalog.c'],
 }
 
@@ -927,7 +928,6 @@ unit_tests += {
     'fakes/game.c',
     'fakes/items.c',
     'fakes/lara.c',
-    'fakes/catalog.c',
     'fakes/sound.c',
   ],
   'engine': [
@@ -949,7 +949,6 @@ unit_tests += {
     'harness/stubs_config_file.c',
     'harness/stubs_console.c',
     'fakes/assault.c',
-    'fakes/catalog.c',
     'fakes/game.c',
     'fakes/level.c',
     'fakes/locale.c',
@@ -1011,7 +1010,6 @@ unit_tests += {
     'harness/stubs_config_file.c',
     'harness/stubs_console.c',
     'fakes/camera.c',
-    'fakes/catalog.c',
     'fakes/creatures.c',
     'fakes/cutseq.c',
     'fakes/game.c',
@@ -1086,7 +1084,6 @@ unit_tests += {
   'bundles': [b_lua_surface, b_console, b_lua_strings, b_lua_math],
   'src': ['fakes/level.c',
     'fakes/camera.c',
-    'fakes/catalog.c',
     'fakes/game.c',
     'fakes/items.c',
     'fakes/lara.c',

--- a/src/trx/game/catalog/keys.c
+++ b/src/trx/game/catalog/keys.c
@@ -29,3 +29,18 @@ const char *Catalog_KeyForEnum(
     key[i] = '\0';
     return key;
 }
+
+bool Catalog_IsValidKey(const char *const key)
+{
+    if (key == nullptr || key[0] == '\0') {
+        return false;
+    }
+    for (const char *c = key; *c != '\0'; c++) {
+        const bool ok = (*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z')
+            || (*c >= '0' && *c <= '9') || *c == ':' || *c == '_' || *c == '-';
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -176,21 +176,6 @@ CATALOG_ID Catalog_MintAnonymous(const CATALOG_CONTEXT context)
     return M_Add(context, nullptr);
 }
 
-bool Catalog_IsValidKey(const char *const key)
-{
-    if (key == nullptr || key[0] == '\0') {
-        return false;
-    }
-    for (const char *c = key; *c != '\0'; c++) {
-        const bool ok = (*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z')
-            || (*c >= '0' && *c <= '9') || *c == ':' || *c == '_' || *c == '-';
-        if (!ok) {
-            return false;
-        }
-    }
-    return true;
-}
-
 RESULT Catalog_Mint(
     const CATALOG_CONTEXT context, const char *const key,
     CATALOG_ID *const out_id)

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -3,9 +3,11 @@
 #include <trx/core/csv.h>
 #include <trx/core/filesystem.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/core/subsystem.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
+#include <trx/game/catalog/table.h>
 #include <trx/game/items/actions/ids.h>
 #include <trx/game/lara/enum.h>
 #include <trx/game/music/ids.h>
@@ -131,6 +133,10 @@ __attribute__((constructor)) static void M_MintBuiltIns(void)
 // starts from what the exe names.
 static void M_Shutdown(void)
 {
+    // Drop what is keyed by a minted identity before the ids are given out
+    // again, so that the next mod does not read the last one's rows.
+    CatalogTable_FreeAll();
+
     for (size_t ctx = 0; ctx < CATALOG_CONTEXT_MAX; ctx++) {
         M_ClearGameIDMap(&m_GameID2EnumMap[ctx]);
         M_NAME_ENTRY *cur, *tmp;
@@ -152,22 +158,48 @@ static void M_Shutdown(void)
     }
 }
 
-RESULT Catalog_Mint(
-    const CATALOG_CONTEXT context, const char *const key,
-    CATALOG_ID *const out_id)
+static CATALOG_ID M_Add(const CATALOG_CONTEXT context, const char *const key)
 {
     const CATALOG_ID id = m_Counts[context];
-    MUST(M_AddName(context, id, key));
-
     m_Counts[context]++;
     m_Keys[context] =
         Memory_Realloc(m_Keys[context], sizeof(char *) * m_Counts[context]);
     m_GameIDs[context] =
         Memory_Realloc(m_GameIDs[context], sizeof(int32_t) * m_Counts[context]);
-    m_Keys[context][id] = Memory_DupStr(key);
+    m_Keys[context][id] = key != nullptr ? Memory_DupStr(key) : nullptr;
     m_GameIDs[context][id] = -1;
+    return id;
+}
 
-    *out_id = id;
+CATALOG_ID Catalog_MintAnonymous(const CATALOG_CONTEXT context)
+{
+    return M_Add(context, nullptr);
+}
+
+bool Catalog_IsValidKey(const char *const key)
+{
+    if (key == nullptr || key[0] == '\0') {
+        return false;
+    }
+    for (const char *c = key; *c != '\0'; c++) {
+        const bool ok = (*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z')
+            || (*c >= '0' && *c <= '9') || *c == ':' || *c == '_' || *c == '-';
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
+}
+
+RESULT Catalog_Mint(
+    const CATALOG_CONTEXT context, const char *const key,
+    CATALOG_ID *const out_id)
+{
+    FAIL_IF(
+        !Catalog_IsValidKey(key), "'%s' is not a name an identity may take",
+        key);
+    MUST(M_AddName(context, m_Counts[context], key));
+    *out_id = M_Add(context, key);
     return OK;
 }
 
@@ -249,9 +281,13 @@ RESULT Catalog_Load(
         char *const name_str = CSV_Trim(name_buf);
         const int32_t game_id = (int32_t)strtol(id_str, nullptr, 10);
 
-        const CATALOG_ID id = Catalog_FromKey(context, name_str, -1);
+        CATALOG_ID id = Catalog_FromKey(context, name_str, -1);
         if (id < 0) {
-            continue;
+            // A row naming something the exe has no constant for declares the
+            // identity it names.
+            if (!SHOULD(Catalog_Mint(context, name_str, &id), csv_path)) {
+                continue;
+            }
         }
 
         RESULT result = Catalog_BindSlot(context, id, game_id);

--- a/src/trx/game/catalog/manager.h
+++ b/src/trx/game/catalog/manager.h
@@ -22,6 +22,16 @@ typedef int32_t CATALOG_ID;
 // initialisation; the next call overwrites the result.
 const char *Catalog_KeyForEnum(CATALOG_CONTEXT context, const char *enum_name);
 
+// Report whether a name is one an identity may take: letters, digits, and any
+// of ":_-".
+bool Catalog_IsValidKey(const char *key);
+
+// Take an id for something nothing names. The engine builds it, uses it and
+// drops it: a level's own sound slot is one, carrying no name for a mod or a
+// savegame to say. It answers to no key, so nothing outside the run can ask
+// for it.
+CATALOG_ID Catalog_MintAnonymous(CATALOG_CONTEXT context);
+
 // Declare an identity and return its ID. Fails if the context already holds
 // the key. The context is the namespace, so the same key in two contexts is
 // two identities.

--- a/src/trx/game/catalog/table.c
+++ b/src/trx/game/catalog/table.c
@@ -2,6 +2,11 @@
 
 #include <trx/core/memory.h>
 
+// The tables that hold a tail. A minted identity is dropped when the session
+// ends, so the rows keyed by one are dropped with it, and the next session
+// does not read what the last one wrote.
+static CATALOG_TABLE *m_Tables = nullptr;
+
 void *CatalogTable_Get(CATALOG_TABLE *const table, const CATALOG_ID id)
 {
     if (id < 0) {
@@ -10,21 +15,38 @@ void *CatalogTable_Get(CATALOG_TABLE *const table, const CATALOG_ID id)
     if (id < table->builtin_count) {
         return (char *)table->builtin + (size_t)id * table->elem_size;
     }
-    const int32_t tail_idx = id - table->builtin_count;
-    if (tail_idx >= table->tail_count) {
+    if (id >= Catalog_GetCount(table->context)) {
         return nullptr;
     }
-    return table->tail[tail_idx];
+    // Add rows for minted identities on demand, because most tables hold data
+    // for few of them.
+    while (id - table->builtin_count >= table->tail_count) {
+        CatalogTable_Append(table);
+    }
+    return table->tail[id - table->builtin_count];
 }
 
 void *CatalogTable_Append(CATALOG_TABLE *const table)
 {
+    if (!table->linked) {
+        table->linked = true;
+        table->next = m_Tables;
+        m_Tables = table;
+    }
     table->tail_count++;
     table->tail =
         Memory_Realloc(table->tail, sizeof(void *) * table->tail_count);
     void *const record = Memory_Alloc(table->elem_size);
     table->tail[table->tail_count - 1] = record;
     return record;
+}
+
+void CatalogTable_FreeAll(void)
+{
+    for (CATALOG_TABLE *table = m_Tables; table != nullptr;
+         table = table->next) {
+        CatalogTable_Free(table);
+    }
 }
 
 void CatalogTable_Free(CATALOG_TABLE *const table)

--- a/src/trx/game/catalog/table.h
+++ b/src/trx/game/catalog/table.h
@@ -9,13 +9,17 @@
 // array sized by the context's sentinel, so a constructor can write to it
 // before main. Minted identities live in the tail, which holds one allocation
 // per record so that growing the table never moves what is already there.
-typedef struct {
+typedef struct CATALOG_TABLE {
     CATALOG_CONTEXT context;
     size_t elem_size;
     void *builtin;
     int32_t builtin_count;
     void **tail;
     int32_t tail_count;
+    // Set once the table grows a tail, so that the catalog can drop every
+    // tail when a session ends.
+    bool linked;
+    struct CATALOG_TABLE *next;
 } CATALOG_TABLE;
 
 #define CATALOG_TABLE_DEFINE(name, ctx, type, count)                           \
@@ -27,12 +31,17 @@ typedef struct {
         .builtin_count = (count),                                              \
     }
 
-// Return the record an ID names, or null if the table holds none.
+// Return the record for an ID, or null if the context has no such identity.
+// Create a zeroed record on first access to a minted identity.
 void *CatalogTable_Get(CATALOG_TABLE *table, CATALOG_ID id);
 
 // Add a record for the next minted identity and return it, zeroed. The
 // records already handed out keep their addresses.
 void *CatalogTable_Append(CATALOG_TABLE *table);
+
+// Release the tail of every table that grew one. The built-in blocks are
+// static and stay.
+void CatalogTable_FreeAll(void);
 
 // Release the tail. The built-in block is static and stays.
 void CatalogTable_Free(CATALOG_TABLE *table);

--- a/src/trx/game/enum.c
+++ b/src/trx/game/enum.c
@@ -27,6 +27,7 @@
 #include <trx/game/sound/ids.h>
 #include <trx/game/ui/elements/frame.h>
 #include <trx/game/ui/elements/stack.h>
+#include <trx/game/ui/regions.h>
 #include <trx/game/ui/settings.h>
 
 static __attribute__((constructor)) void M_Init(void)
@@ -40,35 +41,6 @@ static __attribute__((constructor)) void M_Init(void)
     // as, so this only reads what an older settings file holds.
     ENUM_MAP(
         INPUT_ROLE, INPUT_ROLE_CYCLE_LIGHTING_MODEL, "cycle_lighting_contrast");
-
-    // The catalogs: every object, sample, music track, Lara state, Lara
-    // animation and item action TRX knows, by its canonical name. These are the
-    // names a script says - the O_/SFX_/MX_ prefixes come off in the
-    // declaration, not here, because the prefix is what tells them apart in C.
-#define X_CATALOG_ID(enum_value) ENUM_MAP_SELF(OBJECT_ID, enum_value);
-#include <trx/game/catalog/objects.def>
-#undef X_CATALOG_ID
-
-#define X_CATALOG_ID(enum_value) ENUM_MAP_SELF(SAMPLE_TRX_ID, enum_value);
-#include <trx/game/catalog/samples.def>
-#undef X_CATALOG_ID
-
-#define X_CATALOG_ID(enum_value) ENUM_MAP_SELF(MUSIC_TRX_ID, enum_value);
-#include <trx/game/catalog/music.def>
-#undef X_CATALOG_ID
-
-#define X_CATALOG_ID(enum_value) ENUM_MAP_SELF(LARA_TRX_STATE, enum_value);
-#include <trx/game/catalog/lara_states.def>
-#undef X_CATALOG_ID
-
-#define X_CATALOG_ID(enum_value) ENUM_MAP_SELF(LARA_TRX_ANIMATION, enum_value);
-#include <trx/game/catalog/lara_anims.def>
-#undef X_CATALOG_ID
-
-#define X_CATALOG_ID(enum_value) ENUM_MAP_SELF(ITEM_TRX_ACTION, enum_value);
-#include <trx/game/catalog/item_actions.def>
-#include <trx/game/ui/regions.h>
-#undef X_CATALOG_ID
 
     ENUM_MAP(CATALOG_CONTEXT, CATALOG_OBJECTS, "objects");
     ENUM_MAP(CATALOG_CONTEXT, CATALOG_MUSIC, "music");

--- a/src/trx/game/lua/capi/catalog.c
+++ b/src/trx/game/lua/capi/catalog.c
@@ -4,14 +4,13 @@
 
 #include <lauxlib.h>
 #include <stdint.h>
+#include <string.h>
 
-// The catalogs themselves are enums, reflected out of ENUM_MAP like any other -
-// see trx/game/enum.c. What is left here is the one thing an enum cannot do:
-// turn a TRX id into the id this particular game's files use, and back.
+// Report each catalogue's run-time identities directly because build-time
+// ENUM_MAP entries exclude identities created by mods.
 //
-// Builders call that a slot. It is what Tomb Editor shows, and it is not the
-// same number as the TRX id: TRX names an object once, across all four games,
-// and each game's files number it differently.
+// Convert between a TRX ID and the game-specific slot used by its files and
+// Tomb Editor; TRX IDs span all four games, while slots vary by game.
 
 // Neither Catalog_ToSlot nor Catalog_FromSlot checks the context before
 // indexing its table with it.
@@ -58,7 +57,49 @@ static int M_L_CatalogFromSlot(lua_State *const L)
     return 1;
 }
 
+// trxc.catalog.values(context) -> { { name = "shotgun_item", value = 1 }, ... }
+static int M_L_CatalogValues(lua_State *const L)
+{
+    const CATALOG_CONTEXT context = M_CheckContext(L, 1);
+    const int32_t count = Catalog_GetCount(context);
+    lua_createtable(L, count, 0);
+    int32_t n = 0;
+    for (CATALOG_ID id = 0; id < count; id++) {
+        const char *const key = Catalog_GetKey(context, id);
+        if (key == nullptr) {
+            continue;
+        }
+        lua_createtable(L, 0, 2);
+        lua_pushstring(L, key);
+        lua_setfield(L, -2, "name");
+        lua_pushinteger(L, id);
+        lua_setfield(L, -2, "value");
+        lua_rawseti(L, -2, ++n);
+    }
+    return 1;
+}
+
+// trxc.catalog.from_key(context, name) -> int or nil
+static int M_L_CatalogFromKey(lua_State *const L)
+{
+    const CATALOG_CONTEXT context = M_CheckContext(L, 1);
+    const char *const key = luaL_checkstring(L, 2);
+    const CATALOG_ID id = Catalog_FromKey(context, key, -1);
+    // Return a match only for the canonical key, because aliases are C
+    // spellings used by catalogue CSVs rather than script names.
+    const char *const canonical =
+        id < 0 ? nullptr : Catalog_GetKey(context, id);
+    if (canonical == nullptr || strcmp(canonical, key) != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushinteger(L, id);
+    return 1;
+}
+
 static const luaL_Reg m_Module[] = {
+    { "values", M_L_CatalogValues },
+    { "from_key", M_L_CatalogFromKey },
     { "to_slot", M_L_CatalogToSlot },
     { "from_slot", M_L_CatalogFromSlot },
     { nullptr, nullptr },

--- a/src/trx/game/lua/capi/catalog.c
+++ b/src/trx/game/lua/capi/catalog.c
@@ -1,3 +1,4 @@
+#include <trx/core/result.h>
 #include <trx/game/catalog/manager.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
@@ -18,6 +19,20 @@ static CATALOG_CONTEXT M_CheckContext(lua_State *const L, const int arg)
 {
     return (CATALOG_CONTEXT)LUA_CheckRange(
         L, arg, CATALOG_CONTEXT_MAX, "unknown catalog context");
+}
+
+// trxc.catalog.mint(context, name) -> int or nil
+static int M_L_CatalogMint(lua_State *const L)
+{
+    const CATALOG_CONTEXT context = M_CheckContext(L, 1);
+    const char *const key = luaL_checkstring(L, 2);
+    CATALOG_ID id;
+    if (!IS_OK(Catalog_Mint(context, key, &id))) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, id);
+    }
+    return 1;
 }
 
 // trxc.catalog.key(context, id) -> string or nil
@@ -117,6 +132,7 @@ static int M_L_CatalogFromKey(lua_State *const L)
 
 static const luaL_Reg m_Module[] = {
     { "key", M_L_CatalogKey },
+    { "mint", M_L_CatalogMint },
     { "values", M_L_CatalogValues },
     { "from_key", M_L_CatalogFromKey },
     { "to_slot", M_L_CatalogToSlot },

--- a/src/trx/game/lua/capi/catalog.c
+++ b/src/trx/game/lua/capi/catalog.c
@@ -20,6 +20,24 @@ static CATALOG_CONTEXT M_CheckContext(lua_State *const L, const int arg)
         L, arg, CATALOG_CONTEXT_MAX, "unknown catalog context");
 }
 
+// trxc.catalog.key(context, id) -> string or nil
+static int M_L_CatalogKey(lua_State *const L)
+{
+    const CATALOG_CONTEXT context = M_CheckContext(L, 1);
+    CATALOG_ID id;
+    if (!LUA_CheckBoundedInt(L, 2, INT32_MIN, INT32_MAX, &id)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    const char *const key = Catalog_GetKey(context, id);
+    if (key == nullptr) {
+        lua_pushnil(L);
+    } else {
+        lua_pushstring(L, key);
+    }
+    return 1;
+}
+
 // trxc.catalog.to_slot(context, id) -> int or nil
 static int M_L_CatalogToSlot(lua_State *const L)
 {
@@ -98,6 +116,7 @@ static int M_L_CatalogFromKey(lua_State *const L)
 }
 
 static const luaL_Reg m_Module[] = {
+    { "key", M_L_CatalogKey },
     { "values", M_L_CatalogValues },
     { "from_key", M_L_CatalogFromKey },
     { "to_slot", M_L_CatalogToSlot },

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -1,3 +1,4 @@
+#include <trx/game/catalog/manager.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/struct.h>
@@ -172,7 +173,9 @@ static const char *M_GetPropertyName(const void *const self, const int32_t idx)
 static int M_L_ObjectsGet(lua_State *const L)
 {
     int32_t object_id;
-    if (!LUA_CheckBoundedInt(L, 1, O_FIRST, O_NUMBER_OF - 1, &object_id)) {
+    if (!LUA_CheckBoundedInt(
+            L, 1, O_FIRST, Catalog_GetCount(CATALOG_OBJECTS) - 1, &object_id)
+        || Catalog_GetKey(CATALOG_OBJECTS, object_id) == nullptr) {
         lua_pushnil(L);
         return 1;
     }

--- a/src/trx/game/lua/utils.c
+++ b/src/trx/game/lua/utils.c
@@ -1,5 +1,6 @@
 #include <trx/game/lua/utils.h>
 
+#include <trx/game/catalog/manager.h>
 #include <trx/game/objects/ids.h>
 
 #include <stdint.h>
@@ -143,7 +144,14 @@ int32_t LUA_CheckRange(
 
 OBJECT_ID LUA_CheckObjectID(lua_State *const L, const int arg)
 {
-    return (OBJECT_ID)LUA_CheckRange(L, arg, O_NUMBER_OF, "unknown object id");
+    const OBJECT_ID object_id = (OBJECT_ID)LUA_CheckRange(
+        L, arg, Catalog_GetCount(CATALOG_OBJECTS), "unknown object id");
+    // An anonymous identity answers to no key, so a script has no way to name
+    // one and no business holding one.
+    luaL_argcheck(
+        L, Catalog_GetKey(CATALOG_OBJECTS, object_id) != nullptr, arg,
+        "unknown object id");
+    return object_id;
 }
 
 bool LUA_CheckBoundedInt(

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -94,8 +94,9 @@ OBJECT *Object_Get(const OBJECT_ID object_id)
 
 OBJECT_ID Object_Mint(void)
 {
-    CatalogTable_Append(&m_Objects);
-    return O_NUMBER_OF + m_Objects.tail_count - 1;
+    // Register the object so the object tables recognise its id. It takes no
+    // name, which keeps it out of savegames.
+    return Catalog_MintAnonymous(CATALOG_OBJECTS);
 }
 
 OBJECT *Object_GetByGameID(const int32_t game_id)

--- a/src/trx/game/objects/names.c
+++ b/src/trx/game/objects/names.c
@@ -12,11 +12,6 @@ typedef struct {
     const char *names;
 } M_DEFAULT;
 
-typedef struct {
-    OBJECT_ID object_id;
-    const char *enum_name;
-} M_KEY;
-
 static const M_DEFAULT m_Defaults[] = {
 #define X_OBJ_NAME_DEFINE(object_id_, names_)                                  \
     { .object_id = object_id_, .names = names_ },
@@ -24,20 +19,6 @@ static const M_DEFAULT m_Defaults[] = {
 #undef X_OBJ_NAME_DEFINE
     { .object_id = NO_OBJECT, .names = nullptr },
 };
-
-// List every object with the C spelling its key comes from.
-static const M_KEY m_Keys[] = {
-#define X_CATALOG_ID(enum_value_)                                              \
-    { .object_id = enum_value_, .enum_name = #enum_value_ },
-#include <trx/game/catalog/objects.def>
-#undef X_CATALOG_ID
-    { .object_id = NO_OBJECT, .enum_name = nullptr },
-};
-
-static bool M_KeyMatches(const char *const enum_name, const char *const key)
-{
-    return strcmp(Catalog_KeyForEnum(CATALOG_OBJECTS, enum_name), key) == 0;
-}
 
 static const M_DEFAULT *M_GetDefault(const OBJECT_ID obj_id)
 {
@@ -49,26 +30,15 @@ static const M_DEFAULT *M_GetDefault(const OBJECT_ID obj_id)
     return nullptr;
 }
 
-static const char *M_KeyFromId(const OBJECT_ID obj_id)
-{
-    for (int32_t i = 0; m_Keys[i].object_id != NO_OBJECT; i++) {
-        if (m_Keys[i].object_id == obj_id) {
-            return m_Keys[i].enum_name;
-        }
-    }
-    return nullptr;
-}
-
 // Return the game-string path for an object's name or description. The next
 // call overwrites the result.
 static const char *M_StringPath(const OBJECT_ID obj_id, const char *const what)
 {
-    const char *const enum_name = M_KeyFromId(obj_id);
-    if (enum_name == nullptr) {
+    const char *const key = Catalog_GetKey(CATALOG_OBJECTS, obj_id);
+    if (key == nullptr) {
         return nullptr;
     }
-    return String_FormatStatic(
-        "objects/%s/%s", Catalog_KeyForEnum(CATALOG_OBJECTS, enum_name), what);
+    return String_FormatStatic("objects/%s/%s", key, what);
 }
 
 static const char *M_Get(const OBJECT_ID obj_id, const char *const what)
@@ -137,10 +107,5 @@ void Object_ResetAllNames(void)
 
 OBJECT_ID Object_IdFromKey(const char *const key)
 {
-    for (int32_t i = 0; m_Keys[i].object_id != NO_OBJECT; i++) {
-        if (M_KeyMatches(m_Keys[i].enum_name, key)) {
-            return m_Keys[i].object_id;
-        }
-    }
-    return NO_OBJECT;
+    return Catalog_FromKey(CATALOG_OBJECTS, key, NO_OBJECT);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The catalog now takes identities declared while the game runs: a catalog CSV row, or `trx.catalog.mint` from a script. `trx.catalog.key` turns an id back into a name.

```lua
-- games/tr1/catalog_objects.csv:  372, oil_drum
local drum = trx.catalog.objects.OIL_DRUM
trx.objects[drum].properties.max_hit_points = 30
```

```lua
local drum = trx.catalog.mint(trx.catalog.Context.OBJECTS, "oil_drum")
trx.catalog.key(trx.catalog.Context.OBJECTS, drum)  -- "oil_drum"
```

A catalog row maps a name to a slot number. A mod can name a slot that its own injection file fills, and then use that name anywhere an object ID is accepted, which lets it define objects independently of the TRX build or the OG data.

`trx.catalog.mint` does the same for mods that do not ship a CSV, but it is incomplete. Minted IDs have no slot and no meshes, so `trx.items.spawn` rejects them, and savegames cannot store them because saves still record slot numbers. This PR covers how the engine tracks object IDs; making a minted object usable needs more work.

Also:

- catalog identities leave `ENUM_MAP`, which only holds what the build was compiled with. The catalog reports its own names now, and the Lua docs regenerate unchanged.
- `objects/names.c` asks the registry instead of keeping its own key table.