### PR TITLE
Fix undefined arithmetic the sanitizer reports

### DIFF
--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -62,6 +62,17 @@ static XYZ_32 M_GetMidPos(const ITEM *const item)
     return pos;
 }
 
+// Returns how far the line moves along one axis per sector along another.
+static int32_t M_GetSlope(const int32_t delta, const int32_t span)
+{
+    return ((int64_t)delta * WALL_L) / span;
+}
+
+static int32_t M_ApplySlope(const int32_t slope, const int32_t delta)
+{
+    return ((int64_t)slope * delta) >> WALL_SHIFT;
+}
+
 static int32_t M_CheckX(
     const GAME_VECTOR *const start, GAME_VECTOR *const target)
 {
@@ -70,8 +81,8 @@ static int32_t M_CheckX(
         return 1;
     }
 
-    const int32_t dy = ((target->y - start->y) * WALL_L) / dx;
-    const int32_t dz = ((target->z - start->z) * WALL_L) / dx;
+    const int32_t dy = M_GetSlope(target->y - start->y, dx);
+    const int32_t dz = M_GetSlope(target->z - start->z, dx);
 
     int16_t room_num = start->room_num;
     int16_t last_room_num = start->room_num;
@@ -81,8 +92,8 @@ static int32_t M_CheckX(
     if (dx < 0) {
         XYZ_32 cur_pos;
         cur_pos.x = ROUND_TO_SECTOR(start->x);
-        cur_pos.y = start->y + ((dy * (cur_pos.x - start->x)) >> WALL_SHIFT);
-        cur_pos.z = start->z + ((dz * (cur_pos.x - start->x)) >> WALL_SHIFT);
+        cur_pos.y = start->y + M_ApplySlope(dy, cur_pos.x - start->x);
+        cur_pos.z = start->z + M_ApplySlope(dz, cur_pos.x - start->x);
 
         while (cur_pos.x > target->x) {
             XYZ_32 sample_pos = cur_pos;
@@ -125,8 +136,8 @@ static int32_t M_CheckX(
     } else {
         XYZ_32 cur_pos;
         cur_pos.x = ROUND_TO_SECTOR_END(start->x);
-        cur_pos.y = start->y + (((cur_pos.x - start->x) * dy) >> WALL_SHIFT);
-        cur_pos.z = start->z + (((cur_pos.x - start->x) * dz) >> WALL_SHIFT);
+        cur_pos.y = start->y + M_ApplySlope(dy, cur_pos.x - start->x);
+        cur_pos.z = start->z + M_ApplySlope(dz, cur_pos.x - start->x);
 
         while (cur_pos.x < target->x) {
             XYZ_32 sample_pos = cur_pos;
@@ -180,8 +191,8 @@ static int32_t M_CheckZ(
         return 1;
     }
 
-    const int32_t dx = ((target->x - start->x) * WALL_L) / dz;
-    const int32_t dy = ((target->y - start->y) * WALL_L) / dz;
+    const int32_t dx = M_GetSlope(target->x - start->x, dz);
+    const int32_t dy = M_GetSlope(target->y - start->y, dz);
 
     int16_t room_num = start->room_num;
     int16_t last_room_num = start->room_num;
@@ -191,8 +202,8 @@ static int32_t M_CheckZ(
     if (dz < 0) {
         XYZ_32 cur_pos;
         cur_pos.z = ROUND_TO_SECTOR(start->z);
-        cur_pos.x = start->x + ((dx * (cur_pos.z - start->z)) >> WALL_SHIFT);
-        cur_pos.y = start->y + ((dy * (cur_pos.z - start->z)) >> WALL_SHIFT);
+        cur_pos.x = start->x + M_ApplySlope(dx, cur_pos.z - start->z);
+        cur_pos.y = start->y + M_ApplySlope(dy, cur_pos.z - start->z);
 
         while (cur_pos.z > target->z) {
             XYZ_32 sample_pos = cur_pos;
@@ -235,8 +246,8 @@ static int32_t M_CheckZ(
     } else {
         XYZ_32 cur_pos;
         cur_pos.z = ROUND_TO_SECTOR_END(start->z);
-        cur_pos.x = start->x + ((dx * (cur_pos.z - start->z)) >> WALL_SHIFT);
-        cur_pos.y = start->y + ((dy * (cur_pos.z - start->z)) >> WALL_SHIFT);
+        cur_pos.x = start->x + M_ApplySlope(dx, cur_pos.z - start->z);
+        cur_pos.y = start->y + M_ApplySlope(dy, cur_pos.z - start->z);
 
         while (cur_pos.z < target->z) {
             XYZ_32 sample_pos = cur_pos;

--- a/src/trx/game/creature/shooting.c
+++ b/src/trx/game/creature/shooting.c
@@ -85,6 +85,13 @@ static void M_TriggerTR3GunSmoke(
     Sparks_TriggerGunSmoke(smoke_pos, true, Gun_GetDefaultType(), 32);
 }
 
+// Truncates to 32 bits. The original game overflows while it decides whether
+// a creature's shot hits, and the wrapped values are part of that decision.
+static int32_t M_Wrap(const int64_t value)
+{
+    return (int32_t)(uint32_t)(uint64_t)value;
+}
+
 bool Creature_Shoot(
     ITEM *const item, const AI_INFO *const info, const CREATURE_GUN *const gun,
     const int16_t extra_rotation, const int32_t damage)
@@ -124,12 +131,13 @@ bool Creature_Shoot(
             is_targetable = false;
             is_hit = false;
         } else {
-            int32_t distance =
-                (((target_item->speed * Math_Sin(info->enemy_facing))
-                  >> W2V_SHIFT)
-                 * CREATURE_SHOOT_RANGE)
+            const int32_t lead =
+                (target_item->speed * Math_Sin(info->enemy_facing))
+                >> W2V_SHIFT;
+            int32_t distance = M_Wrap((int64_t)lead * CREATURE_SHOOT_RANGE)
                 / M_SHOOT_TARGETING_SPEED;
-            distance = info->distance + SQUARE(distance);
+            distance = M_Wrap(
+                (int64_t)info->distance + M_Wrap((int64_t)distance * distance));
             if (distance > CREATURE_SHOOT_RANGE) {
                 is_hit = false;
             } else {

--- a/src/trx/game/fx/gun_flash.c
+++ b/src/trx/game/fx/gun_flash.c
@@ -53,6 +53,12 @@ static bool M_GetOwnerItem(
     return *out_item != nullptr;
 }
 
+// Converts a joint axis offset into a world-to-view matrix component.
+static int32_t M_GetAxisScale(const int32_t delta)
+{
+    return ((int64_t)delta * (1 << W2V_SHIFT)) / M_AXIS_UNIT;
+}
+
 static void M_GetJointPose(
     const ITEM *const item, const BITE bite, XYZ_32 *const out_pos,
     MATRIX *const out_rot)
@@ -75,17 +81,17 @@ static void M_GetJointPose(
     *out_pos = pos;
     *out_rot = g_IDMatrix;
 
-    out_rot->_00 = ((int64_t)(axis_x.x - pos.x) << W2V_SHIFT) / M_AXIS_UNIT;
-    out_rot->_10 = ((int64_t)(axis_x.y - pos.y) << W2V_SHIFT) / M_AXIS_UNIT;
-    out_rot->_20 = ((int64_t)(axis_x.z - pos.z) << W2V_SHIFT) / M_AXIS_UNIT;
+    out_rot->_00 = M_GetAxisScale(axis_x.x - pos.x);
+    out_rot->_10 = M_GetAxisScale(axis_x.y - pos.y);
+    out_rot->_20 = M_GetAxisScale(axis_x.z - pos.z);
 
-    out_rot->_01 = ((int64_t)(axis_y.x - pos.x) << W2V_SHIFT) / M_AXIS_UNIT;
-    out_rot->_11 = ((int64_t)(axis_y.y - pos.y) << W2V_SHIFT) / M_AXIS_UNIT;
-    out_rot->_21 = ((int64_t)(axis_y.z - pos.z) << W2V_SHIFT) / M_AXIS_UNIT;
+    out_rot->_01 = M_GetAxisScale(axis_y.x - pos.x);
+    out_rot->_11 = M_GetAxisScale(axis_y.y - pos.y);
+    out_rot->_21 = M_GetAxisScale(axis_y.z - pos.z);
 
-    out_rot->_02 = ((int64_t)(axis_z.x - pos.x) << W2V_SHIFT) / M_AXIS_UNIT;
-    out_rot->_12 = ((int64_t)(axis_z.y - pos.y) << W2V_SHIFT) / M_AXIS_UNIT;
-    out_rot->_22 = ((int64_t)(axis_z.z - pos.z) << W2V_SHIFT) / M_AXIS_UNIT;
+    out_rot->_02 = M_GetAxisScale(axis_z.x - pos.x);
+    out_rot->_12 = M_GetAxisScale(axis_z.y - pos.y);
+    out_rot->_22 = M_GetAxisScale(axis_z.z - pos.z);
 
     out_rot->_03 = 0;
     out_rot->_13 = 0;

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -320,9 +320,9 @@ int16_t Spawn_GunHit(
 {
     const ITEM *const lara_item = Lara_GetItem();
     XYZ_32 vec = {
-        .x = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-        .y = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-        .z = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .x = -((Random_GetDraw() - 0x4000) * 128) / 0x7FFF,
+        .y = -((Random_GetDraw() - 0x4000) * 128) / 0x7FFF,
+        .z = -((Random_GetDraw() - 0x4000) * 128) / 0x7FFF,
     };
     Collide_GetJointAbsPosition(
         lara_item, &vec, Random_GetControl() * LM_NUMBER_OF / 0x7FFF);
@@ -340,9 +340,9 @@ int16_t Spawn_GunMiss(
 {
     const ITEM *const lara_item = Lara_GetItem();
     const GAME_VECTOR pos = {
-        .x = lara_item->pos.x + ((Random_GetDraw() - 0x4000) << 9) / 0x7FFF,
+        .x = lara_item->pos.x + ((Random_GetDraw() - 0x4000) * 512) / 0x7FFF,
         .y = lara_item->floor,
-        .z = lara_item->pos.z + ((Random_GetDraw() - 0x4000) << 9) / 0x7FFF,
+        .z = lara_item->pos.z + ((Random_GetDraw() - 0x4000) * 512) / 0x7FFF,
         .room_num = lara_item->room_num,
     };
     Spawn_Ricochet(pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Removes undefined arithmetic reported by UndefinedBehaviorSanitizer during normal play, including shifts of negative values and 32-bit multiplication overflows.

The only incorrect behavior was in line-of-sight checks. Steep lines over short distances could overflow the per-sector step, causing enemies to shoot Lara through floors or ceilings. The step is now computed in 64 bits.

The other fixes preserve the original behavior. Blood, gun flashes, and creature shots use multiplication instead of shifts. Creature shot calculations still wrap to 32 bits, since the original game relies on that result to determine hits.