### PR TITLE
lara/col/crouch: fix crawl back ceiling test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed Lara slipping into wading-depth water when walking down steps in a water room (OG bug) (TRX1307)
 - Fixed Lara being able to monkey roll too close to sector edges, resulting in her falling after the animation completes (#6459 / TRX1314, regression from 1.10)
 - Fixed Lara beginning to monkey roll for one frame despite being too close to the edge of a sector (#6459 / TRX1314, regression from 1.10)
+- Fixed Lara not being able to crawl backwards in certain sloped crawlspaces (OG bug) (TRX1322)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -264,7 +264,7 @@ static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
             item->goal_anim_state = LS(LS_CRAWL_FORWARD);
         }
     } else if (g_Input.back) {
-        int32_t h = Lara_CeilingFront(item, item->rot.y, -300, LARA_HEIGHT);
+        int32_t h = Lara_CeilingFront(item, item->rot.y, -300, STEP_L / 2);
         if (h == NO_HEIGHT || h > 256) {
             return;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes the ceiling test for crawling backwards using too large a height for Lara. The fix matches TR4's handling here.

Resolves TRX1322.
