### PR TITLE
level/rooms: fix statics vanishing by angle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -120,6 +120,7 @@
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed sprite shadows breaking apart on uneven ground (Graphic Options → Visuals → Shadows shape) (#6388 / TRX1244)
 - Fixed static objects that reach through a doorway taking the water tint and the light of the room next door
+- Fixed static objects disappearing depending on the camera angle (OG bug) (TRX1211)
 - Fixed the underwater view wobbling less at higher supersampling values (TRX1207)
 - Fixed the debug portal and bounding box lines becoming thinner at higher supersampling values (TRX1251)
 

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -6,6 +6,7 @@
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
+#include <trx/game/const.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/items.h>
 #include <trx/game/level/finalize.h>
@@ -13,6 +14,11 @@
 #include <trx/game/rooms.h>
 
 #include <string.h>
+
+// How far a static must reach into the room next door before that room draws
+// it. The bounds are turned corner by corner and carry a few units of slop,
+// which any test on a bare touch would read as a reach.
+#define M_MIN_REACH (WALL_L / 16)
 
 // One placed static reaching one room. The placement is what bleeds, and what
 // the level author has to move; the static it is placed from only says what
@@ -59,6 +65,17 @@ static inline BOUNDS_32 M_GetStaticBounds(const STATIC_MESH *const mesh)
     }
 
     return bounds;
+}
+
+// Reports how deep two boxes reach into one another, measured along the axis
+// they share least. A box that only touches another reaches no depth at all.
+static int32_t M_GetOverlapDepth(
+    const BOUNDS_32 *const a, const BOUNDS_32 *const b)
+{
+    const int32_t x = MIN(a->max.x, b->max.x) - MAX(a->min.x, b->min.x);
+    const int32_t y = MIN(a->max.y, b->max.y) - MAX(a->min.y, b->min.y);
+    const int32_t z = MIN(a->max.z, b->max.z) - MAX(a->min.z, b->min.z);
+    return MIN(MIN(x, y), z);
 }
 
 static void M_ComputePortalBounds(void)
@@ -204,11 +221,15 @@ static void M_FixStaticsVisibility(void)
             if (room->flip_status != dest_room->flip_status) {
                 continue;
             }
+            const BOUNDS_32 dest_bounds = Room_GetRoomBounds(dest_room);
             for (int32_t m = 0; m < own_counts[i]; m++) {
                 const STATIC_MESH *const mesh =
                     Vector_Get(room_stat_vecs[i], m);
                 const BOUNDS_32 bounds = M_GetStaticBounds(mesh);
-                if (!Room_BoundsReachPortal(&bounds, portal)) {
+                // A static standing wholly past the wall reaches no portal,
+                // so the room it reaches into answers for it instead.
+                if (!Room_BoundsReachPortal(&bounds, portal)
+                    && M_GetOverlapDepth(&bounds, &dest_bounds) < M_MIN_REACH) {
                     continue;
                 }
                 if (Vector_Contains(room_stat_vecs[portal->room_num], mesh)) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Rooms now lend statics that reach a short distance into neighboring rooms, preventing meshes near narrow doorways from popping in and out as the camera turns. A small margin avoids lending meshes that only barely cross a boundary, which could otherwise introduce unwanted collision.

Fixes three cases in Angkor Wat while preserving the truck collision in High Security Compound.

Resolves TRX1211