### PR TITLE
objects/puzzle_hole: add property to prevent collision

### DIFF
--- a/data/te/tr1/Properties/default.xml
+++ b/data/te/tr1/Properties/default.xml
@@ -164,6 +164,9 @@
         <property category="TRX" defaultValue="true" description="Show a twinkle effect above the item." displayName="Show Pickup Aid" internalName="show_pickup_aid" type="Bool" />
         <property category="TRX" defaultValue="0" description="How much to rotate the item by each frame while it's active, in engine angle units." displayName="Rotation" internalName="rotation" maxValue="16384" minValue="-16384" type="Int" />
     </moveable>
+    <moveable id="118-125">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the slot after using it." displayName="Collidable When Done" internalName="collidable_when_done" type="Bool" />
+    </moveable>
     <moveable id="145">
         <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
     </moveable>

--- a/data/te/tr1/Properties/extra.xml
+++ b/data/te/tr1/Properties/extra.xml
@@ -292,6 +292,10 @@
         <property category="TRX" defaultValue="80" description="Damage dealt by punches 1 and 2." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
         <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
     </moveable>
+    <!--placeholder for O_PUZZLE_DONE_5..O_PUZZLE_HOLE_12-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the slot after using it." displayName="Collidable When Done" internalName="collidable_when_done" type="Bool" />
+    </moveable>
     <!--placeholder for O_QUAD_BIKE-->
     <moveable id="-1">
         <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />

--- a/data/te/tr2/Properties/default.xml
+++ b/data/te/tr2/Properties/default.xml
@@ -219,6 +219,9 @@
     <moveable id="152">
         <property category="TRX" defaultValue="60" description="How long the flare burns for, in seconds." displayName="Burn Time" internalName="burn_time" minValue="0" type="Float" />
     </moveable>
+    <moveable id="182-189">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the slot after using it." displayName="Collidable When Done" internalName="collidable_when_done" type="Bool" />
+    </moveable>
     <moveable id="214">
         <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
         <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />

--- a/data/te/tr2/Properties/extra.xml
+++ b/data/te/tr2/Properties/extra.xml
@@ -266,6 +266,10 @@
         <property category="TRX" defaultValue="80" description="Damage dealt by punches 1 and 2." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
         <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
     </moveable>
+    <!--placeholder for O_PUZZLE_DONE_5..O_PUZZLE_HOLE_12-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the slot after using it." displayName="Collidable When Done" internalName="collidable_when_done" type="Bool" />
+    </moveable>
     <!--placeholder for O_QUAD_BIKE-->
     <moveable id="-1">
         <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />

--- a/data/te/tr3/Properties/default.xml
+++ b/data/te/tr3/Properties/default.xml
@@ -281,6 +281,9 @@
         <property category="TRX" defaultValue="-1" description="Mesh the crystal is drawn with. -1 picks one from the save crystal mode." displayName="Mesh Index" internalName="mesh_index" minValue="-1" type="Int" />
         <property category="TRX" defaultValue="500" description="Health restored by a healing crystal." displayName="Heal Amount" internalName="heal_amount" minValue="0" type="Int" />
     </moveable>
+    <moveable id="213-220">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the slot after using it." displayName="Collidable When Done" internalName="collidable_when_done" type="Bool" />
+    </moveable>
     <moveable id="287">
         <property category="TRX" defaultValue="800" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
         <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />

--- a/data/te/tr3/Properties/extra.xml
+++ b/data/te/tr3/Properties/extra.xml
@@ -244,6 +244,10 @@
         <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
         <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
     </moveable>
+    <!--placeholder for O_PUZZLE_DONE_5..O_PUZZLE_HOLE_12-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the slot after using it." displayName="Collidable When Done" internalName="collidable_when_done" type="Bool" />
+    </moveable>
     <!--placeholder for O_RAT..O_VOLE-->
     <moveable id="-1">
         <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />

--- a/data/trx/ship/games/tr4/scripts/nutrench.lua
+++ b/data/trx/ship/games/tr4/scripts/nutrench.lua
@@ -3,4 +3,5 @@ trx.events.on_game_start(function()
   trx.objects.switch_type_generic_1.properties.switch_mode =
     trx.items.SwitchMode.SHOVE
   trx.items[17].properties.pickup_mode = trx.items.PickupMode.CROWBAR
+  trx.items[42].properties.collidable_when_done = false
 end)

