### PR TITLE
Let scripts control fog and fog bulbs

### DIFF
--- a/data/trx/ship/cfg/shaders/common.glsl
+++ b/data/trx/ship/cfg/shaders/common.glsl
@@ -23,6 +23,7 @@
 #define VERT_OVERBRIGHT        0x1000u
 #define VERT_TEX_WRAP          0x2000u
 #define VERT_ADDITIVE          0x4000u
+#define VERT_NO_FOG            0x8000u
 
 #define LIGHTING_CURVE_FLAT       0
 #define LIGHTING_CURVE_OVERBRIGHT 1

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -606,7 +606,8 @@ void main(void) {
     }
 
     // Fog
-    if ((gIn.flags & VERT_NO_LIGHTING) == 0u && uLightingEnabled != 0) {
+    if ((gIn.flags & (VERT_NO_FOG | VERT_NO_LIGHTING)) == 0u
+        && uLightingEnabled != 0) {
         texColor = applyFog(texColor, length(gIn.eyePos.xyz));
         // The OG skips fog bulbs on additive polys (AddTriClippedSorted
         // excludes drawtypes 2 and 5 from OmniFog).

--- a/data/trx/ship/games/tr4/modules/fog.lua
+++ b/data/trx/ship/games/tr4/modules/fog.lua
@@ -1,0 +1,95 @@
+-- TR4 levels use flip effect 28 to set the fog color. The timer picks one of
+-- the colors below. Timer 100 turns fog bulbs off.
+--
+-- The table matches the original engine colors. A mod can change it or use
+-- the effect for different behavior.
+--
+--   local fog = require("tr4.fog")
+--   fog.colors[2] = trx.math.color(255, 0, 0)
+
+local M = {}
+
+-- The timer that turns the fog bulbs off rather than choosing a color.
+local BULBS_OFF = 100
+
+local FLIP_EFFECT = 28
+
+M.colors = {
+  [0] = trx.math.color(0, 0, 0),
+  trx.math.color(245, 200, 60),
+  trx.math.color(120, 196, 112),
+  trx.math.color(202, 204, 230),
+  trx.math.color(128, 64, 0),
+  trx.math.color(64, 64, 64),
+  trx.math.color(243, 232, 236),
+  trx.math.color(0, 64, 192),
+  trx.math.color(0, 128, 0),
+  trx.math.color(150, 172, 157),
+  trx.math.color(128, 128, 128),
+  trx.math.color(204, 163, 123),
+  trx.math.color(177, 162, 140),
+  trx.math.color(0, 223, 191),
+  trx.math.color(111, 255, 223),
+  trx.math.color(244, 216, 152),
+  trx.math.color(248, 192, 60),
+  trx.math.color(252, 0, 0),
+  trx.math.color(198, 95, 87),
+  trx.math.color(226, 151, 118),
+  trx.math.color(248, 235, 206),
+  trx.math.color(0, 30, 16),
+  trx.math.color(250, 222, 167),
+  trx.math.color(218, 175, 117),
+  trx.math.color(225, 191, 78),
+  trx.math.color(77, 140, 141),
+  trx.math.color(4, 181, 154),
+  trx.math.color(255, 174, 0),
+}
+
+local BULBS_KEY = "visuals.enable_fog_bulbs"
+
+-- The color the effect last picked, kept so the distance fog goes back to it
+-- when fog bulbs are turned on again.
+local held_color = nil
+
+-- The original colors the distance fog only while volumetric fog is on: the
+-- effect belongs to that feature, so the fog falls back to the level color, or
+-- to the player's, where the bulbs are off.
+local function apply_fog_color()
+  trx.fx.fog_color = trx.config.get(BULBS_KEY) and held_color or nil
+end
+
+trx.config.on_change(BULBS_KEY, apply_fog_color)
+
+-- The color belongs to the level that picked it, and a level change clears the
+-- override the engine holds.
+trx.events.on_level_unload(function()
+  held_color = nil
+end)
+
+-- Turns fog bulbs off, or restores the player setting. The original turns
+-- them back on when the effect picks a color.
+local function hold_bulbs_off(off)
+  if off and not trx.config.is_overridden(BULBS_KEY) then
+    trx.config.override(BULBS_KEY, false)
+  elseif not off and trx.config.is_overridden(BULBS_KEY) then
+    trx.config.restore(BULBS_KEY)
+  end
+end
+
+trx.events.on_flip_effect(FLIP_EFFECT, function(timer)
+  if timer == BULBS_OFF then
+    hold_bulbs_off(true)
+    return
+  end
+  hold_bulbs_off(false)
+
+  local color = M.colors[timer]
+  if color == nil then
+    trx.log.warning("flip effect " .. FLIP_EFFECT .. " has no color " .. timer)
+    return
+  end
+  held_color = color
+  apply_fog_color()
+end)
+
+return M

--- a/data/trx/ship/games/tr4/scripts/_game.lua
+++ b/data/trx/ship/games/tr4/scripts/_game.lua
@@ -1,4 +1,5 @@
 require("common.overlay")
+require("tr4.fog")
 -- How far along a level Lara has got, which its guides follow. TR4 marks the
 -- points with two flip effects and carries the number in the trigger's timer.
 local LOCATION_EFFECT = 30

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -157,6 +157,7 @@
 - Added the timer Race for the Iris runs between its cutscenes (TRX1109)
 - Added the captions that open Angkor Wat and The Tomb of Seth (TRX487)
 - Added the sprite shadow, so the shadow shape setting offers it as in the other games (Graphic Options → Visuals → Shadows shape) (TRX1290)
+- Added the TR4 fog color changes that happen as Lara reaches certain points (TRX658)
 - Added the wobble effect the original shows while the camera is under water (TRX523)
 - Added the drifting specks the original shows in water rooms (TRX553)
 - Added the water ripples the original shows, in their size, their color and the speed they spread at (TRX590)
@@ -229,6 +230,7 @@
 - Added `trx.game.fmvs` and `trx.game.play_fmv()`, so a script can read the movies the game flow declares and play one where the player stands
 - Added `trx.catalog.mint()`, so a mod that ships only a script can declare an object of its own
 - Added `trx.catalog.key()`, which gives back the name an id answers to
+- Added `trx.fx.fog_bulbs` and `trx.fx.fog_color`, so a script can read level fog bulbs and set the distance fog color (TRX658)
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1285,6 +1285,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   └── sparks_gfx.bin
 │   │   ├── modules
 │   │   │   ├── cutscenes.lua
+│   │   │   ├── fog.lua
 │   │   │   └── race_timer.lua
 │   │   ├── scripts
 │   │   │   ├── _game.lua
@@ -2662,6 +2663,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   └── sparks_gfx.bin
     │   │   │   ├── modules
     │   │   │   │   ├── cutscenes.lua
+    │   │   │   │   ├── fog.lua
     │   │   │   │   └── race_timer.lua
     │   │   │   ├── scripts
     │   │   │   │   ├── _game.lua

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -78,6 +78,22 @@
     },
     {
       "countable": true,
+      "description": "The level fog bulbs, counted from 1. `#trx.fx.fog_bulbs` is the count.\n`pairs()` walks them in order. A level shows at most twenty. The player can turn them off.",
+      "examples": [
+        "for _, bulb in pairs(trx.fx.fog_bulbs) do\n  bulb.color = trx.math.color(245, 200, 60)\nend"
+      ],
+      "key": {
+        "type": "integer"
+      },
+      "member": "fog_bulbs",
+      "module": "fx",
+      "value": {
+        "nullable": true,
+        "type": "fx.FogBulb"
+      }
+    },
+    {
+      "countable": true,
       "description": "Indexing the module reaches an entry of Lara's inventory, and `#trx.inventory` is how many kinds of thing she carries. Entries are keyed by the order they are drawn in, and are built one at a time as they are asked for. `pairs()` walks them.",
       "examples": [
         "for _, entry in pairs(trx.inventory) do\n  trx.log.info((\"%d x %s\"):format(entry.count, trx.catalog.objects[entry.object]))\nend"
@@ -7979,6 +7995,12 @@
       "writable": true
     },
     {
+      "description": "The color override for distance fog.\n\n`nil` means no override. Write `nil` to restore the level fog color. A level change clears the\noverride. Savegames keep it. This controls distance fog only. Fog bulbs have their own colors\nin `trx.fx.fog_bulbs`.",
+      "path": "fx.fog_color",
+      "type": "math.Color",
+      "writable": true
+    },
+    {
       "description": "The levels of the game, in order, counted from one.",
       "list": true,
       "path": "game.levels",
@@ -9159,6 +9181,55 @@
       ],
       "operators": [],
       "path": "events.Listener"
+    },
+    {
+      "description": "A level fog bulb is a ball of fog drawn inside a room.\n\nTR4 stores fog bulbs as room lights. A script can change their color and density.\nThe level sets their position and radius. A bulb follows the fog color until a script\ngives it a color of its own.",
+      "extensions": [
+        {
+          "description": "The room the bulb sits in.",
+          "name": "room",
+          "type": "rooms.Room"
+        }
+      ],
+      "fields": [
+        {
+          "description": "The color a script gave the bulb.\n\n`nil` means none was given, and the bulb is drawn in the fog color in force. Write `nil` to hand\na bulb back to that color.",
+          "name": "color",
+          "type": "math.Color",
+          "writable": true
+        },
+        {
+          "description": "Fog density, from `0` for none to `255`. A value outside this range raises an error.",
+          "name": "density",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Center of the fog bulb.",
+          "name": "pos",
+          "type": "math.Vec3",
+          "writable": false
+        },
+        {
+          "description": "How far the fog reaches from that position.",
+          "name": "radius",
+          "type": "math.Distance",
+          "writable": false
+        }
+      ],
+      "handle": true,
+      "methods": [
+        {
+          "description": "Reports whether the handle still names a bulb in the loaded level.\n\nA level change replaces all bulbs. A handle held across one becomes stale, and field access\nraises an error.",
+          "name": "is_valid",
+          "returns": {
+            "description": "False after the level that held the bulb is left.",
+            "type": "boolean"
+          }
+        }
+      ],
+      "operators": [],
+      "path": "fx.FogBulb"
     },
     {
       "description": "A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.",

--- a/docs/trx/lua/reference/FX.md
+++ b/docs/trx/lua/reference/FX.md
@@ -15,6 +15,28 @@ order: 17
 What a script puts in front of the player: things seen rather than things the
 game holds.
 
+### Indexing
+
+The level fog bulbs, counted from 1. `#trx.fx.fog_bulbs` is the count.
+`pairs()` walks them in order. A level shows at most twenty. The player can turn them off.
+
+- <a id="fx.fog_bulbs[]" name="fx.fog_bulbs[]"></a>**`trx.fx.fog_bulbs[key]`** (key: integer, value: [trx.fx.FogBulb](#fx.FogBulb) or `nil`).
+- **`#trx.fx.fog_bulbs`** (integer). How many there are.
+
+Example:
+```lua
+for _, bulb in pairs(trx.fx.fog_bulbs) do
+  bulb.color = trx.math.color(245, 200, 60)
+end
+```
+
+### Properties
+
+- <a id="fx.fog_color" name="fx.fog_color"></a>**`trx.fx.fog_color`** ([trx.math.Color](MATH.md#math.Color)). The color override for distance fog.
+  `nil` means no override. Write `nil` to restore the level fog color. A level change clears the
+  override. Savegames keep it. This controls distance fog only. Fog bulbs have their own colors
+  in [`trx.fx.fog_bulbs`](#fx.fog_bulbs).
+
 ### Constants
 
 - <a id="fx.MAX_LIGHTS" name="fx.MAX_LIGHTS"></a>[lua]`trx.fx.MAX_LIGHTS` = `64` (integer)  
@@ -22,6 +44,41 @@ game holds.
 
 - <a id="fx.MAX_FOG" name="fx.MAX_FOG"></a>[lua]`trx.fx.MAX_FOG` = `10` (integer)  
   How many balls of fog can be seen at once. TR4 levels carry fog of their own, which takes its slots first, so fewer than this reach the screen where a level is already using them.
+
+### Structures
+
+- <a id="fx.FogBulb" name="fx.FogBulb"></a>[lua]`trx.fx.FogBulb`
+
+    A level fog bulb is a ball of fog drawn inside a room.
+
+    TR4 stores fog bulbs as room lights. A script can change their color and density.
+    The level sets their position and radius. A bulb follows the fog color until a script
+    gives it a color of its own.
+
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
+
+    Properties:
+    - <a id="fx.FogBulb.color" name="fx.FogBulb.color"></a>**`color`**: [trx.math.Color](MATH.md#math.Color). The color a script gave the bulb.
+      `nil` means none was given, and the bulb is drawn in the fog color in force. Write `nil` to hand
+      a bulb back to that color.
+    - <a id="fx.FogBulb.density" name="fx.FogBulb.density"></a>**`density`**: integer. Fog density, from `0` for none to `255`. A value outside this range raises an error.
+    - <a id="fx.FogBulb.pos" name="fx.FogBulb.pos"></a>**`pos`**: [trx.math.Vec3](MATH.md#math.Vec3). Center of the fog bulb. *(read-only)*
+    - <a id="fx.FogBulb.radius" name="fx.FogBulb.radius"></a>**`radius`**: [trx.math.Distance](MATH.md#math.Distance). How far the fog reaches from that position. *(read-only)*
+
+    Computed properties (derived, not stored on the object):
+    - <a id="fx.FogBulb.room" name="fx.FogBulb.room"></a>**`room`**: [trx.rooms.Room](ROOMS.md#rooms.Room). The room the bulb sits in.
+
+    Methods:
+
+    - <a id="fx.FogBulb.is_valid" name="fx.FogBulb.is_valid"></a>[lua]`fogbulb:is_valid()`  
+      Reports whether the handle still names a bulb in the loaded level.
+
+      A level change replaces all bulbs. A handle held across one becomes stale, and field access
+      raises an error.
+
+      Returns: boolean. False after the level that held the bulb is left.
 
 ### Functions
 

--- a/src/lua/api/fx.lua
+++ b/src/lua/api/fx.lua
@@ -2,6 +2,7 @@ local raw = trxc.fx
 local api = trx.api
 
 require("trx.math")
+require("trx.rooms")
 
 api.module("fx", {
   order = 17,
@@ -140,6 +141,95 @@ end)]],
       opts.density or 128
     )
   end,
+})
+
+api.type("fx.FogBulb", {
+  backing = "FOG_BULB",
+  description = [[A level fog bulb is a ball of fog drawn inside a room.
+
+TR4 stores fog bulbs as room lights. A script can change their color and density.
+The level sets their position and radius. A bulb follows the fog color until a script
+gives it a color of its own.]],
+  fields = {
+    color = {
+      type = "math.Color",
+      nullable = true,
+      description = [[The color a script gave the bulb.
+
+`nil` means none was given, and the bulb is drawn in the fog color in force. Write `nil` to hand
+a bulb back to that color.]],
+    },
+    density = {
+      from = "density",
+      type = "integer",
+      description = "Fog density, from `0` for none to `255`. A value outside this "
+        .. "range raises an error.",
+    },
+    pos = {
+      from = "pos",
+      type = "math.Vec3",
+      writable = false,
+      description = "Center of the fog bulb.",
+    },
+    radius = {
+      from = "radius",
+      type = "math.Distance",
+      writable = false,
+      description = "How far the fog reaches from that position.",
+    },
+  },
+
+  extensions = {
+    room = {
+      type = "rooms.Room",
+      description = "The room the bulb sits in.",
+      impl = function(bulb)
+        local num = raw.get_fog_bulb_room(bulb)
+        return num and trx.rooms[num] or nil
+      end,
+    },
+  },
+
+  methods = {
+    is_valid = {
+      returns = {
+        type = "boolean",
+        description = "False after the level that held the bulb is left.",
+      },
+      description = [[Reports whether the handle still names a bulb in the loaded level.
+
+A level change replaces all bulbs. A handle held across one becomes stale, and field access
+raises an error.]],
+    },
+  },
+})
+
+api.container("fx.fog_bulbs", {
+  description = [[The level fog bulbs, counted from 1. `#trx.fx.fog_bulbs` is the count.
+`pairs()` walks them in order. A level shows at most twenty. The player can turn them off.]],
+  key = { type = "integer" },
+  value = { type = "fx.FogBulb", nullable = true },
+  examples = {
+    [[for _, bulb in pairs(trx.fx.fog_bulbs) do
+  bulb.color = trx.math.color(245, 200, 60)
+end]],
+  },
+  get = function(idx)
+    return raw.get_fog_bulb(idx - 1)
+  end,
+  count = raw.fog_bulb_count,
+})
+
+api.property("fx.fog_color", {
+  type = "math.Color",
+  nullable = true,
+  description = [[The color override for distance fog.
+
+`nil` means no override. Write `nil` to restore the level fog color. A level change clears the
+override. Savegames keep it. This controls distance fog only. Fog bulbs have their own colors
+in `trx.fx.fog_bulbs`.]],
+  get = raw.get_fog_color,
+  set = raw.set_fog_color,
 })
 
 local blood_pos_field = {

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -4,15 +4,18 @@
 #include <trx/core/filesystem.h>
 #include <trx/core/json/util/file.h>
 #include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/value.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/game_flow/types.h>
 #include <trx/game/game_flow/vars.h>
 #include <trx/game/inventory_ring/types.h>
 #include <trx/game/lara/skin/storage.h>
+#include <trx/game/level/settings.h>
 #include <trx/game/objects/names.h>
 #include <trx/game/output/sky.h>
 #include <trx/game/shell.h>
@@ -41,6 +44,13 @@ typedef struct {
     M_SEQUENCE_EVENT_HANDLER_FUNC handler_func;
     void *handler_func_arg;
 } M_SEQUENCE_EVENT_HANDLER;
+
+typedef struct {
+    const char *key;
+    LEVEL_SETTING setting;
+    TRX_VALUE_TYPE json_type;
+    const void *json_param;
+} M_SETTING_KEY;
 
 typedef RESULT (*M_LOAD_ARRAY_FUNC)(
     const M_CONTEXT *ctx, void *target_elem, size_t target_elem_idx,
@@ -92,6 +102,23 @@ static M_SEQUENCE_EVENT_HANDLER m_SequenceEventHandlers[] = {
     { (GF_SEQUENCE_EVENT_TYPE)-1, nullptr, nullptr },
     // clang-format on
 };
+
+// clang-format off
+static const M_SETTING_KEY m_SettingKeys[] = {
+#define X_SETTING(name_, field_, type_, config_)                               \
+    { .key = #field_,                                                          \
+      .setting = LEVEL_SETTING_##name_,                                        \
+      .json_type = Value_TypeOf(((GF_LEVEL_SETTINGS *)nullptr)->field_.value) },
+#define X_SETTING_ENUM(name_, field_, enum_, fallback_)                        \
+    { .key = #field_,                                                          \
+      .setting = LEVEL_SETTING_##name_,                                        \
+      .json_type = TVT_ENUM,                                                   \
+      .json_param = ENUM_MAP_NAME(enum_) },
+#include <trx/game/level/settings.def>
+#undef X_SETTING
+#undef X_SETTING_ENUM
+};
+// clang-format on
 
 static RESULT M_ReadObjectID(
     const M_CONTEXT *const ctx, OBJECT_ID *const object_id_out)
@@ -208,49 +235,25 @@ static RESULT M_LoadSettings(
 {
     JSON_READ_IO *const io = ctx->io;
 
-    if (JSON_ReadIO_HasKey(io, "fog_start")) {
-        MUST(JSON_READ(io, "fog_start", &settings->fog_start.value));
-        settings->fog_start.is_present = true;
-    }
-
-    if (JSON_ReadIO_HasKey(io, "fog_end")) {
-        MUST(JSON_READ(io, "fog_end", &settings->fog_end.value));
-        settings->fog_end.is_present = true;
-    }
-
-    if (JSON_ReadIO_HasKey(io, "fog_transparency")) {
-        MUST(JSON_READ(
-            io, "fog_transparency", &settings->fog_transparency.value));
-        settings->fog_transparency.is_present = true;
-    }
-
-    if (JSON_ReadIO_HasKey(io, "fog_color")) {
-        MUST(JSON_READ(io, "fog_color", &settings->fog_color.value));
-        settings->fog_color.is_present = true;
-    }
-
-    if (JSON_ReadIO_HasKey(io, "fog_bulbs")) {
-        MUST(JSON_READ(io, "fog_bulbs", &settings->fog_bulbs.value));
-        settings->fog_bulbs.is_present = true;
-    }
-
-    if (JSON_ReadIO_HasKey(io, "water_color")) {
-        MUST(JSON_READ(io, "water_color", &settings->water_color.value));
-        settings->water_color.is_present = true;
-    }
-
-    if (JSON_ReadIO_HasKey(io, "death_tile")) {
-        MUST(JSON_PUSH(io, "death_tile"));
-        const char *tmp_s = nullptr;
-        MUST(JSON_READ_CURRENT(io, &tmp_s));
-        const int32_t value =
-            EnumMap_Get(ENUM_MAP_NAME(GF_DEATH_TILE), tmp_s, -1);
-        if (value < 0) {
-            JSON_ReadIO_SetError(io, "Invalid death_tile value '%s'", tmp_s);
+    for (size_t i = 0; i < ARRAY_SIZE(m_SettingKeys); i++) {
+        const M_SETTING_KEY *const key = &m_SettingKeys[i];
+        if (!JSON_ReadIO_HasKey(io, key->key)) {
+            continue;
         }
-        settings->death_tile.is_present = true;
-        settings->death_tile.value = value;
-        MUST(JSON_POP(io));
+        TRX_VALUE value;
+        RESULT result = JSONValue_Read(
+            JSON_ReadIO_GetCurrentObject(io), key->key, key->json_type,
+            key->json_param, &value);
+        if (IS_OK(result) && key->json_type == TVT_ENUM) {
+            value.type = TVT_S32;
+        }
+        if (IS_OK(result)) {
+            result = Level_SetDeclaredSetting(settings, key->setting, &value);
+        }
+        if (!IS_OK(result)) {
+            JSON_ReadIO_SetError(io, "Invalid %s value", key->key);
+            return result;
+        }
     }
 
     if (JSON_ReadIO_HasKey(io, "sfx_path")) {
@@ -317,10 +320,11 @@ static RESULT M_LoadLevelItemDrops(
     return OK;
 }
 
-static void M_CopyRootSettingsIntoLevel(
+// Copies only the root sound path into the level settings. Other root settings
+// remain fallback values.
+static void M_InheritRootSfxPath(
     GF_LEVEL_SETTINGS *const dst, const GF_LEVEL_SETTINGS *const src)
 {
-    *dst = *src;
     dst->sfx_path =
         src->sfx_path != nullptr ? Memory_DupStr(src->sfx_path) : nullptr;
 }
@@ -914,7 +918,7 @@ static RESULT M_LoadLevel(
     MUST(JSON_READ_D(
         io, "unobtainable_secrets", &level->unobtainable.secrets, 0));
 
-    M_CopyRootSettingsIntoLevel(&level->settings, &ctx->gf->settings);
+    M_InheritRootSfxPath(&level->settings, &ctx->gf->settings);
 
     MUST(M_LoadSettings(ctx, &level->settings));
     MUST(M_LoadLevelItemDrops(ctx, level));

--- a/src/trx/game/game_flow/types.h
+++ b/src/trx/game/game_flow/types.h
@@ -87,33 +87,25 @@ typedef struct {
     MUSIC_SLOT *ids;
 } GF_AMBIENT_DATA;
 
+// Stores declared level settings. Each field generated from level/settings.def
+// has a presence flag and the declared value.
+
+// clang-format off
 typedef struct {
-    struct {
-        bool is_present;
-        float value;
-    } fog_start, fog_end;
-    struct {
-        bool is_present;
-        bool value;
-    } fog_transparency;
-    struct {
-        bool is_present;
-        RGB_888 value;
-    } fog_color;
-    struct {
-        bool is_present;
-        bool value;
-    } fog_bulbs;
-    struct {
-        bool is_present;
-        RGB_888 value;
-    } water_color;
+#define M_SETTING(field_, type_)                                               \
+    struct {                                                                   \
+        bool is_present;                                                       \
+        type_ value;                                                           \
+    } field_;
+#define X_SETTING(name_, field_, type_, config_) M_SETTING(field_, type_)
+#define X_SETTING_ENUM(name_, field_, enum_, fallback_) M_SETTING(field_, int32_t)
+#include <trx/game/level/settings.def>
+#undef X_SETTING
+#undef X_SETTING_ENUM
+#undef M_SETTING
     char *sfx_path;
-    struct {
-        bool is_present;
-        int32_t value;
-    } death_tile;
 } GF_LEVEL_SETTINGS;
+// clang-format on
 
 typedef struct {
     int32_t enemy_num;

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -133,6 +133,7 @@ RESULT Level_Initialise(
     LOT_InitialiseArray();
     FX_Reset();
     FX_Weather_SetWeather(level->weather_type);
+    Level_ResetFogColorOverride();
     Sparks_Reset();
 
     Option_Reset();

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -133,7 +133,7 @@ RESULT Level_Initialise(
     LOT_InitialiseArray();
     FX_Reset();
     FX_Weather_SetWeather(level->weather_type);
-    Level_ResetFogColorOverride();
+    Level_ResetSettingOverrides();
     Sparks_Reset();
 
     Option_Reset();

--- a/src/trx/game/level/settings.c
+++ b/src/trx/game/level/settings.c
@@ -1,6 +1,7 @@
 #include <trx/game/level/settings.h>
 
 #include <trx/config.h>
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_flow/vars.h>
@@ -8,20 +9,18 @@
 
 #include <stddef.h>
 
-#define M_LEVEL(field_)                                                        \
-    .level_offset = offsetof(GF_LEVEL_SETTINGS, field_.value),                 \
-    .level_present_offset = offsetof(GF_LEVEL_SETTINGS, field_.is_present),    \
-    .level_type = Value_TypeOf(((GF_LEVEL_SETTINGS *)nullptr)->field_.value)
-
-#define M_CONFIG(field_)                                                       \
-    .config_ptr = &g_Config.field_, .config_type = Value_TypeOf(g_Config.field_)
+#define M_DECLARED(field_)                                                     \
+    .offset = offsetof(GF_LEVEL_SETTINGS, field_.value),                       \
+    .present_offset = offsetof(GF_LEVEL_SETTINGS, field_.is_present),          \
+    .declared_type =                                                           \
+        Value_TypeOf(((GF_LEVEL_SETTINGS *)nullptr)->field_.value)
 
 // Describes each setting's type, declared storage, config source, and fallback.
 typedef struct {
     TRX_VALUE_TYPE type;
-    size_t level_offset;
-    size_t level_present_offset;
-    TRX_VALUE_TYPE level_type;
+    size_t offset;
+    size_t present_offset;
+    TRX_VALUE_TYPE declared_type;
     // Null if no config source exists.
     const void *config_ptr;
     TRX_VALUE_TYPE config_type;
@@ -29,62 +28,95 @@ typedef struct {
     TRX_VALUE fallback;
 } M_SETTING_INFO;
 
+// clang-format off
 static const M_SETTING_INFO m_Settings[LEVEL_SETTING_NUMBER_OF] = {
-    [LEVEL_SETTING_FOG_START] = {
-        .type = TVT_FLOAT,
-        M_LEVEL(fog_start),
-        M_CONFIG(visuals.fog_start),
+#define X_SETTING(name_, field_, type_, config_)                               \
+    [LEVEL_SETTING_##name_] = {                                                \
+        .type = Value_TypeOf(((GF_LEVEL_SETTINGS *)nullptr)->field_.value),    \
+        M_DECLARED(field_),                                                    \
+        .config_ptr = &g_Config.config_,                                       \
+        .config_type = Value_TypeOf(g_Config.config_),                         \
     },
-    [LEVEL_SETTING_FOG_END] = {
-        .type = TVT_FLOAT,
-        M_LEVEL(fog_end),
-        M_CONFIG(visuals.fog_end),
+#define X_SETTING_ENUM(name_, field_, enum_, fallback_)                        \
+    [LEVEL_SETTING_##name_] = {                                                \
+        .type = TVT_S32,                                                       \
+        M_DECLARED(field_),                                                    \
+        .fallback = { .type = TVT_S32, .as_int = fallback_ },                  \
     },
-    [LEVEL_SETTING_FOG_TRANSPARENCY] = {
-        .type = TVT_BOOL,
-        M_LEVEL(fog_transparency),
-        M_CONFIG(visuals.fog_transparency),
-    },
-    [LEVEL_SETTING_FOG_COLOR] = {
-        .type = TVT_RGB_888,
-        M_LEVEL(fog_color),
-        M_CONFIG(visuals.fog_color),
-    },
-    [LEVEL_SETTING_FOG_BULBS] = {
-        .type = TVT_BOOL,
-        M_LEVEL(fog_bulbs),
-        M_CONFIG(visuals.enable_fog_bulbs),
-    },
-    [LEVEL_SETTING_WATER_COLOR] = {
-        .type = TVT_RGB_888,
-        M_LEVEL(water_color),
-        M_CONFIG(visuals.water_color),
-    },
-    [LEVEL_SETTING_DEATH_TILE] = {
-        .type = TVT_S32,
-        M_LEVEL(death_tile),
-        .fallback = { .type = TVT_S32, .as_int = GF_DEATH_TILE_LAVA },
-    },
+#include <trx/game/level/settings.def>
+#undef X_SETTING
+#undef X_SETTING_ENUM
 };
+// clang-format on
 
 static struct {
     bool is_present;
     TRX_VALUE value;
 } m_Overrides[LEVEL_SETTING_NUMBER_OF];
 
-// Reads the value at `src` as `type` and brings it into the type the setting is
-// declared with.
-static bool M_Read(
+// Coerces `in` to the setting type and checks the range.
+static RESULT M_Normalize(
+    const M_SETTING_INFO *const info, const TRX_VALUE *const in,
+    TRX_VALUE *const out)
+{
+    if (in->type == info->type) {
+        *out = *in;
+    } else if (!Value_Coerce(info->type, in, out)) {
+        return FAIL(
+            "expected %s, got %s", Value_TypeName(info->type),
+            Value_TypeName(in->type));
+    }
+
+    const char *const error = Value_CheckRange(info->type, out);
+    FAIL_IF(error != nullptr, "%s", error);
+    return OK;
+}
+
+// Reads trusted engine storage as a normalized setting value.
+static TRX_VALUE M_Read(
     const M_SETTING_INFO *const info, const TRX_VALUE_TYPE type,
-    const void *const src, TRX_VALUE *const out)
+    const void *const src)
 {
     TRX_VALUE raw;
     Value_ReadPtr(type, src, &raw);
-    if (raw.type == info->type) {
-        *out = raw;
-        return true;
+    TRX_VALUE out;
+    RESULT result = M_Normalize(info, &raw, &out);
+    ASSERT(IS_OK(result));
+    IGNORE(result);
+    return out;
+}
+
+// Returns a declared setting value from game flow storage.
+static bool M_ReadDeclared(
+    const M_SETTING_INFO *const info, const GF_LEVEL_SETTINGS *const settings,
+    TRX_VALUE *const out)
+{
+    const char *const base = (const char *)settings;
+    if (!*(const bool *)(base + info->present_offset)) {
+        return false;
     }
-    return Value_Coerce(info->type, &raw, out);
+    *out = M_Read(info, info->declared_type, base + info->offset);
+    return true;
+}
+
+RESULT Level_SetDeclaredSetting(
+    GF_LEVEL_SETTINGS *const settings, const LEVEL_SETTING setting,
+    const TRX_VALUE *const value)
+{
+    ASSERT(settings != nullptr);
+    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
+    ASSERT(value != nullptr);
+
+    const M_SETTING_INFO *const info = &m_Settings[setting];
+    TRX_VALUE normalized;
+    MUST(M_Normalize(info, value, &normalized));
+
+    char *const base = (char *)settings;
+    const char *const error =
+        Value_WritePtr(info->declared_type, base + info->offset, &normalized);
+    FAIL_IF(error != nullptr, "%s", error);
+    *(bool *)(base + info->present_offset) = true;
+    return OK;
 }
 
 TRX_VALUE Level_GetEffectiveSetting(const LEVEL_SETTING setting)
@@ -96,18 +128,16 @@ TRX_VALUE Level_GetEffectiveSetting(const LEVEL_SETTING setting)
     }
 
     const GF_LEVEL *const level = GF_GetCurrentLevel();
-    const GF_LEVEL_SETTINGS *const declared =
-        level != nullptr ? &level->settings : &g_GameFlow.settings;
-    const char *const base = (const char *)declared;
     TRX_VALUE value;
-    if (*(const bool *)(base + info->level_present_offset)
-        && M_Read(info, info->level_type, base + info->level_offset, &value)) {
+    if (level != nullptr && M_ReadDeclared(info, &level->settings, &value)) {
+        return value;
+    }
+    if (M_ReadDeclared(info, &g_GameFlow.settings, &value)) {
         return value;
     }
 
-    if (info->config_ptr != nullptr
-        && M_Read(info, info->config_type, info->config_ptr, &value)) {
-        return value;
+    if (info->config_ptr != nullptr) {
+        return M_Read(info, info->config_type, info->config_ptr);
     }
     return info->fallback;
 }
@@ -129,23 +159,15 @@ RESULT Level_SetSettingOverride(
     }
 
     const M_SETTING_INFO *const info = &m_Settings[setting];
-    TRX_VALUE held = *value;
-    if (held.type != info->type && !Value_Coerce(info->type, value, &held)) {
-        return FAIL(
-            "expected %s, got %s", Value_TypeName(info->type),
-            Value_TypeName(value->type));
-    }
-    const char *const error = Value_CheckRange(info->type, &held);
-    if (error != nullptr) {
-        return FAIL("%s", error);
-    }
+    TRX_VALUE normalized;
+    MUST(M_Normalize(info, value, &normalized));
 
     if (m_Overrides[setting].is_present
-        && Value_Equal(&m_Overrides[setting].value, &held)) {
+        && Value_Equal(&m_Overrides[setting].value, &normalized)) {
         return OK;
     }
     m_Overrides[setting].is_present = true;
-    m_Overrides[setting].value = held;
+    m_Overrides[setting].value = normalized;
     Output_ApplyLevelSettings();
     return OK;
 }

--- a/src/trx/game/level/settings.c
+++ b/src/trx/game/level/settings.c
@@ -1,128 +1,209 @@
 #include <trx/game/level/settings.h>
 
 #include <trx/config.h>
+#include <trx/debug.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_flow/vars.h>
 #include <trx/game/output.h>
 
+#include <stddef.h>
+
+#define M_LEVEL(field_)                                                        \
+    .level_offset = offsetof(GF_LEVEL_SETTINGS, field_.value),                 \
+    .level_present_offset = offsetof(GF_LEVEL_SETTINGS, field_.is_present),    \
+    .level_type = Value_TypeOf(((GF_LEVEL_SETTINGS *)nullptr)->field_.value)
+
+#define M_CONFIG(field_)                                                       \
+    .config_ptr = &g_Config.field_, .config_type = Value_TypeOf(g_Config.field_)
+
+// Describes each setting's type, declared storage, config source, and fallback.
+typedef struct {
+    TRX_VALUE_TYPE type;
+    size_t level_offset;
+    size_t level_present_offset;
+    TRX_VALUE_TYPE level_type;
+    // Null if no config source exists.
+    const void *config_ptr;
+    TRX_VALUE_TYPE config_type;
+    // Used when no source supplies a value.
+    TRX_VALUE fallback;
+} M_SETTING_INFO;
+
+static const M_SETTING_INFO m_Settings[LEVEL_SETTING_NUMBER_OF] = {
+    [LEVEL_SETTING_FOG_START] = {
+        .type = TVT_FLOAT,
+        M_LEVEL(fog_start),
+        M_CONFIG(visuals.fog_start),
+    },
+    [LEVEL_SETTING_FOG_END] = {
+        .type = TVT_FLOAT,
+        M_LEVEL(fog_end),
+        M_CONFIG(visuals.fog_end),
+    },
+    [LEVEL_SETTING_FOG_TRANSPARENCY] = {
+        .type = TVT_BOOL,
+        M_LEVEL(fog_transparency),
+        M_CONFIG(visuals.fog_transparency),
+    },
+    [LEVEL_SETTING_FOG_COLOR] = {
+        .type = TVT_RGB_888,
+        M_LEVEL(fog_color),
+        M_CONFIG(visuals.fog_color),
+    },
+    [LEVEL_SETTING_FOG_BULBS] = {
+        .type = TVT_BOOL,
+        M_LEVEL(fog_bulbs),
+        M_CONFIG(visuals.enable_fog_bulbs),
+    },
+    [LEVEL_SETTING_WATER_COLOR] = {
+        .type = TVT_RGB_888,
+        M_LEVEL(water_color),
+        M_CONFIG(visuals.water_color),
+    },
+    [LEVEL_SETTING_DEATH_TILE] = {
+        .type = TVT_S32,
+        M_LEVEL(death_tile),
+        .fallback = { .type = TVT_S32, .as_int = GF_DEATH_TILE_LAVA },
+    },
+};
+
 static struct {
     bool is_present;
-    RGB_888 value;
-} m_FogColorOverride;
+    TRX_VALUE value;
+} m_Overrides[LEVEL_SETTING_NUMBER_OF];
+
+// Reads the value at `src` as `type` and brings it into the type the setting is
+// declared with.
+static bool M_Read(
+    const M_SETTING_INFO *const info, const TRX_VALUE_TYPE type,
+    const void *const src, TRX_VALUE *const out)
+{
+    TRX_VALUE raw;
+    Value_ReadPtr(type, src, &raw);
+    if (raw.type == info->type) {
+        *out = raw;
+        return true;
+    }
+    return Value_Coerce(info->type, &raw, out);
+}
+
+TRX_VALUE Level_GetEffectiveSetting(const LEVEL_SETTING setting)
+{
+    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
+    const M_SETTING_INFO *const info = &m_Settings[setting];
+    if (m_Overrides[setting].is_present) {
+        return m_Overrides[setting].value;
+    }
+
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    const GF_LEVEL_SETTINGS *const declared =
+        level != nullptr ? &level->settings : &g_GameFlow.settings;
+    const char *const base = (const char *)declared;
+    TRX_VALUE value;
+    if (*(const bool *)(base + info->level_present_offset)
+        && M_Read(info, info->level_type, base + info->level_offset, &value)) {
+        return value;
+    }
+
+    if (info->config_ptr != nullptr
+        && M_Read(info, info->config_type, info->config_ptr, &value)) {
+        return value;
+    }
+    return info->fallback;
+}
+
+const TRX_VALUE *Level_GetSettingOverride(const LEVEL_SETTING setting)
+{
+    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
+    return m_Overrides[setting].is_present ? &m_Overrides[setting].value
+                                           : nullptr;
+}
+
+RESULT Level_SetSettingOverride(
+    const LEVEL_SETTING setting, const TRX_VALUE *const value)
+{
+    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
+    if (value == nullptr) {
+        Level_ResetSettingOverride(setting);
+        return OK;
+    }
+
+    const M_SETTING_INFO *const info = &m_Settings[setting];
+    TRX_VALUE held = *value;
+    if (held.type != info->type && !Value_Coerce(info->type, value, &held)) {
+        return FAIL(
+            "expected %s, got %s", Value_TypeName(info->type),
+            Value_TypeName(value->type));
+    }
+    const char *const error = Value_CheckRange(info->type, &held);
+    if (error != nullptr) {
+        return FAIL("%s", error);
+    }
+
+    if (m_Overrides[setting].is_present
+        && Value_Equal(&m_Overrides[setting].value, &held)) {
+        return OK;
+    }
+    m_Overrides[setting].is_present = true;
+    m_Overrides[setting].value = held;
+    Output_ApplyLevelSettings();
+    return OK;
+}
+
+void Level_ResetSettingOverride(const LEVEL_SETTING setting)
+{
+    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
+    if (!m_Overrides[setting].is_present) {
+        return;
+    }
+    m_Overrides[setting].is_present = false;
+    Output_ApplyLevelSettings();
+}
+
+void Level_ResetSettingOverrides(void)
+{
+    for (int32_t i = 0; i < LEVEL_SETTING_NUMBER_OF; i++) {
+        Level_ResetSettingOverride((LEVEL_SETTING)i);
+    }
+}
 
 RGB_888 Level_GetWaterColor(void)
 {
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.water_color.is_present) {
-        return level->settings.water_color.value;
-    }
-    return g_Config.visuals.water_color;
-}
-
-const RGB_888 *Level_GetFogColorOverride(void)
-{
-    return m_FogColorOverride.is_present ? &m_FogColorOverride.value : nullptr;
-}
-
-void Level_SetFogColorOverride(const RGB_888 *const color)
-{
-    if (color == nullptr) {
-        Level_ResetFogColorOverride();
-        return;
-    }
-    const RGB_888 held = m_FogColorOverride.value;
-    if (m_FogColorOverride.is_present && held.r == color->r
-        && held.g == color->g && held.b == color->b) {
-        return;
-    }
-    m_FogColorOverride.is_present = true;
-    m_FogColorOverride.value = *color;
-    Output_ApplyLevelSettings();
-}
-
-void Level_ResetFogColorOverride(void)
-{
-    if (!m_FogColorOverride.is_present) {
-        return;
-    }
-    m_FogColorOverride.is_present = false;
-    Output_ApplyLevelSettings();
+    return Level_GetEffectiveSetting(LEVEL_SETTING_WATER_COLOR).as_rgb;
 }
 
 RGB_888 Level_GetFogTint(void)
 {
-    if (m_FogColorOverride.is_present) {
-        return m_FogColorOverride.value;
-    }
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.fog_color.is_present) {
-        return level->settings.fog_color.value;
-    }
-    return g_Config.visuals.fog_color;
+    return Level_GetEffectiveSetting(LEVEL_SETTING_FOG_COLOR).as_rgb;
 }
 
 RGBA_8888 Level_GetFogColor(void)
 {
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    RGB_888 color = { 0, 0, 0 };
-    uint8_t alpha = 255;
-    if (m_FogColorOverride.is_present) {
-        color = m_FogColorOverride.value;
-    } else if (
-        level != nullptr && level->settings.fog_transparency.is_present
-        && level->settings.fog_transparency.value) {
-        alpha = 0;
-    } else if (level != nullptr && level->settings.fog_color.is_present) {
-        color = level->settings.fog_color.value;
-    } else if (g_Config.visuals.fog_transparency) {
-        alpha = 0;
-    } else {
-        color = g_Config.visuals.fog_color;
+    if (Level_GetSettingOverride(LEVEL_SETTING_FOG_COLOR) == nullptr
+        && Level_GetEffectiveSetting(LEVEL_SETTING_FOG_TRANSPARENCY).as_bool) {
+        return (RGBA_8888) { .r = 0, .g = 0, .b = 0, .a = 0 };
     }
-    return (RGBA_8888) { .r = color.r, .g = color.g, .b = color.b, .a = alpha };
+    const RGB_888 color = Level_GetFogTint();
+    return (RGBA_8888) { .r = color.r, .g = color.g, .b = color.b, .a = 255 };
 }
 
 bool Level_AreFogBulbsEnabled(void)
 {
-    if (!g_Config.visuals.enable_fog_bulbs) {
-        return false;
-    }
-    // The OG disables volumetric fog bulbs on some levels (GF_TRAIN).
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.fog_bulbs.is_present) {
-        return level->settings.fog_bulbs.value;
-    }
-    return true;
+    return Level_GetEffectiveSetting(LEVEL_SETTING_FOG_BULBS).as_bool;
 }
 
 float Level_GetFogStart(void)
 {
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.fog_start.is_present) {
-        return level->settings.fog_start.value;
-    }
-    return g_Config.visuals.fog_start;
+    return Level_GetEffectiveSetting(LEVEL_SETTING_FOG_START).as_num;
 }
 
 float Level_GetFogEnd(void)
 {
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.fog_end.is_present) {
-        return level->settings.fog_end.value;
-    }
-    return g_Config.visuals.fog_end;
+    return Level_GetEffectiveSetting(LEVEL_SETTING_FOG_END).as_num;
 }
 
 GF_DEATH_TILE Level_GetDeathTile(void)
 {
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.death_tile.is_present) {
-        return level->settings.death_tile.value;
-    }
-
-    if (g_GameFlow.settings.death_tile.is_present) {
-        return g_GameFlow.settings.death_tile.value;
-    }
-
-    return GF_DEATH_TILE_LAVA;
+    return (GF_DEATH_TILE)Level_GetEffectiveSetting(LEVEL_SETTING_DEATH_TILE)
+        .as_int;
 }

--- a/src/trx/game/level/settings.c
+++ b/src/trx/game/level/settings.c
@@ -3,6 +3,12 @@
 #include <trx/config.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_flow/vars.h>
+#include <trx/game/output.h>
+
+static struct {
+    bool is_present;
+    RGB_888 value;
+} m_FogColorOverride;
 
 RGB_888 Level_GetWaterColor(void)
 {
@@ -13,12 +19,57 @@ RGB_888 Level_GetWaterColor(void)
     return g_Config.visuals.water_color;
 }
 
+const RGB_888 *Level_GetFogColorOverride(void)
+{
+    return m_FogColorOverride.is_present ? &m_FogColorOverride.value : nullptr;
+}
+
+void Level_SetFogColorOverride(const RGB_888 *const color)
+{
+    if (color == nullptr) {
+        Level_ResetFogColorOverride();
+        return;
+    }
+    const RGB_888 held = m_FogColorOverride.value;
+    if (m_FogColorOverride.is_present && held.r == color->r
+        && held.g == color->g && held.b == color->b) {
+        return;
+    }
+    m_FogColorOverride.is_present = true;
+    m_FogColorOverride.value = *color;
+    Output_ApplyLevelSettings();
+}
+
+void Level_ResetFogColorOverride(void)
+{
+    if (!m_FogColorOverride.is_present) {
+        return;
+    }
+    m_FogColorOverride.is_present = false;
+    Output_ApplyLevelSettings();
+}
+
+RGB_888 Level_GetFogTint(void)
+{
+    if (m_FogColorOverride.is_present) {
+        return m_FogColorOverride.value;
+    }
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    if (level != nullptr && level->settings.fog_color.is_present) {
+        return level->settings.fog_color.value;
+    }
+    return g_Config.visuals.fog_color;
+}
+
 RGBA_8888 Level_GetFogColor(void)
 {
     const GF_LEVEL *const level = GF_GetCurrentLevel();
     RGB_888 color = { 0, 0, 0 };
     uint8_t alpha = 255;
-    if (level != nullptr && level->settings.fog_transparency.is_present
+    if (m_FogColorOverride.is_present) {
+        color = m_FogColorOverride.value;
+    } else if (
+        level != nullptr && level->settings.fog_transparency.is_present
         && level->settings.fog_transparency.value) {
         alpha = 0;
     } else if (level != nullptr && level->settings.fog_color.is_present) {

--- a/src/trx/game/level/settings.c
+++ b/src/trx/game/level/settings.c
@@ -99,6 +99,29 @@ static bool M_ReadDeclared(
     return true;
 }
 
+static TRX_VALUE M_Resolve(const LEVEL_SETTING setting, const bool held)
+{
+    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
+    const M_SETTING_INFO *const info = &m_Settings[setting];
+    if (held && m_Overrides[setting].is_present) {
+        return m_Overrides[setting].value;
+    }
+
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    TRX_VALUE value;
+    if (level != nullptr && M_ReadDeclared(info, &level->settings, &value)) {
+        return value;
+    }
+    if (M_ReadDeclared(info, &g_GameFlow.settings, &value)) {
+        return value;
+    }
+
+    if (info->config_ptr != nullptr) {
+        return M_Read(info, info->config_type, info->config_ptr);
+    }
+    return info->fallback;
+}
+
 RESULT Level_SetDeclaredSetting(
     GF_LEVEL_SETTINGS *const settings, const LEVEL_SETTING setting,
     const TRX_VALUE *const value)
@@ -121,25 +144,12 @@ RESULT Level_SetDeclaredSetting(
 
 TRX_VALUE Level_GetEffectiveSetting(const LEVEL_SETTING setting)
 {
-    ASSERT(setting >= 0 && setting < LEVEL_SETTING_NUMBER_OF);
-    const M_SETTING_INFO *const info = &m_Settings[setting];
-    if (m_Overrides[setting].is_present) {
-        return m_Overrides[setting].value;
-    }
+    return M_Resolve(setting, true);
+}
 
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    TRX_VALUE value;
-    if (level != nullptr && M_ReadDeclared(info, &level->settings, &value)) {
-        return value;
-    }
-    if (M_ReadDeclared(info, &g_GameFlow.settings, &value)) {
-        return value;
-    }
-
-    if (info->config_ptr != nullptr) {
-        return M_Read(info, info->config_type, info->config_ptr);
-    }
-    return info->fallback;
+TRX_VALUE Level_GetDeclaredSetting(const LEVEL_SETTING setting)
+{
+    return M_Resolve(setting, false);
 }
 
 const TRX_VALUE *Level_GetSettingOverride(const LEVEL_SETTING setting)
@@ -197,6 +207,14 @@ RGB_888 Level_GetWaterColor(void)
 RGB_888 Level_GetFogTint(void)
 {
     return Level_GetEffectiveSetting(LEVEL_SETTING_FOG_COLOR).as_rgb;
+}
+
+RGB_888 Level_GetBackgroundColor(void)
+{
+    if (Level_GetEffectiveSetting(LEVEL_SETTING_FOG_TRANSPARENCY).as_bool) {
+        return (RGB_888) { 0, 0, 0 };
+    }
+    return Level_GetDeclaredSetting(LEVEL_SETTING_FOG_COLOR).as_rgb;
 }
 
 RGBA_8888 Level_GetFogColor(void)

--- a/src/trx/game/level/settings.def
+++ b/src/trx/game/level/settings.def
@@ -1,0 +1,16 @@
+// Declares each level setting in resolver order. Game flow storage, game flow
+// reading, and level/settings.c resolution all use these rows. Player-facing
+// behavior is documented in docs/gameflow.schema.json.
+//
+// Names the game flow key, the game flow storage type, and the matching config
+// option. Use X_SETTING_ENUM for settings without a config source, with the
+// final argument as the fallback.
+
+X_SETTING(FOG_START,        fog_start,        float,   visuals.fog_start)
+X_SETTING(FOG_END,          fog_end,          float,   visuals.fog_end)
+X_SETTING(FOG_TRANSPARENCY, fog_transparency, bool,    visuals.fog_transparency)
+X_SETTING(FOG_COLOR,        fog_color,        RGB_888, visuals.fog_color)
+X_SETTING(FOG_BULBS,        fog_bulbs,        bool,    visuals.enable_fog_bulbs)
+X_SETTING(WATER_COLOR,      water_color,      RGB_888, visuals.water_color)
+
+X_SETTING_ENUM(DEATH_TILE,  death_tile,       GF_DEATH_TILE, GF_DEATH_TILE_LAVA)

--- a/src/trx/game/level/settings.h
+++ b/src/trx/game/level/settings.h
@@ -39,6 +39,10 @@ void Level_ResetSettingOverride(LEVEL_SETTING setting);
 void Level_ResetSettingOverrides(void);
 
 RGB_888 Level_GetWaterColor(void);
+
+// The color behind everything the world draws: the fog color the level or the
+// player chose, and black where the fog is transparent.
+RGB_888 Level_GetBackgroundColor(void);
 RGBA_8888 Level_GetFogColor(void);
 
 // Returns the fog draw color, regardless of source and transparency. Fog bulbs

--- a/src/trx/game/level/settings.h
+++ b/src/trx/game/level/settings.h
@@ -5,6 +5,18 @@
 
 RGB_888 Level_GetWaterColor(void);
 RGBA_8888 Level_GetFogColor(void);
+
+// Returns the fog draw color, regardless of source and transparency. Fog bulbs
+// use this color as their seed.
+RGB_888 Level_GetFogTint(void);
+
+// The fog color a script is holding the level to, which outranks both the
+// level's own color and the player's. Null means none is held, and the level
+// is back to the color it carries. TR4 changes it mid-level through a flip
+// effect, and the save carries what it was changed to.
+const RGB_888 *Level_GetFogColorOverride(void);
+void Level_SetFogColorOverride(const RGB_888 *color);
+void Level_ResetFogColorOverride(void);
 bool Level_AreFogBulbsEnabled(void);
 float Level_GetFogStart(void);
 float Level_GetFogEnd(void);

--- a/src/trx/game/level/settings.h
+++ b/src/trx/game/level/settings.h
@@ -8,16 +8,21 @@
 // Lists settings a level can declare, a player can choose, and a script can
 // override. Each setting resolves from script override, level, game flow root,
 // config, then built-in default.
+// clang-format off
 typedef enum {
-    LEVEL_SETTING_FOG_START,
-    LEVEL_SETTING_FOG_END,
-    LEVEL_SETTING_FOG_TRANSPARENCY,
-    LEVEL_SETTING_FOG_COLOR,
-    LEVEL_SETTING_FOG_BULBS,
-    LEVEL_SETTING_WATER_COLOR,
-    LEVEL_SETTING_DEATH_TILE,
+#define X_SETTING(name_, field_, type_, config_) LEVEL_SETTING_##name_,
+#define X_SETTING_ENUM(name_, field_, enum_, fallback_) LEVEL_SETTING_##name_,
+#include <trx/game/level/settings.def>
+#undef X_SETTING
+#undef X_SETTING_ENUM
     LEVEL_SETTING_NUMBER_OF,
 } LEVEL_SETTING;
+// clang-format on
+
+// Writes a declared value into `settings`. Values are coerced to the setting
+// type and refused when they do not fit.
+RESULT Level_SetDeclaredSetting(
+    GF_LEVEL_SETTINGS *settings, LEVEL_SETTING setting, const TRX_VALUE *value);
 
 // Returns the effective value resolved through the setting stack. The returned
 // type is the setting type, whichever source supplies the value.

--- a/src/trx/game/level/settings.h
+++ b/src/trx/game/level/settings.h
@@ -1,7 +1,37 @@
 #pragma once
 
 #include <trx/core/colors.h>
+#include <trx/core/result.h>
+#include <trx/core/value.h>
 #include <trx/game/game_flow/types.h>
+
+// Lists settings a level can declare, a player can choose, and a script can
+// override. Each setting resolves from script override, level, game flow root,
+// config, then built-in default.
+typedef enum {
+    LEVEL_SETTING_FOG_START,
+    LEVEL_SETTING_FOG_END,
+    LEVEL_SETTING_FOG_TRANSPARENCY,
+    LEVEL_SETTING_FOG_COLOR,
+    LEVEL_SETTING_FOG_BULBS,
+    LEVEL_SETTING_WATER_COLOR,
+    LEVEL_SETTING_DEATH_TILE,
+    LEVEL_SETTING_NUMBER_OF,
+} LEVEL_SETTING;
+
+// Returns the effective value resolved through the setting stack. The returned
+// type is the setting type, whichever source supplies the value.
+TRX_VALUE Level_GetEffectiveSetting(LEVEL_SETTING setting);
+
+// Returns the script override. Null means no override is active. TR4 can change
+// fog color during a level through a flip effect, and saves carry that value.
+const TRX_VALUE *Level_GetSettingOverride(LEVEL_SETTING setting);
+
+// Sets the script override to `value`, or clears it when `value` is null.
+// Values are coerced to the setting type and refused when they do not fit.
+RESULT Level_SetSettingOverride(LEVEL_SETTING setting, const TRX_VALUE *value);
+void Level_ResetSettingOverride(LEVEL_SETTING setting);
+void Level_ResetSettingOverrides(void);
 
 RGB_888 Level_GetWaterColor(void);
 RGBA_8888 Level_GetFogColor(void);
@@ -10,13 +40,6 @@ RGBA_8888 Level_GetFogColor(void);
 // use this color as their seed.
 RGB_888 Level_GetFogTint(void);
 
-// The fog color a script is holding the level to, which outranks both the
-// level's own color and the player's. Null means none is held, and the level
-// is back to the color it carries. TR4 changes it mid-level through a flip
-// effect, and the save carries what it was changed to.
-const RGB_888 *Level_GetFogColorOverride(void);
-void Level_SetFogColorOverride(const RGB_888 *color);
-void Level_ResetFogColorOverride(void);
 bool Level_AreFogBulbsEnabled(void);
 float Level_GetFogStart(void);
 float Level_GetFogEnd(void);

--- a/src/trx/game/lua/capi/fx.c
+++ b/src/trx/game/lua/capi/fx.c
@@ -192,12 +192,13 @@ static int M_L_GetFogBulbRoom(lua_State *const L)
 // trxc.fx.get_fog_color() -> color or nil
 static int M_L_GetFogColor(lua_State *const L)
 {
-    const RGB_888 *const color = Level_GetFogColorOverride();
+    const TRX_VALUE *const color =
+        Level_GetSettingOverride(LEVEL_SETTING_FOG_COLOR);
     if (color == nullptr) {
         lua_pushnil(L);
         return 1;
     }
-    LUA_PushValue(L, &(TRX_VALUE) { .type = TVT_RGB_888, .as_rgb = *color });
+    LUA_PushValue(L, color);
     return 1;
 }
 
@@ -205,11 +206,11 @@ static int M_L_GetFogColor(lua_State *const L)
 static int M_L_SetFogColor(lua_State *const L)
 {
     if (lua_isnoneornil(L, 1)) {
-        Level_ResetFogColorOverride();
+        Level_ResetSettingOverride(LEVEL_SETTING_FOG_COLOR);
         return 0;
     }
     const TRX_VALUE value = LUA_CheckValue(L, 1, TVT_RGB_888);
-    Level_SetFogColorOverride(&value.as_rgb);
+    SHOULD(Level_SetSettingOverride(LEVEL_SETTING_FOG_COLOR, &value));
     return 0;
 }
 

--- a/src/trx/game/lua/capi/fx.c
+++ b/src/trx/game/lua/capi/fx.c
@@ -1,7 +1,11 @@
 #include <trx/core/utils.h>
+#include <trx/game/level/settings.h>
+#include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
+#include <trx/game/lua/struct.h>
 #include <trx/game/lua/utils.h>
 #include <trx/game/output/lights.h>
+#include <trx/game/output/lights/fog_bulbs.h>
 #include <trx/game/rooms/common.h>
 #include <trx/game/spawn.h>
 
@@ -108,17 +112,124 @@ static int M_L_BloodBath(lua_State *const L)
     return 0;
 }
 
+// A bulb with no color of its own has none to report: it is drawn in the fog
+// color in force.
+static bool M_GetBulbColor(const void *const self, TRX_VALUE *const out)
+{
+    const FOG_BULB *const bulb = self;
+    if (!bulb->has_own_color) {
+        return false;
+    }
+    *out = (TRX_VALUE) { .type = TVT_RGB_888, .as_rgb = bulb->color };
+    return true;
+}
+
+static const char *M_SetBulbColor(void *const self, const TRX_VALUE *const in)
+{
+    Output_FogBulbs_SetColor(self, in != nullptr ? &in->as_rgb : nullptr);
+    return nullptr;
+}
+
+// Density reads as a share of the way to opaque, as the level data writes it,
+// so a value outside the byte it is stored in is refused rather than folded.
+static const char *M_SetBulbDensity(void *const self, const TRX_VALUE *const in)
+{
+    if (in->as_int < 0 || in->as_int > 255) {
+        return "density runs from 0 to 255";
+    }
+    FOG_BULB *const bulb = self;
+    bulb->density = in->as_int;
+    return nullptr;
+}
+
+// clang-format off
+static const FIELD_DESC m_BulbFields[] = {
+    FIELD_FN_NULLABLE("color", TVT_RGB_888, M_GetBulbColor, M_SetBulbColor),
+    FIELD_SET(FOG_BULB, density, M_SetBulbDensity),
+
+    FIELD_RO(FOG_BULB, pos),
+    FIELD_RO(FOG_BULB, radius),
+};
+// clang-format on
+
+TYPE_DEFINE(FOG_BULB, m_BulbFields)
+
+static void *M_ResolveBulb(const LUA_STRUCT_REF *const ref)
+{
+    return Output_FogBulbs_FromHandle(ref->handle);
+}
+
+// trxc.fx.fog_bulb_count() -> int
+static int M_L_FogBulbCount(lua_State *const L)
+{
+    lua_pushinteger(L, Output_FogBulbs_GetStaticCount());
+    return 1;
+}
+
+// trxc.fx.get_fog_bulb(index) -> FogBulb or nil
+static int M_L_GetFogBulb(lua_State *const L)
+{
+    int32_t idx;
+    if (!LUA_CheckBoundedInt(
+            L, 1, 0, Output_FogBulbs_GetStaticCount() - 1, &idx)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    LUA_Struct_Push(
+        L, &TYPE_FOG_BULB, M_ResolveBulb, Output_FogBulbs_GetStaticHandle(idx));
+    return 1;
+}
+
+// trxc.fx.get_fog_bulb_room(bulb) -> room number or nil
+static int M_L_GetFogBulbRoom(lua_State *const L)
+{
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_FOG_BULB);
+    const FOG_BULB *const bulb = LUA_Struct_Deref(L, ref);
+    LUA_PushOptIndex(L, bulb->room_num, NO_ROOM);
+    return 1;
+}
+
+// trxc.fx.get_fog_color() -> color or nil
+static int M_L_GetFogColor(lua_State *const L)
+{
+    const RGB_888 *const color = Level_GetFogColorOverride();
+    if (color == nullptr) {
+        lua_pushnil(L);
+        return 1;
+    }
+    LUA_PushValue(L, &(TRX_VALUE) { .type = TVT_RGB_888, .as_rgb = *color });
+    return 1;
+}
+
+// trxc.fx.set_fog_color(color or nil)
+static int M_L_SetFogColor(lua_State *const L)
+{
+    if (lua_isnoneornil(L, 1)) {
+        Level_ResetFogColorOverride();
+        return 0;
+    }
+    const TRX_VALUE value = LUA_CheckValue(L, 1, TVT_RGB_888);
+    Level_SetFogColorOverride(&value.as_rgb);
+    return 0;
+}
+
 static const luaL_Reg m_Module[] = {
     { "blood", M_L_Blood },
     { "blood_bath", M_L_BloodBath },
     { "emit_light", M_L_EmitLight },
     { "emit_fog", M_L_EmitFog },
+    { "fog_bulb_count", M_L_FogBulbCount },
+    { "get_fog_bulb", M_L_GetFogBulb },
+    { "get_fog_bulb_room", M_L_GetFogBulbRoom },
+    { "get_fog_color", M_L_GetFogColor },
+    { "set_fog_color", M_L_SetFogColor },
     { nullptr, nullptr },
 };
 
 static void M_Create(lua_State *const L)
 {
     LUA_RegisterModule(L, "fx", m_Module);
+    LUA_Struct_Register(L, &TYPE_FOG_BULB, nullptr);
 
     LUA_GetModule(L, "fx");
     lua_pushinteger(L, OUTPUT_MAX_PENDING_LIGHTS);

--- a/src/trx/game/lua/capi/struct.c
+++ b/src/trx/game/lua/capi/struct.c
@@ -86,8 +86,14 @@ static int M_NewIndex(lua_State *const L)
             L, "unknown %s field '%s'", ref->type->name, lua_tostring(L, 2));
     }
 
-    const TRX_VALUE value = LUA_CheckValue(L, 3, field->type);
-    const char *const err = Field_Set(field, LUA_Struct_Deref(L, ref), &value);
+    const bool is_null =
+        (field->flags & FF_NULLABLE) != 0 && lua_isnoneornil(L, 3);
+    TRX_VALUE value;
+    if (!is_null) {
+        value = LUA_CheckValue(L, 3, field->type);
+    }
+    const char *const err =
+        Field_Set(field, LUA_Struct_Deref(L, ref), is_null ? nullptr : &value);
     if (err != nullptr) {
         return luaL_error(
             L, "cannot set %s.%s: %s", ref->type->name, lua_tostring(L, 2),

--- a/src/trx/game/lua/field.c
+++ b/src/trx/game/lua/field.c
@@ -65,6 +65,7 @@ void Field_ValidateType(const TYPE_DESC *const type)
         // Only fields that address memory carry a backing member to check:
         // Field_Get uses the offset when there is no getter, and Field_Set uses
         // it when there is no setter and the field is writable.
+        ASSERT((field->flags & FF_NULLABLE) == 0 || field->set != nullptr);
         const bool reads_member = field->get == nullptr;
         const bool writes_member =
             field->set == nullptr && !(field->flags & FF_READONLY);
@@ -101,6 +102,13 @@ const char *Field_Set(
 {
     if (field->flags & FF_READONLY) {
         return "field is read-only";
+    }
+
+    // A null value names the state the member has outside its type, so it goes
+    // to the setter as it is, with no width to check it against.
+    if (in == nullptr) {
+        ASSERT((field->flags & FF_NULLABLE) != 0);
+        return field->set(self, nullptr);
     }
 
     // A cyclic member has no value outside its width: one is spelled the long

--- a/src/trx/game/lua/field.h
+++ b/src/trx/game/lua/field.h
@@ -16,6 +16,10 @@ typedef enum {
     // value outside its width names a value inside it, and wraps instead of
     // being rejected.
     FF_MODULAR = 1 << 1,
+    // The member has a state that no value names, so nil reaches its setter as
+    // a null value rather than being turned away as the wrong type. Only a
+    // member with a setter can carry this.
+    FF_NULLABLE = 1 << 2,
 } FIELD_FLAGS;
 
 typedef struct {
@@ -73,6 +77,17 @@ typedef struct {
         .get = get_,                                                           \
         .set = set_,                                                           \
         .flags = (set_) == nullptr ? FF_READONLY : FF_NONE,                    \
+    }
+
+// Computed member whose setter also takes nil, for a member with a state that
+// no value names. The setter is handed a null value where nil is written.
+#define FIELD_FN_NULLABLE(name_, type_, get_, set_)                            \
+    {                                                                          \
+        .name = name_,                                                         \
+        .type = type_,                                                         \
+        .get = get_,                                                           \
+        .set = set_,                                                           \
+        .flags = FF_NULLABLE,                                                  \
     }
 
 // Defines a TYPE_DESC and adds it to the global type registry, so consumers

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -205,6 +205,7 @@ void Output_ApplyLevelSettings(void)
 {
     Output_SetWaterColor(Level_GetWaterColor());
     Output_SetFogColor(Level_GetFogColor());
+    Output_SetBackgroundColor(Level_GetBackgroundColor());
     Output_SetFogStart(Level_GetFogStart() * WALL_L);
     Output_SetFogEnd(Level_GetFogEnd() * WALL_L);
 }

--- a/src/trx/game/output/lights/fog_bulbs.c
+++ b/src/trx/game/output/lights/fog_bulbs.c
@@ -27,10 +27,8 @@
 #define M_MAX_SQ_DIST 0x19000000 // = 20480^2, the OG CreateFogPos
 
 typedef struct {
-    XYZ_F world_pos;
-    float rad, sqrad, inv_sqrad;
-    int32_t density;
-    RGB_888 color; // timed bulbs only; level bulbs use the fog color
+    FOG_BULB data;
+    float sqrad, inv_sqrad;
     int32_t timer;
     int32_t fx_rad;
     bool active; // timed bulbs only
@@ -44,6 +42,11 @@ typedef struct {
 
 static M_BULB m_Static[M_MAX_STATIC_BULBS];
 static int32_t m_StaticCount = 0;
+// The order the level's bulbs are staged in, nearest camera first. The bulbs
+// themselves stay where the level put them, so that a script holding one keeps
+// hold of the same bulb as the camera moves.
+static int32_t m_StaticOrder[M_MAX_STATIC_BULBS];
+static HANDLE_EPOCH m_StaticEpoch = {};
 static M_BULB m_Timed[M_MAX_TIMED_BULBS];
 static M_BULB m_Frame[M_MAX_FRAME_BULBS];
 static int32_t m_FrameCount = 0;
@@ -67,25 +70,30 @@ static void M_CreateFogPos(M_BULB *const bulb)
 {
     bulb->in_range = false;
 
+    const XYZ_F world_pos = {
+        (float)bulb->data.pos.x,
+        (float)bulb->data.pos.y,
+        (float)bulb->data.pos.z,
+    };
     const XYZ_F cam = {
         (float)g_Camera.pos.pos.x,
         (float)g_Camera.pos.pos.y,
         (float)g_Camera.pos.pos.z,
     };
     const XYZ_F d = {
-        bulb->world_pos.x - cam.x,
-        bulb->world_pos.y - cam.y,
-        bulb->world_pos.z - cam.z,
+        world_pos.x - cam.x,
+        world_pos.y - cam.y,
+        world_pos.z - cam.z,
     };
     bulb->sq_cam_dist = SQUARE(d.x) + SQUARE(d.y) + SQUARE(d.z);
     if (bulb->sq_cam_dist > (float)M_MAX_SQ_DIST) {
         return;
     }
 
-    const XYZ_F pos = M_ViewTransform(bulb->world_pos);
+    const XYZ_F pos = M_ViewTransform(world_pos);
     // Rough frustum cull (the OG uses S_GetObjectBounds): reject bulbs
     // entirely behind the camera.
-    if (pos.z < -bulb->rad) {
+    if (pos.z < -bulb->data.radius) {
         return;
     }
 
@@ -100,9 +108,9 @@ static void M_CreateFogPos(M_BULB *const bulb)
         dir.z /= len;
     }
     bulb->edge_view = (XYZ_F) {
-        bulb->rad * dir.x + pos.x,
-        bulb->rad * dir.y + pos.y,
-        bulb->rad * dir.z + pos.z,
+        bulb->data.radius * dir.x + pos.x,
+        bulb->data.radius * dir.y + pos.y,
+        bulb->data.radius * dir.z + pos.z,
     };
 }
 
@@ -112,30 +120,31 @@ static void M_ControlTimedBulb(M_BULB *const bulb)
 {
     if (bulb->timer > 0) {
         bulb->timer--;
-        bulb->rad += (float)((Random_GetDraw() - 0x100) & 0x1FF);
-        if (bulb->rad > (float)bulb->fx_rad) {
-            bulb->rad = (float)(bulb->fx_rad + (Random_GetDraw() & 0xFF));
+        bulb->data.radius += (float)((Random_GetDraw() - 0x100) & 0x1FF);
+        if (bulb->data.radius > (float)bulb->fx_rad) {
+            bulb->data.radius =
+                (float)(bulb->fx_rad + (Random_GetDraw() & 0xFF));
         }
     } else {
         bulb->timer--;
         if (bulb->timer < -30) {
             bulb->timer = 0;
         }
-        bulb->rad -= 255.0f;
-        if (bulb->rad < 0.0f) {
-            bulb->rad = 0.0f;
+        bulb->data.radius -= 255.0f;
+        if (bulb->data.radius < 0.0f) {
+            bulb->data.radius = 0.0f;
             bulb->active = false;
         }
     }
 
-    bulb->sqrad = SQUARE(bulb->rad);
+    bulb->sqrad = SQUARE(bulb->data.radius);
     bulb->inv_sqrad = 1.0f / bulb->sqrad;
 }
 
 static int M_CompareBulbDist(const void *const a, const void *const b)
 {
-    const M_BULB *const bulb_a = a;
-    const M_BULB *const bulb_b = b;
+    const M_BULB *const bulb_a = &m_Static[*(const int32_t *)a];
+    const M_BULB *const bulb_b = &m_Static[*(const int32_t *)b];
     if (bulb_a->sq_cam_dist > bulb_b->sq_cam_dist) {
         return 1;
     }
@@ -143,6 +152,13 @@ static int M_CompareBulbDist(const void *const a, const void *const b)
         return -1;
     }
     return 0;
+}
+
+// The color a bulb is drawn in: its own where a script gave it one, and the
+// fog color in force where none was given.
+static RGB_888 M_GetColor(const FOG_BULB *const bulb)
+{
+    return bulb->has_own_color ? bulb->color : Level_GetFogTint();
 }
 
 static bool M_FillUniform(
@@ -161,10 +177,11 @@ static bool M_FillUniform(
     dst->bulbs[i].edge[1] = bulb->edge_view.y;
     dst->bulbs[i].edge[2] = bulb->edge_view.z;
     dst->bulbs[i].edge[3] = bulb->sqrad;
-    dst->bulbs[i].color[0] = bulb->color.r / 255.0f;
-    dst->bulbs[i].color[1] = bulb->color.g / 255.0f;
-    dst->bulbs[i].color[2] = bulb->color.b / 255.0f;
-    dst->bulbs[i].color[3] = (float)bulb->density;
+    const RGB_888 color = M_GetColor(&bulb->data);
+    dst->bulbs[i].color[0] = color.r / 255.0f;
+    dst->bulbs[i].color[1] = color.g / 255.0f;
+    dst->bulbs[i].color[2] = color.b / 255.0f;
+    dst->bulbs[i].color[3] = (float)bulb->data.density;
     dst->bulbs[i].params[0] = bulb->inv_sqrad;
     dst->bulbs[i].params[1] = is_fx ? 1.0f : 0.0f;
     return true;
@@ -173,6 +190,7 @@ static bool M_FillUniform(
 void Output_FogBulbs_ResetStatic(void)
 {
     m_StaticCount = 0;
+    Handle_EpochBump(&m_StaticEpoch);
 }
 
 void Output_FogBulbs_ResetUploadCache(void)
@@ -189,22 +207,58 @@ void Output_FogBulbs_Reset(void)
     }
 }
 
+void Output_FogBulbs_SetColor(FOG_BULB *const bulb, const RGB_888 *const color)
+{
+    bulb->has_own_color = color != nullptr;
+    if (color != nullptr) {
+        bulb->color = *color;
+    }
+}
+
 void Output_FogBulbs_AddStatic(
-    const XYZ_F world_pos, const float radius, const RGB_888 color,
-    const int32_t density)
+    const XYZ_32 pos, const float radius, const int32_t density,
+    const int16_t room_num)
 {
     if (m_StaticCount >= M_MAX_STATIC_BULBS) {
         return;
     }
 
     m_Static[m_StaticCount++] = (M_BULB) {
-        .world_pos = world_pos,
-        .density = density,
-        .color = color,
-        .rad = radius,
+        .data = {
+            .pos = pos,
+            .radius = radius,
+            .density = density,
+            .room_num = room_num,
+        },
         .sqrad = SQUARE(radius),
         .inv_sqrad = 1.0f / SQUARE(radius),
     };
+}
+
+int32_t Output_FogBulbs_GetStaticCount(void)
+{
+    return m_StaticCount;
+}
+
+FOG_BULB *Output_FogBulbs_GetStatic(const int32_t idx)
+{
+    if (idx < 0 || idx >= m_StaticCount) {
+        return nullptr;
+    }
+    return &m_Static[idx].data;
+}
+
+TRX_HANDLE Output_FogBulbs_GetStaticHandle(const int32_t idx)
+{
+    return Handle_EpochMint(&m_StaticEpoch, idx);
+}
+
+FOG_BULB *Output_FogBulbs_FromHandle(const TRX_HANDLE handle)
+{
+    if (!Handle_EpochIsLive(&m_StaticEpoch, handle)) {
+        return nullptr;
+    }
+    return Output_FogBulbs_GetStatic(handle.id);
 }
 
 void Output_FogBulbs_AddFrame(
@@ -217,10 +271,13 @@ void Output_FogBulbs_AddFrame(
 
     const float rad = (float)radius;
     m_Frame[m_FrameCount++] = (M_BULB) {
-        .world_pos = { (float)pos.x, (float)pos.y, (float)pos.z },
-        .density = density,
-        .color = color,
-        .rad = rad,
+        .data = {
+            .pos = pos,
+            .radius = rad,
+            .density = density,
+            .color = color,
+            .has_own_color = true,
+        },
         .sqrad = SQUARE(rad),
         .inv_sqrad = 1.0f / SQUARE(rad),
     };
@@ -245,12 +302,12 @@ void Output_FogBulbs_AddTimed(
     }
 
     m_Timed[num] = (M_BULB) {
-        .world_pos = { (float)pos.x, (float)pos.y, (float)pos.z },
-        .density = density,
-        .color = color,
-        .rad = 0.0f,
-        .sqrad = 0.0f,
-        .inv_sqrad = 0.0f,
+        .data = {
+            .pos = pos,
+            .density = density,
+            .color = color,
+            .has_own_color = true,
+        },
         .timer = 50,
         .fx_rad = fx_rad,
         .active = true,
@@ -295,20 +352,23 @@ void Output_FogBulbs_PrepareScene(void)
 
         for (int32_t i = 0; i < m_StaticCount; i++) {
             const XYZ_F d = {
-                m_Static[i].world_pos.x - g_Camera.pos.pos.x,
-                m_Static[i].world_pos.y - g_Camera.pos.pos.y,
-                m_Static[i].world_pos.z - g_Camera.pos.pos.z,
+                (float)m_Static[i].data.pos.x - (float)g_Camera.pos.pos.x,
+                (float)m_Static[i].data.pos.y - (float)g_Camera.pos.pos.y,
+                (float)m_Static[i].data.pos.z - (float)g_Camera.pos.pos.z,
             };
             m_Static[i].sq_cam_dist = SQUARE(d.x) + SQUARE(d.y) + SQUARE(d.z);
+            m_StaticOrder[i] = i;
         }
-        qsort(m_Static, m_StaticCount, sizeof(M_BULB), M_CompareBulbDist);
+        qsort(
+            m_StaticOrder, m_StaticCount, sizeof(m_StaticOrder[0]),
+            M_CompareBulbDist);
 
         int32_t n_active = 0;
         for (int32_t i = 0; i < m_StaticCount && n_active < M_MAX_ACTIVE_BULBS;
              i++) {
-            M_CreateFogPos(&m_Static[i]);
-            if (m_Static[i].in_range
-                && M_FillUniform(&fog, &m_Static[i], false)) {
+            M_BULB *const bulb = &m_Static[m_StaticOrder[i]];
+            M_CreateFogPos(bulb);
+            if (bulb->in_range && M_FillUniform(&fog, bulb, false)) {
                 n_active++;
             }
         }

--- a/src/trx/game/output/lights/fog_bulbs.h
+++ b/src/trx/game/output/lights/fog_bulbs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trx/core/colors.h>
+#include <trx/core/handle.h>
 #include <trx/core/math/types.h>
 
 // Volumetric fog bulbs. The shader evaluates them per fragment for every
@@ -8,14 +9,41 @@
 // lights and the OG triggers timed ones for such things as underwater flares,
 // while a script can ask for one anywhere.
 
+// A fog bulb the level carries. How it looks is a script's to change; where it
+// sits and how far it reaches belong to the level.
+typedef struct {
+    XYZ_32 pos;
+    float radius;
+    int32_t density;
+    RGB_888 color;
+    // Whether `color` is a script's choice. A bulb that has none is drawn in
+    // the fog color in force, and follows it as that color changes.
+    bool has_own_color;
+    int16_t room_num;
+} FOG_BULB;
+
 void Output_FogBulbs_Reset(void);
 // The level's own bulbs alone, for a game letting go of what it baked them
 // from.
 void Output_FogBulbs_ResetStatic(void);
 
+// Gives a bulb a color of its own, or hands it back to the fog color where
+// `color` is null.
+void Output_FogBulbs_SetColor(FOG_BULB *bulb, const RGB_888 *color);
+
 // A bulb the level carries, kept until the level is let go of.
 void Output_FogBulbs_AddStatic(
-    XYZ_F world_pos, float radius, RGB_888 color, int32_t density);
+    XYZ_32 pos, float radius, int32_t density, int16_t room_num);
+
+// The level's own bulbs, in the order the level carries them.
+int32_t Output_FogBulbs_GetStaticCount(void);
+FOG_BULB *Output_FogBulbs_GetStatic(int32_t idx);
+
+// A weak reference to one of the level's bulbs. Letting the level's bulbs go
+// retires every handle, so one kept across a level change resolves to null
+// rather than to another level's bulb at the same index.
+TRX_HANDLE Output_FogBulbs_GetStaticHandle(int32_t idx);
+FOG_BULB *Output_FogBulbs_FromHandle(TRX_HANDLE handle);
 
 // A bulb asked for this frame, forgotten at the start of the next one. It is
 // staged after the level's own, so it draws only where the buffer has room

--- a/src/trx/game/output/lights/tr4.c
+++ b/src/trx/game/output/lights/tr4.c
@@ -184,18 +184,13 @@ static void M_BakeRoomLights(void)
             }
 
             if (light->type == LIGHT_TYPE_FOG_BULB) {
-                // The OG PC renderer reads the red channel as the density
-                // and discards the bulb color (blending toward the script
-                // fog color instead); the data carries a real per-bulb RGB
-                // which the PSX renderer used — keep it (e.g. the cyan
-                // waterfall mist in Angkor Wat).
+                // A fog bulb carries no color of its own: the level data
+                // holds its density in the red channel and leaves the other
+                // two alone. The OG draws the bulb in the fog color, which a
+                // bulb follows until a script gives it a color.
                 Output_FogBulbs_AddStatic(
-                    (XYZ_F) {
-                        (float)light->pos.x,
-                        (float)light->pos.y,
-                        (float)light->pos.z,
-                    },
-                    light->u.tr4.outer_radius, light->color, light->color.r);
+                    light->pos, light->u.tr4.outer_radius, light->color.r,
+                    (int16_t)room_num);
                 continue;
             }
 

--- a/src/trx/game/output/shaders/mesh.h
+++ b/src/trx/game/output/shaders/mesh.h
@@ -20,6 +20,7 @@
 #define VERT_OVERBRIGHT      0b1'0000'0000'0000 // = 0x1000
 #define VERT_TEX_WRAP       0b10'0000'0000'0000 // = 0x2000
 #define VERT_ADDITIVE      0b100'0000'0000'0000 // = 0x4000
+#define VERT_NO_FOG       0b1000'0000'0000'0000 // = 0x8000
 // clang-format on
 
 // GL attribute mapping in the shader

--- a/src/trx/game/output/sky.c
+++ b/src/trx/game/output/sky.c
@@ -324,7 +324,11 @@ void Output_Sky_ObserveLevelLoad(void)
     // adder, whichever way the level's mesh data is lit. TR3/TR4 must keep the
     // path their mesh data selects: forcing own light there makes the horizon
     // eligible for the dynamic point-light term (the binoculars lighting it).
-    m_SkyboxMeshPolicy.vertex_flags = g_TRVersion < 3 ? VERT_USE_OWN_LIGHT : 0;
+    // The OG leaves the horizon unfogged: every sky vertex carries a full fog
+    // factor (output.cpp ProcessObjectMeshVertices), and the levels that want
+    // a fogged horizon paint the gradient on themselves.
+    m_SkyboxMeshPolicy.vertex_flags =
+        VERT_NO_FOG | (g_TRVersion < 3 ? VERT_USE_OWN_LIGHT : 0);
     for (int32_t i = 0; i < skybox->mesh_count; i++) {
         OutputSource_Objects_AddMeshPolicy(
             skybox->mesh_idx + i, &m_SkyboxMeshPolicy);

--- a/src/trx/game/output/sources/sky.c
+++ b/src/trx/game/output/sources/sky.c
@@ -232,11 +232,9 @@ static void M_UploadFogGradient(
             const int32_t k = OUTPUT_QUAD_TO_FAN(j);
             const XYZ_16 pos = mesh->vertices[face->vertices[k]];
             // OG paints half fog on each quad's first two vertices and full
-            // fog on the last two (the mesh's bottom edge). OG's values
-            // *replace* the mesh's distance fog, but this overlay composites
-            // on top of it - the shader fog stays active on the skybox mesh
-            // and already contributes about that much at the top edge - so
-            // start from zero to avoid a visible half-fogged seam.
+            // fog on the last two, at the mesh's bottom edge. The overlay
+            // starts from zero instead, so the gradient fades in rather than
+            // meeting the unfogged sky above it at a seam.
             const float fog = k < 2 ? 0.0f : 1.0f;
             vertices[v++] = (M_GRADIENT_VERTEX) {
                 .pos = {

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -34,6 +34,7 @@ static int32_t m_UVRotateSpeed = 0;
 static int32_t m_FogStart = 0;
 static int32_t m_FogEnd = 0;
 static RGBA_F m_FogColor = {};
+static RGBA_F m_BackgroundColor = {};
 static RGB_F m_WaterColor = {};
 
 static float m_DepthFactor = 0.0f;
@@ -106,6 +107,21 @@ bool Output_IsSkyboxEnabled(void)
 RGBA_F Output_GetFogColor(void)
 {
     return m_FogColor;
+}
+
+RGBA_F Output_GetBackgroundColor(void)
+{
+    return m_BackgroundColor;
+}
+
+void Output_SetBackgroundColor(const RGB_888 color)
+{
+    m_BackgroundColor = (RGBA_F) {
+        .r = color.r / 255.0f,
+        .g = color.g / 255.0f,
+        .b = color.b / 255.0f,
+        .a = 0.0f,
+    };
 }
 
 int32_t Output_GetFogStart(void)

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -44,6 +44,10 @@ bool Output_GetWibbleEffect(void);
 bool Output_GetObjectWibbleEffect(void);
 
 RGBA_F Output_GetFogColor(void);
+
+// The color the game view is cleared to, behind everything the world draws.
+RGBA_F Output_GetBackgroundColor(void);
+void Output_SetBackgroundColor(RGB_888 color);
 int32_t Output_GetFogStart(void);
 int32_t Output_GetFogEnd(void);
 

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -16,6 +16,7 @@
 #include <trx/game/inventory.h>
 #include <trx/game/items/carrier.h>
 #include <trx/game/lara.h>
+#include <trx/game/level/settings.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/general/flare_item.h>
@@ -1342,6 +1343,15 @@ RESULT SG_File_LoadMisc(JSON_READ_IO *const io)
             } else {
                 FX_Weather_SetWeather(WEATHER_NONE);
             }
+        }
+    }
+
+    {
+        Level_ResetFogColorOverride();
+        if (JSON_ReadIO_HasKey(io, "fog_color")) {
+            RGB_888 fog_color;
+            MUST(JSON_READ(io, "fog_color", &fog_color));
+            Level_SetFogColorOverride(&fog_color);
         }
     }
 

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -1347,11 +1347,13 @@ RESULT SG_File_LoadMisc(JSON_READ_IO *const io)
     }
 
     {
-        Level_ResetFogColorOverride();
+        Level_ResetSettingOverride(LEVEL_SETTING_FOG_COLOR);
         if (JSON_ReadIO_HasKey(io, "fog_color")) {
             RGB_888 fog_color;
             MUST(JSON_READ(io, "fog_color", &fog_color));
-            Level_SetFogColorOverride(&fog_color);
+            SHOULD(Level_SetSettingOverride(
+                LEVEL_SETTING_FOG_COLOR,
+                &(TRX_VALUE) { .type = TVT_RGB_888, .as_rgb = fog_color }));
         }
     }
 

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -705,9 +705,10 @@ void SG_File_DumpMisc(JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "rng_control_seed", Random_GetControlSeed());
     JSONW_WRITE(io, "rng_draw_seed", Random_GetDrawSeed());
     JSONW_WRITE(io, "weather_type", FX_Weather_GetWeather());
-    const RGB_888 *const fog_color = Level_GetFogColorOverride();
+    const TRX_VALUE *const fog_color =
+        Level_GetSettingOverride(LEVEL_SETTING_FOG_COLOR);
     if (fog_color != nullptr) {
-        JSONW_WRITE(io, "fog_color", *fog_color);
+        JSONW_WRITE(io, "fog_color", fog_color->as_rgb);
     }
     JSONW_WRITE(io, "cutscenes_played", CutSeq_GetPlayedMask());
     JSONW_WRITE(io, "waypoint", Waypoint_Get());

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -14,6 +14,7 @@
 #include <trx/game/items.h>
 #include <trx/game/items/carrier.h>
 #include <trx/game/lara.h>
+#include <trx/game/level/settings.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/general/flare_item.h>
@@ -704,6 +705,10 @@ void SG_File_DumpMisc(JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "rng_control_seed", Random_GetControlSeed());
     JSONW_WRITE(io, "rng_draw_seed", Random_GetDrawSeed());
     JSONW_WRITE(io, "weather_type", FX_Weather_GetWeather());
+    const RGB_888 *const fog_color = Level_GetFogColorOverride();
+    if (fog_color != nullptr) {
+        JSONW_WRITE(io, "fog_color", *fog_color);
+    }
     JSONW_WRITE(io, "cutscenes_played", CutSeq_GetPlayedMask());
     JSONW_WRITE(io, "waypoint", Waypoint_Get());
     JSONW_WRITE(io, "waypoint_highest", Waypoint_GetHighest());

--- a/src/trx/gl/context.c
+++ b/src/trx/gl/context.c
@@ -29,7 +29,7 @@ typedef struct {
     TRX_GL_RENDERER *renderer;
 } TRX_GL_CONTEXT;
 
-extern RGBA_F Output_GetFogColor(void);
+extern RGBA_F Output_GetBackgroundColor(void);
 
 static TRX_GL_CONTEXT m_Context = {};
 
@@ -272,12 +272,12 @@ void *TRX_GL_Context_GetWindowHandle(void)
 void TRX_GL_Context_Clear(void)
 {
     const RGBA_F white = { 1.0f, 1.0f, 1.0f, 0.0f };
-    const RGBA_F fog = Output_GetFogColor();
+    const RGBA_F background = Output_GetBackgroundColor();
     const RGBA_F black = { 0.0f, 0.0f, 0.0f, 0.0f };
     const RGBA_F color =
         m_Context.space == VIEWPORT_GAME && m_Context.config.enable_wireframe
         ? white
-        : m_Context.space == VIEWPORT_GAME ? fog
+        : m_Context.space == VIEWPORT_GAME ? background
                                            : black;
     glClearBufferfv(GL_COLOR, 0, &color.r);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds `trx.fx.fog_bulbs` for reading a level's fog bulbs, and `trx.fx.fog_color` for holding distance fog to a color. Each bulb exposes its position and radius, and lets scripts set its color and density.

```lua
trx.fx.fog_color = trx.math.color(245, 200, 60)
trx.fx.fog_color = nil                             -- back to the level color

for _, bulb in pairs(trx.fx.fog_bulbs) do
  bulb.color = trx.math.color(0, 64, 192)
  bulb.density = 128
end
```

TR4 now uses flip effect 28 to control fog colors, with the timer selecting a color from `tr4.fog`. Timer 100 disables fog bulbs. Mods can customize these colors or reuse the effect in their own scripts. Angkor Wat uses the effect at startup and at the waterfall.

Fog bulbs now initialize with the level fog color. Their level data does not contain color information: density is stored in the red channel, while the remaining channels are unused.

Levels with a custom fog color no longer make fog opaque when transparent fog is enabled. Game flows containing an unknown `death_tile` value now fail to load instead of leaving the level without death tile behavior.

Resolves TRX658

#### Testing

##### TR4, The Angkor Wat and Race for the Iris

- [x] The fog is sand colored at the start of the level, and changes at the waterfall
- [x] Fog bulbs are drawn in the fog color, and disappear where the original turns them off
- [x] Saving inside a changed fog color and loading the save keeps that color
- [x] Leaving the level and coming back puts the level fog color back (hubs)

##### Settings

- [x] Turning fog bulbs off in the settings removes them, in every game
- [x] Fog color, fog distance and water color in the settings still take effect
- [x] A level that names its own fog color keeps that color, unless transparent fog is turned on