### PR TITLE
lara/state/land: fix wading wall animation twitches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed Lara sliding on walkable items (trapdoors, bridges etc) when there is a steep slope directly below and touching the item (OG bug)
 - Fixed Lara teleporting to the floor when killed by spikes that are to her side rather than directly below her (OG bug) (#6351 / TRX1204)
 - Fixed Lara briefly teleporting above the water line if she is stepping backwards from 2-click to 3-click wading depth (TRX1309, regression from 1.0)
+- Fixed Lara's arms twitching when stopped against walls in shallow water with either forward or backward input pressed against the wall (OG bug) (#6254 / TRX1121)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -362,6 +362,30 @@ static bool M_CanSideStep(const ITEM *const item, const int16_t angle)
     return ABS(height) < STEP_L / 2 && Room_GetHeightType() != HT_BIG_SLOPE;
 }
 
+static void M_HandleWadeStopToForward(ITEM *const item, COLL_INFO *const coll)
+{
+    const DIRECTION dir = Math_GetDirection(item->rot.y);
+    const int32_t fheight =
+        Lara_FloorFront(item, Math_DirectionToAngle(dir), M_WALK_DIST);
+    if (fheight <= (-STEPUP_HEIGHT + 1)) {
+        Lara_GetLaraInfo()->move_angle = item->rot.y;
+        coll->bad_pos = NO_BAD_POS;
+        coll->bad_neg = -STEPUP_HEIGHT;
+        coll->bad_ceiling = 0;
+        coll->radius = LARA_RADIUS + 2;
+        coll->slopes_are_walls = 1;
+        Lara_Col_GetInfo(item, coll);
+
+        if (!Lara_Col_TestVault(item, coll)) {
+            coll->radius = LARA_RADIUS;
+        }
+    } else if (Room_Get(item->room_num)->flags.swamp || g_Input.slow) {
+        M_Wade(item, coll);
+    } else {
+        M_Walk(item, coll);
+    }
+}
+
 static void M_Stop(ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -453,12 +477,8 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
         }
 
         if (g_Input.forward) {
-            if (room->flags.swamp || g_Input.slow) {
-                M_Wade(item, coll);
-            } else {
-                M_Walk(item, coll);
-            }
-        } else if (g_Input.back) {
+            M_HandleWadeStopToForward(item, coll);
+        } else if (g_Input.back && ABS(rheight) < (STEPUP_HEIGHT - 1)) {
             M_WalkBack(item, coll);
         }
     } else if (g_Input.jump) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes Lara's arms twitching when she is stopped at wading depth and the player either holds forward while facing a wall, or backwards with her back to a wall. OG would transition to the walking/wading animation for one frame, before the later collision routines reverted her to the stop animation. This would then repeat every frame, causing the twitching.

The fix is similar to how TR4 handles these scenarios, but goes one step further by performing the wall test against Lara's axis-snapped angle. This fixes the issue when Lara is at a small angle to the wall.

Test level available.

Resolves #6254 / TRX1121.
