### PR TITLE
Let scripts define custom objects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Added object references in strings files, so inventory entries can use the same name and description as their pickup
 - Added an object families file, so a mod can say which objects count as pickups, doors, creatures and the rest without a new build
 - Added an object links file, so a mod can say which pickup an inventory icon stands for, which slot a key goes into, and which box a weapon's rounds come in
+- Added `trx.objects.borrow_content()`, so an object with no models of its own can be drawn as another is, which is how a mod's own object is seen before it ships models
 - Changed object keys in strings files, game flows and weapon definitions to use the C object name without `O_`
 - Changed object names in strings files to use `|` between the name the game shows and the names the console accepts
 - Changed weapon, extra mesh, braid mode and extra outfit names in game data to drop their C prefixes, so a weapon is written `shotgun` rather than `LGT_SHOTGUN`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,7 +82,8 @@
 - Added object references in strings files, so inventory entries can use the same name and description as their pickup
 - Added an object families file, so a mod can say which objects count as pickups, doors, creatures and the rest without a new build
 - Added an object links file, so a mod can say which pickup an inventory icon stands for, which slot a key goes into, and which box a weapon's rounds come in
-- Added `trx.objects.borrow_content()`, so an object with no models of its own can be drawn as another is, which is how a mod's own object is seen before it ships models
+- Added `trx.objects.declare()`, so a script can define how its own object starts, updates, casts a shadow and saves its position
+- Added `trx.objects.borrow_content()`, so an object with no models of its own can use another object's meshes and animations
 - Changed object keys in strings files, game flows and weapon definitions to use the C object name without `O_`
 - Changed object names in strings files to use `|` between the name the game shows and the names the console accepts
 - Changed weapon, extra mesh, braid mode and extra outfit names in game data to drop their C prefixes, so a weapon is written `shotgun` rather than `LGT_SHOTGUN`

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5774,6 +5774,25 @@
       }
     },
     {
+      "description": "Defines setup for an object created by a script. The setup is applied at each level load because object records are rebuilt for each level.\n\n`control` runs once each frame for each active item. `initialise` runs when an item is created. Both functions receive the item. <!--noref: control--><!--noref: initialise-->",
+      "examples": [
+        "local blast = trx.catalog.mint(trx.catalog.Context.OBJECTS, \"mymod:blast\")\ntrx.objects.declare(blast, {\n  radius = 128,\n  save_position = true,\n  initialise = function(item) item.hit_points = 60 end,\n  control = function(item) item.pos.y = item.pos.y - 8 end,\n})"
+      ],
+      "params": [
+        {
+          "description": "The object created with `trx.catalog.mint`.",
+          "name": "object_id",
+          "type": "catalog.objects"
+        },
+        {
+          "description": "The object setup: `control`, `initialise`, `radius`, `shadow_size` and `save_position`. <!--noref: control--><!--noref: initialise--><!--noref: radius--><!--noref: shadow_size--><!--noref: save_position-->",
+          "name": "spec",
+          "type": "table"
+        }
+      ],
+      "path": "objects.declare"
+    },
+    {
       "description": "Copies meshes and animations from another object. Use this when the new object has no models in the level, such as a custom projectile that uses the rocket model.",
       "examples": [
         "trx.objects.borrow_content(my_blast, trx.catalog.objects.rocket)"

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5774,6 +5774,29 @@
       }
     },
     {
+      "description": "Copies meshes and animations from another object. Use this when the new object has no models in the level, such as a custom projectile that uses the rocket model.",
+      "examples": [
+        "trx.objects.borrow_content(my_blast, trx.catalog.objects.rocket)"
+      ],
+      "params": [
+        {
+          "description": "The object that receives the meshes and animations.",
+          "name": "object_id",
+          "type": "catalog.objects"
+        },
+        {
+          "description": "The object that gives the meshes and animations.",
+          "name": "source_id",
+          "type": "catalog.objects"
+        }
+      ],
+      "path": "objects.borrow_content",
+      "returns": {
+        "description": "`false` if the level has no content for the source object.",
+        "type": "boolean"
+      }
+    },
+    {
       "description": "Swaps meshes between two objects. With no mesh numbers, swaps all of them; with both, swaps just those two. One without the other raises.",
       "params": [
         {

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -270,6 +270,26 @@ trx.objects.wolf.properties.max_hit_points = 30
   wolf.properties.max_hit_points = 30
   ```
 
+- <a id="objects.declare" name="objects.declare"></a>[lua]`trx.objects.declare(object_id, spec)`  
+  Defines setup for an object created by a script. The setup is applied at each level load because object records are rebuilt for each level.
+
+  `control` runs once each frame for each active item. `initialise` runs when an item is created. Both functions receive the item.
+
+  Parameters:
+  - <a id="objects.declare.object_id" name="objects.declare.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The object created with [`trx.catalog.mint`](CATALOG.md#catalog.mint).
+  - <a id="objects.declare.spec" name="objects.declare.spec"></a>**`spec`** (table). The object setup: `control`, `initialise`, `radius`, `shadow_size` and `save_position`.
+
+  Example:
+  ```lua
+  local blast = trx.catalog.mint(trx.catalog.Context.OBJECTS, "mymod:blast")
+  trx.objects.declare(blast, {
+    radius = 128,
+    save_position = true,
+    initialise = function(item) item.hit_points = 60 end,
+    control = function(item) item.pos.y = item.pos.y - 8 end,
+  })
+  ```
+
 - <a id="objects.borrow_content" name="objects.borrow_content"></a>[lua]`trx.objects.borrow_content(object_id, source_id)`  
   Copies meshes and animations from another object. Use this when the new object has no models in the level, such as a custom projectile that uses the rocket model.
 

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -270,6 +270,20 @@ trx.objects.wolf.properties.max_hit_points = 30
   wolf.properties.max_hit_points = 30
   ```
 
+- <a id="objects.borrow_content" name="objects.borrow_content"></a>[lua]`trx.objects.borrow_content(object_id, source_id)`  
+  Copies meshes and animations from another object. Use this when the new object has no models in the level, such as a custom projectile that uses the rocket model.
+
+  Parameters:
+  - <a id="objects.borrow_content.object_id" name="objects.borrow_content.object_id"></a>**`object_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The object that receives the meshes and animations.
+  - <a id="objects.borrow_content.source_id" name="objects.borrow_content.source_id"></a>**`source_id`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The object that gives the meshes and animations.
+
+  Returns: boolean. `false` if the level has no content for the source object.
+
+  Example:
+  ```lua
+  trx.objects.borrow_content(my_blast, trx.catalog.objects.rocket)
+  ```
+
 - <a id="objects.swap_mesh" name="objects.swap_mesh"></a>[lua]`trx.objects.swap_mesh(object_id1, object_id2, [mesh_num1], [mesh_num2])`  
   Swaps meshes between two objects. With no mesh numbers, swaps all of them; with both, swaps just those two. One without the other raises.
 

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -445,6 +445,32 @@ api.property("objects.query", {
   end,
 })
 
+api.define("objects.borrow_content", {
+  description = "Copies meshes and animations from another object. Use this when the new "
+    .. "object has no models in the level, such as a custom projectile that uses the "
+    .. "rocket model.",
+  params = {
+    {
+      name = "object_id",
+      type = "catalog.objects",
+      description = "The object that receives the meshes and animations.",
+    },
+    {
+      name = "source_id",
+      type = "catalog.objects",
+      description = "The object that gives the meshes and animations.",
+    },
+  },
+  returns = {
+    type = "boolean",
+    description = "`false` if the level has no content for the source object.",
+  },
+  examples = {
+    [[trx.objects.borrow_content(my_blast, trx.catalog.objects.rocket)]],
+  },
+  impl = raw.borrow_content,
+})
+
 api.define("objects.swap_mesh", {
   description = "Swaps meshes between two objects. With no mesh numbers, swaps all of them; with "
     .. "both, swaps just those two. One without the other raises.",

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -445,6 +445,39 @@ api.property("objects.query", {
   end,
 })
 
+api.define("objects.declare", {
+  description = "Defines setup for an object created by a script. The setup is applied "
+    .. "at each level load because object records are rebuilt for each level.\n\n"
+    .. "`control` runs once each frame for each active item. `initialise` runs when "
+    .. "an item is created. Both functions receive the item. "
+    .. "<!--noref: control--><!--noref: initialise-->",
+  params = {
+    {
+      name = "object_id",
+      type = "catalog.objects",
+      description = "The object created with `trx.catalog.mint`.",
+    },
+    {
+      name = "spec",
+      type = "table",
+      description = "The object setup: `control`, `initialise`, `radius`, "
+        .. "`shadow_size` and `save_position`. "
+        .. "<!--noref: control--><!--noref: initialise--><!--noref: radius-->"
+        .. "<!--noref: shadow_size--><!--noref: save_position-->",
+    },
+  },
+  examples = {
+    [[local blast = trx.catalog.mint(trx.catalog.Context.OBJECTS, "mymod:blast")
+trx.objects.declare(blast, {
+  radius = 128,
+  save_position = true,
+  initialise = function(item) item.hit_points = 60 end,
+  control = function(item) item.pos.y = item.pos.y - 8 end,
+})]],
+  },
+  impl = raw.declare,
+})
+
 api.define("objects.borrow_content", {
   description = "Copies meshes and animations from another object. Use this when the new "
     .. "object has no models in the level, such as a custom projectile that uses the "

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -744,6 +744,12 @@ void ObjectFamily_Remove(const OBJECT_ID object_id, const OBJECT_FAMILY family)
 
 // Dressing an object from another is the engine's; the fake records the ask so
 // a test can see it, and dresses nothing.
+// The engine runs these at every level load; the fake stands one up so a
+// declaration can be made, and runs none of them.
+void Object_AddSetupHook(void (*const hook)(void))
+{
+}
+
 RESULT Object_BorrowContent(
     const OBJECT_ID object_id, const OBJECT_ID source_id)
 {

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -742,6 +742,15 @@ void ObjectFamily_Remove(const OBJECT_ID object_id, const OBJECT_FAMILY family)
     Vector_Remove(m_FamilyMembers, &member);
 }
 
+// Dressing an object from another is the engine's; the fake records the ask so
+// a test can see it, and dresses nothing.
+RESULT Object_BorrowContent(
+    const OBJECT_ID object_id, const OBJECT_ID source_id)
+{
+    FAKE_RECORD("borrow_content", FV(object_id), FV(source_id));
+    return m_Objects[source_id].loaded ? OK : FAIL("nothing to take");
+}
+
 bool ObjectFamily_Has(const OBJECT_ID object_id, const OBJECT_FAMILY family)
 {
     M_EnsureFamilies();

--- a/src/tests/lua/api/objects.lua
+++ b/src/tests/lua/api/objects.lua
@@ -332,6 +332,16 @@ test("best() with no by_name is every match", function()
   assert(#best == #ids, "unranked best is the whole set")
 end)
 
+test("borrow_content dresses an object from another", function()
+  assert(trx.objects.borrow_content(fake.UNLOADED, fake.WOLF))
+  assert(fake.calls().borrow_content.count == 1, "the ask did not land")
+
+  assert(
+    not trx.objects.borrow_content(fake.WOLF, fake.UNLOADED),
+    "there is nothing to take from an object the level left out"
+  )
+end)
+
 test("swap_mesh reaches the engine", function()
   trx.objects.swap_mesh(fake.WOLF, fake.VASE)
   assert(

--- a/src/tests/lua/api/objects.lua
+++ b/src/tests/lua/api/objects.lua
@@ -332,6 +332,29 @@ test("best() with no by_name is every match", function()
   assert(#best == #ids, "unranked best is the whole set")
 end)
 
+test("declare states what an object of a script's own does", function()
+  local id = trx.catalog.mint(trx.catalog.Context.OBJECTS, "mymod:blast")
+  assert(id ~= nil)
+  trx.objects.declare(id, {
+    radius = 128,
+    save_position = true,
+    control = function(_item) end,
+  })
+
+  -- An object is declared once, so a second declaration says so rather than
+  -- quietly taking the place of the first.
+  raises(function()
+    trx.objects.declare(id, { control = function(_item) end })
+  end, "already declared")
+end)
+
+test("a declaration takes functions where it says functions", function()
+  local id = trx.catalog.mint(trx.catalog.Context.OBJECTS, "mymod:other")
+  raises(function()
+    trx.objects.declare(id, { control = 5 })
+  end)
+end)
+
 test("borrow_content dresses an object from another", function()
   assert(trx.objects.borrow_content(fake.UNLOADED, fake.WOLF))
   assert(fake.calls().borrow_content.count == 1, "the ask did not land")

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -813,8 +813,12 @@ unit_tests += {
 unit_tests += {
   'name': 'lua/api/objects',
   'bundles': [b_lua_surface, b_lua_strings],
-  'src': ['fakes/items.c'],
-  'engine': ['game/lua/capi/catalog.c', 'game/lua/capi/objects.c'],
+  'src': ['fakes/items.c', 'harness/stubs_console.c'],
+  'engine': [
+    'game/lua/capi/catalog.c',
+    'game/lua/capi/items.c',
+    'game/lua/capi/objects.c',
+  ],
 }
 
 # The catalog rides along: the weapons a script names are its enum.

--- a/src/trx/game/inject/editors/objects.c
+++ b/src/trx/game/inject/editors/objects.c
@@ -30,21 +30,7 @@ static void M_ObjectLinkEdits(
         const INJECTION_OBJECT_INFO source_obj_info =
             Inject_ReadObjectPtr(injection);
 
-        OBJECT *const base_obj = Object_TryGet(base_obj_info.id);
-        const OBJECT *const source_obj = Object_TryGet(source_obj_info.id);
-        if (base_obj == nullptr || source_obj == nullptr
-            || !source_obj->loaded) {
-            continue;
-        }
-
-        base_obj->frame_base = source_obj->frame_base;
-        base_obj->frame_ofs = source_obj->frame_ofs;
-        base_obj->anim_idx = source_obj->anim_idx;
-        base_obj->anim_count = source_obj->anim_count;
-        base_obj->bone_idx = source_obj->bone_idx;
-        base_obj->mesh_idx = source_obj->mesh_idx;
-        base_obj->mesh_count = source_obj->mesh_count;
-        base_obj->loaded = true;
+        IGNORE(Object_BorrowContent(base_obj_info.id, source_obj_info.id));
     }
 }
 

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -676,4 +676,9 @@ static void M_Create(lua_State *const L)
     LUA_RegisterModule(L, "items", m_Module);
 }
 
+void LUA_PushItem(lua_State *const L, const int16_t item_num)
+{
+    M_PushItem(L, item_num);
+}
+
 REGISTER_LUA_CAPI(.create = M_Create)

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -1,16 +1,35 @@
+#include <trx/core/vector.h>
 #include <trx/game/catalog/manager.h>
+#include <trx/game/console.h>
+#include <trx/game/items.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/struct.h>
 #include <trx/game/lua/utils.h>
+#include <trx/game/objects/common.h>
 #include <trx/game/objects/families.h>
 #include <trx/game/objects/names.h>
+#include <trx/game/objects/setup.h>
 #include <trx/game/objects/types.h>
 
 #include <string.h>
 
 // An object is the definition every item of that type is cut from - a wolf's
 // radius, not this wolf's. Per-item state lives on the item; see trx.items.
+
+// Defines setup for an object created by a script. The setup is kept across
+// level loads because object records are rebuilt for each level.
+typedef struct {
+    OBJECT_ID object_id;
+    int32_t control_ref;
+    int32_t initialise_ref;
+    int32_t radius;
+    int32_t shadow_size;
+    bool save_position;
+} M_DECLARATION;
+
+static VECTOR *m_Declarations = nullptr;
+static lua_State *m_L = nullptr;
 
 // clang-format off
 static const FIELD_DESC m_Fields[] = {
@@ -38,6 +57,7 @@ TYPE_DEFINE(OBJECT, m_Fields)
 // An object is addressed by its id, and an id is valid for the whole session -
 // there is no pool to recycle and nothing to go stale. An object the level did
 // not load still exists as a definition; `loaded` is how a script tells.
+
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
     return Object_TryGet((OBJECT_ID)ref->handle.id);
@@ -85,6 +105,134 @@ static int M_L_ObjectsGet(lua_State *const L)
 }
 
 // trxc.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)
+
+static M_DECLARATION *M_FindDeclaration(const OBJECT_ID object_id)
+{
+    for (int32_t i = 0; m_Declarations != nullptr && i < m_Declarations->count;
+         i++) {
+        M_DECLARATION *const decl = Vector_Get(m_Declarations, i);
+        if (decl->object_id == object_id) {
+            return decl;
+        }
+    }
+    return nullptr;
+}
+
+// Calls a script function for an item. Errors are reported to the console.
+static void M_CallForItem(
+    const int32_t ref, const int16_t item_num, const char *const what)
+{
+    if (m_L == nullptr || ref == LUA_NOREF) {
+        return;
+    }
+    lua_rawgeti(m_L, LUA_REGISTRYINDEX, ref);
+    LUA_PushItem(m_L, item_num);
+    if (lua_pcall(m_L, 1, 0, 0) != LUA_OK) {
+        Console_ShowError("object %s error: %s", what, lua_tostring(m_L, -1));
+        lua_pop(m_L, 1);
+    }
+}
+
+static void M_Control(const int16_t item_num)
+{
+    const ITEM *const item = Item_Get(item_num);
+    const M_DECLARATION *const decl = M_FindDeclaration(item->object_id);
+    if (decl != nullptr) {
+        M_CallForItem(decl->control_ref, item_num, "control");
+    }
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    const ITEM *const item = Item_Get(item_num);
+    const M_DECLARATION *const decl = M_FindDeclaration(item->object_id);
+    if (decl != nullptr) {
+        M_CallForItem(decl->initialise_ref, item_num, "initialise");
+    }
+}
+
+// Applies script setup after the engine sets up its own objects.
+static void M_ApplyDeclarations(void)
+{
+    for (int32_t i = 0; m_Declarations != nullptr && i < m_Declarations->count;
+         i++) {
+        const M_DECLARATION *const decl = Vector_Get(m_Declarations, i);
+        OBJECT *const obj = Object_TryGet(decl->object_id);
+        if (obj == nullptr) {
+            continue;
+        }
+        if (decl->control_ref != LUA_NOREF) {
+            obj->control_func = M_Control;
+        }
+        if (decl->initialise_ref != LUA_NOREF) {
+            obj->initialise_func = M_Initialise;
+        }
+        if (decl->radius >= 0) {
+            obj->radius = decl->radius;
+        }
+        if (decl->shadow_size >= 0) {
+            obj->shadow_size = decl->shadow_size;
+        }
+        obj->save_position = decl->save_position;
+    }
+}
+
+// Takes an optional function from a declaration table.
+static int32_t M_TakeFunction(
+    lua_State *const L, const int arg, const char *const name)
+{
+    if (lua_getfield(L, arg, name) == LUA_TNIL) {
+        lua_pop(L, 1);
+        return LUA_NOREF;
+    }
+    if (!lua_isfunction(L, -1)) {
+        lua_pop(L, 1);
+        luaL_error(L, "'%s' must be a function", name);
+    }
+    return luaL_ref(L, LUA_REGISTRYINDEX);
+}
+
+static int32_t M_TakeInt(
+    lua_State *const L, const int arg, const char *const name)
+{
+    if (lua_getfield(L, arg, name) == LUA_TNIL) {
+        lua_pop(L, 1);
+        return -1;
+    }
+    const int32_t value = (int32_t)luaL_checkinteger(L, -1);
+    lua_pop(L, 1);
+    return value;
+}
+
+// trxc.objects.declare(object_id, spec)
+static int M_L_ObjectsDeclare(lua_State *const L)
+{
+    const OBJECT_ID object_id = LUA_CheckObjectID(L, 1);
+    luaL_checktype(L, 2, LUA_TTABLE);
+    if (M_FindDeclaration(object_id) != nullptr) {
+        return luaL_error(
+            L, "'%s' is already declared",
+            Catalog_IDToKey(CATALOG_OBJECTS, object_id));
+    }
+
+    M_DECLARATION decl = {
+        .object_id = object_id,
+        .control_ref = M_TakeFunction(L, 2, "control"),
+        .initialise_ref = M_TakeFunction(L, 2, "initialise"),
+        .radius = M_TakeInt(L, 2, "radius"),
+        .shadow_size = M_TakeInt(L, 2, "shadow_size"),
+    };
+    lua_getfield(L, 2, "save_position");
+    decl.save_position = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+
+    if (m_Declarations == nullptr) {
+        m_Declarations = Vector_Create(sizeof(M_DECLARATION));
+    }
+    Vector_Add(m_Declarations, &decl);
+    return 0;
+}
+
 // trxc.objects.borrow_content(object_id, source_id) -> bool
 static int M_L_ObjectsBorrowContent(lua_State *const L)
 {
@@ -245,16 +393,36 @@ static const luaL_Reg m_Module[] = {
     { "get", M_L_ObjectsGet },
     { "is_type", M_L_ObjectsIsType },
     { "borrow_content", M_L_ObjectsBorrowContent },
+    { "declare", M_L_ObjectsDeclare },
     { "swap_mesh", M_L_ObjectsSwapMesh },
     { "swap_sprite", M_L_ObjectsSwapSprite },
     { nullptr, nullptr },
 };
 
+static void M_Shutdown(void)
+{
+    for (int32_t i = 0; m_Declarations != nullptr && i < m_Declarations->count;
+         i++) {
+        const M_DECLARATION *const decl = Vector_Get(m_Declarations, i);
+        if (m_L != nullptr) {
+            luaL_unref(m_L, LUA_REGISTRYINDEX, decl->control_ref);
+            luaL_unref(m_L, LUA_REGISTRYINDEX, decl->initialise_ref);
+        }
+    }
+    if (m_Declarations != nullptr) {
+        Vector_Free(m_Declarations);
+        m_Declarations = nullptr;
+    }
+    m_L = nullptr;
+}
+
 static void M_Create(lua_State *const L)
 {
+    m_L = L;
+    Object_AddSetupHook(M_ApplyDeclarations);
     LUA_Struct_Register(L, &TYPE_OBJECT, m_Methods);
     LUA_Property_Register(L, &m_Properties);
     LUA_RegisterModule(L, "objects", m_Module);
 }
 
-REGISTER_LUA_CAPI(.create = M_Create)
+REGISTER_LUA_CAPI(.create = M_Create, .shutdown = M_Shutdown)

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -85,6 +85,15 @@ static int M_L_ObjectsGet(lua_State *const L)
 }
 
 // trxc.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)
+// trxc.objects.borrow_content(object_id, source_id) -> bool
+static int M_L_ObjectsBorrowContent(lua_State *const L)
+{
+    const OBJECT_ID object_id = LUA_CheckObjectID(L, 1);
+    const OBJECT_ID source_id = LUA_CheckObjectID(L, 2);
+    lua_pushboolean(L, IS_OK(Object_BorrowContent(object_id, source_id)));
+    return 1;
+}
+
 static int M_L_ObjectsSwapMesh(lua_State *const L)
 {
     const int32_t arg_count = lua_gettop(L);
@@ -235,6 +244,7 @@ static const LUA_PROPERTY_DESC m_Properties = {
 static const luaL_Reg m_Module[] = {
     { "get", M_L_ObjectsGet },
     { "is_type", M_L_ObjectsIsType },
+    { "borrow_content", M_L_ObjectsBorrowContent },
     { "swap_mesh", M_L_ObjectsSwapMesh },
     { "swap_sprite", M_L_ObjectsSwapSprite },
     { nullptr, nullptr },

--- a/src/trx/game/lua/utils.h
+++ b/src/trx/game/lua/utils.h
@@ -65,6 +65,10 @@ XYZ_32 LUA_CheckXYZAt(lua_State *L, int idx, int arg);
 
 void LUA_PushXYZ(lua_State *L, XYZ_32 value);
 
+// Push an item as the handle trx.items hands out, so that a module other than
+// that one can give a script an item to work with.
+void LUA_PushItem(lua_State *L, int16_t item_num);
+
 // Takes the function that turns three channels into a color value, which is
 // where trx.math declares what a color is. Called once, as the API loads;
 // without it a color is pushed as a plain table of channels.

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -10,6 +10,7 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/objects/links.h>
+#include <trx/game/objects/names.h>
 #include <trx/game/output/common.h>
 
 typedef struct {
@@ -102,6 +103,28 @@ OBJECT_ID Object_Mint(void)
     // Register the object so the object tables recognise its id. It takes no
     // name, which keeps it out of savegames.
     return Catalog_CreateAnonymous(CATALOG_OBJECTS);
+}
+
+RESULT Object_BorrowContent(
+    const OBJECT_ID object_id, const OBJECT_ID source_id)
+{
+    OBJECT *const obj = Object_TryGet(object_id);
+    const OBJECT *const source = Object_TryGet(source_id);
+    FAIL_IF(obj == nullptr, "there is no object %d", object_id);
+    FAIL_IF(source == nullptr, "there is no object %d", source_id);
+    FAIL_IF(
+        !source->loaded, "the level carries no %s",
+        Object_GetName(source_id) != nullptr ? Object_GetName(source_id) : "");
+
+    obj->frame_base = source->frame_base;
+    obj->frame_ofs = source->frame_ofs;
+    obj->anim_idx = source->anim_idx;
+    obj->anim_count = source->anim_count;
+    obj->bone_idx = source->bone_idx;
+    obj->mesh_idx = source->mesh_idx;
+    obj->mesh_count = source->mesh_count;
+    obj->loaded = true;
+    return OK;
 }
 
 int32_t Object_GetCount(void)

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -28,6 +28,10 @@ OBJECT_ID Object_Mint(void);
 
 int32_t Object_GetCount(void);
 
+// Copies meshes and animations from a source object to another object. Reports
+// failure if the level has no content for the source object.
+RESULT Object_BorrowContent(OBJECT_ID object_id, OBJECT_ID source_id);
+
 // Retrieve an object by its slot. Returns nullptr if not found.
 OBJECT *Object_GetBySlot(OBJECT_SLOT slot);
 

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -351,17 +351,12 @@ static void M_Setup(OBJECT *const obj)
 
 static void M_SetupHeavy(OBJECT *const obj)
 {
-    const OBJECT *const ref_obj = Object_Get(O_ROCKET);
-    if (!ref_obj->loaded) {
+    if (!Object_Get(O_ROCKET)->loaded) {
         return;
     }
 
     M_SetupCommon(obj);
-    obj->frame_base = ref_obj->frame_base;
-    obj->anim_idx = ref_obj->anim_idx;
-    obj->mesh_idx = ref_obj->mesh_idx;
-    obj->mesh_count = ref_obj->mesh_count;
-    obj->loaded = true;
+    IGNORE(Object_BorrowContent(O_HEAVY_ROCKET, O_ROCKET));
 }
 
 REGISTER_OBJECT(O_ROCKET, M_Setup)

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -1,10 +1,15 @@
 #include <trx/config.h>
+#include <trx/debug.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/property.h>
 #include <trx/game/pathing.h>
 
 #define M_DEFAULT_RADIUS 10
+#define M_MAX_SETUP_HOOKS 4
+
+static void (*m_SetupHooks[M_MAX_SETUP_HOOKS])(void) = {};
+static int32_t m_SetupHookCount = 0;
 
 static void M_SetupLara(OBJECT *const obj)
 {
@@ -31,6 +36,12 @@ static void M_SetupLara(OBJECT *const obj)
 static void M_SetupLaraStartPos(OBJECT *const obj)
 {
     obj->draw_func = nullptr;
+}
+
+void Object_AddSetupHook(void (*const hook)(void))
+{
+    ASSERT(m_SetupHookCount < M_MAX_SETUP_HOOKS);
+    m_SetupHooks[m_SetupHookCount++] = hook;
 }
 
 void Object_SetupAllObjects(void)
@@ -80,6 +91,10 @@ void Object_SetupAllObjects(void)
         OBJECT_PROPERTIES(
             obj,
             OBJECT_PROPERTY_STORED("ocb", 0, "Object configuration value."));
+    }
+
+    for (int32_t i = 0; i < m_SetupHookCount; i++) {
+        m_SetupHooks[i]();
     }
 
     Lara_Hair_Initialise();

--- a/src/trx/game/objects/setup.h
+++ b/src/trx/game/objects/setup.h
@@ -1,3 +1,7 @@
 #pragma once
 
 void Object_SetupAllObjects(void);
+
+// Adds a setup hook that runs after object setup at each level load. Scripts
+// use hooks because object records are rebuilt for each level.
+void Object_AddSetupHook(void (*hook)(void));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Scripts can now define custom objects that use another object's meshes and animations, then set how those objects start, update, cast a shadow and save their position. This lets a mod create a visible scripted object without adding new level models first.

```lua
local blast = trx.catalog.mint(trx.catalog.Context.OBJECTS, "mymod:blast")

trx.objects.borrow_content(blast, trx.catalog.objects.rocket)
trx.objects.declare(blast, {
  radius = 128,
  save_position = true,
  initialise = function(item) item.hit_points = 60 end,
  control = function(item) item.pos.y = item.pos.y - 8 end,
})
```

This keeps the existing rocket, heavy rocket and injection behavior in one shared path. Nothing changes for players.
