### PR TITLE
lara/col/land: fix wading step-down

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed static meshes affecting ledge jumps when soft static collision is not enabled (#6366 / TRX1218)
 - Fixed Lara sliding on walkable items (trapdoors, bridges etc) when there is a steep slope directly below and touching the item (OG bug)
 - Fixed Lara teleporting to the floor when killed by spikes that are to her side rather than directly below her (OG bug) (#6351 / TRX1204)
+- Fixed Lara briefly teleporting above the water line if she is stepping backwards from 2-click to 3-click wading depth (TRX1309, regression from 1.0)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -341,8 +341,9 @@ static void M_WalkBack(ITEM *const item, COLL_INFO *const coll)
     }
 
     const ROOM *const room = Room_Get(item->room_num);
-    if (coll->side_mid.floor > STEP_L / 2
-        && coll->side_mid.floor < STEPUP_HEIGHT && !room->flags.swamp) {
+    const bool stepping_down = coll->side_mid.floor > STEP_L / 2
+        && coll->side_mid.floor < STEPUP_HEIGHT && !room->flags.swamp;
+    if (stepping_down) {
         if (Item_TestFrameRange(
                 item, M_LF_WALK_BACK_R_START, M_LF_WALK_BACK_R_END)) {
             Item_SwitchToAnim(item, LA(LA_WALK_DOWN_BACK_RIGHT), 0);
@@ -357,7 +358,9 @@ static void M_WalkBack(ITEM *const item, COLL_INFO *const coll)
 
     if (coll->side_mid.floor >= 0 && room->flags.swamp) {
         item->pos.y += M_SWAMP_SINK_RATE;
-    } else if (lara->water_status == LWS_WADE && coll->side_mid.floor >= 50) {
+    } else if (
+        lara->water_status == LWS_WADE && coll->side_mid.floor >= 50
+        && !stepping_down) {
         item->pos.y += 50;
     } else {
         item->pos.y += coll->side_mid.floor;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes Lara briefly teleporting above the water line if she is stepping backwards from 2-click to 3-click wading depth.

Resolves TRX1309.
