### PR TITLE
output/sky: fix sky tint loss

### DIFF
--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -391,7 +391,8 @@ void main(void) {
 
     // Applies PlayStation depth cue before texture modulation, as tomb3's
     // transform.cpp does, so fog keeps the surface texture.
-    if (uPS1FogEnabled != 0 && (gOut.flags & VERT_NO_LIGHTING) == 0u
+    if (uPS1FogEnabled != 0
+        && (gOut.flags & (VERT_NO_FOG | VERT_NO_LIGHTING)) == 0u
         && uLightingEnabled != 0) {
         gOut.color.rgb = mix(gOut.color.rgb, uFogColor.rgb, fogFactor);
         gOut.add *= 1.0 - fogFactor;

--- a/src/trx/game/output/sources/sky.c
+++ b/src/trx/game/output/sources/sky.c
@@ -153,8 +153,10 @@ static void M_RenderPass(
     glVertexAttrib1f(OUTPUT_MESH_ATTR_SHADE, SHADE_NEUTRAL);
 
     // With a sky image, tint it with the layer color; without one, fall
-    // back to flat-shaded colored quads.
-    uint32_t flags = VERT_NO_LIGHTING | VERT_NO_WIBBLE | VERT_NO_ALPHA_DISCARD;
+    // back to flat-shaded colored quads. The layer color is a light value, so
+    // the quads suppress fog without suppressing the overbright lighting that
+    // carries most of the sky hue.
+    uint32_t flags = VERT_NO_FOG | VERT_NO_WIBBLE | VERT_NO_ALPHA_DISCARD;
     if (texture_page >= 0) {
         glEnableVertexAttribArray(OUTPUT_MESH_ATTR_UVW);
         // Layer colors are in the OG 128-neutral scale; the shader doubles


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where TR4 sky layers were drawn white in the Overbright mode, making colored skies such as Valley of the Kings and KV5 show grey clouds. The layers now disable fog instead of lighting. The mesh shader also disables the PlayStation depth cue when fog is disabled.

Resolves TRX1311