### PR TITLE
Fix Von Croy appearing out of thin air

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -155,6 +155,7 @@
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)
 - Fixed Lara flinching when she bumps into Von Croy (TRX1095)
+- Fixed characters not being drawn while an animation carries them into the next room, such as Von Croy climbing down in Race for the Iris (TRX1232)
 - Fixed rooms and their contents sometimes disappearing while an in-game cutscene plays (TRX1052)
 - Fixed parts of the level dropping out of the picture during the cutscene that opens Karnak (TRX1092)
 - Fixed the parked jeep showing in the temple during the cutscene that opens Karnak (TRX1092)

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -10,6 +10,7 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/items/carrier.h>
+#include <trx/game/items/col.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/lua/events.h>
 #include <trx/game/objects.h>
@@ -22,6 +23,10 @@
 
 #include <string.h>
 
+// How far to one side a mesh must sit before it is worth asking which room it
+// landed in. A quarter of a tile keeps every upright item out of the search.
+#define M_MESH_OFFSET_MIN (WALL_L / 4)
+
 static int32_t m_LevelItemCount = 0;
 static int16_t m_MaxUsedItemCount = 0;
 static ITEM *m_Items = nullptr;
@@ -32,20 +37,58 @@ static int16_t m_NextItemFree = NO_ITEM;
 static uint32_t m_ItemGens[MAX_ITEMS];
 static HANDLE_REGISTRY m_ItemHandles;
 
