### PR TITLE
items/manager: keep destroyed level items counted

### DIFF
--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -530,7 +530,10 @@ void Item_Destroy(const int16_t item_num)
         m_NextItemFree = item_num;
     }
 
-    while (m_MaxUsedItemCount > 0
+    // The count stops at the level items, whose slots are never handed out
+    // again however many of them are destroyed. A count below them hides
+    // live slots from every caller that reads it.
+    while (m_MaxUsedItemCount > m_LevelItemCount
            && m_Items[m_MaxUsedItemCount - 1].is_destroyed) {
         m_MaxUsedItemCount--;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The used item count includes level item slots after their items are destroyed. Spawned slots above them can still be reused.

Previously, the count skipped destroyed level items. Callers then missed live slots after them. High Security Compound has six AI markers at the end of the item list. They are destroyed during setup. Loading a save reported that their names referred to missing items. Script handles also went stale while their slots were still valid.