### PR TITLE
objects/traps/electric_fence: fix death while immune

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Fixed a crash when switching mods (TRX1239)
 - Fixed the game crashing on a damaged level file, which is now refused with a message naming what is wrong with it
 - Fixed Lara's arms leaving their intended positions when looking around in the crouched stance (OG bug) (#6402)
+- Fixed Lara being killed by electric fences while immune (#6475)
 - Fixed Lara clipping into or underneath lifts if she tries to step on top of or into one from an exterior floor whose height matches the lift ceiling or floor (OG bug) (#3905 / TRX1014)
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)

--- a/src/trx/game/objects/traps/electric_fence.c
+++ b/src/trx/game/objects/traps/electric_fence.c
@@ -1,3 +1,4 @@
+#include <trx/config.h>
 #include <trx/core/log.h>
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
@@ -63,6 +64,12 @@ static void M_TriggerFenceSparks(const XYZ_32 pos, const bool kill)
 
 static void M_TouchFence(const XZ_32 spark_axis, XYZ_32 spark_pos)
 {
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (g_Config.debug.enable_invulnerability || lara->electric != 0
+        || lara->water_status == LWS_CHEAT) {
+        return;
+    }
+
     ITEM *const lara_item = Lara_GetItem();
     const XYZ_32 old_spark_pos = spark_pos;
     const int32_t iterations = (Random_GetControl() & 0xF) + 3;
@@ -92,7 +99,6 @@ static void M_TouchFence(const XZ_32 spark_axis, XYZ_32 spark_pos)
         spark_pos = old_spark_pos;
     }
 
-    LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->electric = 1;
     Lara_Kill();
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Prevents Lara from being killed by electric fences if the immunity cheat is active, and also prevents her from getting the electrified visual effects if she touches one while in DOZY mode.

Fixes #6475