### PR TITLE
Add the TR4 intro captions

### DIFF
--- a/data/trx/ship/games/tr4/scripts/angkor1.lua
+++ b/data/trx/ship/games/tr4/scripts/angkor1.lua
@@ -101,3 +101,8 @@ cutscenes.register(ENTRANCE_CUTSCENE, {
     },
   },
 })
+
+-- The caption the level opens with, which the level's strings carry.
+require("common.legend").setup(function()
+  return trx.locale.get("general/legend")
+end)

--- a/data/trx/ship/games/tr4/scripts/settomb1.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb1.lua
@@ -11,3 +11,8 @@ trx.events.on_game_start(function()
   trx.objects.waterfall_2.properties.loop_sound = trx.items.WaterfallSound.SAND
   trx.objects.waterfall_2.properties.hide_when_inactive = true
 end)
+
+-- The caption the level opens with, which the level's strings carry.
+require("common.legend").setup(function()
+  return trx.locale.get("general/legend")
+end)

--- a/data/trx/ship/games/tr4/strings-de.json5
+++ b/data/trx/ship/games/tr4/strings-de.json5
@@ -13,7 +13,9 @@
     "levels": [
         {
             "title": "Angkor Wat",
-            "legend": "Kambodscha, 1984",
+            "general": {
+                "legend": "Kambodscha, 1984",
+            },
             "objects": {
                 "puzzle_item_1": {
                     "name": "Der goldene Totenschädel",
@@ -30,7 +32,9 @@
         },
         {
             "title": "Das Grabmal des Seth",
-            "legend": "Ägypten, heute",
+            "general": {
+                "legend": "Ägypten, heute",
+            },
             "objects": {
                 "puzzle_item_1": {
                     "name": "Auge des Horus",

--- a/data/trx/ship/games/tr4/strings-it.json5
+++ b/data/trx/ship/games/tr4/strings-it.json5
@@ -13,7 +13,9 @@
     "levels": [
         {
             "title": "Angkor Wat",
-            "legend": "Cambogia, 1984",
+            "general": {
+                "legend": "Cambogia, 1984",
+            },
             "objects": {
                 "puzzle_item_1": {
                     "name": "Teschio Dorato",
@@ -30,7 +32,9 @@
         },
         {
             "title": "Tomba di Seth",
-            "legend": "Egitto, presente",
+            "general": {
+                "legend": "Egitto, presente",
+            },
             "objects": {
                 "puzzle_item_1": {
                     "name": "Occhio di Horus",

--- a/data/trx/ship/games/tr4/strings.json5
+++ b/data/trx/ship/games/tr4/strings.json5
@@ -13,7 +13,9 @@
     "levels": [
         {
             "title": "Angkor Wat",
-            "legend": "Cambodia, 1984",
+            "general": {
+                "legend": "Cambodia, 1984",
+            },
             "objects": {
                 "puzzle_item_1": {
                     "name": "Golden Skull",
@@ -30,7 +32,9 @@
         },
         {
             "title": "The Tomb of Seth",
-            "legend": "Egypt, present day",
+            "general": {
+                "legend": "Egypt, present day",
+            },
             "objects": {
                 "puzzle_item_1": {
                     "name": "Eye of Horus",

--- a/data/trx/ship/modules/legend.lua
+++ b/data/trx/ship/modules/legend.lua
@@ -1,0 +1,78 @@
+-- The caption a level opens with, which TR4 shows in Angkor Wat and in The
+-- Tomb of Seth.
+--
+-- A level that wants one names its text, either outright or as a function.
+-- A function is read once the level is running and again whenever the player
+-- changes language, which is what a caption held in the level's strings needs:
+-- those are applied as the level loads, and a script is built before that.
+--
+--   require("common.legend").setup(function()
+--     return trx.locale.get("general/legend")
+--   end)
+--
+-- The caption stands for five seconds of play. The original engine counts it
+-- down only while it is on screen, so a caption waits out the opening scenes
+-- rather than expiring behind them, and an inventory the player opens costs it
+-- nothing.
+
+local M = {}
+
+local FRAMES = 150
+
+-- The bars are up while a cutscene or a flyby holds the screen, which is when
+-- the original engine keeps the caption off it.
+local function is_clear()
+  return trx.game.is_playing
+    and not trx.cutscenes.is_playing
+    and not trx.overlay.has_letterbox
+    -- A flyby draws no bars of its own yet, so the sequence itself answers for
+    -- the ones it will draw.
+    and not trx.camera.is_flyby_active
+end
+
+-- Shows the caption the level opens with. The text is either a string or a
+-- function returning one.
+function M.setup(source)
+  local read = source
+  if type(source) ~= "function" then
+    read = function()
+      return source
+    end
+  end
+
+  local text = trx.signal.new("")
+  local clear = trx.signal.polled(is_clear)
+  local running = trx.signal.new(false)
+  local left = 0
+
+  local function refresh()
+    text:set(read())
+  end
+
+  trx.events.on_game_start(function(is_save)
+    refresh()
+    left = is_save and 0 or FRAMES
+    running:set(left > 0)
+  end)
+
+  trx.signal.config("language"):on(refresh)
+
+  trx.events.before_control(function()
+    if left > 0 and clear:get() then
+      left = left - 1
+      if left == 0 then
+        running:set(false)
+      end
+    end
+  end)
+
+  trx.ui.regions.place(
+    trx.ui.Region.BOTTOM_CENTER,
+    trx.ui.widgets.Label({
+      text = text,
+      shown = clear & running,
+    })
+  )
+end
+
+return M

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -194,6 +194,7 @@
 - Added `trx.lara.is_controllable`, `trx.lara.vehicle`, `trx.lara.MAX_AIR`, `trx.lara.MAX_SPRINT`, what her arms and the flare in them are doing, and what she is lining herself up with, so a script can report what the overlay reports
 - Added `trx.game.is_playing`, `trx.game.is_suspended`, `trx.game.is_photo_mode`, `trx.game.tr_version`, `trx.game.real_time` and `trx.game.measured_fps`, so a script can tell what the game is doing and how fast it is drawing
 - Added a new Lua module, `trx.overlay`, for the part of the overlay the engine still owns, so a script drawing the rest can follow it
+- Added `trx.overlay.has_letterbox` and `trx.overlay.signals.letterbox`, so a script can hold something back while the cinematic bars have the screen
 - Added `trx.objects.Object.name`, for the name the game shows for an object
 - Added `trx.items.Item.is_ally` and a `boss` family to `trx.objects.query`, so a script can tell a creature that fights for Lara from one that fights her, and pick out the ones the game treats as bosses
 - Added `trx.weapons.Weapon.has_infinite_ammo` and `trx.weapons.Weapon.ammo_icon`, so a script can tell a weapon that never runs dry from one whose shots are worth counting, and draw the icon the count is shown with

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -148,6 +148,7 @@
 - Added Collapsible Floor control, with a `requires_heavy_trigger` property for those that need heavy activators (TRX1230)
 - Added level statistics scanning (TRX1201)
 - Added the timer Race for the Iris runs between its cutscenes (TRX1109)
+- Added the captions that open Angkor Wat and The Tomb of Seth (TRX487)
 - Added the sprite shadow, so the shadow shape setting offers it as in the other games (Graphic Options → Visuals → Shadows shape) (TRX1290)
 - Added the wobble effect the original shows while the camera is under water (TRX523)
 - Added the drifting specks the original shows in water rooms (TRX553)

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1339,6 +1339,7 @@ If you install everything correctly, your game directory should look more or les
 │       └── strings.json5
 ├── modules
 │   ├── assault.lua
+│   ├── legend.lua
 │   ├── overlay.lua
 │   ├── save_crystal.lua
 │   └── water_color.lua
@@ -2715,6 +2716,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │       └── strings.json5
     │   ├── modules
     │   │   ├── assault.lua
+    │   │   ├── legend.lua
     │   │   ├── overlay.lua
     │   │   ├── save_crystal.lua
     │   │   └── water_color.lua

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -8296,6 +8296,18 @@
       "writable": false
     },
     {
+      "description": "Whether the cinematic bars take any of the screen. It stays true while they\nmove, so a script can hold something back until they have gone.",
+      "path": "overlay.has_letterbox",
+      "type": "boolean",
+      "writable": false
+    },
+    {
+      "description": "Says when the cinematic bars take the screen and when they give it back. True\nwhile they are moving, so a script can hold something back until they have gone.",
+      "path": "overlay.signals.letterbox",
+      "type": "signal.Signal",
+      "writable": false
+    },
+    {
       "description": "Says when something asks for Lara's health bar whatever else is on screen, which the inventory ring does while it shows a medipack.",
       "path": "overlay.signals.health_bar_forced",
       "type": "signal.Signal",

--- a/docs/trx/lua/reference/OVERLAY.md
+++ b/docs/trx/lua/reference/OVERLAY.md
@@ -18,6 +18,10 @@ Only what a script has to answer for is here. The lines of text are the engine's
 
 ### Properties
 
+- <a id="overlay.has_letterbox" name="overlay.has_letterbox"></a>**`trx.overlay.has_letterbox`** (boolean). Whether the cinematic bars take any of the screen. It stays true while they
+  move, so a script can hold something back until they have gone. *(read-only)*
+- <a id="overlay.signals.letterbox" name="overlay.signals.letterbox"></a>**`trx.overlay.signals.letterbox`** ([trx.signal.Signal](SIGNAL.md#signal.Signal)). Says when the cinematic bars take the screen and when they give it back. True
+  while they are moving, so a script can hold something back until they have gone. *(read-only)*
 - <a id="overlay.signals.health_bar_forced" name="overlay.signals.health_bar_forced"></a>**`trx.overlay.signals.health_bar_forced`** ([trx.signal.Signal](SIGNAL.md#signal.Signal)). Says when something asks for Lara's health bar whatever else is on screen, which the inventory ring does while it shows a medipack. *(read-only)*
 
 ### Functions

--- a/src/lua/api/overlay.lua
+++ b/src/lua/api/overlay.lua
@@ -17,6 +17,26 @@ api.namespace("overlay.signals", {
 })
 
 local held = nil
+local letterbox_held = nil
+
+api.property("overlay.has_letterbox", {
+  type = "boolean",
+  description = [[Whether the cinematic bars take any of the screen. It stays true while they
+move, so a script can hold something back until they have gone.]],
+  get = raw.has_letterbox,
+})
+
+api.property("overlay.signals.letterbox", {
+  type = "signal.Signal",
+  description = [[Says when the cinematic bars take the screen and when they give it back. True
+while they are moving, so a script can hold something back until they have gone.]],
+  get = function()
+    if letterbox_held == nil then
+      letterbox_held = trx.signal.polled(raw.has_letterbox)
+    end
+    return letterbox_held
+  end,
+})
 
 api.property("overlay.signals.health_bar_forced", {
   type = "signal.Signal",

--- a/src/tests/fakes/overlay.c
+++ b/src/tests/fakes/overlay.c
@@ -1,17 +1,20 @@
-// The one overlay flag a script reads: whether something asks for Lara's
-// health bar.
+// The overlay flags a script reads: whether something asks for Lara's health
+// bar, and whether the cinematic bars have the screen.
 
 #include <fakes/overlay.h>
 
 #include <harness/fake_calls.h>
 
+#include <trx/game/output/overlay.h>
 #include <trx/game/overlay.h>
 
 static bool m_ForcedHealthBar;
+static bool m_Letterbox;
 
 static void M_Reset(void)
 {
     m_ForcedHealthBar = false;
+    m_Letterbox = false;
 }
 
 void FakeOverlay_ForceHealthBar(const bool show)
@@ -22,6 +25,16 @@ void FakeOverlay_ForceHealthBar(const bool show)
 bool Overlay_IsHealthBarForced(void)
 {
     return m_ForcedHealthBar;
+}
+
+void FakeOverlay_SetLetterbox(const bool shown)
+{
+    m_Letterbox = shown;
+}
+
+bool Output_Overlay_HasLetterbox(void)
+{
+    return m_Letterbox;
 }
 
 FAKE_ON_RESET(M_Reset)

--- a/src/tests/fakes/overlay.h
+++ b/src/tests/fakes/overlay.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void FakeOverlay_ForceHealthBar(bool show);
+void FakeOverlay_SetLetterbox(bool shown);

--- a/src/trx/game/lua/capi/overlay.c
+++ b/src/trx/game/lua/capi/overlay.c
@@ -1,6 +1,7 @@
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/utils.h>
+#include <trx/game/output/overlay.h>
 #include <trx/game/overlay.h>
 
 #include <lauxlib.h>
@@ -12,7 +13,15 @@ static int M_L_OverlayIsHealthBarForced(lua_State *const L)
     return 1;
 }
 
+// trxc.overlay.has_letterbox() -> bool
+static int M_L_OverlayHasLetterbox(lua_State *const L)
+{
+    lua_pushboolean(L, Output_Overlay_HasLetterbox());
+    return 1;
+}
+
 static const luaL_Reg m_Module[] = {
+    { "has_letterbox", M_L_OverlayHasLetterbox },
     { "is_health_bar_forced", M_L_OverlayIsHealthBarForced },
     { nullptr, nullptr },
 };

--- a/src/trx/game/output/overlay.h
+++ b/src/trx/game/output/overlay.h
@@ -23,6 +23,8 @@ void Output_Overlay_SetLetterbox(float ratio);
 void Output_Overlay_SlideLetterbox(float ratio);
 void Output_Overlay_UpdateLetterbox(void);
 float Output_Overlay_GetLetterbox(void);
+// Whether the bars take any of the screen.
+bool Output_Overlay_HasLetterbox(void);
 void Output_Overlay_DrawLetterbox(void);
 
 // How black the view is over the top, from 0 to 1, for whoever is framing a

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -1083,6 +1083,11 @@ float Output_Overlay_GetLetterbox(void)
     return m_Letterbox;
 }
 
+bool Output_Overlay_HasLetterbox(void)
+{
+    return m_Letterbox > 0.0f;
+}
+
 void Output_Overlay_SetFade(const float opacity)
 {
     m_Fade = opacity;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Angkor Wat and The Tomb of Seth now show the captions from the original game: `Cambodia, 1984` and `Egypt, present day`. These strings were already shipped in English, German and Italian, but nothing used them. They are now level game strings drawn by a script.

A level only needs to name its caption; a shared module handles its timing and placement:

```lua
require("common.legend").setup(function()
  return trx.locale.get("general/legend")
end)
```

The caption stays on screen for five seconds of gameplay. Its timer pauses during flybys, cutscenes, inventory, pause and photo mode.

For mods, `trx.overlay.has_letterbox` and `trx.overlay.signals.letterbox` expose whether cinematic bars are active, which the caption uses to stay hidden.

Resolves TRX487

#### Testing

- [x] Angkor Wat shows `Cambodia, 1984` for about five seconds after the opening cutscene
- [x] The Tomb of Seth shows `Egypt, present day` the same way
- [x] The caption shows text, not `general/legend`
- [x] German and Italian use their translated text
- [x] Captions stay hidden during opening cutscenes and flybys
- [x] Inventory, pause and photo mode pause the five-second timer
- [x] Loading a save in either level does not show a caption
- [x] Adjacent levels show no caption