### PR TITLE
lua+rooms: add flip groups to the room surface

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -212,6 +212,7 @@
 - Fixed the game stuttering while it writes its log
 
 **Lua**
+- Added `trx.rooms.flip_groups()`, so a level script can move some flip pairs while the rest stay where they are
 - Added `trx.lara.signals`, `trx.game.signals` and `trx.cutscenes.signals`, so a script hears when Lara's state, the game's or a cutscene's changes rather than asking after it
 - Added `trx.lara.is_controllable`, `trx.lara.vehicle`, `trx.lara.MAX_AIR`, `trx.lara.MAX_SPRINT`, what her arms and the flare in them are doing, and what she is lining herself up with, so a script can report what the overlay reports
 - Added `trx.game.is_playing`, `trx.game.is_suspended`, `trx.game.is_photo_mode`, `trx.game.tr_version`, `trx.game.real_time` and `trx.game.measured_fps`, so a script can tell what the game is doing and how fast it is drawing

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6013,6 +6013,20 @@
       }
     },
     {
+      "description": "Puts rooms in flip groups. A level script can then move some flip pairs while the\nrest stay where they are. Each entry names one room and the group it belongs to. Its flip pair\njoins the same group.\n\nCall this only from the top level of a level script. Rooms must be grouped before the level\nstarts, so the game can restore flipped groups correctly when it loads a save.\n\nA level with no groups moves all flip pairs together. After a script names any group, each flip\ntrigger moves only the group with the same number.",
+      "examples": [
+        "trx.rooms.flip_groups({ [33] = 1, [37] = 2 })"
+      ],
+      "params": [
+        {
+          "description": "Flip groups, keyed by `trx.rooms.Num`.",
+          "name": "groups",
+          "type": "table"
+        }
+      ],
+      "path": "rooms.flip_groups"
+    },
+    {
       "description": "Flips rooms, swapping each with its flip pair. With no group given, every group\nmoves.",
       "examples": [
         "trx.rooms.flip()",

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -211,6 +211,25 @@ end
 
   Returns: integer. How many rooms the loaded level holds.
 
+- <a id="rooms.flip_groups" name="rooms.flip_groups"></a>[lua]`trx.rooms.flip_groups(groups)`  
+  Puts rooms in flip groups. A level script can then move some flip pairs while the
+  rest stay where they are. Each entry names one room and the group it belongs to. Its flip pair
+  joins the same group.
+
+  Call this only from the top level of a level script. Rooms must be grouped before the level
+  starts, so the game can restore flipped groups correctly when it loads a save.
+
+  A level with no groups moves all flip pairs together. After a script names any group, each flip
+  trigger moves only the group with the same number.
+
+  Parameters:
+  - <a id="rooms.flip_groups.groups" name="rooms.flip_groups.groups"></a>**`groups`** (table). Flip groups, keyed by [`trx.rooms.Num`](#rooms.Num).
+
+  Example:
+  ```lua
+  trx.rooms.flip_groups({ [33] = 1, [37] = 2 })
+  ```
+
 - <a id="rooms.flip" name="rooms.flip"></a>[lua]`trx.rooms.flip([group])`  
   Flips rooms, swapping each with its flip pair. With no group given, every group
   moves.

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -294,6 +294,39 @@ api.property("rooms.flip_group_count", {
   get = raw.flip_group_count,
 })
 
+api.define("rooms.flip_groups", {
+  description = [[Puts rooms in flip groups. A level script can then move some flip pairs while the
+    rest stay where they are. Each entry names one room and the group it belongs to. Its flip pair
+    joins the same group.
+
+    Call this only from the top level of a level script. Rooms must be grouped before the level
+    starts, so the game can restore flipped groups correctly when it loads a save.
+
+    A level with no groups moves all flip pairs together. After a script names any group, each flip
+    trigger moves only the group with the same number.]],
+  params = {
+    {
+      name = "groups",
+      type = "table",
+      description = "Flip groups, keyed by `trx.rooms.Num`.",
+    },
+  },
+  examples = {
+    [[trx.rooms.flip_groups({ [33] = 1, [37] = 2 })]],
+  },
+  impl = function(groups)
+    for room_num, group in pairs(groups) do
+      if math.type(room_num) ~= "integer" then
+        error("a room is named by number", 2)
+      end
+      if math.type(group) ~= "integer" then
+        error("a flip group is named by number", 2)
+      end
+      raw.declare_flip_group(room_num, group)
+    end
+  end,
+})
+
 local FLIP_GROUP_PARAM = {
   name = "group",
   type = "integer",

--- a/src/tests/fakes/level.c
+++ b/src/tests/fakes/level.c
@@ -1,8 +1,17 @@
 #include <fakes/level.h>
 
+#include <harness/fake_calls.h>
+
 #include <trx/game/level/common.h>
 
 static bool m_WorldLoaded = true;
+
+static void M_Reset(void)
+{
+    m_WorldLoaded = true;
+}
+
+FAKE_ON_RESET(M_Reset)
 
 void FakeLevel_SetWorldLoaded(const bool loaded)
 {

--- a/src/tests/fakes/rooms.c
+++ b/src/tests/fakes/rooms.c
@@ -107,6 +107,11 @@ void Room_FlipMap(const int32_t group)
     m_FlipStatus = !m_FlipStatus;
 }
 
+void Room_SetFlipGroup(const int32_t room_num, const int32_t group)
+{
+    FAKE_RECORD("set_flip_group", FV(room_num), FV(group));
+}
+
 bool Room_GetFlipStatus(void)
 {
     return m_FlipStatus;

--- a/src/tests/lua/api/rooms.c
+++ b/src/tests/lua/api/rooms.c
@@ -2,6 +2,7 @@
 // stands up the world they run against.
 
 #include <fakes/items.h>
+#include <fakes/level.h>
 #include <fakes/rooms.h>
 #include <harness/lua_surface.h>
 
@@ -34,6 +35,36 @@ static int M_L_LoadNextLevel(lua_State *const L)
     return 0;
 }
 
+// Set the world-loaded state because level scripts declare flip groups before
+// the level is read.
+static int M_L_SetWorldLoaded(lua_State *const L)
+{
+    FakeLevel_SetWorldLoaded(lua_toboolean(L, 1));
+    return 0;
+}
+
+// Apply declared flip groups once Level_Initialise has created the rooms.
+static int M_L_ApplyFlipGroups(lua_State *const L)
+{
+    LUA_Rooms_ApplyFlipGroups();
+    return 0;
+}
+
+// Set whether the current script is a level script, since only level scripts
+// may declare flip groups.
+static int M_L_SetLevelScript(lua_State *const L)
+{
+    LUA_SetScriptContext(
+        lua_toboolean(L, 1) ? LUA_CONTEXT_LEVEL : LUA_CONTEXT_GLOBAL);
+    return 0;
+}
+
+static int M_L_ClearFlipGroups(lua_State *const L)
+{
+    LUA_Rooms_ClearFlipGroups();
+    return 0;
+}
+
 static void M_PushFake(lua_State *const L)
 {
     lua_pushinteger(L, FAKE_ROOM_COUNT);
@@ -42,6 +73,14 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "load_next_level");
     lua_pushcfunction(L, M_L_FireRoomChange);
     lua_setfield(L, -2, "fire_room_change");
+    lua_pushcfunction(L, M_L_SetWorldLoaded);
+    lua_setfield(L, -2, "set_world_loaded");
+    lua_pushcfunction(L, M_L_ApplyFlipGroups);
+    lua_setfield(L, -2, "apply_flip_groups");
+    lua_pushcfunction(L, M_L_ClearFlipGroups);
+    lua_setfield(L, -2, "clear_flip_groups");
+    lua_pushcfunction(L, M_L_SetLevelScript);
+    lua_setfield(L, -2, "set_level_script");
 }
 
 int main(void)

--- a/src/tests/lua/api/rooms.lua
+++ b/src/tests/lua/api/rooms.lua
@@ -119,6 +119,75 @@ test("module functions reach the engine", function()
   assert(fake.calls().set_flip_timer.flip_timer == 10)
 end)
 
+-- A level script names its flip groups before the level's rooms are read, so
+-- the declaration waits and Level_Initialise applies it.
+test("declared flip groups reach the rooms once the level is read", function()
+  fake.clear_flip_groups()
+  fake.set_level_script(true)
+  fake.set_world_loaded(false)
+  trx.rooms.flip_groups({ [0] = 1 })
+  assert(
+    fake.calls().set_flip_group.count == 0,
+    "a declaration must not touch the rooms of the outgoing level"
+  )
+
+  fake.set_world_loaded(true)
+  fake.apply_flip_groups()
+  assert(fake.calls().set_flip_group.room_num == 0)
+  assert(fake.calls().set_flip_group.group == 1)
+end)
+
+test("a flip group must be declared before the level is read", function()
+  fake.clear_flip_groups()
+  fake.set_level_script(true)
+  raises(function()
+    trx.rooms.flip_groups({ [0] = 1 })
+  end, "before the level is read")
+end)
+
+test("a flip group can only be declared by a level script", function()
+  fake.clear_flip_groups()
+  fake.set_level_script(false)
+  fake.set_world_loaded(false)
+  raises(function()
+    trx.rooms.flip_groups({ [0] = 1 })
+  end, "by a level script")
+end)
+
+test("a room that cannot hold a group is passed over", function()
+  fake.clear_flip_groups()
+  fake.set_level_script(true)
+  fake.set_world_loaded(false)
+  -- Room 2 has no flip pair, and the fake level stops at room 3.
+  trx.rooms.flip_groups({ [2] = 1, [9] = 1, [0] = 2 })
+  fake.set_world_loaded(true)
+  fake.apply_flip_groups()
+
+  assert(
+    fake.calls().set_flip_group.count == 1,
+    "only the room with a flip pair may be grouped"
+  )
+  assert(fake.calls().set_flip_group.room_num == 0)
+end)
+
+test("a flip group is named by number, on both sides", function()
+  fake.clear_flip_groups()
+  fake.set_level_script(true)
+  fake.set_world_loaded(false)
+  raises(function()
+    trx.rooms.flip_groups({ ["0"] = 1 })
+  end, "named by number")
+  raises(function()
+    trx.rooms.flip_groups({ [0] = "1" })
+  end, "named by number")
+  raises(function()
+    trx.rooms.flip_groups({ [0] = trx.rooms.flip_group_count })
+  end, "no such flip group")
+
+  -- The rest of the file is the surface as a game script sees it.
+  fake.set_level_script(false)
+end)
+
 test("find_valid_pos nudges a position, or gives nil", function()
   local pos, num = trx.rooms.find_valid_pos({ x = 0, y = 0, z = 0 }, 0)
   assert(pos ~= nil and num == 0, "expected a valid position")

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -545,7 +545,12 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/rooms',
   'bundles': [b_lua_surface, b_lua_math],
-  'src': ['harness/stubs_console.c', 'fakes/rooms.c', 'fakes/items.c'],
+  'src': [
+    'harness/stubs_console.c',
+    'fakes/level.c',
+    'fakes/rooms.c',
+    'fakes/items.c',
+  ],
   'engine': [
     'game/lua/capi/events.c',
     'game/lua/capi/items.c',
@@ -678,7 +683,9 @@ unit_tests += {
   'name': 'lua/api/camera',
   'bundles': [b_lua_surface, b_lua_math],
   'src': [
+    'harness/stubs_console.c',
     'fakes/camera.c',
+    'fakes/level.c',
     'fakes/rooms.c',
     # for Room_GetIndexFromPos, which rooms.c reaches for
     'fakes/items.c',

--- a/src/tests/trx/game/lua/common.c
+++ b/src/tests/trx/game/lua/common.c
@@ -226,6 +226,11 @@ void LUA_Config_ClearLevelWatchers(void)
 {
 }
 
+// Keep flip-group declarations outside the unlinked room bridge.
+void LUA_Rooms_ClearFlipGroups(void)
+{
+}
+
 void LUA_Guard_Install(lua_State *const L, const double budget_sec)
 {
 }

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -122,6 +122,9 @@ RESULT Level_Initialise(
     // The level script ran before any of this was here, so the watchers it
     // attached are still owed the call for the value in force.
     LUA_Config_FlushPendingWatchers();
+    // Resolve script-declared flip groups before savegame loading replays
+    // their moved state.
+    LUA_Rooms_ApplyFlipGroups();
 
     UI_LoadText();
     Output_SetSkyboxEnabled(Object_Get(O_SKYBOX)->loaded);

--- a/src/trx/game/lua/capi/rooms.c
+++ b/src/trx/game/lua/capi/rooms.c
@@ -1,5 +1,8 @@
+#include <trx/core/vector.h>
+#include <trx/game/console/common.h>
 #include <trx/game/items/actions/ids.h>
 #include <trx/game/items/const.h>
+#include <trx/game/level/common.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
@@ -8,6 +11,13 @@
 #include <trx/game/rooms.h>
 
 #include <lauxlib.h>
+
+typedef struct {
+    int32_t room_num;
+    int32_t group;
+} M_FLIP_GROUP_DECL;
+
+static VECTOR *m_FlipGroupDecls = nullptr;
 
 // Scripts and the engine both count rooms from 0. There is no Room_GetIndex, so
 // derive it the way Item_GetIndex does.
@@ -138,6 +148,38 @@ static int M_L_RoomsFlipGroupCount(lua_State *const L)
     return 1;
 }
 
+// trxc.rooms.declare_flip_group(room_num, group)
+//
+// Stores flip groups until Level_Initialise, when rooms are ready.
+// Keeps declarations level-scoped, like the listeners from the same script.
+static int M_L_RoomsDeclareFlipGroup(lua_State *const L)
+{
+    if (LUA_GetScriptContext() != LUA_CONTEXT_LEVEL) {
+        return luaL_error(
+            L, "a flip group can only be declared by a level script");
+    }
+    if (Level_IsWorldLoaded()) {
+        return luaL_error(
+            L, "a flip group must be declared before the level is read");
+    }
+
+    const lua_Integer room_num = luaL_checkinteger(L, 1);
+    luaL_argcheck(L, room_num >= 0, 1, "unknown room");
+    const lua_Integer group = luaL_checkinteger(L, 2);
+    luaL_argcheck(
+        L, group >= 0 && group < MAX_FLIP_MAPS, 2, "no such flip group");
+
+    if (m_FlipGroupDecls == nullptr) {
+        m_FlipGroupDecls = Vector_Create(sizeof(M_FLIP_GROUP_DECL));
+    }
+    const M_FLIP_GROUP_DECL decl = {
+        .room_num = (int32_t)room_num,
+        .group = (int32_t)group,
+    };
+    Vector_Add(m_FlipGroupDecls, &decl);
+    return 0;
+}
+
 // trxc.rooms.flip([group])
 static int M_L_RoomsFlip(lua_State *const L)
 {
@@ -260,6 +302,7 @@ static const luaL_Reg m_Module[] = {
     { "get", M_L_RoomsGet },
     { "get_bounds", M_L_RoomsGetBounds },
     { "point_inside", M_L_RoomsPointInside },
+    { "declare_flip_group", M_L_RoomsDeclareFlipGroup },
     { "flip", M_L_RoomsFlip },
     { "flip_group_count", M_L_RoomsFlipGroupCount },
     { "get_flipped", M_L_RoomsGetFlipped },
@@ -272,6 +315,35 @@ static void M_Create(lua_State *const L)
 {
     LUA_Struct_Register(L, &TYPE_ROOM, nullptr);
     LUA_RegisterModule(L, "rooms", m_Module);
+}
+
+void LUA_Rooms_ClearFlipGroups(void)
+{
+    if (m_FlipGroupDecls != nullptr) {
+        Vector_Clear(m_FlipGroupDecls);
+    }
+}
+
+void LUA_Rooms_ApplyFlipGroups(void)
+{
+    if (m_FlipGroupDecls == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < m_FlipGroupDecls->count; i++) {
+        const M_FLIP_GROUP_DECL *const decl = Vector_Get(m_FlipGroupDecls, i);
+        if (decl->room_num >= Room_GetCount()) {
+            Console_ShowError(
+                "Lua flip group error: unknown room %d", decl->room_num);
+            continue;
+        }
+        if (Room_Get(decl->room_num)->flipped_room == NO_ROOM) {
+            Console_ShowError(
+                "Lua flip group error: room %d has no flip pair",
+                decl->room_num);
+            continue;
+        }
+        Room_SetFlipGroup(decl->room_num, decl->group);
+    }
 }
 
 REGISTER_LUA_CAPI(.create = M_Create)

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -501,6 +501,7 @@ void LUA_DropLevelScript(void)
 
     LUA_ClearLevelListeners();
     LUA_Config_ClearLevelWatchers();
+    LUA_Rooms_ClearFlipGroups();
     LUA_DropLevelModules(p->state);
 }
 

--- a/src/trx/game/lua/common.h
+++ b/src/trx/game/lua/common.h
@@ -74,6 +74,12 @@ void LUA_Config_ClearLevelWatchers(void);
 // has its objects. Level_Initialise does this once the level is read.
 void LUA_Config_FlushPendingWatchers(void);
 
+// Clears flip groups declared by a level script.
+void LUA_Rooms_ClearFlipGroups(void);
+
+// Applies level-script flip groups after rooms are read.
+void LUA_Rooms_ApplyFlipGroups(void);
+
 // Let go of the outgoing level's script: what it set up hears about it, and
 // then its listeners go. Level_Unload does this for a level change; a path that
 // re-runs a script without unloading the level does it for itself. The event

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -522,6 +522,16 @@ void Room_SetFlipStatus(const bool status)
     m_FlipStatus = status;
 }
 
+void Room_SetFlipGroup(const int32_t room_num, const int32_t group)
+{
+    ROOM *const room = Room_Get(room_num);
+    ASSERT(room != nullptr);
+    room->alternate_group = group;
+    if (room->flipped_room != NO_ROOM) {
+        Room_Get(room->flipped_room)->alternate_group = group;
+    }
+}
+
 int32_t Room_GetFlipGroup(const int32_t flip_slot)
 {
     for (int32_t i = 0; i < m_RoomCount; i++) {

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -36,6 +36,10 @@ bool Room_GetFlipStatus(void);
 // Whether the given group is showing its pairs.
 bool Room_GetFlipGroupStatus(int32_t group);
 
+// Puts a room and its flip pair in a flip group. A room without a flip pair
+// keeps the group it has.
+void Room_SetFlipGroup(int32_t room_num, int32_t group);
+
 // The group a flip slot moves. A TR4 trigger names the group in the same
 // number it uses for the slot, where a TR1-3 trigger means the slot alone and
 // moves every pair in the level. A level that puts no room in a group is read


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds `trx.rooms.flip_groups`, which assigns rooms to flip groups from a level script. A level can flip some groups independently of others. Previously, flip groups came only from level data, so multiple groups required a TR4 level or an injection.

Scripts run before rooms are read. Savegames replay flips for each recorded group after the script settings are applied.