-static void M_RemoveFromDrawQueues(
-    const int16_t item_num, const int16_t room_num)
+// Takes the item out of every room. An item is drawn from as many rooms as its
+// bounds reach into, and which those were is not answerable from where the
+// item now stands, so each room is asked rather than worked out. Clearing a
+// room that never held the item costs one masked read.
+static void M_RemoveFromDrawQueues(const int16_t item_num)
 {
-    if (room_num == NO_ROOM) {
+    const int32_t room_count = Room_GetCount();
+    for (int32_t i = 0; i < room_count; i++) {
+        Room_RemoveDrawnItem((int16_t)i, item_num);
+    }
+}
+
+// Draws the item from the room and from every neighbour its bounds reach a
+// portal into.
+static void M_AddToRoomAndNeighbours(
+    const int16_t item_num, const int16_t room_num,
+    const BOUNDS_32 *const bounds)
+{
+    Room_AddDrawnItem(room_num, item_num);
+    const ROOM *const room = Room_Get(room_num);
+    if (room == nullptr || room->portals == nullptr) {
         return;
     }
-    Room_RemoveDrawnItem(room_num, item_num);
-    const ROOM *const room = Room_Get(room_num);
-    if (room != nullptr && room->portals != nullptr) {
-        for (int32_t i = 0; i < room->portals->count; i++) {
-            Room_RemoveDrawnItem(room->portals->portal[i].room_num, item_num);
+    for (int32_t i = 0; i < room->portals->count; i++) {
+        const PORTAL *const portal = &room->portals->portal[i];
+        if (Room_BoundsReachPortal(bounds, portal)) {
+            Room_AddDrawnItem(portal->room_num, item_num);
         }
-        M_RemoveFromDrawQueues(item_num, room->flipped_room);
     }
+}
+
+// Where the item's mesh sits this frame, which an animation can put well away
+// from the item itself: a climb hangs the body a room below the ledge the item
+// stands on, and a rotated offset puts it past the wall beside it.
+static XYZ_32 M_GetMeshCenter(const ITEM *const item)
+{
+    const BOUNDS_16 *const b = Item_GetBoundsAccurate(item);
+    const XYZ_32 offset = {
+        .x = ((int32_t)b->min.x + b->max.x) / 2,
+        .y = ((int32_t)b->min.y + b->max.y) / 2,
+        .z = ((int32_t)b->min.z + b->max.z) / 2,
+    };
+    return XYZ_32_OffsetLocalYaw(item->pos, offset, item->rot.y);
+}
+
+// Whether the mesh is held far enough to one side to land past a wall. An
+// upright mesh always shares the item's room, so it skips the search.
+static bool M_IsMeshHeldAside(const ITEM *const item)
+{
+    const BOUNDS_16 *const b = Item_GetBoundsAccurate(item);
+    return ABS((int32_t)b->min.x + b->max.x) / 2 > M_MESH_OFFSET_MIN
+        || ABS((int32_t)b->min.z + b->max.z) / 2 > M_MESH_OFFSET_MIN;
 }
 
 static BOUNDS_32 M_GetOccupancyBounds(const ITEM *const item)
@@ -73,17 +116,19 @@ static void M_AddToDrawQueues(const int16_t item_num, const int16_t room_num)
     if (room_num == NO_ROOM) {
         return;
     }
-    Room_AddDrawnItem(room_num, item_num);
-    const ROOM *const room = Room_Get(room_num);
-    if (room == nullptr || room->portals == nullptr) {
+    const ITEM *const item = &m_Items[item_num];
+    const BOUNDS_32 bounds = M_GetOccupancyBounds(item);
+    M_AddToRoomAndNeighbours(item_num, room_num, &bounds);
+
+    // An animation can carry the mesh into a room that the item's own room
+    // does not border, which no portal of that room reaches.
+    if (!M_IsMeshHeldAside(item)) {
         return;
     }
-    const BOUNDS_32 bounds = M_GetOccupancyBounds(&m_Items[item_num]);
-    for (int32_t i = 0; i < room->portals->count; i++) {
-        const PORTAL *const portal = &room->portals->portal[i];
-        if (Room_BoundsReachPortal(&bounds, portal)) {
-            Room_AddDrawnItem(portal->room_num, item_num);
-        }
+    int16_t mesh_room_num = room_num;
+    Room_GetSector(M_GetMeshCenter(item), &mesh_room_num);
+    if (mesh_room_num != room_num) {
+        M_AddToRoomAndNeighbours(item_num, mesh_room_num, &bounds);
     }
 }
 
@@ -524,7 +569,7 @@ void Item_DetachFromRoom(const int16_t item_num)
     const bool was_present = item->is_present;
     item->is_present = false;
 
-    M_RemoveFromDrawQueues(item_num, item->room_num);
+    M_RemoveFromDrawQueues(item_num);
     M_UnlinkChain(item_num, item->room_num);
 
     // Only when it was in the world, so an already-detached item does not fire.
@@ -667,7 +712,7 @@ void Item_UpdateRoom(const int16_t item_num, const int16_t room_num)
     ITEM *const item = &m_Items[item_num];
     const int16_t old_room_num = item->room_num;
 
-    M_RemoveFromDrawQueues(item_num, old_room_num);
+    M_RemoveFromDrawQueues(item_num);
     M_AddToDrawQueues(item_num, room_num);
 
     if (old_room_num != room_num) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

In this episode of item room drawing list queue fixes, we fix Von Croy disappearing while climbing down in Race for the Iris, where his mesh enters room 49 while the item remains in room 51, two portals away.

Implementation-wise, items are now added to every room their mesh occupies, with removal checking each room directly instead of searching the old room and its neighbours.

Resolves TRX1232

#### Testing

##### Race for the Iris
- [x] [TRX1232] TR4 Race for the Iris: Von Croy is drawn for the whole climb down, and no longer appears out of thin air at the foot of the wall

##### Items reaching into neighbouring rooms
- [x] [TRX854 / #6029] TR3:LA Highland Fling: the Loch Ness monster stays visible as the camera turns
- [x] [#6029] TR3:LA Highland Fling: the helicopter crossing portals
- [x] [#2438] TR1 Natla's Mines: the cowboy does not lose his head
- [x] [#2005] TR1 Vilcabamba: the entrance gates
- [x] [#2005] TR2 Catacombs: room 30, walk Lara forward and watch the trapdoor
- [x] [#2452] TR1 City of Khamoon: the trapdoors and the cat statue's faces
- [x] [#3668] TR1 Atlantean Stronghold: `/play 3`, `/tp 16`
- [x] [#2393] TR2 The Deck: `/play 10`, drop through the opening, kill the barracudas with a conventional weapon, `/tp 51 4 48`, then move the camera
- [x] [#1870] TR2 Lara's Home: the meshes in room 62
- [x] [#5929] TR3 Antarctica: Willard in the cutscene
- [x] [#6029] TR3 Sleeping with the Fishes: the animating diver
- [x] [#6029] Any level: fish crossing room boundaries
- [x] [#6029] Any level: bats leaving their spawn room

##### Statics bleeding into nearby rooms
- [x] [#6028] TR2 Venice: the Bartoli gazebo
- [x] [TRX854 / #6028] TR3 It's a Madhouse!: the street lamp and its glow
- [x] [TRX933 / #6082] TR3 High Security Compound: the statics beside the truck stay in room 98, and the way to the level's end is clear

##### Overlapping rooms
- [x] [TRX1168 / #6299] TR1 Tomb of Tihocan: the boulder does not show in the room beside it
- [x] [TRX1159 / #6299] TR3 Crash Site: the tall pillar is not cut off at the portal

##### Draw queue rebuilds
- [x] [TRX1097] Any level: a door is still drawn from the far side of its doorway after loading a save
- [x] [TRX1072] Any level: items in flipped rooms are not left behind when the flipmap changes
