### PR TITLE
Address saved identities by key

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -877,6 +877,7 @@ common_sources = [
   'trx/game/savegame/file.c',
   'trx/game/savegame/file_read.c',
   'trx/game/savegame/file_write.c',
+  'trx/game/savegame/identity.c',
   'trx/game/savegame/manager.c',
   'trx/game/savegame/resume.c',
   'trx/game/savegame/vars.c',

--- a/src/tests/fakes/music.c
+++ b/src/tests/fakes/music.c
@@ -30,7 +30,7 @@ static void M_Reset(void)
     }
 }
 
-int32_t Music_Play_Direct(const MUSIC_SLOT track, const MUSIC_PLAY_MODE mode)
+int32_t Music_PlayBySlot(const MUSIC_SLOT track, const MUSIC_PLAY_MODE mode)
 {
     FAKE_RECORD("play", FV(track), FV(mode));
     if (track != FAKE_MUSIC_TRACK) {
@@ -59,7 +59,7 @@ MUSIC_SLOT Music_GetCurrentLoopedTrack(void)
     return m_Looped;
 }
 
-bool Music_IsTrackAvailable_Direct(const MUSIC_SLOT track)
+bool Music_IsTrackAvailableBySlot(const MUSIC_SLOT track)
 {
     return track == FAKE_MUSIC_TRACK;
 }

--- a/src/tests/harness/stubs_catalog.c
+++ b/src/tests/harness/stubs_catalog.c
@@ -7,7 +7,7 @@
 
 int32_t Catalog_GetCount(const CATALOG_CONTEXT context)
 {
-    return context == CATALOG_OBJECTS ? FAKE_OBJ_COUNT : 0;
+    return FAKE_OBJ_COUNT;
 }
 
 int32_t Catalog_GetBuiltInCount(const CATALOG_CONTEXT context)

--- a/src/tests/trx/game/items/actions.c
+++ b/src/tests/trx/game/items/actions.c
@@ -64,7 +64,7 @@ TEST(run_direct_hands_a_claimed_number_to_the_interceptor)
 {
     M_Reset((int32_t)ITEM_ACTION_LARA_NORMAL);
 
-    ItemAction_RunDirect((ITEM_ACTION_SLOT)ITEM_ACTION_LARA_NORMAL, &m_Item);
+    ItemAction_RunBySlot((ITEM_ACTION_SLOT)ITEM_ACTION_LARA_NORMAL, &m_Item);
 
     CHECK_EQ_INT(m_SeenEffect, (int32_t)ITEM_ACTION_LARA_NORMAL);
     CHECK_EQ_INT(m_SeenTimer, 0);
@@ -76,7 +76,7 @@ TEST(run_direct_with_fx_hands_a_claimed_number_to_the_interceptor)
 {
     M_Reset((int32_t)ITEM_ACTION_LARA_NORMAL);
 
-    ItemAction_RunDirectWithFX(
+    ItemAction_RunWithFXBySlot(
         (ITEM_ACTION_SLOT)ITEM_ACTION_LARA_NORMAL, &m_Item, 3);
 
     CHECK_EQ_INT(m_SeenEffect, (int32_t)ITEM_ACTION_LARA_NORMAL);
@@ -89,7 +89,7 @@ TEST(an_unclaimed_number_runs_its_stock_routine)
     // Claim a different number, so this one falls through to the routine.
     M_Reset((int32_t)ITEM_ACTION_TURN_180);
 
-    ItemAction_RunDirect((ITEM_ACTION_SLOT)ITEM_ACTION_LARA_NORMAL, &m_Item);
+    ItemAction_RunBySlot((ITEM_ACTION_SLOT)ITEM_ACTION_LARA_NORMAL, &m_Item);
 
     CHECK_EQ_INT(m_SeenEffect, -1);
     CHECK(m_RoutineRan);

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -170,6 +170,7 @@ static CATALOG_ID M_Add(const CATALOG_CONTEXT context, const char *const key)
         Memory_Realloc(m_GameIDs[context], sizeof(int32_t) * m_Counts[context]);
     m_Keys[context][id] = key != nullptr ? Memory_DupStr(key) : nullptr;
     m_GameIDs[context][id] = -1;
+    CatalogTable_Reserve(context, m_Counts[context]);
     return id;
 }
 

--- a/src/trx/game/catalog/table.c
+++ b/src/trx/game/catalog/table.c
@@ -2,44 +2,83 @@
 
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
+#include <trx/debug.h>
 
 #include <string.h>
 
 static CATALOG_TABLE *m_Tables = nullptr;
 
-static void *M_At(CATALOG_TABLE *const table, const CATALOG_ID id)
+static void M_Grow(CATALOG_TABLE *const table, const int32_t count)
+{
+    const int32_t chunk_count =
+        (count + CATALOG_TABLE_CHUNK - 1) / CATALOG_TABLE_CHUNK;
+    if (chunk_count <= table->chunk_count) {
+        return;
+    }
+    table->chunks = Memory_Realloc(table->chunks, sizeof(void *) * chunk_count);
+    for (int32_t i = table->chunk_count; i < chunk_count; i++) {
+        table->chunks[i] = Memory_Alloc(table->elem_size * CATALOG_TABLE_CHUNK);
+    }
+    table->chunk_count = chunk_count;
+}
+
+static void *M_Peek(const CATALOG_TABLE *const table, const CATALOG_ID id)
 {
     const int32_t chunk_idx = id / CATALOG_TABLE_CHUNK;
     if (chunk_idx >= table->chunk_count) {
-        if (!table->linked) {
-            table->linked = true;
-            table->next = m_Tables;
-            m_Tables = table;
-        }
-        table->chunks =
-            Memory_Realloc(table->chunks, sizeof(void *) * (chunk_idx + 1));
-        for (int32_t i = table->chunk_count; i <= chunk_idx; i++) {
-            table->chunks[i] =
-                Memory_Alloc(table->elem_size * CATALOG_TABLE_CHUNK);
-        }
-        table->chunk_count = chunk_idx + 1;
+        return nullptr;
     }
     return (char *)table->chunks[chunk_idx]
         + (size_t)(id % CATALOG_TABLE_CHUNK) * table->elem_size;
 }
 
+static void *M_Claim(CATALOG_TABLE *const table, const CATALOG_ID id)
+{
+    ASSERT(id >= 0);
+    M_Grow(table, id + 1);
+    return M_Peek(table, id);
+}
+
+void CatalogTable_Link(CATALOG_TABLE *const table)
+{
+    table->next = m_Tables;
+    m_Tables = table;
+    M_Grow(table, Catalog_GetCount(table->context));
+}
+
+void CatalogTable_Reserve(const CATALOG_CONTEXT context, const int32_t count)
+{
+    for (CATALOG_TABLE *table = m_Tables; table != nullptr;
+         table = table->next) {
+        if (table->context == context) {
+            M_Grow(table, count);
+        }
+    }
+}
+
 void *CatalogTable_Get(CATALOG_TABLE *const table, const CATALOG_ID id)
 {
-    if (id < 0) {
+    ASSERT(Catalog_IsValidID(table->context, id));
+    return M_Claim(table, id);
+}
+
+void *CatalogTable_TryGet(CATALOG_TABLE *const table, const CATALOG_ID id)
+{
+    if (!Catalog_IsValidID(table->context, id)) {
         return nullptr;
     }
-    // Allocate a built-in identity record before catalogue initialisation when
-    // a constructor registers its routine.
-    const int32_t count = Catalog_GetCount(table->context);
-    if (count > 0 && id >= count) {
-        return nullptr;
-    }
-    return M_At(table, id);
+    return M_Peek(table, id);
+}
+
+void *CatalogTable_Claim(CATALOG_TABLE *const table, const CATALOG_ID id)
+{
+    return M_Claim(table, id);
+}
+
+void CatalogTable_Add(
+    CATALOG_TABLE *const table, const CATALOG_ID id, const void *const record)
+{
+    memcpy(M_Claim(table, id), record, table->elem_size);
 }
 
 void CatalogTable_FreeAll(void)

--- a/src/trx/game/catalog/table.h
+++ b/src/trx/game/catalog/table.h
@@ -12,21 +12,43 @@ typedef struct CATALOG_TABLE {
     size_t elem_size;
     void **chunks;
     int32_t chunk_count;
-    // Mark the table as non-empty so the catalogue drops records keyed by
-    // minted identities when the session ends.
-    bool linked;
     struct CATALOG_TABLE *next;
 } CATALOG_TABLE;
 
 #define CATALOG_TABLE_DEFINE(name, ctx, type)                                  \
+    static CATALOG_TABLE name;                                                 \
+    __attribute__((constructor)) static void M_LinkTable_##name(void)          \
+    {                                                                          \
+        CatalogTable_Link(&name);                                              \
+    }                                                                          \
     static CATALOG_TABLE name = {                                              \
         .context = (ctx),                                                      \
         .elem_size = sizeof(type),                                             \
     }
 
-// Return the zero-initialised record for an ID, or return null after catalogue
-// initialisation if the identity does not exist.
+// Link a table to the catalogue table set and allocate records for the
+// identities the context already holds. Table definitions call this before
+// main, so constructor order does not matter.
+void CatalogTable_Link(CATALOG_TABLE *table);
+
+// Allocate records in every table of a context for the first count identities.
+void CatalogTable_Reserve(CATALOG_CONTEXT context, int32_t count);
+
+// Return the zero-initialised record for an ID the context holds. Fails on any
+// other ID.
 void *CatalogTable_Get(CATALOG_TABLE *table, CATALOG_ID id);
+
+// Return the record for an ID, or null where the context holds no such ID.
+// Leaves the table size unchanged.
+void *CatalogTable_TryGet(CATALOG_TABLE *table, CATALOG_ID id);
+
+// Return the record for an ID, allocating it where the table has no record.
+// Use before catalogue setup when a constructor writes part of a record.
+void *CatalogTable_Claim(CATALOG_TABLE *table, CATALOG_ID id);
+
+// Store a record against an ID, allocating it where the table has no record.
+// Use before catalogue setup when a constructor registers a routine.
+void CatalogTable_Add(CATALOG_TABLE *table, CATALOG_ID id, const void *record);
 
 // Drop minted identity records from every table while retaining built-in
 // records initialised by constructors before main.

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -366,7 +366,7 @@ bool Cutscene_Start(const int32_t level_num)
     Camera_GetCineData()->frame_idx = 0;
 
     if (level->music_track != MX_INACTIVE) {
-        Music_Play_Direct(level->music_track, MPM_ONCE);
+        Music_PlayBySlot(level->music_track, MPM_ONCE);
     }
 
     return true;

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -316,7 +316,7 @@ static bool M_Begin(const int32_t num)
     Lara_Hair_Initialise();
 
     if (info->audio_track != -1) {
-        Music_Play_Direct((MUSIC_SLOT)info->audio_track, MPM_ONCE);
+        Music_PlayBySlot((MUSIC_SLOT)info->audio_track, MPM_ONCE);
     }
 
     Output_Overlay_SetFade(0.0f);
@@ -344,7 +344,7 @@ static void M_Finish(void)
     const int32_t num = m_State.num;
     const CUTSEQ_INFO *const info = &m_State.info;
     if (info->audio_track != -1) {
-        Music_StopTrack_Direct((MUSIC_SLOT)info->audio_track);
+        Music_StopTrackBySlot((MUSIC_SLOT)info->audio_track);
     }
 
     M_ReleaseNodes();
@@ -668,7 +668,7 @@ void CutSeq_Reset(void)
 {
     const int32_t num = m_State.num;
     if (num != M_NO_CUTSCENE && m_State.info.audio_track != -1) {
-        Music_StopTrack_Direct((MUSIC_SLOT)m_State.info.audio_track);
+        Music_StopTrackBySlot((MUSIC_SLOT)m_State.info.audio_track);
     }
 
     M_ReleaseNodes();

--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -184,7 +184,7 @@ bool Demo_Start(const int32_t level_num)
     }
 
     if (p->level->music_track != MX_INACTIVE) {
-        Music_Play_Direct(p->level->music_track, MPM_LOOP);
+        Music_PlayBySlot(p->level->music_track, MPM_LOOP);
     }
 
     p->demo_ptr = p->data;

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -54,8 +54,7 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
     const bool is_cutscene = level->type == GFL_CUTSCENE;
     if (level->music_track != MX_INACTIVE
         && (is_cutscene || Music_GetCurrentLoopedTrack() == MX_INACTIVE)) {
-        Music_Play_Direct(
-            level->music_track, is_cutscene ? MPM_ONCE : MPM_LOOP);
+        Music_PlayBySlot(level->music_track, is_cutscene ? MPM_ONCE : MPM_LOOP);
     }
 
     // Which level this is, and what kind, is trx.game.current_level's to

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -261,7 +261,7 @@ M_GF_HANDLER(M_HandlePlayMusic)
     if (seq_ctx != GFSC_STORY) {
         const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
         Music_SetVolume(g_Config.audio.music_volume);
-        Music_Play_Direct((int32_t)(intptr_t)event->data, MPM_ONCE);
+        Music_PlayBySlot((int32_t)(intptr_t)event->data, MPM_ONCE);
     }
     *out_cmd = (GF_COMMAND) { .action = GF_NOOP };
     return OK;

--- a/src/trx/game/items/actions.h
+++ b/src/trx/game/items/actions.h
@@ -8,8 +8,8 @@
 void ItemAction_Register(
     ITEM_ACTION_ID action, void (*action_func)(ITEM *item));
 void ItemAction_Run(ITEM_ACTION_ID action_id, ITEM *item);
-void ItemAction_RunDirect(ITEM_ACTION_SLOT action_id, ITEM *item);
-void ItemAction_RunDirectWithFX(
+void ItemAction_RunBySlot(ITEM_ACTION_SLOT action_id, ITEM *item);
+void ItemAction_RunWithFXBySlot(
     ITEM_ACTION_SLOT action_id, ITEM *item, int16_t fx_type);
 void ItemAction_RunActive(void);
 int16_t ItemAction_GetFXType(void);

--- a/src/trx/game/items/actions/common.c
+++ b/src/trx/game/items/actions/common.c
@@ -36,13 +36,13 @@ int16_t ItemAction_GetFXType(void)
 void ItemAction_Register(
     const ITEM_ACTION_ID action, void (*const action_func)(ITEM *item))
 {
-    *(M_ACTION_ROUTINE *)CatalogTable_Get(&m_Routines, action) = action_func;
+    CatalogTable_Add(&m_Routines, action, &action_func);
 }
 
 void ItemAction_Run(const ITEM_ACTION_ID action_id, ITEM *const item)
 {
     const M_ACTION_ROUTINE *const routine =
-        CatalogTable_Get(&m_Routines, action_id);
+        CatalogTable_TryGet(&m_Routines, action_id);
     if (routine != nullptr && *routine != nullptr) {
         (*routine)(item);
     }

--- a/src/trx/game/items/actions/common.c
+++ b/src/trx/game/items/actions/common.c
@@ -21,7 +21,7 @@ static void M_RunWithFX(
 // An animation command carries no trigger field, so the timer is 0. The stored
 // floor effect reaches here through RunActive with a null item, but a claimed
 // number is never stored, so that path never intercepts.
-static bool M_InterceptDirect(
+static bool M_InterceptBySlot(
     const ITEM_ACTION_SLOT action_id, ITEM *const item)
 {
     const int16_t item_num = item != nullptr ? Item_GetIndex(item) : NO_ITEM;
@@ -60,19 +60,19 @@ bool ItemAction_Intercept(
         && m_Interceptor(effect_num, timer, item_num);
 }
 
-void ItemAction_RunDirect(const ITEM_ACTION_SLOT action_id, ITEM *const item)
+void ItemAction_RunBySlot(const ITEM_ACTION_SLOT action_id, ITEM *const item)
 {
-    if (M_InterceptDirect(action_id, item)) {
+    if (M_InterceptBySlot(action_id, item)) {
         return;
     }
     const ITEM_ACTION_ID trx_id = ItemAction_SlotToID(action_id);
     ItemAction_Run(trx_id, item);
 }
 
-void ItemAction_RunDirectWithFX(
+void ItemAction_RunWithFXBySlot(
     const ITEM_ACTION_SLOT action_id, ITEM *const item, const int16_t fx_type)
 {
-    if (M_InterceptDirect(action_id, item)) {
+    if (M_InterceptBySlot(action_id, item)) {
         return;
     }
     const ITEM_ACTION_ID trx_id = ItemAction_SlotToID(action_id);
@@ -83,6 +83,6 @@ void ItemAction_RunActive(void)
 {
     const int32_t flip_effect = Room_GetFlipEffect();
     if (flip_effect != -1) {
-        ItemAction_RunDirect(flip_effect, nullptr);
+        ItemAction_RunBySlot(flip_effect, nullptr);
     }
 }

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -285,7 +285,7 @@ void Item_Animate(ITEM *const item)
             const ANIM_COMMAND_EFFECT_DATA *const data =
                 (ANIM_COMMAND_EFFECT_DATA *)command->data;
             if (item->frame_num == data->frame_num) {
-                ItemAction_RunDirectWithFX(
+                ItemAction_RunWithFXBySlot(
                     data->effect_num, item, data->fx_type);
             }
             break;

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -105,17 +105,14 @@ void Lara_Col_Register(
     const LARA_STATE_ID state,
     void (*const handle_func)(ITEM *item, COLL_INFO *coll))
 {
-    M_COLLISION_ROUTINE *const routine =
-        CatalogTable_Get(&m_CollisionRoutines, state);
-    ASSERT(routine != nullptr);
-    *routine = handle_func;
+    CatalogTable_Add(&m_CollisionRoutines, state, &handle_func);
 }
 
 void Lara_Col_Update(ITEM *const item, COLL_INFO *const coll)
 {
     const LARA_STATE_ID state = LS_U(item->current_anim_state);
     const M_COLLISION_ROUTINE *const routine =
-        CatalogTable_Get(&m_CollisionRoutines, state);
+        CatalogTable_TryGet(&m_CollisionRoutines, state);
     if (routine != nullptr && *routine != nullptr) {
         (*routine)(item, coll);
     }

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -515,7 +515,7 @@ void Lara_Animate(ITEM *const item)
             }
 
             if (g_TRVersion >= 3) {
-                ItemAction_RunDirectWithFX(
+                ItemAction_RunWithFXBySlot(
                     data->effect_num, item, data->fx_type);
                 break;
             }
@@ -528,7 +528,7 @@ void Lara_Animate(ITEM *const item)
                 break;
             }
 
-            ItemAction_RunDirect(data->effect_num, item);
+            ItemAction_RunBySlot(data->effect_num, item);
             break;
         }
 

--- a/src/trx/game/lara/state.c
+++ b/src/trx/game/lara/state.c
@@ -44,7 +44,7 @@ void Lara_State_Register(
     const LARA_STATE_ID state,
     void (*const handle_func)(ITEM *item, COLL_INFO *coll))
 {
-    *(M_STATE_ROUTINE *)CatalogTable_Get(&m_StateRoutines, state) = handle_func;
+    CatalogTable_Add(&m_StateRoutines, state, &handle_func);
 }
 
 void Lara_State_RegisterExtra(
@@ -59,15 +59,15 @@ void Lara_State_Initialise(void)
 {
     for (int32_t i = 0; m_TestResponsiveAnims[i] != NO_CATALOG_ID; i++) {
         const LARA_ANIMATION_ID anim = m_TestResponsiveAnims[i];
-        *(bool *)CatalogTable_Get(&m_ResponsiveAnims, anim) =
-            M_HasResponsiveState(anim);
+        const bool responsive = M_HasResponsiveState(anim);
+        CatalogTable_Add(&m_ResponsiveAnims, anim, &responsive);
     }
 }
 
 bool Lara_State_IsResponsive(const LARA_ANIMATION_ID anim_idx)
 {
     const bool *const responsive =
-        CatalogTable_Get(&m_ResponsiveAnims, anim_idx);
+        CatalogTable_TryGet(&m_ResponsiveAnims, anim_idx);
     return responsive != nullptr && *responsive;
 }
 
@@ -83,7 +83,7 @@ void Lara_State_Update(ITEM *const item, COLL_INFO *const coll)
 
     const LARA_STATE_ID state = LS_U(item->current_anim_state);
     const M_STATE_ROUTINE *const routine =
-        CatalogTable_Get(&m_StateRoutines, state);
+        CatalogTable_TryGet(&m_StateRoutines, state);
     if (routine != nullptr && *routine != nullptr) {
         (*routine)(item, coll);
     }

--- a/src/trx/game/lua/capi/music.c
+++ b/src/trx/game/lua/capi/music.c
@@ -169,7 +169,7 @@ TYPE_DEFINE(MUSIC_TRACK_VIEW, m_TrackFields)
 static void *M_ResolveTrack(const LUA_STRUCT_REF *const ref)
 {
     const int32_t id = ref->handle.id;
-    if (id < 0 || !Music_IsTrackAvailable_Direct((MUSIC_SLOT)id)) {
+    if (id < 0 || !Music_IsTrackAvailableBySlot((MUSIC_SLOT)id)) {
         return nullptr;
     }
     m_TrackView.id = id;
@@ -191,7 +191,7 @@ static int M_L_MusicTrackPlay(lua_State *const L)
         }
         lua_pop(L, 1);
     }
-    M_PushPlayedStream(L, Music_Play_Direct((MUSIC_SLOT)ref->handle.id, mode));
+    M_PushPlayedStream(L, Music_PlayBySlot((MUSIC_SLOT)ref->handle.id, mode));
     return 1;
 }
 
@@ -221,7 +221,7 @@ static const luaL_Reg m_TrackMethods[] = {
 static int M_L_MusicTrackGet(lua_State *const L)
 {
     const int32_t id = (int32_t)luaL_checkinteger(L, 1);
-    if (id < 0 || !Music_IsTrackAvailable_Direct((MUSIC_SLOT)id)) {
+    if (id < 0 || !Music_IsTrackAvailableBySlot((MUSIC_SLOT)id)) {
         lua_pushnil(L);
         return 1;
     }
@@ -243,7 +243,7 @@ static int M_L_MusicTrackAvailableCount(lua_State *const L)
     int32_t count = 0;
     const int32_t limit = Music_GetTrackLimit();
     for (int32_t id = 0; id < limit; id++) {
-        if (Music_IsTrackAvailable_Direct((MUSIC_SLOT)id)) {
+        if (Music_IsTrackAvailableBySlot((MUSIC_SLOT)id)) {
             count++;
         }
     }

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -181,7 +181,7 @@ static void M_StreamFinished(const int32_t stream_id, void *const user_data)
         m_TrackCurrent = MX_INACTIVE;
         M_StreamReset(stream);
         if (m_TrackLooped >= 0) {
-            Music_Play_Direct(m_TrackLooped, MPM_LOOP);
+            Music_PlayBySlot(m_TrackLooped, MPM_LOOP);
         }
     } else {
         M_StreamReset(stream);
@@ -506,12 +506,12 @@ finish:
     return Audio_Init();
 }
 
-int32_t Music_Play_Direct(const MUSIC_SLOT track_id, const MUSIC_PLAY_MODE mode)
+int32_t Music_PlayBySlot(const MUSIC_SLOT track_id, const MUSIC_PLAY_MODE mode)
 {
     return M_Play(track_id, mode, -1.0);
 }
 
-int32_t Music_Play_DirectAt(
+int32_t Music_PlayAtBySlot(
     const MUSIC_SLOT track_id, const MUSIC_PLAY_MODE mode,
     const double timestamp)
 {
@@ -520,10 +520,10 @@ int32_t Music_Play_DirectAt(
 
 int32_t Music_Play(const MUSIC_ID track, const MUSIC_PLAY_MODE mode)
 {
-    return Music_Play_Direct(Music_IDToSlot(track), mode);
+    return Music_PlayBySlot(Music_IDToSlot(track), mode);
 }
 
-bool Music_IsTrackAvailable_Direct(const MUSIC_SLOT track)
+bool Music_IsTrackAvailableBySlot(const MUSIC_SLOT track)
 {
     if (!m_Initialised || m_Backend == nullptr
         || m_Backend->is_track_available == nullptr) {
@@ -586,7 +586,7 @@ void Music_Stop(void)
     M_ResetStreamState();
 }
 
-void Music_StopTrack_Direct(const MUSIC_SLOT track)
+void Music_StopTrackBySlot(const MUSIC_SLOT track)
 {
     if (track != m_TrackCurrent || M_IsBrokenTrack(track)) {
         return;
@@ -595,7 +595,7 @@ void Music_StopTrack_Direct(const MUSIC_SLOT track)
     M_StopMainStream();
     m_TrackCurrent = MX_INACTIVE;
     if (m_TrackLooped >= 0) {
-        Music_Play_Direct(m_TrackLooped, MPM_LOOP);
+        Music_PlayBySlot(m_TrackLooped, MPM_LOOP);
     }
 }
 
@@ -733,7 +733,7 @@ void Music_StopStream(const int32_t slot)
         M_StopMainStream();
         m_TrackCurrent = MX_INACTIVE;
         if (had_current && looped >= 0) {
-            Music_Play_Direct(looped, MPM_LOOP);
+            Music_PlayBySlot(looped, MPM_LOOP);
         } else {
             m_TrackLooped = MX_INACTIVE;
         }
@@ -844,7 +844,7 @@ void Music_Trigger(MUSIC_SLOT track_id, const MUSIC_TRIGGER *const trigger)
     }
 
     if (M_IsAmbientTrack(track_id)) {
-        Music_Play_Direct(track_id, MPM_LOOP);
+        Music_PlayBySlot(track_id, MPM_LOOP);
         return;
     }
 
@@ -873,9 +873,9 @@ void Music_Trigger(MUSIC_SLOT track_id, const MUSIC_TRIGGER *const trigger)
             if (trigger->one_shot) {
                 track->is_one_shot = true;
             }
-            Music_Play_Direct(track_id, play_mode);
+            Music_PlayBySlot(track_id, play_mode);
         } else {
-            Music_StopTrack_Direct(track_id);
+            Music_StopTrackBySlot(track_id);
         }
         return;
     }
@@ -890,12 +890,12 @@ void Music_Trigger(MUSIC_SLOT track_id, const MUSIC_TRIGGER *const trigger)
         }
 
         if (trigger->timer == 0) {
-            Music_Play_Direct(track_id, play_mode);
+            Music_PlayBySlot(track_id, play_mode);
             return;
         }
 
         if (track_id != Music_GetDelayedTrack()) {
-            Music_Play_Direct(track_id, MPM_DELAY);
+            Music_PlayBySlot(track_id, MPM_DELAY);
             track->delay = LOGIC_FPS * trigger->timer;
             return;
         }
@@ -906,7 +906,7 @@ void Music_Trigger(MUSIC_SLOT track_id, const MUSIC_TRIGGER *const trigger)
 
         track->delay--;
         if (track->delay == 0) {
-            Music_Play_Direct(track_id, play_mode);
+            Music_PlayBySlot(track_id, play_mode);
         }
 
         return;
@@ -936,7 +936,7 @@ void Music_Trigger(MUSIC_SLOT track_id, const MUSIC_TRIGGER *const trigger)
             track->is_one_shot |= trigger->one_shot;
         }
 
-        Music_Play_Direct(track_id, play_mode);
+        Music_PlayBySlot(track_id, play_mode);
     }
 }
 

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -490,6 +490,17 @@ RESULT Music_Init(void)
     LOG_INFO("Chosen music backend: %s", m_Backend->describe(m_Backend));
     Music_SetVolume(g_Config.audio.music_volume);
 
+    // Give every track the backend carries an identity, so that a save or an
+    // injection naming one finds it whether or not the catalog names it.
+    const int32_t track_limit = Music_GetTrackLimit();
+    for (MUSIC_SLOT slot = 0; slot < track_limit; slot++) {
+        if (!Music_IsTrackAvailableBySlot(slot)) {
+            continue;
+        }
+        CATALOG_ID id = NO_CATALOG_ID;
+        SHOULD(Catalog_CreateSlot(CATALOG_MUSIC, slot, &id));
+    }
+
 finish:
     m_TrackCurrent = MX_INACTIVE;
     m_TrackLastPlayed = MX_INACTIVE;

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -36,25 +36,25 @@ RESULT Music_Init(void);
 // Returns the stream slot the track plays in - the main stream is slot 0, the
 // overlays slots 1.. - or -1 when it does not play, which includes a track
 // marked for later (delay) or a deferred ambient.
-int32_t Music_Play_Direct(MUSIC_SLOT track, MUSIC_PLAY_MODE mode);
+int32_t Music_PlayBySlot(MUSIC_SLOT track, MUSIC_PLAY_MODE mode);
 
-// Plays a track from the given timestamp in seconds, as Music_Play_Direct does
+// Plays a track from the given timestamp in seconds, as Music_PlayBySlot does
 // otherwise. The track is seeked before it becomes audible, so its beginning is
 // never heard. A negative timestamp plays the track from where it would
 // normally start.
-int32_t Music_Play_DirectAt(
+int32_t Music_PlayAtBySlot(
     MUSIC_SLOT track, MUSIC_PLAY_MODE mode, double timestamp);
 
 // Stops the provided single track and restarts the looped track if applicable.
-void Music_StopTrack_Direct(MUSIC_SLOT track);
+void Music_StopTrackBySlot(MUSIC_SLOT track);
 
 // Play a music track with a semantical ID that will get mapped to a specific
 // music track slot depending on the game. Returns the stream slot, as
-// Music_Play_Direct does, or -1.
+// Music_PlayBySlot does, or -1.
 int32_t Music_Play(MUSIC_ID track, MUSIC_PLAY_MODE mode);
 
 // Returns true when the active backend can play the given direct track ID.
-bool Music_IsTrackAvailable_Direct(MUSIC_SLOT track);
+bool Music_IsTrackAvailableBySlot(MUSIC_SLOT track);
 
 // Returns one past the largest direct track ID worth probing on the active
 // backend, or 0 if no backend is available.
@@ -109,7 +109,7 @@ int32_t Music_GetStreamSlotCount(void);
 bool Music_GetStreamSlotState(int32_t slot, MUSIC_STREAM_STATE *state);
 
 // Stops the stream in a slot. The main slot resumes the deferred ambient loop,
-// as Music_StopTrack_Direct does; an overlay slot just closes.
+// as Music_StopTrackBySlot does; an overlay slot just closes.
 void Music_StopStream(int32_t slot);
 
 // Pauses or resumes the stream in a slot.

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -78,9 +78,16 @@ int32_t Object_GetStaticObjects2DCount(void)
     return m_StaticObjects2DCount;
 }
 
+void Object_Register(
+    const OBJECT_ID object_id, void (*const setup_func)(OBJECT *obj))
+{
+    OBJECT *const obj = CatalogTable_Claim(&m_Objects, object_id);
+    obj->setup_func = setup_func;
+}
+
 OBJECT *Object_TryGet(const OBJECT_ID object_id)
 {
-    return CatalogTable_Get(&m_Objects, object_id);
+    return CatalogTable_TryGet(&m_Objects, object_id);
 }
 
 OBJECT *Object_Get(const OBJECT_ID object_id)

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -106,8 +106,11 @@ void Object_SetSemiTransparent(OBJECT_ID obj_id, bool enabled);
 
 bool Object_CanInterpolate(const ITEM *item, int32_t frame_a, int32_t frame_b);
 
+// Bind the setup routine of an object before catalogue setup.
+void Object_Register(OBJECT_ID object_id, void (*setup_func)(OBJECT *obj));
+
 #define REGISTER_OBJECT(object_id, setup_func_)                                \
     __attribute__((constructor)) static void M_RegisterObject##object_id(void) \
     {                                                                          \
-        Object_Get(object_id)->setup_func = setup_func_;                       \
+        Object_Register(object_id, setup_func_);                               \
     }

--- a/src/trx/game/objects/creatures/von_croy.c
+++ b/src/trx/game/objects/creatures/von_croy.c
@@ -419,7 +419,7 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
         if (lara->current_anim_state == LS(LS_HANG)
             || lara->current_anim_state == LS(LS_SHIMMY_LEFT)
             || lara->current_anim_state == LS(LS_SHIMMY_RIGHT)) {
-            Music_Play_Direct((MUSIC_SLOT)(M_GetTrack(p->waypoint)), MPM_ONCE);
+            Music_PlayBySlot((MUSIC_SLOT)(M_GetTrack(p->waypoint)), MPM_ONCE);
             M_SetCutPlayed(p, p->waypoint);
             p->hold = 2;
         }
@@ -495,7 +495,7 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
             Fader_InitTo(&m_Fader, 1.0f, 0.0f, 16.0f / (float)LOGIC_FPS);
             p->cut_phase++;
             const MUSIC_SLOT track = (MUSIC_SLOT)M_GetTrack(p->waypoint);
-            Music_Play_Direct(track, MPM_ONCE);
+            Music_PlayBySlot(track, MPM_ONCE);
             const double length = Music_GetTrackDuration(track);
             p->cut_length = length > 0.0 ? (int32_t)(length * LOGIC_FPS) : 0;
             p->cut_timer = 0;
@@ -541,7 +541,7 @@ static void M_DoCutscene(ITEM *const item, CREATURE *const info)
         M_ClearCutCamera();
         const MUSIC_SLOT ambient = Music_GetCurrentLoopedTrack();
         Music_Stop();
-        Music_Play_Direct(ambient, MPM_LOOP);
+        Music_PlayBySlot(ambient, MPM_LOOP);
         Lara_SetControllable(true);
         p->swap_bits &= ~M_SWAP_BOOK;
         p->cut_phase = 0;

--- a/src/trx/game/objects/vehicles/common.c
+++ b/src/trx/game/objects/vehicles/common.c
@@ -175,7 +175,7 @@ void Vehicle_PlayTrackPool(
     if (track_count <= 0) {
         return;
     }
-    Music_Play_Direct(tracks[Random_GetControl() % track_count], mode);
+    Music_PlayBySlot(tracks[Random_GetControl() % track_count], mode);
 }
 
 void Vehicle_PlayOneShotTrackPool(
@@ -195,7 +195,7 @@ void Vehicle_PlayOneShotTrackPool(
     }
 
     const MUSIC_SLOT track = tracks[Random_GetControl() % track_count];
-    Music_Play_Direct(track, MPM_ONCE);
+    Music_PlayBySlot(track, MPM_ONCE);
     Music_GetTrackState(track)->is_one_shot = true;
 }
 

--- a/src/trx/game/phase/phase_inventory.c
+++ b/src/trx/game/phase/phase_inventory.c
@@ -24,7 +24,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
         Music_Stop();
         const GF_LEVEL *const level = GF_GetTitleLevel();
         if (g_Config.audio.enable_music_in_menu && level->music_track >= 0) {
-            Music_Play_Direct(level->music_track, MPM_LOOP);
+            Music_PlayBySlot(level->music_track, MPM_LOOP);
         }
     }
 

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -10,6 +10,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 #include <trx/game/savegame/file.h>
+#include <trx/game/savegame/identity.h>
 #include <trx/version.h>
 
 static SAVEGAME_VERSION m_InitialVersion = SG_VERSION_LEGACY;
@@ -123,6 +124,7 @@ RESULT Savegame_Load(const SAVEGAME_SLOT_REF slot)
     ASSERT(savegame_info->full_path != nullptr);
 
     M_LoadPreprocess();
+    SaveGame_ResetDropped();
 
     TRX_FILE *fp = nullptr;
     RESULT result =
@@ -133,6 +135,12 @@ RESULT Savegame_Load(const SAVEGAME_SLOT_REF slot)
     }
 
     M_LoadPostprocess();
+    const int32_t dropped = SaveGame_GetDroppedCount();
+    if (dropped > 0) {
+        LOG_WARNING(
+            "%d records in this save name something the game no longer holds",
+            dropped);
+    }
     m_InitialVersion = savegame_info->initial_version;
     return result;
 }

--- a/src/trx/game/savegame/enum.h
+++ b/src/trx/game/savegame/enum.h
@@ -65,6 +65,9 @@ typedef enum {
     // Animations are persisted as an object and an index relative to it.
     SG_VERSION_19 = 19,
 
+    // Persists identities and music track flags by key.
+    SG_VERSION_20 = 20,
+
     SG_MIN_SUPPORTED_VERSION = SG_VERSION_13,
-    SG_CURRENT_VERSION = SG_VERSION_19,
+    SG_CURRENT_VERSION = SG_VERSION_20,
 } SAVEGAME_VERSION;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -28,6 +28,7 @@
 #include <trx/game/rules.h>
 #include <trx/game/savegame.h>
 #include <trx/game/savegame/file.h>
+#include <trx/game/savegame/identity.h>
 #include <trx/game/stats.h>
 #include <trx/game/waypoint.h>
 #include <trx/version.h>
@@ -37,12 +38,9 @@
 static RESULT M_ReadObjectID(
     JSON_READ_IO *const io, const char *const key, OBJECT_ID *const target)
 {
-    int32_t game_id = 0;
-    MUST(JSON_READ(io, key, &game_id));
-    *target = Object_SlotToID(game_id);
-    if (*target == NO_OBJECT) {
-        return JSON_ReadIO_Fail(io, "unsupported object #%d", game_id);
-    }
+    CATALOG_ID id = NO_OBJECT;
+    MUST(SaveGame_ReadIdentity(io, key, "object_key", CATALOG_OBJECTS, &id));
+    *target = id;
     return OK;
 }
 
@@ -496,7 +494,10 @@ static RESULT M_ReadItem(JSON_READ_IO *const io, const int16_t read_index)
     ITEM *const item = Item_Get(item_num);
 
     OBJECT_ID object_id = NO_OBJECT;
-    MUST(M_ReadObjectID(io, "object_id", &object_id));
+    if (!SHOULD(M_ReadObjectID(io, "object_id", &object_id))) {
+        SaveGame_NoteDropped("an item");
+        return OK;
+    }
 
     const OBJECT *const obj = Object_Get(object_id);
     item->object_id = object_id;
@@ -879,6 +880,36 @@ static RESULT M_ReadMusicTracks(JSON_READ_IO *const io)
     return OK;
 }
 
+static void M_ApplyMusicTrackFlags(const MUSIC_SLOT slot, const uint32_t flags)
+{
+    MUSIC_TRACK_STATE *const track = Music_GetTrackState(slot);
+    track->mask = (flags & MTF_CODE_BITS) >> TRIGGER_MASK_SHIFT;
+    track->is_one_shot = (flags & MTF_ONE_SHOT) != 0;
+    track->delay = flags & 0xFF;
+}
+
+static RESULT M_ReadMusicTrackFlagsByTrack(JSON_READ_IO *const io)
+{
+    if (!g_Config.audio.load_music_triggers) {
+        return OK;
+    }
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        MUST(JSON_PUSH_INDEX(io, i));
+        CATALOG_ID id = NO_CATALOG_ID;
+        MUST(SaveGame_ReadIdentity(io, "slot", "key", CATALOG_MUSIC, &id));
+        const MUSIC_SLOT slot = Catalog_IDToSlot(CATALOG_MUSIC, id, -1);
+        uint32_t flags = 0;
+        MUST(JSON_READ(io, "flags", &flags));
+        if (slot >= 0 && slot < MAX_MUSIC_TRACKS) {
+            M_ApplyMusicTrackFlags(slot, flags);
+        }
+        MUST(JSON_POP(io));
+    }
+    return OK;
+}
+
 static RESULT M_ReadMusicTrackFlags(JSON_READ_IO *const io)
 {
     if (!g_Config.audio.load_music_triggers) {
@@ -895,10 +926,7 @@ static RESULT M_ReadMusicTrackFlags(JSON_READ_IO *const io)
     for (int32_t i = 0; i < count; i++) {
         uint32_t flags;
         MUST(JSON_READ_A(io, i, &flags));
-        MUSIC_TRACK_STATE *const track = Music_GetTrackState(i);
-        track->mask = (flags & MTF_CODE_BITS) >> TRIGGER_MASK_SHIFT;
-        track->is_one_shot = (flags & MTF_ONE_SHOT) != 0;
-        track->delay = flags & 0xFF;
+        M_ApplyMusicTrackFlags(i, flags);
     }
 
     return OK;
@@ -1179,9 +1207,17 @@ RESULT SG_File_LoadMusic(JSON_READ_IO *const io)
     MUST(JSON_PUSH(io, "current"));
     MUST(M_ReadMusicTracks(io));
     MUST(JSON_POP(io));
-    MUST(JSON_PUSH(io, "flags"));
-    MUST(M_ReadMusicTrackFlags(io));
-    MUST(JSON_POP(io));
+    // Prefer named music flags when present. Positional flags remain for saves
+    // that do not carry names.
+    if (JSON_ReadIO_HasKey(io, "track_flags")) {
+        MUST(JSON_PUSH(io, "track_flags"));
+        MUST(M_ReadMusicTrackFlagsByTrack(io));
+        MUST(JSON_POP(io));
+    } else {
+        MUST(JSON_PUSH(io, "flags"));
+        MUST(M_ReadMusicTrackFlags(io));
+        MUST(JSON_POP(io));
+    }
     MUST(JSON_POP(io));
     return OK;
 }

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -825,7 +825,7 @@ static RESULT M_ReadMusicTracks(JSON_READ_IO *const io)
     if (ambient_track != MX_INACTIVE) {
         // Always restart the ambient as it may have changed based on the
         // current position in the level.
-        Music_Play_Direct(ambient_track, MPM_LOOP);
+        Music_PlayBySlot(ambient_track, MPM_LOOP);
     }
 
     if (g_Config.audio.music_load_condition == MUSIC_LOAD_CONDITION_NEVER) {
@@ -851,7 +851,7 @@ static RESULT M_ReadMusicTracks(JSON_READ_IO *const io)
             }
             const double seek_to = M_GetMusicSeekTimestamp(
                 track_id, mode, ambient_track, timestamp);
-            if (Music_Play_DirectAt(track_id, mode, seek_to) < 0) {
+            if (Music_PlayAtBySlot(track_id, mode, seek_to) < 0) {
                 LOG_WARNING(
                     "Could not load stream track %d at timestamp %lf.",
                     track_id, timestamp);
@@ -869,7 +869,7 @@ static RESULT M_ReadMusicTracks(JSON_READ_IO *const io)
         const double seek_to = M_GetMusicSeekTimestamp(
             current_track, mode, ambient_track, timestamp);
         if (current_track != MX_INACTIVE
-            && Music_Play_DirectAt(current_track, mode, seek_to) < 0) {
+            && Music_PlayAtBySlot(current_track, mode, seek_to) < 0) {
             LOG_WARNING(
                 "Could not load current track %d at timestamp %lf.",
                 current_track, timestamp);

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -24,6 +24,7 @@
 #include <trx/game/rules.h>
 #include <trx/game/savegame.h>
 #include <trx/game/savegame/file.h>
+#include <trx/game/savegame/identity.h>
 #include <trx/game/waypoint.h>
 #include <trx/version.h>
 
@@ -153,7 +154,8 @@ static void M_WriteItem(JSON_WRITE_IO *const io, const ITEM *const item)
     }
 
     const OBJECT *const obj = Object_Get(item->object_id);
-    JSONW_WRITE(io, "object_id", Object_IDToSlot(item->object_id));
+    SaveGame_WriteIdentity(
+        io, "object_id", "object_key", CATALOG_OBJECTS, item->object_id);
     JSONW_WRITE(io, "mesh_bits", item->mesh_bits);
 
     if (obj->save_position) {
@@ -245,7 +247,9 @@ static void M_WriteItem(JSON_WRITE_IO *const io, const ITEM *const item)
         }
 
         JSONW_PUSH_OBJECT(io);
-        JSONW_WRITE(io, "object_id", Object_IDToSlot(drop_item->object_id));
+        SaveGame_WriteIdentity(
+            io, "object_id", "object_key", CATALOG_OBJECTS,
+            drop_item->object_id);
         M_WriteXYZ32(io, "pos", drop_pos);
         JSONW_WRITE(io, "y_rot", drop_rot_y);
         JSONW_WRITE(io, "room_num", drop_room_num);
@@ -405,7 +409,8 @@ void SG_File_DumpEffects(JSON_WRITE_IO *const io)
         M_WriteXYZ32(io, "pos", effect->pos);
         M_WriteXYZ16(io, "rot", effect->rot);
         JSONW_WRITE(io, "room_num", effect->room_num);
-        JSONW_WRITE(io, "object_id", Object_IDToSlot(effect->object_id));
+        SaveGame_WriteIdentity(
+            io, "object_id", "object_key", CATALOG_OBJECTS, effect->object_id);
         JSONW_WRITE(io, "speed", effect->speed);
         JSONW_WRITE(io, "fall_speed", effect->fall_speed);
         // Introduced in TRX 1.2
@@ -490,6 +495,22 @@ void SG_File_DumpMusic(JSON_WRITE_IO *const io)
         JSONW_POP_AND_APPEND(io);
     }
     JSONW_POP_AND_SET(io, "flags");
+
+    // Write both music flag layouts. Positional flags keep older readers
+    // working; named flags keep the data tied to catalog identities.
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < track_flag_count; i++) {
+        const uint16_t flags = M_PackMusicTrackFlags(i);
+        if (flags == 0) {
+            continue;
+        }
+        const CATALOG_ID id = Music_SlotToID(i);
+        JSONW_PUSH_OBJECT(io);
+        SaveGame_WriteIdentity(io, "slot", "key", CATALOG_MUSIC, id);
+        JSONW_WRITE(io, "flags", flags);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET(io, "track_flags");
 
     const MUSIC_SLOT current_ambient = Music_GetCurrentLoopedTrack();
     JSONW_PUSH_OBJECT(io);
@@ -624,7 +645,9 @@ void SG_File_DumpLara(JSON_WRITE_IO *const io)
     if (lara->gun_item_num != NO_ITEM) {
         JSONW_PUSH_OBJECT(io);
         const ITEM *const weapon_item = Item_Get(lara->gun_item_num);
-        JSONW_WRITE(io, "object_id", Object_IDToSlot(weapon_item->object_id));
+        SaveGame_WriteIdentity(
+            io, "object_id", "object_key", CATALOG_OBJECTS,
+            weapon_item->object_id);
         M_WriteAnimNum(io, weapon_item->anim_num);
         JSONW_WRITE(io, "frame_num", weapon_item->frame_num);
         JSONW_WRITE(io, "current_anim_state", weapon_item->current_anim_state);

--- a/src/trx/game/savegame/identity.c
+++ b/src/trx/game/savegame/identity.c
@@ -1,0 +1,67 @@
+#include <trx/game/savegame/identity.h>
+
+#include <trx/core/log.h>
+
+static int32_t m_DroppedCount = 0;
+
+bool SaveGame_WriteIdentity(
+    JSON_WRITE_IO *const io, const char *const slot_field,
+    const char *const key_field, const CATALOG_CONTEXT context,
+    const CATALOG_ID id)
+{
+    const int32_t slot = Catalog_IDToSlot(context, id, -1);
+    const char *const key = Catalog_IDToKey(context, id);
+    if (slot < 0 && key == nullptr) {
+        return false;
+    }
+    if (slot >= 0) {
+        JSONW_WRITE(io, slot_field, slot);
+    }
+    if (key != nullptr) {
+        JSONW_WRITE(io, key_field, key);
+    }
+    return true;
+}
+
+RESULT SaveGame_ReadIdentity(
+    JSON_READ_IO *const io, const char *const slot_field,
+    const char *const key_field, const CATALOG_CONTEXT context,
+    CATALOG_ID *const out_id)
+{
+    const char *key = nullptr;
+    MUST(JSON_READ_OPT(io, key_field, &key));
+    if (key != nullptr) {
+        const CATALOG_ID id = Catalog_KeyToID(context, key, NO_CATALOG_ID);
+        if (id >= 0) {
+            *out_id = id;
+            return OK;
+        }
+    }
+
+    int32_t slot = -1;
+    MUST(JSON_READ_OPT(io, slot_field, &slot));
+    const CATALOG_ID id = Catalog_SlotToID(context, slot, NO_CATALOG_ID);
+    if (id < 0) {
+        return JSON_ReadIO_Fail(
+            io, "no identity called '%s' or held in slot %d",
+            key != nullptr ? key : "", slot);
+    }
+    *out_id = id;
+    return OK;
+}
+
+void SaveGame_NoteDropped(const char *const what)
+{
+    m_DroppedCount++;
+    LOG_WARNING("dropping a record this game cannot place: %s", what);
+}
+
+int32_t SaveGame_GetDroppedCount(void)
+{
+    return m_DroppedCount;
+}
+
+void SaveGame_ResetDropped(void)
+{
+    m_DroppedCount = 0;
+}

--- a/src/trx/game/savegame/identity.h
+++ b/src/trx/game/savegame/identity.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
+#include <trx/core/result.h>
+#include <trx/game/catalog/manager.h>
+
+// Write an identity as its slot and key. Return false if neither form exists.
+bool SaveGame_WriteIdentity(
+    JSON_WRITE_IO *io, const char *slot_field, const char *key_field,
+    CATALOG_CONTEXT context, CATALOG_ID id);
+
+// Read an identity by key when present, otherwise by slot. Report failure when
+// neither form resolves.
+RESULT SaveGame_ReadIdentity(
+    JSON_READ_IO *io, const char *slot_field, const char *key_field,
+    CATALOG_CONTEXT context, CATALOG_ID *out_id);
+
+// Record one savegame record that this game cannot place.
+void SaveGame_NoteDropped(const char *what);
+
+// Return the number of unplaced records for the current load.
+int32_t SaveGame_GetDroppedCount(void);
+
+// Clear the unplaced-record count.
+void SaveGame_ResetDropped(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Savegames can now name catalog identities by key, beside the slot number they already write. This lets moved mod content keep resolving to the same object or music track instead of following an old slot number to the wrong place.

```c
bool SaveGame_WriteIdentity(
    JSON_WRITE_IO *io, const char *slot_field, const char *key_field,
    CATALOG_CONTEXT context, CATALOG_ID id);
RESULT SaveGame_ReadIdentity(
    JSON_READ_IO *io, const char *slot_field, const char *key_field,
    CATALOG_CONTEXT context, CATALOG_ID *out_id);
```

Savegame reads take the key when one is present and fall back to the number, so saves remain compatible in both directions. A record naming something the game no longer has is skipped and counted instead of blocking the whole save. Music track flags also gain identity records, because their old positional list can shift when a game adds tracks.

#### Testing

- [x] Save and reload in each game.
  Expected outcome: items, music and the rest resume as before.
- [x] Load a save written by an earlier build.
  Expected outcome: it loads, reading the numbers it carries.
- [x] Load a save written here on an earlier build.
  Expected outcome: it loads, ignoring the keys it does not know.