--- a/data/trx/ship/games/tr4/scripts/settomb1.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb1.lua
@@ -10,6 +10,7 @@ trx.events.on_game_start(function()
   trx.objects.waterfall_1.properties.hide_when_inactive = true
   trx.objects.waterfall_2.properties.loop_sound = trx.items.WaterfallSound.SAND
   trx.objects.waterfall_2.properties.hide_when_inactive = true
+  trx.items[0].properties.collidable_when_done = false
 end)
 
 -- The caption the level opens with, which the level's strings carry.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - Added Natla as an outfit for Lara, selectable in every game (Graphic Options → Visuals → Lara's outfit) (TRX1050)
 - Added injection support for putting a room in a flip group, which only TR4 levels carry themselves (#5336 / TRX173)
 - Added a `requires_alert` property to the sentry gun, which lets a plain trigger set it firing where it would otherwise wait for a security laser (TRX1141)
+- Added a `collidable_when_done` property to puzzle slots, which applies to animated interactions only (TRX1046)
 - Added object references in strings files, so inventory entries can use the same name and description as their pickup
 - Changed object keys in strings files, game flows and weapon definitions to use the C object name without `O_`
 - Changed object names in strings files to use `|` between the name the game shows and the names the console accepts

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -2741,6 +2741,198 @@ This page lists documented moveable object properties.
 </tbody>
 </table>
 
+#### puzzle_done_1
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (122)</th><th align="center">TR2 (186)</th><th align="center">TR3 (217)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_2
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (123)</th><th align="center">TR2 (187)</th><th align="center">TR3 (218)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_3
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (124)</th><th align="center">TR2 (188)</th><th align="center">TR3 (219)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_4
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (125)</th><th align="center">TR2 (189)</th><th align="center">TR3 (220)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_5
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_6
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_7
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_8
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_9
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_10
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_11
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_done_12
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_1
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (118)</th><th align="center">TR2 (182)</th><th align="center">TR3 (213)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_2
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (119)</th><th align="center">TR2 (183)</th><th align="center">TR3 (214)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_3
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (120)</th><th align="center">TR2 (184)</th><th align="center">TR3 (215)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_4
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (121)</th><th align="center">TR2 (185)</th><th align="center">TR3 (216)</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_5
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_6
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_7
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_8
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_9
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_10
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_11
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
+#### puzzle_hole_12
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>collidable_when_done</code></td><td colspan="3" align="center">true</td><td>Whether or not Lara can collide with the slot after using it.</td></tr>
+</tbody>
+</table>
+
 #### puzzle_item_1
 <table width="100%">
 <thead><tr><th>Property</th><th align="center">TR1 (110)</th><th align="center">TR2 (174)</th><th align="center">TR3 (205)</th><th>Description</th></tr></thead>

--- a/src/trx/game/objects/general/puzzle_hole.c
+++ b/src/trx/game/objects/general/puzzle_hole.c
@@ -10,6 +10,10 @@
 
 #define M_LF_USE_PUZZLE 80
 
+typedef struct {
+    bool collidable_when_done;
+} M_PRIV;
+
 static XYZ_32 m_DefaultPosition = {
     .x = 0,
     .y = 0,
@@ -210,7 +214,8 @@ static void M_CollisionDone(
     const OBJECT *const obj = Object_Get(item->object_id);
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
-    if (g_Config.gameplay.enable_walk_to_items) {
+    const M_PRIV *const p = item->priv;
+    if (g_Config.gameplay.enable_walk_to_items && p->collidable_when_done) {
         Object_Collision(item_num, lara_item, coll);
     }
 
@@ -224,6 +229,16 @@ static void M_CollisionDone(
     Lara_RefuseInteraction();
 }
 
+static void M_DeclareProperties(OBJECT *const obj)
+{
+    obj->priv_size = sizeof(M_PRIV);
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY(
+            M_PRIV, collidable_when_done, true,
+            "Whether or not Lara can collide with the slot after using it."));
+}
+
 static void M_SetupEmpty(OBJECT *const obj)
 {
     obj->control_func = M_Control;
@@ -233,6 +248,7 @@ static void M_SetupEmpty(OBJECT *const obj)
     obj->bounds_func = M_Bounds;
     obj->save_flags = true;
     obj->save_anim = true;
+    M_DeclareProperties(obj);
 }
 
 static void M_SetupDone(OBJECT *const obj)
@@ -242,6 +258,7 @@ static void M_SetupDone(OBJECT *const obj)
     obj->bounds_func = M_Bounds;
     obj->save_flags = true;
     obj->save_anim = true;
+    M_DeclareProperties(obj);
 }
 
 #define X_PICKUP_PUZZLE(n)                                                     \

--- a/tools/lint/gen/object_docs
+++ b/tools/lint/gen/object_docs
@@ -41,24 +41,41 @@ def expand_pickup_includes(source: str) -> str:
     C preprocessor over pickups.def with the consumer's macro bodies and
     splice the expansion back into the source in place of the block.
     """
-    while (include_match := PICKUPS_DEF_INCLUDE_RE.search(source)) is not None:
-        # Walk backward over contiguous #define lines immediately preceding
-        # the #include (allowing blank lines between them).
+    lines = source.splitlines(keepends=True)
+    logical_lines: list[tuple[int, int, str]] = []
+    start = 0
+    i = 0
+
+    while i < len(lines):
+        end = i + 1
+        while lines[end - 1].rstrip("\r\n").endswith("\\") and end < len(lines):
+            end += 1
+
+        text = "".join(lines[i:end])
+        logical_lines.append((start, start + len(text), text))
+        start += len(text)
+        i = end
+
+    for index in range(len(logical_lines) - 1, -1, -1):
+        start, end, line = logical_lines[index]
+        if not PICKUPS_DEF_INCLUDE_RE.fullmatch(line):
+            continue
+
         defines: list[re.Match[str]] = []
-        block_start = include_match.start()
-        pos = block_start
-        while True:
-            line_start = source.rfind("\n", 0, pos - 1) + 1 if pos > 0 else 0
-            line = source[line_start:pos]
-            if line.strip() == "":
-                pos = line_start
+        block_start = start
+        j = index - 1
+        while j >= 0:
+            define_match = DEFINE_RE.fullmatch(logical_lines[j][2])
+            if define_match is None:
+                if logical_lines[j][2].strip():
+                    break
+                j -= 1
                 continue
-            if (define_match := DEFINE_RE.match(source, line_start)) is not None:
-                defines.append(define_match)
-                block_start = line_start
-                pos = line_start
-                continue
-            break
+
+            defines.append(define_match)
+            block_start = logical_lines[j][0]
+            j -= 1
+
         defines.reverse()
 
         macro_defs: dict[str, str] = {}
@@ -69,8 +86,11 @@ def expand_pickup_includes(source: str) -> str:
             body = define_match.group("body").replace("\\\n", "\n").strip()
             macro_defs[signature] = body
 
-        pos = include_match.end()
-        while (undef_match := UNDEF_RE.match(source, pos)) is not None:
+        pos = end
+        while pos < len(source):
+            undef_match = UNDEF_RE.match(source, pos)
+            if undef_match is None:
+                break
             pos = undef_match.end()
 
         expansion = expand_def_file(PICKUPS_DEF, macro_defs) if macro_defs else ""
@@ -308,6 +328,9 @@ class RegisteredPropertyCatalog:
                 if len(parts) != 2:
                     continue
                 object_id, func_name = parts[0].strip(), parts[1].strip()
+                # Ignore unexpanded macro arguments such as O_FOO_##n.
+                if not re.fullmatch(r"O_[A-Za-z0-9_]+", object_id):
+                    continue
                 func_to_objects.setdefault(func_name, []).append(object_id)
 
             for func_name, object_ids in func_to_objects.items():

--- a/tools/shared/cdefs.py
+++ b/tools/shared/cdefs.py
@@ -42,9 +42,12 @@ def _expand_def_file(
     if cpp is None:
         raise RuntimeError("cpp (the C preprocessor) is required but missing")
 
-    stub = "".join(
-        f"#define {signature} {body}\n" for signature, body in macro_defs
-    )
+    stub = ""
+    for signature, body in macro_defs:
+        # A body that spans lines keeps its continuations. Without them the
+        # first newline ends the #define and the rest becomes stray text.
+        body = body.replace("\n", " \\\n")
+        stub += f"#define {signature} {body}\n"
     stub += f'#include "{def_path}"\n'
 
     with tempfile.NamedTemporaryFile("w", suffix=".c") as tmp:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows puzzle slots to mark that they should not be collidable after Lara has used them. This applies to animated interactions only and is used on item 0 in Tomb of Seth and item 42 in Trenches.

A tweak was needed to the object docs generator to handle the `REGISTER_OBJECT(O_PUZZLE_HOLE_##n...` case. LMK if that looks OK.

Resolves TRX1046.
