### PR TITLE
objects/body_part: prevent zero fall speed at ceiling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@
 **TR1**
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)
 - Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand (TRX1073)
+- Fixed a rare chance of exploded body parts getting stuck indefinitely at ceiling height (OG bug) (TRX1301)
 
 **TR3**
 - Added crystals to each of the levels in The Lost Artefact, and made the crystal mode option visible (Gameplay → General → Crystal mode) (TRX1111)

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -42,7 +42,7 @@ static void M_Control_TR12(const int16_t effect_num)
     const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
     if (effect->pos.y < ceiling) {
         effect->pos.y = ceiling;
-        effect->fall_speed = -effect->fall_speed;
+        effect->fall_speed = MAX(1, -effect->fall_speed);
     }
 
     const int32_t height = Room_GetHeight(sector, effect->pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes a rare chance of body parts getting stuck at ceiling height.

Resolves TRX1301.
