### PR TITLE
Fix the TR4 title screen's cutscenes and water

### DIFF
--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -180,6 +180,14 @@ static float M_GetDefaultLetterbox(void)
                                                         : M_DEFAULT_LETTERBOX;
 }
 
+// Reports whether a scene may be cut short. The title plays its scenes as
+// scenery behind the menu, where there is nothing for the player to get past.
+static bool M_IsSkippable(void)
+{
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    return level == nullptr || level->type != GFL_TITLE;
+}
+
 static void M_ReleaseNodes(void)
 {
     for (int32_t i = 0; i < CUTSEQ_MAX_ACTORS; i++) {
@@ -709,7 +717,7 @@ void CutSeq_Control(void)
 {
     // As a cutscene level answers them, and for the same reason: a scene the
     // player has seen before is a scene to get past.
-    if (g_InputDB.menu_skip || g_InputDB.look) {
+    if (M_IsSkippable() && (g_InputDB.menu_skip || g_InputDB.look)) {
         CutSeq_Skip();
         Input_HoldOffSkip();
     }

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -51,21 +51,6 @@ static bool M_IsPreLoadEvent(const GF_SEQUENCE_EVENT_TYPE type)
     return type == GFS_SETUP_HORIZON || type == GFS_SETUP_UV_ROTATE;
 }
 
-static void M_PreSequenceHook(
-    const GF_SEQUENCE_CONTEXT seq_ctx, void *const seq_ctx_arg)
-{
-    Room_SetAbyssHeight(0);
-    Output_SetSunsetEnabled(false);
-    Output_Sky_Reset();
-    Output_LensFlares_Reset();
-    Output_SetUVRotateSpeed(0);
-    Lara_SetControllable(false);
-    Lara_SetStartAnimState(LS_EXTRA_BREATH);
-    if (seq_ctx == GFSC_SAVED) {
-        Game_SetBonusFlag(GBF_NONE);
-    }
-}
-
 static GF_SEQUENCE_CONTEXT M_SwitchSequenceContext(
     const GF_SEQUENCE_EVENT *const event, const GF_SEQUENCE_CONTEXT seq_ctx)
 {
@@ -128,6 +113,20 @@ static bool M_IsLevelDescendantOf(
     return false;
 }
 
+void GF_ResetLevelSetup(const GF_SEQUENCE_CONTEXT seq_ctx)
+{
+    Room_SetAbyssHeight(0);
+    Output_SetSunsetEnabled(false);
+    Output_Sky_Reset();
+    Output_LensFlares_Reset();
+    Output_SetUVRotateSpeed(0);
+    Lara_SetControllable(false);
+    Lara_SetStartAnimState(LS_EXTRA_BREATH);
+    if (seq_ctx == GFSC_SAVED) {
+        Game_SetBonusFlag(GBF_NONE);
+    }
+}
+
 RESULT GF_InterpretSequence(
     const GF_LEVEL *const level, GF_SEQUENCE_CONTEXT seq_ctx,
     void *const seq_ctx_arg, GF_COMMAND *const out_cmd)
@@ -142,7 +141,7 @@ RESULT GF_InterpretSequence(
         return OK;
     }
 
-    M_PreSequenceHook(seq_ctx, seq_ctx_arg);
+    GF_ResetLevelSetup(seq_ctx);
 
     GF_COMMAND gf_cmd = { .action = GF_EXIT_TO_TITLE };
 

--- a/src/trx/game/game_flow/sequencer.h
+++ b/src/trx/game/game_flow/sequencer.h
@@ -33,6 +33,10 @@ RESULT GF_DoDemoSequence(int32_t demo_num, GF_COMMAND *out_cmd);
 RESULT GF_DoCutsceneSequence(
     int32_t cutscene_num, bool cross_fade_in, GF_COMMAND *out_cmd);
 
+// Puts back what a level's sequence sets up, so that nothing one level asks
+// for is carried into the next one.
+void GF_ResetLevelSetup(GF_SEQUENCE_CONTEXT seq_ctx);
+
 RESULT GF_InterpretSequence(
     const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg,
     GF_COMMAND *out_cmd);

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -36,6 +36,7 @@ RESULT GF_RunTitle(GF_COMMAND *const out_cmd)
 {
     SG_Manager_UnbindSlot();
     GameStringTable_Apply(nullptr);
+    GF_ResetLevelSetup(GFSC_NORMAL);
     const GF_LEVEL *const title_level = GF_GetTitleLevel();
     MUST(Level_Initialise(title_level, GFSC_NORMAL), "the title level");
     *out_cmd = GF_ShowInventory(INV_TITLE_MODE);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes two issues in the TR4 title screen:

- Background scenes no longer respond to the skip or look keys.
- Level settings no longer carry over to the title. This includes UV rotation speed, horizon, lens flares, sunset height, and abyss height.

Neither issue reached a release, so no changelog entry is needed.

Resolves TRX1319 / TRX1320

#### Testing

- [x] On the title screen, press the skip and look keys during a scene. It should play to the end.
- [x] In a level, confirm both keys still skip cutscenes.
- [x] Launch TR4 and note the water speed in the title's flooded room.
- [x] Enter Angkor Wat, return to the title, and confirm the water speed is unchanged.