### PR TITLE
 lara/control: improve start state handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed Lara teleporting to the floor when killed by spikes that are to her side rather than directly below her (OG bug) (#6351 / TRX1204)
 - Fixed Lara briefly teleporting above the water line if she is stepping backwards from 2-click to 3-click wading depth (TRX1309, regression from 1.0)
 - Fixed Lara's arms twitching when stopped against walls in shallow water with either forward or backward input pressed against the wall (OG bug) (#6254 / TRX1121)
+- Fixed Lara assuming a fully underwater animation in custom levels if she begins at wading or water surface depths (OG bug) (TRX1312)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -176,8 +176,7 @@ void Lara_Col_WadeSplash(ITEM *const item)
         return;
     }
 
-    const int32_t water_depth = Lara_GetWaterDepth(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_depth = Lara_GetWaterDepth(item->pos, item->room_num);
     const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
     if (water_height != NO_HEIGHT && water_depth != NO_HEIGHT

--- a/src/trx/game/lara/col/swim.c
+++ b/src/trx/game/lara/col/swim.c
@@ -124,8 +124,7 @@ static void M_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
 {
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-    const int32_t water_depth =
-        Lara_GetWaterDepth(item->pos.x, item->pos.y, item->pos.z, room_num);
+    const int32_t water_depth = Lara_GetWaterDepth(item->pos, room_num);
 
     if (g_Config.gameplay.fix_water_exit && water_depth == NO_HEIGHT) {
         item->pos = coll->old_pos;

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -370,8 +370,7 @@ static void M_UpdateEnvironment(void)
     }
 
     const ROOM *const room = Room_Get(item->room_num);
-    const int32_t water_depth = Lara_GetWaterDepth(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_depth = Lara_GetWaterDepth(item->pos, item->room_num);
     const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     const int32_t water_height_diff =
         water_height == NO_HEIGHT ? NO_HEIGHT : item->pos.y - water_height;
@@ -981,9 +980,8 @@ void Lara_Control_Initialise(
     }
 
     if (Room_Get(lara_item->room_num)->flags.underwater) {
-        const int32_t water_depth = Lara_GetWaterDepth(
-            lara_item->pos.x, lara_item->pos.y, lara_item->pos.z,
-            lara_item->room_num);
+        const int32_t water_depth =
+            Lara_GetWaterDepth(lara_item->pos, lara_item->room_num);
         const int32_t water_height =
             Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
         const int32_t water_height_diff = water_height == NO_HEIGHT

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -972,23 +972,47 @@ void Lara_Control_Initialise(
 {
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    lara_info->water_status = LWS_ABOVE_WATER;
 
     if ((level_type == GFL_NORMAL || level_type == GFL_BONUS)
         && start_state != LS_EXTRA_BREATH) {
-        lara_info->water_status = LWS_ABOVE_WATER;
         M_HandleStartState(start_state);
-    } else if (Room_Get(lara_item->room_num)->flags.underwater) {
-        lara_info->water_status = LWS_UNDERWATER;
-        lara_item->fall_speed = 0;
-        lara_item->goal_anim_state = LS(LS_TREAD);
-        lara_item->current_anim_state = LS(LS_TREAD);
-        Item_SwitchToAnim(lara_item, LA(LA_UNDERWATER_IDLE), 0);
-    } else {
-        lara_info->water_status = LWS_ABOVE_WATER;
-        lara_item->goal_anim_state = LS(LS_STOP);
-        lara_item->current_anim_state = LS(LS_STOP);
-        Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
+        return;
     }
+
+    if (Room_Get(lara_item->room_num)->flags.underwater) {
+        const int32_t water_depth = Lara_GetWaterDepth(
+            lara_item->pos.x, lara_item->pos.y, lara_item->pos.z,
+            lara_item->room_num);
+        const int32_t water_height =
+            Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
+        const int32_t water_height_diff = water_height == NO_HEIGHT
+            ? NO_HEIGHT
+            : lara_item->pos.y - water_height;
+        if (water_depth > LARA_SWIM_DEPTH || !g_Config.gameplay.enable_wading) {
+            if (water_height_diff > LARA_SWIM_DEPTH) {
+                lara_info->water_status = LWS_UNDERWATER;
+                lara_item->goal_anim_state = LS(LS_TREAD);
+                lara_item->current_anim_state = LS(LS_TREAD);
+                Item_SwitchToAnim(lara_item, LA(LA_UNDERWATER_IDLE), 0);
+            } else {
+                lara_info->water_status = LWS_SURFACE;
+                lara_item->pos.y = 1 + water_height;
+                lara_item->goal_anim_state = LS(LS_SURF_TREAD);
+                lara_item->current_anim_state = LS(LS_SURF_TREAD);
+                Item_SwitchToAnim(lara_item, LA(LA_ONWATER_IDLE), 0);
+            }
+            return;
+        } else if (
+            g_Config.gameplay.enable_wading
+            && water_height_diff > M_WADE_DEPTH) {
+            lara_info->water_status = LWS_WADE;
+        }
+    }
+
+    lara_item->goal_anim_state = LS(LS_STOP);
+    lara_item->current_anim_state = LS(LS_STOP);
+    Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
 }
 
 void Lara_Control(void)

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -345,15 +345,14 @@ void Lara_UpdateRoomToHeight(const int32_t height)
     Item_UpdateRoom(item_num, room_num);
 }
 
-int32_t Lara_GetWaterDepth(
-    const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
+int32_t Lara_GetWaterDepth(const XYZ_32 pos, int16_t room_num)
 {
     const ROOM *room = Room_Get(room_num);
     const SECTOR *sector;
 
     while (true) {
-        int32_t z_sector = (z - room->pos.z) >> WALL_SHIFT;
-        int32_t x_sector = (x - room->pos.x) >> WALL_SHIFT;
+        int32_t z_sector = (pos.z - room->pos.z) >> WALL_SHIFT;
+        int32_t x_sector = (pos.x - room->pos.x) >> WALL_SHIFT;
 
         if (z_sector <= 0) {
             z_sector = 0;
@@ -387,12 +386,11 @@ int32_t Lara_GetWaterDepth(
         while (sector->portal_room.sky != NO_ROOM) {
             room = Room_Get(sector->portal_room.sky);
             if (!room->flags.underwater && !room->flags.swamp) {
-                const XYZ_32 pos = { x, y, z };
                 const int32_t water_height = Room_GetWaterHeight(pos, room_num);
                 sector = Room_GetSector(pos, &room_num);
                 return Room_GetHeight(sector, pos) - water_height;
             }
-            sector = Room_GetWorldSector(room, x, z);
+            sector = Room_GetWorldSector(room, pos.x, pos.z);
         }
         return 0x7FFF;
     }
@@ -400,12 +398,11 @@ int32_t Lara_GetWaterDepth(
     while (sector->portal_room.pit != NO_ROOM) {
         room = Room_Get(sector->portal_room.pit);
         if (room->flags.underwater || room->flags.swamp) {
-            const XYZ_32 pos = { x, y, z };
             const int32_t water_height = Room_GetWaterHeight(pos, room_num);
             sector = Room_GetSector(pos, &room_num);
             return Room_GetHeight(sector, pos) - water_height;
         }
-        sector = Room_GetWorldSector(room, x, z);
+        sector = Room_GetWorldSector(room, pos.x, pos.z);
     }
     return NO_HEIGHT;
 }

--- a/src/trx/game/lara/misc.h
+++ b/src/trx/game/lara/misc.h
@@ -23,7 +23,7 @@ void Lara_CatchFireEx(FLAME_TYPE type);
 void Lara_CatchFire(void);
 
 void Lara_UpdateRoomToHeight(int32_t height);
-int32_t Lara_GetWaterDepth(int32_t x, int32_t y, int32_t z, int16_t room_num);
+int32_t Lara_GetWaterDepth(XYZ_32 pos, int16_t room_num);
 
 // Whether Lara holds a machine gun and is in either anim state: 0 (start
 // aim); 2 (firing); or 4 (stopping firing).


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This improves the handling of Lara's start state in a level by catering for her being at wading or water surface depths; OG assumed she was only ever on dry land (or 1-click water) or fully submerged.

Test levels available; would be good to sanity check the following OG cases too:

- [x] Midas (fully submerged, no room above)
- [x] Tihocan (above water)
- [x] Bartoli's (start in boat)
- [x] Rig (special start anim)
- [x] 40 Fathoms (similar to Midas, but a different water room above)
- [x] It's a Madhouse (fully submerged, dry room above)

Resolves TRX1312.
