### PR TITLE
lara/control: handle stepping into wading depth

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed Lara briefly teleporting above the water line if she is stepping backwards from 2-click to 3-click wading depth (TRX1309, regression from 1.0)
 - Fixed Lara's arms twitching when stopped against walls in shallow water with either forward or backward input pressed against the wall (OG bug) (#6254 / TRX1121)
 - Fixed Lara assuming a fully underwater animation in custom levels if she begins at wading or water surface depths (OG bug) (TRX1312)
+- Fixed Lara slipping into wading-depth water when walking down steps in a water room (OG bug) (TRX1307)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -400,34 +400,44 @@ static void M_UpdateEnvironment(void)
 
         if (water_depth > LARA_SWIM_DEPTH - STEP_L && !room->flags.swamp) {
             if (room->flags.underwater) {
-                lara_info->air = LARA_MAX_AIR;
-                lara_info->water_status = LWS_UNDERWATER;
-                item->gravity = false;
-                item->pos.y += 100;
-                Lara_UpdateRoomToHeight(0);
-                Sound_StopEffect(SFX_LARA_FALL);
-                if (item->current_anim_state == LS(LS_SWAN_DIVE)) {
-                    item->rot.x = -M_DIVE_TILT_MED;
-                    item->goal_anim_state = LS(LS_DIVE);
-                    Lara_Animate(item);
-                    item->fall_speed *= 2;
-                } else if (item->current_anim_state == LS(LS_FAST_DIVE)) {
-                    item->rot.x = -M_DIVE_TILT_MAX;
-                    item->goal_anim_state = LS(LS_DIVE);
-                    Lara_Animate(item);
-                    item->fall_speed *= 2;
+                if (g_Config.gameplay.enable_wading
+                    && (item->current_anim_state == LS_U(LS_WALK_BACK)
+                        || item->current_anim_state == LS_U(LS_WALK))) {
+                    // Previous collision tests will have deemed the walking
+                    // state to be valid, so Lara can safely continue the linked
+                    // animation into wading depth.
+                    lara_info->water_status = LWS_WADE;
                 } else {
-                    item->rot.x = -M_DIVE_TILT_MED;
-                    Item_SwitchToAnim(item, LA(LA_FREEFALL_TO_UNDERWATER), 0);
-                    item->current_anim_state = LS(LS_DIVE);
-                    item->goal_anim_state = LS(LS_SWIM);
-                    item->fall_speed = (item->fall_speed * 3) / 2;
+                    lara_info->air = LARA_MAX_AIR;
+                    lara_info->water_status = LWS_UNDERWATER;
+                    item->gravity = false;
+                    item->pos.y += 100;
+                    Lara_UpdateRoomToHeight(0);
+                    Sound_StopEffect(SFX_LARA_FALL);
+                    if (item->current_anim_state == LS(LS_SWAN_DIVE)) {
+                        item->rot.x = -M_DIVE_TILT_MED;
+                        item->goal_anim_state = LS(LS_DIVE);
+                        Lara_Animate(item);
+                        item->fall_speed *= 2;
+                    } else if (item->current_anim_state == LS(LS_FAST_DIVE)) {
+                        item->rot.x = -M_DIVE_TILT_MAX;
+                        item->goal_anim_state = LS(LS_DIVE);
+                        Lara_Animate(item);
+                        item->fall_speed *= 2;
+                    } else {
+                        item->rot.x = -M_DIVE_TILT_MED;
+                        Item_SwitchToAnim(
+                            item, LA(LA_FREEFALL_TO_UNDERWATER), 0);
+                        item->current_anim_state = LS(LS_DIVE);
+                        item->goal_anim_state = LS(LS_SWIM);
+                        item->fall_speed = (item->fall_speed * 3) / 2;
+                    }
+                    lara_info->head_rot.x = 0;
+                    lara_info->head_rot.y = 0;
+                    lara_info->torso_rot.x = 0;
+                    lara_info->torso_rot.y = 0;
+                    Spawn_Splash(item);
                 }
-                lara_info->head_rot.x = 0;
-                lara_info->head_rot.y = 0;
-                lara_info->torso_rot.x = 0;
-                lara_info->torso_rot.y = 0;
-                Spawn_Splash(item);
             }
         } else if (
             g_Config.gameplay.enable_wading


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This adds handling for Lara transitioning down steps into wading depth water as long as she is walking. If she is moving quickly, she will continue to slip and splash.

Resolves TRX1307.
