### PR TITLE
lua/fx: expand what a script can put on screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -261,6 +261,8 @@
 - Added `trx.objects.Object:add_family()` and `trx.objects.Object:remove_family()`, and `trx.objects.query:family()`, so a script can mint a family of its own and narrow to it
 - Added `trx.console.copy()`, `trx.console.complete()`, and the option to read back console command output, so a script can wrap another command
 - Added `trx.fx.fog_bulbs` and `trx.fx.fog_color`, so a script can read level fog bulbs and set the distance fog color (TRX658)
+- Added more world effects to `trx.fx`: explosions, fires, splashes, ripples, footprints, underwater blood and blast rings
+- Added `trx.fx.sparks`, so a script can throw the particles the games use for smoke, flames, sparks and splashes, and read or change every live particle
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -13,6 +13,12 @@
       "value": 10
     },
     {
+      "description": "How many sparks the pool holds. A spark spawned after that takes the slot of the one with the least life left.",
+      "path": "fx.sparks.MAX_COUNT",
+      "type": "integer",
+      "value": 400
+    },
+    {
       "description": "What this build reports as its version: `1.9.3` for a release, and the tag with the commits since then for a development build.",
       "path": "game.TRX_VERSION",
       "type": "string",
@@ -90,6 +96,22 @@
       "value": {
         "nullable": true,
         "type": "fx.FogBulb"
+      }
+    },
+    {
+      "countable": true,
+      "description": "The spark pool, counted from 1. `#trx.fx.sparks.pool` is\n`trx.fx.sparks.MAX_COUNT` rather than how many sparks are alive: a slot holding\nno live spark reads as `nil`.",
+      "examples": [
+        "for _, spark in pairs(trx.fx.sparks.pool) do\n  spark.color = trx.math.color(255, 0, 0)\nend"
+      ],
+      "key": {
+        "type": "integer"
+      },
+      "member": "sparks.pool",
+      "module": "fx",
+      "value": {
+        "nullable": true,
+        "type": "fx.Spark"
       }
     },
     {
@@ -2200,6 +2222,107 @@
           "description": "The player typed it wrong.",
           "name": "BAD_INVOCATION",
           "value": 3
+        }
+      ]
+    },
+    {
+      "bulk": false,
+      "count": 11,
+      "description": "Which spark-set sprite a spark is drawn with.",
+      "path": "fx.SparkType",
+      "values": [
+        {
+          "description": "The soft round puff fire, smoke and explosions are drawn with.",
+          "name": "EXPLOSION",
+          "value": 0
+        },
+        {
+          "description": "A single drop of water.",
+          "name": "SMALL_SPLASH",
+          "value": 4
+        },
+        {
+          "description": "A sheet of water.",
+          "name": "BIG_SPLASH",
+          "value": 8
+        },
+        {
+          "description": "A ring on the water surface.",
+          "name": "RIPPLE",
+          "value": 9
+        },
+        {
+          "description": "The plain speck, which is also what a footprint is drawn with.",
+          "name": "PARTICLE",
+          "value": 10
+        },
+        {
+          "description": "The bubble drawn around a shielded target.",
+          "name": "SHIELD",
+          "value": 11
+        },
+        {
+          "description": "A length of rope.",
+          "name": "ROPE",
+          "value": 19
+        },
+        {
+          "description": "The forward gear light of a vehicle.",
+          "name": "DRIVE",
+          "value": 20
+        },
+        {
+          "description": "The reverse gear light of a vehicle.",
+          "name": "REVERSE",
+          "value": 21
+        },
+        {
+          "description": "The spark struck off a wall by a shot.",
+          "name": "RICOCHET",
+          "value": 36
+        },
+        {
+          "description": "A drop of blood.",
+          "name": "BLOOD",
+          "value": 39
+        }
+      ]
+    },
+    {
+      "bulk": false,
+      "count": 6,
+      "description": "How a sprite is laid over what is behind it.",
+      "path": "fx.DrawType",
+      "values": [
+        {
+          "description": "It covers what is behind it.",
+          "name": "OPAQUE",
+          "value": 0
+        },
+        {
+          "description": "It is mixed with what is behind it.",
+          "name": "BLEND",
+          "value": 1
+        },
+        {
+          "description": "It is added to what is behind it, so it lightens.",
+          "name": "BLEND_ADD",
+          "value": 2
+        },
+        {
+          "description": "It is taken from what is behind it, so it darkens.",
+          "name": "BLEND_SUB",
+          "value": 3
+        },
+        {
+          "description": "Opaque, and carrying the room reflection.",
+          "name": "REFLECTIVE_OPAQUE",
+          "value": 8
+        },
+        {
+          "description": "Added, and carrying the room reflection.",
+          "name": "REFLECTIVE_BLEND_ADD",
+          "value": 9
         }
       ]
     },
@@ -5143,6 +5266,1052 @@
       "path": "fx.blood_bath"
     },
     {
+      "description": "Shows the explosion a rocket or a grenade leaves behind, without the damage.\n\nTR1, TR2 and TR4 draw the explosion sprite the level carries. TR3 has none, and\ngets a fireball of sparks instead. Under water the effect uses the drowned\nversion, which throws a burst of bubbles and lifts a splash where the water\nends.",
+      "examples": [
+        "trx.fx.explosion({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the explosion is and whether it is heard.",
+          "fields": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": true,
+              "description": "Whether the explosion sound plays with it.",
+              "name": "sound",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.explosion"
+    },
+    {
+      "description": "Burns a fire at a point for this frame. Make the call every frame to keep the\nfire alight.\n\nTR4 only. The other games have no such fire, so the call does nothing there.",
+      "examples": [
+        "trx.events.after_control(function()\n  trx.fx.fire({ pos = trx.lara.item.pos, size = 2 })\nend)"
+      ],
+      "params": [
+        {
+          "description": "Where the fire is and how it burns.",
+          "fields": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 1,
+              "description": "How big it burns: `0` small, `1` medium, `2` big.",
+              "name": "size",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "How far it is dimmed, `0` being full strength.",
+              "name": "fade",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.fire"
+    },
+    {
+      "description": "Breaks the water at an item, the way a body falling in does. The item says\nwhere the splash is; the water it lands in says how big.",
+      "examples": [
+        "trx.fx.splash(trx.lara.item)"
+      ],
+      "params": [
+        {
+          "description": "The item the splash rises around.",
+          "name": "item",
+          "type": "items.Item"
+        }
+      ],
+      "path": "fx.splash"
+    },
+    {
+      "description": "Breaks the water around an item wading through it.",
+      "examples": [
+        "trx.fx.wade_splash(trx.lara.item, 512)"
+      ],
+      "params": [
+        {
+          "description": "The item doing the wading.",
+          "name": "item",
+          "type": "items.Item"
+        },
+        {
+          "description": "How deep the water stands about it.",
+          "name": "depth",
+          "type": "math.Distance"
+        }
+      ],
+      "path": "fx.wade_splash"
+    },
+    {
+      "description": "Spreads a ring on the water surface. The ring widens and fades on its own.",
+      "examples": [
+        "trx.fx.ripple({ pos = trx.lara.item.pos, size = 16 })"
+      ],
+      "params": [
+        {
+          "description": "Where the ring is and how it spreads.",
+          "fields": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 8,
+              "description": "How wide it starts, from 1 to 255.",
+              "name": "size",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it spreads at half speed.",
+              "name": "slow",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether it is drawn dark rather than bright.",
+              "name": "dark",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether it is drawn in the blood color.",
+              "name": "blood",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether the ring wavers as it spreads.",
+              "name": "jitter",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.ripple"
+    },
+    {
+      "description": "Throws a handful of drops off the water surface.",
+      "examples": [
+        "trx.fx.small_splash({ pos = trx.lara.item.pos, count = 8 })"
+      ],
+      "params": [
+        {
+          "description": "Where the drops are and how many of them.",
+          "fields": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 1,
+              "description": "How many drops, from 1 to 255.",
+              "name": "count",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.small_splash"
+    },
+    {
+      "description": "Spreads a cloud of blood under water, the way a hit that lands there does.",
+      "examples": [
+        "trx.fx.underwater_blood({ pos = trx.lara.item.pos, size = 32 })"
+      ],
+      "params": [
+        {
+          "description": "Where the cloud is and how wide it spreads.",
+          "fields": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 8,
+              "description": "How wide it spreads, from 1 to 255.",
+              "name": "size",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it is drawn in the darker TR3 gold color.",
+              "name": "dark",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.underwater_blood"
+    },
+    {
+      "description": "Leaves a footprint under an item, on the floor the item stands on. The floor\nmaterial decides whether one is left at all.",
+      "examples": [
+        "trx.fx.footprint(trx.lara.item, true)"
+      ],
+      "params": [
+        {
+          "description": "The item the print is taken from.",
+          "name": "item",
+          "type": "items.Item"
+        },
+        {
+          "description": "Whether it is the left foot rather than the right.",
+          "name": "left_foot",
+          "type": "boolean"
+        }
+      ],
+      "path": "fx.footprint"
+    },
+    {
+      "description": "Spreads a ring of force out from a point, as a blast does. The ring is drawn\nand widens on its own.",
+      "examples": [
+        "trx.fx.knockback({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the ring starts.",
+          "fields": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.knockback"
+    },
+    {
+      "description": "Puts one spark in the world and hands it back, so a script can draw with the\npool the game draws its own smoke and flames with.\n\nThe spark lives for the frames it is given, moving, resizing and fading on its\nown, and then frees its slot. Nothing has to be called each frame to keep it up.\n\nReturns `nil` where the level carries no spark set, which is every TR1 and TR2\nlevel.",
+      "examples": [
+        "trx.fx.sparks.spawn({\n  pos = trx.lara.item.pos,\n  vel = { x = 0, y = -8, z = 0 },\n  sprite_type = trx.fx.SparkType.EXPLOSION,\n  life = 48,\n  color = trx.math.color(255, 200, 64),\n  end_color = trx.math.color(64, 0, 0),\n  width = 16,\n  end_width = 48,\n  scales = true,\n})"
+      ],
+      "params": [
+        {
+          "description": "What the spark is and how it behaves.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How far it moves each frame. Defaults to standing still.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            },
+            {
+              "default": 10,
+              "description": "Which sprite it is drawn with.",
+              "name": "sprite_type",
+              "optional": true,
+              "type": "fx.SparkType"
+            },
+            {
+              "default": 16,
+              "description": "How many frames it lives, from 1 to 255.",
+              "name": "life",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "description": "The color it starts in. Defaults to white.",
+              "name": "color",
+              "optional": true,
+              "type": "math.Color"
+            },
+            {
+              "description": "The color it fades to. Defaults to the color it starts in, so it holds one color.",
+              "name": "end_color",
+              "optional": true,
+              "type": "math.Color"
+            },
+            {
+              "default": 8,
+              "description": "How fast it travels between the two colors.",
+              "name": "fade_speed",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 8,
+              "description": "How many frames of life are left when it starts to darken toward black.",
+              "name": "fade_to_black",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 4,
+              "description": "How wide it starts, from 0 to 255.",
+              "name": "width",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 4,
+              "description": "How tall it starts, from 0 to 255.",
+              "name": "height",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "description": "The width it grows to, for a spark that scales. Defaults to the width it starts at.",
+              "name": "end_width",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "description": "The height it grows to, for a spark that scales. Defaults to the height it starts at.",
+              "name": "end_height",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it travels from its start size to its end size over its life.",
+              "name": "scales",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": 2,
+              "description": "How strongly the size is scaled with distance.",
+              "name": "scalar",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "How much it is pulled down each frame.",
+              "name": "gravity",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "As fast as gravity may carry it down.",
+              "name": "max_y_vel",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "How fast it is slowed each frame.",
+              "name": "friction",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "How far it starts turned about the view, from 0 to 4095.",
+              "name": "rot_angle",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "How far it turns each frame, for a spark that turns.",
+              "name": "rot_add",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it turns as it lives.",
+              "name": "rotates",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": 0,
+              "description": "How many further sparks it leaves behind as it ends.",
+              "name": "extras",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 2,
+              "description": "How it is laid over what is behind it.",
+              "name": "draw_type",
+              "optional": true,
+              "type": "fx.DrawType"
+            },
+            {
+              "default": false,
+              "description": "Whether the wind carries it.",
+              "name": "is_outside",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether it drifts like an underwater particle.",
+              "name": "is_underwater",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether it is drawn in the green of the poison gas.",
+              "name": "is_green",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether it is drawn with the second sprite of its kind.",
+              "name": "uses_alt_sprite",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.spawn",
+      "returns": {
+        "description": "The spark, or `nil` where the level carries no spark set.",
+        "nullable": true,
+        "type": "fx.Spark"
+      }
+    },
+    {
+      "description": "Throws the fireball of sparks an explosion is drawn with.",
+      "examples": [
+        "trx.fx.sparks.explosion({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the fireball is and how strongly it bursts.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 3,
+              "description": "How many further sparks each one leaves behind as it ends, from 0 to 3.",
+              "name": "extras",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": -2,
+              "description": "How the fireball lights the room around it: `-2` bright, `-1` dim, `0` not at all.",
+              "name": "light",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it uses the underwater burst.",
+              "name": "underwater",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.explosion"
+    },
+    {
+      "description": "Lifts the smoke an explosion leaves behind.",
+      "examples": [
+        "trx.fx.sparks.explosion_smoke({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the smoke is and which part of the burst it is.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": false,
+              "description": "Whether it lifts as it does under water.",
+              "name": "underwater",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "default": false,
+              "description": "Whether it is the thinner smoke that closes the burst rather than the smoke that opens it.",
+              "name": "ending",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.explosion_smoke"
+    },
+    {
+      "description": "Throws the burst of bubbles an explosion under water makes.",
+      "examples": [
+        "trx.fx.sparks.explosion_bubble({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the bubbles rise.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.explosion_bubble"
+    },
+    {
+      "description": "Throws one tongue of flame, the way a burning body does. Make the call every\nframe to keep a fire burning.\n\nNo flame is thrown more than twenty sectors from Lara.",
+      "examples": [
+        "trx.fx.sparks.fire_flame({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the flame is and what color it burns.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 0,
+              "description": "Which colors it burns in: `0` orange, `2` pale, `254` green.",
+              "name": "variant",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.fire_flame"
+    },
+    {
+      "description": "Lifts one puff of the smoke a fire gives off.",
+      "examples": [
+        "trx.fx.sparks.fire_smoke({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the smoke is and which flame color it follows.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 0,
+              "description": "Which colors it burns in: `0` orange, `2` pale, `254` green.",
+              "name": "variant",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.fire_smoke"
+    },
+    {
+      "description": "Throws one tongue of the flame a standing fire burns with.",
+      "examples": [
+        "trx.fx.sparks.static_flame({ pos = trx.lara.item.pos, size = 64 })"
+      ],
+      "params": [
+        {
+          "description": "Where the flame is and how big it burns.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 32,
+              "description": "How big it burns.",
+              "name": "size",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.static_flame"
+    },
+    {
+      "description": "Throws a tongue of flame sideways, as a jet does.",
+      "examples": [
+        "trx.fx.sparks.side_flame({\n  pos = trx.lara.item.pos,\n  angle = trx.lara.item.rot.y,\n})"
+      ],
+      "params": [
+        {
+          "description": "Where the jet is and which way it burns.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "The way the flame is thrown.",
+              "name": "angle",
+              "type": "math.Angle"
+            },
+            {
+              "default": 32,
+              "description": "How hard it is thrown.",
+              "name": "speed",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it is the small pilot flame rather than the jet itself.",
+              "name": "pilot",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.side_flame"
+    },
+    {
+      "description": "Throws the flame a flamethrower leaves where its jet lands.",
+      "examples": [
+        "trx.fx.sparks.flamethrower_flame({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the flame lands.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.flamethrower_flame"
+    },
+    {
+      "description": "Lifts the smoke a flamethrower jet leaves behind.",
+      "examples": [
+        "trx.fx.sparks.flamethrower_smoke({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the smoke is.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": false,
+              "description": "Whether it lifts as it does under water.",
+              "name": "underwater",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.flamethrower_smoke"
+    },
+    {
+      "description": "Lifts the smoke a fired weapon leaves at its muzzle.",
+      "examples": [
+        "trx.fx.sparks.gun_smoke({\n  pos = trx.lara.item.pos,\n  weapon = trx.catalog.weapons.pistols,\n  initial = true,\n})"
+      ],
+      "params": [
+        {
+          "description": "Where the smoke is and which weapon left it.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "Which weapon it is drawn for. `UNKNOWN`, `UNARMED`, and out-of-range values raise.",
+              "name": "weapon",
+              "type": "catalog.weapons"
+            },
+            {
+              "default": 64,
+              "description": "How light the smoke is, from 0 to 255.",
+              "name": "shade",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether it is the first puff of a shot, which is denser than the ones that follow.",
+              "name": "initial",
+              "optional": true,
+              "type": "boolean"
+            },
+            {
+              "description": "Which way the smoke is pushed. Left out, it lifts straight up.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.gun_smoke"
+    },
+    {
+      "description": "Lifts the trail of smoke a flying dart leaves.",
+      "examples": [
+        "trx.fx.sparks.dart_smoke({ pos = trx.lara.item.pos, hit = true })"
+      ],
+      "params": [
+        {
+          "description": "Where the smoke is and which way the dart flies.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How far it moves each frame. Defaults to standing still.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            },
+            {
+              "default": false,
+              "description": "Whether the dart has landed, which puffs the smoke out rather than trailing it.",
+              "name": "hit",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.dart_smoke"
+    },
+    {
+      "description": "Lifts the trail of smoke a flying rocket leaves.",
+      "examples": [
+        "trx.fx.sparks.rocket_smoke({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the smoke is and how light it lifts.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 0,
+              "description": "How light the smoke turns as it fades, from 0 to 191.",
+              "name": "shade",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.rocket_smoke"
+    },
+    {
+      "description": "Throws the sparks a burning flare gives off.",
+      "examples": [
+        "trx.fx.sparks.flare({ pos = trx.lara.item.pos, smoke = true })"
+      ],
+      "params": [
+        {
+          "description": "Where the sparks are and which way they fly.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How far it moves each frame. Defaults to standing still.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            },
+            {
+              "default": false,
+              "description": "Whether smoke is lifted with them.",
+              "name": "smoke",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.flare"
+    },
+    {
+      "description": "Throws the sparks a shotgun blast strikes off what it hits.",
+      "examples": [
+        "trx.fx.sparks.shotgun({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the sparks are and which way they fly.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How far it moves each frame. Defaults to standing still.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.shotgun"
+    },
+    {
+      "description": "Strikes the sparks a shot makes where it lands on a wall.\n\nTR4 throws as many streaks as asked for and can lift smoke instead. TR3 throws\none burst, and uses the count as its size.",
+      "examples": [
+        "trx.fx.sparks.ricochet({ pos = trx.lara.item.pos, angle = 0 })"
+      ],
+      "params": [
+        {
+          "description": "Where the shot lands and which way the sparks fly.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "The way the sparks fly.",
+              "name": "angle",
+              "type": "math.Angle"
+            },
+            {
+              "default": 3,
+              "description": "How many streaks, from 1 to 255.",
+              "name": "count",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": false,
+              "description": "Whether smoke is lifted rather than sparks struck. TR4 only.",
+              "name": "smoke_only",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.ricochet"
+    },
+    {
+      "description": "Lifts one bubble through the water.",
+      "examples": [
+        "trx.fx.sparks.bubble({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the bubble is and how big it is.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "default": 8,
+              "description": "How big it is at its smallest.",
+              "name": "size",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 8,
+              "description": "How much bigger than that it may be drawn.",
+              "name": "size_range",
+              "optional": true,
+              "type": "integer"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.bubble"
+    },
+    {
+      "description": "Puffs the cloud of breath a body gives off in the cold.",
+      "examples": [
+        "trx.fx.sparks.breath({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the breath is and which way it drifts.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How far it moves each frame. Defaults to standing still.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.breath"
+    },
+    {
+      "description": "Throws the twinkle that marks a pickup worth reaching.",
+      "examples": [
+        "trx.fx.sparks.pickup_aid({ pos = trx.lara.item.pos })"
+      ],
+      "params": [
+        {
+          "description": "Where the twinkle is and which way it drifts.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How far it moves each frame. Defaults to standing still.",
+              "name": "vel",
+              "optional": true,
+              "type": "math.Vec3"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.pickup_aid"
+    },
+    {
+      "description": "Lifts the mist that stands at the foot of a waterfall.",
+      "examples": [
+        "trx.fx.sparks.waterfall_mist({ pos = trx.lara.item.pos, angle = 0 })"
+      ],
+      "params": [
+        {
+          "description": "Where the mist is and which way it faces.",
+          "fields": [
+            {
+              "description": "World position. Must lie inside the level.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "The way the waterfall faces.",
+              "name": "angle",
+              "type": "math.Angle"
+            }
+          ],
+          "name": "opts",
+          "type": "table"
+        }
+      ],
+      "path": "fx.sparks.waterfall_mist"
+    },
+    {
       "description": "Starts a level from `trx.game.levels`.",
       "examples": [
         "trx.game.play_level(1)"
@@ -7947,6 +9116,11 @@
     },
     {
       "callable": false,
+      "description": "The spark pool: the particles TR3 and TR4 draw their smoke, flames, sparks and\nsplashes with.\n\nTR1 and TR2 carry no spark set. There the pool stays empty, and everything here\nreturns nothing rather than raising.",
+      "path": "fx.sparks"
+    },
+    {
+      "callable": false,
       "description": "The signals the game's own state speaks through, for a script that would rather hear about a change than ask after one. Each is read once a frame, so what listens runs on a change rather than on a frame.",
       "path": "game.signals"
     },
@@ -8237,6 +9411,12 @@
       "description": "The color override for distance fog.\n\n`nil` means no override. Write `nil` to restore the level fog color. A level change clears the\noverride. Savegames keep it. This controls distance fog only. Fog bulbs have their own colors\nin `trx.fx.fog_bulbs`.",
       "path": "fx.fog_color",
       "type": "math.Color",
+      "writable": true
+    },
+    {
+      "description": "The wind that carries the sparks marked `trx.fx.Spark.is_outside`.\n\nThe engine works this out again every frame from the breeze setting, so a value\nwritten here holds for that frame alone.",
+      "path": "fx.sparks.wind",
+      "type": "fx.Wind",
       "writable": true
     },
     {
@@ -9469,6 +10649,257 @@
       ],
       "operators": [],
       "path": "fx.FogBulb"
+    },
+    {
+      "description": "A spark is one particle from the spark pool: a sprite that lives for a set\nnumber of frames, moving, resizing and fading on its own as it does.\n\nTR3 and TR4 only. The earlier games carry no spark set, so nothing spawns one\nand the pool stays empty.\n\nA spark that runs out of life leaves its slot to the next one asked for. A\nhandle held across that becomes stale, and field access raises an error.",
+      "extensions": [
+        {
+          "description": "The item it is attached to, and `nil` where it hangs on nothing.",
+          "name": "item",
+          "type": "items.Item"
+        },
+        {
+          "description": "The room it was spawned in.",
+          "name": "room",
+          "type": "rooms.Room"
+        },
+        {
+          "description": "Where it is drawn, which is where it sits unless it is attached to something that carries it.",
+          "name": "world_pos",
+          "type": "math.Vec3"
+        }
+      ],
+      "fields": [
+        {
+          "description": "The color it is drawn in now.",
+          "name": "color",
+          "type": "math.Color",
+          "writable": true
+        },
+        {
+          "description": "How it is laid over what is behind it.",
+          "name": "draw_type",
+          "type": "fx.DrawType",
+          "writable": false
+        },
+        {
+          "description": "The color it fades to.",
+          "name": "end_color",
+          "type": "math.Color",
+          "writable": true
+        },
+        {
+          "description": "The height it grows to.",
+          "name": "end_height",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "The width it grows to.",
+          "name": "end_width",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How many further sparks it leaves behind as it ends.",
+          "name": "extras",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How fast it travels from one color to the other.",
+          "name": "fade_speed",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How many frames of life are left when it starts to darken toward black.",
+          "name": "fade_to_black",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How fast it is slowed each frame.",
+          "name": "friction",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How much it is pulled down each frame.",
+          "name": "gravity",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How tall it is drawn now.",
+          "name": "height",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether it counts as blood, which the pool sheds first when it runs short of slots.",
+          "name": "is_blood",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "Whether it is drawn in the green of the poison gas.",
+          "name": "is_green",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "Whether the wind carries it.",
+          "name": "is_outside",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "Whether it drifts like an underwater particle.",
+          "name": "is_underwater",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "Frames of life left. It reaches zero and the spark ends.",
+          "name": "life",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Frames of life it started with, which the fades are measured against.",
+          "name": "life_span",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "As fast as gravity may carry it down.",
+          "name": "max_y_vel",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Which of the sixteen body points it hangs off, where it is attached to one.",
+          "name": "node_num",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Where it sits, in the world, or from what it is attached to. Read `trx.fx.Spark.world_pos` for the position it is drawn at.",
+          "name": "pos",
+          "type": "math.Vec3",
+          "writable": true
+        },
+        {
+          "description": "The room it was spawned in.",
+          "name": "room_num",
+          "type": "rooms.Num",
+          "writable": false
+        },
+        {
+          "description": "How far it turns each frame.",
+          "name": "rot_add",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How far it is turned about the view, from 0 to 4095.",
+          "name": "rot_angle",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether it turns as it lives.",
+          "name": "rotates",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "How strongly the size is scaled with distance.",
+          "name": "scalar",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether it travels from its start size to its end size.",
+          "name": "scales",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "The color it fades from.",
+          "name": "start_color",
+          "type": "math.Color",
+          "writable": true
+        },
+        {
+          "description": "The height it grows from.",
+          "name": "start_height",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "The width it grows from.",
+          "name": "start_width",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether it is drawn with the second sprite of its kind.",
+          "name": "uses_alt_sprite",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "How far it moves each frame.",
+          "name": "vel",
+          "type": "math.Vec3",
+          "writable": true
+        },
+        {
+          "description": "How wide it is drawn now.",
+          "name": "width",
+          "type": "integer",
+          "writable": true
+        }
+      ],
+      "handle": true,
+      "methods": [
+        {
+          "description": "Reports whether the handle still names a live spark.\n\nA spark that runs out of life leaves its slot to the next one asked for.",
+          "name": "is_valid",
+          "returns": {
+            "description": "False once the spark has ended.",
+            "type": "boolean"
+          }
+        },
+        {
+          "description": "Ends the spark now and frees its slot.",
+          "name": "kill"
+        }
+      ],
+      "operators": [],
+      "path": "fx.Spark"
+    },
+    {
+      "description": "How far the wind carries a spark each frame.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "The east-west axis.",
+          "name": "x",
+          "type": "math.Distance"
+        },
+        {
+          "description": "The north-south axis.",
+          "name": "z",
+          "type": "math.Distance"
+        }
+      ],
+      "handle": false,
+      "methods": [],
+      "operators": [],
+      "path": "fx.Wind"
     },
     {
       "description": "A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.",

--- a/docs/trx/lua/reference/FX.md
+++ b/docs/trx/lua/reference/FX.md
@@ -30,12 +30,29 @@ for _, bulb in pairs(trx.fx.fog_bulbs) do
 end
 ```
 
+The spark pool, counted from 1. `#trx.fx.sparks.pool` is
+[`MAX_COUNT`](#fx.sparks.MAX_COUNT) rather than how many sparks are alive: a slot holding
+no live spark reads as `nil`.
+
+- <a id="fx.sparks.pool[]" name="fx.sparks.pool[]"></a>**`trx.fx.sparks.pool[key]`** (key: integer, value: [trx.fx.Spark](#fx.Spark) or `nil`).
+- **`#trx.fx.sparks.pool`** (integer). How many there are.
+
+Example:
+```lua
+for _, spark in pairs(trx.fx.sparks.pool) do
+  spark.color = trx.math.color(255, 0, 0)
+end
+```
+
 ### Properties
 
 - <a id="fx.fog_color" name="fx.fog_color"></a>**`trx.fx.fog_color`** ([trx.math.Color](MATH.md#math.Color)). The color override for distance fog.
   `nil` means no override. Write `nil` to restore the level fog color. A level change clears the
   override. Savegames keep it. This controls distance fog only. Fog bulbs have their own colors
   in [`trx.fx.fog_bulbs`](#fx.fog_bulbs).
+- <a id="fx.sparks.wind" name="fx.sparks.wind"></a>**`trx.fx.sparks.wind`** ([trx.fx.Wind](#fx.Wind)). The wind that carries the sparks marked [`trx.fx.Spark.is_outside`](#fx.Spark.is_outside).
+  The engine works this out again every frame from the breeze setting, so a value
+  written here holds for that frame alone.
 
 ### Constants
 
@@ -44,6 +61,55 @@ end
 
 - <a id="fx.MAX_FOG" name="fx.MAX_FOG"></a>[lua]`trx.fx.MAX_FOG` = `10` (integer)  
   How many balls of fog can be seen at once. TR4 levels carry fog of their own, which takes its slots first, so fewer than this reach the screen where a level is already using them.
+
+- <a id="fx.sparks.MAX_COUNT" name="fx.sparks.MAX_COUNT"></a>[lua]`trx.fx.sparks.MAX_COUNT` = `400` (integer)  
+  How many sparks the pool holds. A spark spawned after that takes the slot of the one with the least life left.
+
+### Enums
+
+- <a id="fx.SparkType" name="fx.SparkType"></a>[lua]`trx.fx.SparkType`
+
+    Which spark-set sprite a spark is drawn with.
+
+    - `trx.fx.SparkType.EXPLOSION` = `0`  
+        The soft round puff fire, smoke and explosions are drawn with.
+    - `trx.fx.SparkType.SMALL_SPLASH` = `4`  
+        A single drop of water.
+    - `trx.fx.SparkType.BIG_SPLASH` = `8`  
+        A sheet of water.
+    - `trx.fx.SparkType.RIPPLE` = `9`  
+        A ring on the water surface.
+    - `trx.fx.SparkType.PARTICLE` = `10`  
+        The plain speck, which is also what a footprint is drawn with.
+    - `trx.fx.SparkType.SHIELD` = `11`  
+        The bubble drawn around a shielded target.
+    - `trx.fx.SparkType.ROPE` = `19`  
+        A length of rope.
+    - `trx.fx.SparkType.DRIVE` = `20`  
+        The forward gear light of a vehicle.
+    - `trx.fx.SparkType.REVERSE` = `21`  
+        The reverse gear light of a vehicle.
+    - `trx.fx.SparkType.RICOCHET` = `36`  
+        The spark struck off a wall by a shot.
+    - `trx.fx.SparkType.BLOOD` = `39`  
+        A drop of blood.
+
+- <a id="fx.DrawType" name="fx.DrawType"></a>[lua]`trx.fx.DrawType`
+
+    How a sprite is laid over what is behind it.
+
+    - `trx.fx.DrawType.OPAQUE` = `0`  
+        It covers what is behind it.
+    - `trx.fx.DrawType.BLEND` = `1`  
+        It is mixed with what is behind it.
+    - `trx.fx.DrawType.BLEND_ADD` = `2`  
+        It is added to what is behind it, so it lightens.
+    - `trx.fx.DrawType.BLEND_SUB` = `3`  
+        It is taken from what is behind it, so it darkens.
+    - `trx.fx.DrawType.REFLECTIVE_OPAQUE` = `8`  
+        Opaque, and carrying the room reflection.
+    - `trx.fx.DrawType.REFLECTIVE_BLEND_ADD` = `9`  
+        Added, and carrying the room reflection.
 
 ### Structures
 
@@ -80,7 +146,88 @@ end
 
       Returns: boolean. False after the level that held the bulb is left.
 
+- <a id="fx.Spark" name="fx.Spark"></a>[lua]`trx.fx.Spark`
+
+    A spark is one particle from the spark pool: a sprite that lives for a set
+    number of frames, moving, resizing and fading on its own as it does.
+
+    TR3 and TR4 only. The earlier games carry no spark set, so nothing spawns one
+    and the pool stays empty.
+
+    A spark that runs out of life leaves its slot to the next one asked for. A
+    handle held across that becomes stale, and field access raises an error.
+
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
+
+    Properties:
+    - <a id="fx.Spark.color" name="fx.Spark.color"></a>**`color`**: [trx.math.Color](MATH.md#math.Color). The color it is drawn in now.
+    - <a id="fx.Spark.draw_type" name="fx.Spark.draw_type"></a>**`draw_type`**: [trx.fx.DrawType](#fx.DrawType). How it is laid over what is behind it. *(read-only)*
+    - <a id="fx.Spark.end_color" name="fx.Spark.end_color"></a>**`end_color`**: [trx.math.Color](MATH.md#math.Color). The color it fades to.
+    - <a id="fx.Spark.end_height" name="fx.Spark.end_height"></a>**`end_height`**: integer. The height it grows to.
+    - <a id="fx.Spark.end_width" name="fx.Spark.end_width"></a>**`end_width`**: integer. The width it grows to.
+    - <a id="fx.Spark.extras" name="fx.Spark.extras"></a>**`extras`**: integer. How many further sparks it leaves behind as it ends.
+    - <a id="fx.Spark.fade_speed" name="fx.Spark.fade_speed"></a>**`fade_speed`**: integer. How fast it travels from one color to the other.
+    - <a id="fx.Spark.fade_to_black" name="fx.Spark.fade_to_black"></a>**`fade_to_black`**: integer. How many frames of life are left when it starts to darken toward black.
+    - <a id="fx.Spark.friction" name="fx.Spark.friction"></a>**`friction`**: integer. How fast it is slowed each frame.
+    - <a id="fx.Spark.gravity" name="fx.Spark.gravity"></a>**`gravity`**: integer. How much it is pulled down each frame.
+    - <a id="fx.Spark.height" name="fx.Spark.height"></a>**`height`**: integer. How tall it is drawn now.
+    - <a id="fx.Spark.is_blood" name="fx.Spark.is_blood"></a>**`is_blood`**: boolean. Whether it counts as blood, which the pool sheds first when it runs short of slots.
+    - <a id="fx.Spark.is_green" name="fx.Spark.is_green"></a>**`is_green`**: boolean. Whether it is drawn in the green of the poison gas.
+    - <a id="fx.Spark.is_outside" name="fx.Spark.is_outside"></a>**`is_outside`**: boolean. Whether the wind carries it.
+    - <a id="fx.Spark.is_underwater" name="fx.Spark.is_underwater"></a>**`is_underwater`**: boolean. Whether it drifts like an underwater particle.
+    - <a id="fx.Spark.life" name="fx.Spark.life"></a>**`life`**: integer. Frames of life left. It reaches zero and the spark ends.
+    - <a id="fx.Spark.life_span" name="fx.Spark.life_span"></a>**`life_span`**: integer. Frames of life it started with, which the fades are measured against.
+    - <a id="fx.Spark.max_y_vel" name="fx.Spark.max_y_vel"></a>**`max_y_vel`**: integer. As fast as gravity may carry it down.
+    - <a id="fx.Spark.node_num" name="fx.Spark.node_num"></a>**`node_num`**: integer. Which of the sixteen body points it hangs off, where it is attached to one.
+    - <a id="fx.Spark.pos" name="fx.Spark.pos"></a>**`pos`**: [trx.math.Vec3](MATH.md#math.Vec3). Where it sits, in the world, or from what it is attached to. Read [`world_pos`](#fx.Spark.world_pos) for the position it is drawn at.
+    - <a id="fx.Spark.room_num" name="fx.Spark.room_num"></a>**`room_num`**: [trx.rooms.Num](ROOMS.md#rooms.Num). The room it was spawned in. *(read-only)*
+    - <a id="fx.Spark.rot_add" name="fx.Spark.rot_add"></a>**`rot_add`**: integer. How far it turns each frame.
+    - <a id="fx.Spark.rot_angle" name="fx.Spark.rot_angle"></a>**`rot_angle`**: integer. How far it is turned about the view, from 0 to 4095.
+    - <a id="fx.Spark.rotates" name="fx.Spark.rotates"></a>**`rotates`**: boolean. Whether it turns as it lives.
+    - <a id="fx.Spark.scalar" name="fx.Spark.scalar"></a>**`scalar`**: integer. How strongly the size is scaled with distance.
+    - <a id="fx.Spark.scales" name="fx.Spark.scales"></a>**`scales`**: boolean. Whether it travels from its start size to its end size.
+    - <a id="fx.Spark.start_color" name="fx.Spark.start_color"></a>**`start_color`**: [trx.math.Color](MATH.md#math.Color). The color it fades from.
+    - <a id="fx.Spark.start_height" name="fx.Spark.start_height"></a>**`start_height`**: integer. The height it grows from.
+    - <a id="fx.Spark.start_width" name="fx.Spark.start_width"></a>**`start_width`**: integer. The width it grows from.
+    - <a id="fx.Spark.uses_alt_sprite" name="fx.Spark.uses_alt_sprite"></a>**`uses_alt_sprite`**: boolean. Whether it is drawn with the second sprite of its kind.
+    - <a id="fx.Spark.vel" name="fx.Spark.vel"></a>**`vel`**: [trx.math.Vec3](MATH.md#math.Vec3). How far it moves each frame.
+    - <a id="fx.Spark.width" name="fx.Spark.width"></a>**`width`**: integer. How wide it is drawn now.
+
+    Computed properties (derived, not stored on the object):
+    - <a id="fx.Spark.item" name="fx.Spark.item"></a>**`item`**: [trx.items.Item](ITEMS.md#items.Item). The item it is attached to, and `nil` where it hangs on nothing.
+    - <a id="fx.Spark.room" name="fx.Spark.room"></a>**`room`**: [trx.rooms.Room](ROOMS.md#rooms.Room). The room it was spawned in.
+    - <a id="fx.Spark.world_pos" name="fx.Spark.world_pos"></a>**`world_pos`**: [trx.math.Vec3](MATH.md#math.Vec3). Where it is drawn, which is where it sits unless it is attached to something that carries it.
+
+    Methods:
+
+    - <a id="fx.Spark.is_valid" name="fx.Spark.is_valid"></a>[lua]`spark:is_valid()`  
+      Reports whether the handle still names a live spark.
+
+      A spark that runs out of life leaves its slot to the next one asked for.
+
+      Returns: boolean. False once the spark has ended.
+
+    - <a id="fx.Spark.kill" name="fx.Spark.kill"></a>[lua]`spark:kill()`  
+      Ends the spark now and frees its slot.
+
+- <a id="fx.Wind" name="fx.Wind"></a>[lua]`trx.fx.Wind`
+
+    How far the wind carries a spark each frame.
+
+    Properties:
+    - <a id="fx.Wind.x" name="fx.Wind.x"></a>**`x`**: [trx.math.Distance](MATH.md#math.Distance). The east-west axis.
+    - <a id="fx.Wind.z" name="fx.Wind.z"></a>**`z`**: [trx.math.Distance](MATH.md#math.Distance). The north-south axis.
+
 ### Functions
+
+- <a id="fx.sparks" name="fx.sparks"></a>[lua]`trx.fx.sparks`  
+  The spark pool: the particles TR3 and TR4 draw their smoke, flames, sparks and
+  splashes with.
+
+  TR1 and TR2 carry no spark set. There the pool stays empty, and everything here
+  returns nothing rather than raising.
 
 - <a id="fx.emit_light" name="fx.emit_light"></a>[lua]`trx.fx.emit_light(opts)`  
   Lights the world around a point for this frame. Make the call every frame to
@@ -189,4 +336,514 @@ end
   Example:
   ```lua
   trx.fx.blood_bath({ pos = trx.lara.item.pos, count = 10 })
+  ```
+
+- <a id="fx.explosion" name="fx.explosion"></a>[lua]`trx.fx.explosion(opts)`  
+  Shows the explosion a rocket or a grenade leaves behind, without the damage.
+
+  TR1, TR2 and TR4 draw the explosion sprite the level carries. TR3 has none, and
+  gets a fireball of sparks instead. Under water the effect uses the drowned
+  version, which throws a burst of bubbles and lifts a splash where the water
+  ends.
+
+  Parameters:
+  - <a id="fx.explosion.opts" name="fx.explosion.opts"></a>**`opts`** (table). Where the explosion is and whether it is heard.
+
+    Keys:
+    - <a id="fx.explosion.opts.pos" name="fx.explosion.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+    - <a id="fx.explosion.opts.sound" name="fx.explosion.opts.sound"></a>**`sound`** (boolean, optional, default `true`). Whether the explosion sound plays with it.
+
+  Example:
+  ```lua
+  trx.fx.explosion({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.fire" name="fx.fire"></a>[lua]`trx.fx.fire(opts)`  
+  Burns a fire at a point for this frame. Make the call every frame to keep the
+  fire alight.
+
+  TR4 only. The other games have no such fire, so the call does nothing there.
+
+  Parameters:
+  - <a id="fx.fire.opts" name="fx.fire.opts"></a>**`opts`** (table). Where the fire is and how it burns.
+
+    Keys:
+    - <a id="fx.fire.opts.pos" name="fx.fire.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+    - <a id="fx.fire.opts.size" name="fx.fire.opts.size"></a>**`size`** (integer, optional, default `1`). How big it burns: `0` small, `1` medium, `2` big.
+    - <a id="fx.fire.opts.fade" name="fx.fire.opts.fade"></a>**`fade`** (integer, optional, default `0`). How far it is dimmed, `0` being full strength.
+
+  Example:
+  ```lua
+  trx.events.after_control(function()
+    trx.fx.fire({ pos = trx.lara.item.pos, size = 2 })
+  end)
+  ```
+
+- <a id="fx.splash" name="fx.splash"></a>[lua]`trx.fx.splash(item)`  
+  Breaks the water at an item, the way a body falling in does. The item says
+  where the splash is; the water it lands in says how big.
+
+  Parameters:
+  - <a id="fx.splash.item" name="fx.splash.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item the splash rises around.
+
+  Example:
+  ```lua
+  trx.fx.splash(trx.lara.item)
+  ```
+
+- <a id="fx.wade_splash" name="fx.wade_splash"></a>[lua]`trx.fx.wade_splash(item, depth)`  
+  Breaks the water around an item wading through it.
+
+  Parameters:
+  - <a id="fx.wade_splash.item" name="fx.wade_splash.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item doing the wading.
+  - <a id="fx.wade_splash.depth" name="fx.wade_splash.depth"></a>**`depth`** ([trx.math.Distance](MATH.md#math.Distance)). How deep the water stands about it.
+
+  Example:
+  ```lua
+  trx.fx.wade_splash(trx.lara.item, 512)
+  ```
+
+- <a id="fx.ripple" name="fx.ripple"></a>[lua]`trx.fx.ripple(opts)`  
+  Spreads a ring on the water surface. The ring widens and fades on its own.
+
+  Parameters:
+  - <a id="fx.ripple.opts" name="fx.ripple.opts"></a>**`opts`** (table). Where the ring is and how it spreads.
+
+    Keys:
+    - <a id="fx.ripple.opts.pos" name="fx.ripple.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+    - <a id="fx.ripple.opts.size" name="fx.ripple.opts.size"></a>**`size`** (integer, optional, default `8`). How wide it starts, from 1 to 255.
+    - <a id="fx.ripple.opts.slow" name="fx.ripple.opts.slow"></a>**`slow`** (boolean, optional, default `false`). Whether it spreads at half speed.
+    - <a id="fx.ripple.opts.dark" name="fx.ripple.opts.dark"></a>**`dark`** (boolean, optional, default `false`). Whether it is drawn dark rather than bright.
+    - <a id="fx.ripple.opts.blood" name="fx.ripple.opts.blood"></a>**`blood`** (boolean, optional, default `false`). Whether it is drawn in the blood color.
+    - <a id="fx.ripple.opts.jitter" name="fx.ripple.opts.jitter"></a>**`jitter`** (boolean, optional, default `false`). Whether the ring wavers as it spreads.
+
+  Example:
+  ```lua
+  trx.fx.ripple({ pos = trx.lara.item.pos, size = 16 })
+  ```
+
+- <a id="fx.small_splash" name="fx.small_splash"></a>[lua]`trx.fx.small_splash(opts)`  
+  Throws a handful of drops off the water surface.
+
+  Parameters:
+  - <a id="fx.small_splash.opts" name="fx.small_splash.opts"></a>**`opts`** (table). Where the drops are and how many of them.
+
+    Keys:
+    - <a id="fx.small_splash.opts.pos" name="fx.small_splash.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+    - <a id="fx.small_splash.opts.count" name="fx.small_splash.opts.count"></a>**`count`** (integer, optional, default `1`). How many drops, from 1 to 255.
+
+  Example:
+  ```lua
+  trx.fx.small_splash({ pos = trx.lara.item.pos, count = 8 })
+  ```
+
+- <a id="fx.underwater_blood" name="fx.underwater_blood"></a>[lua]`trx.fx.underwater_blood(opts)`  
+  Spreads a cloud of blood under water, the way a hit that lands there does.
+
+  Parameters:
+  - <a id="fx.underwater_blood.opts" name="fx.underwater_blood.opts"></a>**`opts`** (table). Where the cloud is and how wide it spreads.
+
+    Keys:
+    - <a id="fx.underwater_blood.opts.pos" name="fx.underwater_blood.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+    - <a id="fx.underwater_blood.opts.size" name="fx.underwater_blood.opts.size"></a>**`size`** (integer, optional, default `8`). How wide it spreads, from 1 to 255.
+    - <a id="fx.underwater_blood.opts.dark" name="fx.underwater_blood.opts.dark"></a>**`dark`** (boolean, optional, default `false`). Whether it is drawn in the darker TR3 gold color.
+
+  Example:
+  ```lua
+  trx.fx.underwater_blood({ pos = trx.lara.item.pos, size = 32 })
+  ```
+
+- <a id="fx.footprint" name="fx.footprint"></a>[lua]`trx.fx.footprint(item, left_foot)`  
+  Leaves a footprint under an item, on the floor the item stands on. The floor
+  material decides whether one is left at all.
+
+  Parameters:
+  - <a id="fx.footprint.item" name="fx.footprint.item"></a>**`item`** ([trx.items.Item](ITEMS.md#items.Item)). The item the print is taken from.
+  - <a id="fx.footprint.left_foot" name="fx.footprint.left_foot"></a>**`left_foot`** (boolean). Whether it is the left foot rather than the right.
+
+  Example:
+  ```lua
+  trx.fx.footprint(trx.lara.item, true)
+  ```
+
+- <a id="fx.knockback" name="fx.knockback"></a>[lua]`trx.fx.knockback(opts)`  
+  Spreads a ring of force out from a point, as a blast does. The ring is drawn
+  and widens on its own.
+
+  Parameters:
+  - <a id="fx.knockback.opts" name="fx.knockback.opts"></a>**`opts`** (table). Where the ring starts.
+
+    Keys:
+    - <a id="fx.knockback.opts.pos" name="fx.knockback.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+
+  Example:
+  ```lua
+  trx.fx.knockback({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.spawn" name="fx.sparks.spawn"></a>[lua]`trx.fx.sparks.spawn(opts)`  
+  Puts one spark in the world and hands it back, so a script can draw with the
+  pool the game draws its own smoke and flames with.
+
+  The spark lives for the frames it is given, moving, resizing and fading on its
+  own, and then frees its slot. Nothing has to be called each frame to keep it up.
+
+  Returns `nil` where the level carries no spark set, which is every TR1 and TR2
+  level.
+
+  Parameters:
+  - <a id="fx.sparks.spawn.opts" name="fx.sparks.spawn.opts"></a>**`opts`** (table). What the spark is and how it behaves.
+
+    Keys:
+    - <a id="fx.sparks.spawn.opts.pos" name="fx.sparks.spawn.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.spawn.opts.vel" name="fx.sparks.spawn.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). How far it moves each frame. Defaults to standing still.
+    - <a id="fx.sparks.spawn.opts.sprite_type" name="fx.sparks.spawn.opts.sprite_type"></a>**`sprite_type`** ([trx.fx.SparkType](#fx.SparkType), optional, default [`trx.fx.SparkType.PARTICLE`](#fx.SparkType)). Which sprite it is drawn with.
+    - <a id="fx.sparks.spawn.opts.life" name="fx.sparks.spawn.opts.life"></a>**`life`** (integer, optional, default `16`). How many frames it lives, from 1 to 255.
+    - <a id="fx.sparks.spawn.opts.color" name="fx.sparks.spawn.opts.color"></a>**`color`** ([trx.math.Color](MATH.md#math.Color), optional). The color it starts in. Defaults to white.
+    - <a id="fx.sparks.spawn.opts.end_color" name="fx.sparks.spawn.opts.end_color"></a>**`end_color`** ([trx.math.Color](MATH.md#math.Color), optional). The color it fades to. Defaults to the color it starts in, so it holds one color.
+    - <a id="fx.sparks.spawn.opts.fade_speed" name="fx.sparks.spawn.opts.fade_speed"></a>**`fade_speed`** (integer, optional, default `8`). How fast it travels between the two colors.
+    - <a id="fx.sparks.spawn.opts.fade_to_black" name="fx.sparks.spawn.opts.fade_to_black"></a>**`fade_to_black`** (integer, optional, default `8`). How many frames of life are left when it starts to darken toward black.
+    - <a id="fx.sparks.spawn.opts.width" name="fx.sparks.spawn.opts.width"></a>**`width`** (integer, optional, default `4`). How wide it starts, from 0 to 255.
+    - <a id="fx.sparks.spawn.opts.height" name="fx.sparks.spawn.opts.height"></a>**`height`** (integer, optional, default `4`). How tall it starts, from 0 to 255.
+    - <a id="fx.sparks.spawn.opts.end_width" name="fx.sparks.spawn.opts.end_width"></a>**`end_width`** (integer, optional). The width it grows to, for a spark that scales. Defaults to the width it starts at.
+    - <a id="fx.sparks.spawn.opts.end_height" name="fx.sparks.spawn.opts.end_height"></a>**`end_height`** (integer, optional). The height it grows to, for a spark that scales. Defaults to the height it starts at.
+    - <a id="fx.sparks.spawn.opts.scales" name="fx.sparks.spawn.opts.scales"></a>**`scales`** (boolean, optional, default `false`). Whether it travels from its start size to its end size over its life.
+    - <a id="fx.sparks.spawn.opts.scalar" name="fx.sparks.spawn.opts.scalar"></a>**`scalar`** (integer, optional, default `2`). How strongly the size is scaled with distance.
+    - <a id="fx.sparks.spawn.opts.gravity" name="fx.sparks.spawn.opts.gravity"></a>**`gravity`** (integer, optional, default `0`). How much it is pulled down each frame.
+    - <a id="fx.sparks.spawn.opts.max_y_vel" name="fx.sparks.spawn.opts.max_y_vel"></a>**`max_y_vel`** (integer, optional, default `0`). As fast as gravity may carry it down.
+    - <a id="fx.sparks.spawn.opts.friction" name="fx.sparks.spawn.opts.friction"></a>**`friction`** (integer, optional, default `0`). How fast it is slowed each frame.
+    - <a id="fx.sparks.spawn.opts.rot_angle" name="fx.sparks.spawn.opts.rot_angle"></a>**`rot_angle`** (integer, optional, default `0`). How far it starts turned about the view, from 0 to 4095.
+    - <a id="fx.sparks.spawn.opts.rot_add" name="fx.sparks.spawn.opts.rot_add"></a>**`rot_add`** (integer, optional, default `0`). How far it turns each frame, for a spark that turns.
+    - <a id="fx.sparks.spawn.opts.rotates" name="fx.sparks.spawn.opts.rotates"></a>**`rotates`** (boolean, optional, default `false`). Whether it turns as it lives.
+    - <a id="fx.sparks.spawn.opts.extras" name="fx.sparks.spawn.opts.extras"></a>**`extras`** (integer, optional, default `0`). How many further sparks it leaves behind as it ends.
+    - <a id="fx.sparks.spawn.opts.draw_type" name="fx.sparks.spawn.opts.draw_type"></a>**`draw_type`** ([trx.fx.DrawType](#fx.DrawType), optional, default [`trx.fx.DrawType.BLEND_ADD`](#fx.DrawType)). How it is laid over what is behind it.
+    - <a id="fx.sparks.spawn.opts.is_outside" name="fx.sparks.spawn.opts.is_outside"></a>**`is_outside`** (boolean, optional, default `false`). Whether the wind carries it.
+    - <a id="fx.sparks.spawn.opts.is_underwater" name="fx.sparks.spawn.opts.is_underwater"></a>**`is_underwater`** (boolean, optional, default `false`). Whether it drifts like an underwater particle.
+    - <a id="fx.sparks.spawn.opts.is_green" name="fx.sparks.spawn.opts.is_green"></a>**`is_green`** (boolean, optional, default `false`). Whether it is drawn in the green of the poison gas.
+    - <a id="fx.sparks.spawn.opts.uses_alt_sprite" name="fx.sparks.spawn.opts.uses_alt_sprite"></a>**`uses_alt_sprite`** (boolean, optional, default `false`). Whether it is drawn with the second sprite of its kind.
+
+  Returns: [trx.fx.Spark](#fx.Spark) or `nil`. The spark, or `nil` where the level carries no spark set.
+
+  Example:
+  ```lua
+  trx.fx.sparks.spawn({
+    pos = trx.lara.item.pos,
+    vel = { x = 0, y = -8, z = 0 },
+    sprite_type = trx.fx.SparkType.EXPLOSION,
+    life = 48,
+    color = trx.math.color(255, 200, 64),
+    end_color = trx.math.color(64, 0, 0),
+    width = 16,
+    end_width = 48,
+    scales = true,
+  })
+  ```
+
+- <a id="fx.sparks.explosion" name="fx.sparks.explosion"></a>[lua]`trx.fx.sparks.explosion(opts)`  
+  Throws the fireball of sparks an explosion is drawn with.
+
+  Parameters:
+  - <a id="fx.sparks.explosion.opts" name="fx.sparks.explosion.opts"></a>**`opts`** (table). Where the fireball is and how strongly it bursts.
+
+    Keys:
+    - <a id="fx.sparks.explosion.opts.pos" name="fx.sparks.explosion.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.explosion.opts.extras" name="fx.sparks.explosion.opts.extras"></a>**`extras`** (integer, optional, default `3`). How many further sparks each one leaves behind as it ends, from 0 to 3.
+    - <a id="fx.sparks.explosion.opts.light" name="fx.sparks.explosion.opts.light"></a>**`light`** (integer, optional, default `-2`). How the fireball lights the room around it: `-2` bright, `-1` dim, `0` not at all.
+    - <a id="fx.sparks.explosion.opts.underwater" name="fx.sparks.explosion.opts.underwater"></a>**`underwater`** (boolean, optional, default `false`). Whether it uses the underwater burst.
+
+  Example:
+  ```lua
+  trx.fx.sparks.explosion({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.explosion_smoke" name="fx.sparks.explosion_smoke"></a>[lua]`trx.fx.sparks.explosion_smoke(opts)`  
+  Lifts the smoke an explosion leaves behind.
+
+  Parameters:
+  - <a id="fx.sparks.explosion_smoke.opts" name="fx.sparks.explosion_smoke.opts"></a>**`opts`** (table). Where the smoke is and which part of the burst it is.
+
+    Keys:
+    - <a id="fx.sparks.explosion_smoke.opts.pos" name="fx.sparks.explosion_smoke.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.explosion_smoke.opts.underwater" name="fx.sparks.explosion_smoke.opts.underwater"></a>**`underwater`** (boolean, optional, default `false`). Whether it lifts as it does under water.
+    - <a id="fx.sparks.explosion_smoke.opts.ending" name="fx.sparks.explosion_smoke.opts.ending"></a>**`ending`** (boolean, optional, default `false`). Whether it is the thinner smoke that closes the burst rather than the smoke that opens it.
+
+  Example:
+  ```lua
+  trx.fx.sparks.explosion_smoke({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.explosion_bubble" name="fx.sparks.explosion_bubble"></a>[lua]`trx.fx.sparks.explosion_bubble(opts)`  
+  Throws the burst of bubbles an explosion under water makes.
+
+  Parameters:
+  - <a id="fx.sparks.explosion_bubble.opts" name="fx.sparks.explosion_bubble.opts"></a>**`opts`** (table). Where the bubbles rise.
+
+    Keys:
+    - <a id="fx.sparks.explosion_bubble.opts.pos" name="fx.sparks.explosion_bubble.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+
+  Example:
+  ```lua
+  trx.fx.sparks.explosion_bubble({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.fire_flame" name="fx.sparks.fire_flame"></a>[lua]`trx.fx.sparks.fire_flame(opts)`  
+  Throws one tongue of flame, the way a burning body does. Make the call every
+  frame to keep a fire burning.
+
+  No flame is thrown more than twenty sectors from Lara.
+
+  Parameters:
+  - <a id="fx.sparks.fire_flame.opts" name="fx.sparks.fire_flame.opts"></a>**`opts`** (table). Where the flame is and what color it burns.
+
+    Keys:
+    - <a id="fx.sparks.fire_flame.opts.pos" name="fx.sparks.fire_flame.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.fire_flame.opts.variant" name="fx.sparks.fire_flame.opts.variant"></a>**`variant`** (integer, optional, default `0`). Which colors it burns in: `0` orange, `2` pale, `254` green.
+
+  Example:
+  ```lua
+  trx.fx.sparks.fire_flame({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.fire_smoke" name="fx.sparks.fire_smoke"></a>[lua]`trx.fx.sparks.fire_smoke(opts)`  
+  Lifts one puff of the smoke a fire gives off.
+
+  Parameters:
+  - <a id="fx.sparks.fire_smoke.opts" name="fx.sparks.fire_smoke.opts"></a>**`opts`** (table). Where the smoke is and which flame color it follows.
+
+    Keys:
+    - <a id="fx.sparks.fire_smoke.opts.pos" name="fx.sparks.fire_smoke.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.fire_smoke.opts.variant" name="fx.sparks.fire_smoke.opts.variant"></a>**`variant`** (integer, optional, default `0`). Which colors it burns in: `0` orange, `2` pale, `254` green.
+
+  Example:
+  ```lua
+  trx.fx.sparks.fire_smoke({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.static_flame" name="fx.sparks.static_flame"></a>[lua]`trx.fx.sparks.static_flame(opts)`  
+  Throws one tongue of the flame a standing fire burns with.
+
+  Parameters:
+  - <a id="fx.sparks.static_flame.opts" name="fx.sparks.static_flame.opts"></a>**`opts`** (table). Where the flame is and how big it burns.
+
+    Keys:
+    - <a id="fx.sparks.static_flame.opts.pos" name="fx.sparks.static_flame.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.static_flame.opts.size" name="fx.sparks.static_flame.opts.size"></a>**`size`** (integer, optional, default `32`). How big it burns.
+
+  Example:
+  ```lua
+  trx.fx.sparks.static_flame({ pos = trx.lara.item.pos, size = 64 })
+  ```
+
+- <a id="fx.sparks.side_flame" name="fx.sparks.side_flame"></a>[lua]`trx.fx.sparks.side_flame(opts)`  
+  Throws a tongue of flame sideways, as a jet does.
+
+  Parameters:
+  - <a id="fx.sparks.side_flame.opts" name="fx.sparks.side_flame.opts"></a>**`opts`** (table). Where the jet is and which way it burns.
+
+    Keys:
+    - <a id="fx.sparks.side_flame.opts.pos" name="fx.sparks.side_flame.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.side_flame.opts.angle" name="fx.sparks.side_flame.opts.angle"></a>**`angle`** ([trx.math.Angle](MATH.md#math.Angle)). The way the flame is thrown.
+    - <a id="fx.sparks.side_flame.opts.speed" name="fx.sparks.side_flame.opts.speed"></a>**`speed`** (integer, optional, default `32`). How hard it is thrown.
+    - <a id="fx.sparks.side_flame.opts.pilot" name="fx.sparks.side_flame.opts.pilot"></a>**`pilot`** (boolean, optional, default `false`). Whether it is the small pilot flame rather than the jet itself.
+
+  Example:
+  ```lua
+  trx.fx.sparks.side_flame({
+    pos = trx.lara.item.pos,
+    angle = trx.lara.item.rot.y,
+  })
+  ```
+
+- <a id="fx.sparks.flamethrower_flame" name="fx.sparks.flamethrower_flame"></a>[lua]`trx.fx.sparks.flamethrower_flame(opts)`  
+  Throws the flame a flamethrower leaves where its jet lands.
+
+  Parameters:
+  - <a id="fx.sparks.flamethrower_flame.opts" name="fx.sparks.flamethrower_flame.opts"></a>**`opts`** (table). Where the flame lands.
+
+    Keys:
+    - <a id="fx.sparks.flamethrower_flame.opts.pos" name="fx.sparks.flamethrower_flame.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+
+  Example:
+  ```lua
+  trx.fx.sparks.flamethrower_flame({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.flamethrower_smoke" name="fx.sparks.flamethrower_smoke"></a>[lua]`trx.fx.sparks.flamethrower_smoke(opts)`  
+  Lifts the smoke a flamethrower jet leaves behind.
+
+  Parameters:
+  - <a id="fx.sparks.flamethrower_smoke.opts" name="fx.sparks.flamethrower_smoke.opts"></a>**`opts`** (table). Where the smoke is.
+
+    Keys:
+    - <a id="fx.sparks.flamethrower_smoke.opts.pos" name="fx.sparks.flamethrower_smoke.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.flamethrower_smoke.opts.underwater" name="fx.sparks.flamethrower_smoke.opts.underwater"></a>**`underwater`** (boolean, optional, default `false`). Whether it lifts as it does under water.
+
+  Example:
+  ```lua
+  trx.fx.sparks.flamethrower_smoke({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.gun_smoke" name="fx.sparks.gun_smoke"></a>[lua]`trx.fx.sparks.gun_smoke(opts)`  
+  Lifts the smoke a fired weapon leaves at its muzzle.
+
+  Parameters:
+  - <a id="fx.sparks.gun_smoke.opts" name="fx.sparks.gun_smoke.opts"></a>**`opts`** (table). Where the smoke is and which weapon left it.
+
+    Keys:
+    - <a id="fx.sparks.gun_smoke.opts.pos" name="fx.sparks.gun_smoke.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.gun_smoke.opts.weapon" name="fx.sparks.gun_smoke.opts.weapon"></a>**`weapon`** ([trx.catalog.weapons](CATALOG.md#catalog.weapons)). Which weapon it is drawn for. `UNKNOWN`, `UNARMED`, and out-of-range values raise.
+    - <a id="fx.sparks.gun_smoke.opts.shade" name="fx.sparks.gun_smoke.opts.shade"></a>**`shade`** (integer, optional, default `64`). How light the smoke is, from 0 to 255.
+    - <a id="fx.sparks.gun_smoke.opts.initial" name="fx.sparks.gun_smoke.opts.initial"></a>**`initial`** (boolean, optional, default `false`). Whether it is the first puff of a shot, which is denser than the ones that follow.
+    - <a id="fx.sparks.gun_smoke.opts.vel" name="fx.sparks.gun_smoke.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). Which way the smoke is pushed. Left out, it lifts straight up.
+
+  Example:
+  ```lua
+  trx.fx.sparks.gun_smoke({
+    pos = trx.lara.item.pos,
+    weapon = trx.catalog.weapons.pistols,
+    initial = true,
+  })
+  ```
+
+- <a id="fx.sparks.dart_smoke" name="fx.sparks.dart_smoke"></a>[lua]`trx.fx.sparks.dart_smoke(opts)`  
+  Lifts the trail of smoke a flying dart leaves.
+
+  Parameters:
+  - <a id="fx.sparks.dart_smoke.opts" name="fx.sparks.dart_smoke.opts"></a>**`opts`** (table). Where the smoke is and which way the dart flies.
+
+    Keys:
+    - <a id="fx.sparks.dart_smoke.opts.pos" name="fx.sparks.dart_smoke.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.dart_smoke.opts.vel" name="fx.sparks.dart_smoke.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). How far it moves each frame. Defaults to standing still.
+    - <a id="fx.sparks.dart_smoke.opts.hit" name="fx.sparks.dart_smoke.opts.hit"></a>**`hit`** (boolean, optional, default `false`). Whether the dart has landed, which puffs the smoke out rather than trailing it.
+
+  Example:
+  ```lua
+  trx.fx.sparks.dart_smoke({ pos = trx.lara.item.pos, hit = true })
+  ```
+
+- <a id="fx.sparks.rocket_smoke" name="fx.sparks.rocket_smoke"></a>[lua]`trx.fx.sparks.rocket_smoke(opts)`  
+  Lifts the trail of smoke a flying rocket leaves.
+
+  Parameters:
+  - <a id="fx.sparks.rocket_smoke.opts" name="fx.sparks.rocket_smoke.opts"></a>**`opts`** (table). Where the smoke is and how light it lifts.
+
+    Keys:
+    - <a id="fx.sparks.rocket_smoke.opts.pos" name="fx.sparks.rocket_smoke.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.rocket_smoke.opts.shade" name="fx.sparks.rocket_smoke.opts.shade"></a>**`shade`** (integer, optional, default `0`). How light the smoke turns as it fades, from 0 to 191.
+
+  Example:
+  ```lua
+  trx.fx.sparks.rocket_smoke({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.flare" name="fx.sparks.flare"></a>[lua]`trx.fx.sparks.flare(opts)`  
+  Throws the sparks a burning flare gives off.
+
+  Parameters:
+  - <a id="fx.sparks.flare.opts" name="fx.sparks.flare.opts"></a>**`opts`** (table). Where the sparks are and which way they fly.
+
+    Keys:
+    - <a id="fx.sparks.flare.opts.pos" name="fx.sparks.flare.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.flare.opts.vel" name="fx.sparks.flare.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). How far it moves each frame. Defaults to standing still.
+    - <a id="fx.sparks.flare.opts.smoke" name="fx.sparks.flare.opts.smoke"></a>**`smoke`** (boolean, optional, default `false`). Whether smoke is lifted with them.
+
+  Example:
+  ```lua
+  trx.fx.sparks.flare({ pos = trx.lara.item.pos, smoke = true })
+  ```
+
+- <a id="fx.sparks.shotgun" name="fx.sparks.shotgun"></a>[lua]`trx.fx.sparks.shotgun(opts)`  
+  Throws the sparks a shotgun blast strikes off what it hits.
+
+  Parameters:
+  - <a id="fx.sparks.shotgun.opts" name="fx.sparks.shotgun.opts"></a>**`opts`** (table). Where the sparks are and which way they fly.
+
+    Keys:
+    - <a id="fx.sparks.shotgun.opts.pos" name="fx.sparks.shotgun.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.shotgun.opts.vel" name="fx.sparks.shotgun.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). How far it moves each frame. Defaults to standing still.
+
+  Example:
+  ```lua
+  trx.fx.sparks.shotgun({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.ricochet" name="fx.sparks.ricochet"></a>[lua]`trx.fx.sparks.ricochet(opts)`  
+  Strikes the sparks a shot makes where it lands on a wall.
+
+  TR4 throws as many streaks as asked for and can lift smoke instead. TR3 throws
+  one burst, and uses the count as its size.
+
+  Parameters:
+  - <a id="fx.sparks.ricochet.opts" name="fx.sparks.ricochet.opts"></a>**`opts`** (table). Where the shot lands and which way the sparks fly.
+
+    Keys:
+    - <a id="fx.sparks.ricochet.opts.pos" name="fx.sparks.ricochet.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.ricochet.opts.angle" name="fx.sparks.ricochet.opts.angle"></a>**`angle`** ([trx.math.Angle](MATH.md#math.Angle)). The way the sparks fly.
+    - <a id="fx.sparks.ricochet.opts.count" name="fx.sparks.ricochet.opts.count"></a>**`count`** (integer, optional, default `3`). How many streaks, from 1 to 255.
+    - <a id="fx.sparks.ricochet.opts.smoke_only" name="fx.sparks.ricochet.opts.smoke_only"></a>**`smoke_only`** (boolean, optional, default `false`). Whether smoke is lifted rather than sparks struck. TR4 only.
+
+  Example:
+  ```lua
+  trx.fx.sparks.ricochet({ pos = trx.lara.item.pos, angle = 0 })
+  ```
+
+- <a id="fx.sparks.bubble" name="fx.sparks.bubble"></a>[lua]`trx.fx.sparks.bubble(opts)`  
+  Lifts one bubble through the water.
+
+  Parameters:
+  - <a id="fx.sparks.bubble.opts" name="fx.sparks.bubble.opts"></a>**`opts`** (table). Where the bubble is and how big it is.
+
+    Keys:
+    - <a id="fx.sparks.bubble.opts.pos" name="fx.sparks.bubble.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.bubble.opts.size" name="fx.sparks.bubble.opts.size"></a>**`size`** (integer, optional, default `8`). How big it is at its smallest.
+    - <a id="fx.sparks.bubble.opts.size_range" name="fx.sparks.bubble.opts.size_range"></a>**`size_range`** (integer, optional, default `8`). How much bigger than that it may be drawn.
+
+  Example:
+  ```lua
+  trx.fx.sparks.bubble({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.breath" name="fx.sparks.breath"></a>[lua]`trx.fx.sparks.breath(opts)`  
+  Puffs the cloud of breath a body gives off in the cold.
+
+  Parameters:
+  - <a id="fx.sparks.breath.opts" name="fx.sparks.breath.opts"></a>**`opts`** (table). Where the breath is and which way it drifts.
+
+    Keys:
+    - <a id="fx.sparks.breath.opts.pos" name="fx.sparks.breath.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.breath.opts.vel" name="fx.sparks.breath.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). How far it moves each frame. Defaults to standing still.
+
+  Example:
+  ```lua
+  trx.fx.sparks.breath({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.pickup_aid" name="fx.sparks.pickup_aid"></a>[lua]`trx.fx.sparks.pickup_aid(opts)`  
+  Throws the twinkle that marks a pickup worth reaching.
+
+  Parameters:
+  - <a id="fx.sparks.pickup_aid.opts" name="fx.sparks.pickup_aid.opts"></a>**`opts`** (table). Where the twinkle is and which way it drifts.
+
+    Keys:
+    - <a id="fx.sparks.pickup_aid.opts.pos" name="fx.sparks.pickup_aid.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.pickup_aid.opts.vel" name="fx.sparks.pickup_aid.opts.vel"></a>**`vel`** ([trx.math.Vec3](MATH.md#math.Vec3), optional). How far it moves each frame. Defaults to standing still.
+
+  Example:
+  ```lua
+  trx.fx.sparks.pickup_aid({ pos = trx.lara.item.pos })
+  ```
+
+- <a id="fx.sparks.waterfall_mist" name="fx.sparks.waterfall_mist"></a>[lua]`trx.fx.sparks.waterfall_mist(opts)`  
+  Lifts the mist that stands at the foot of a waterfall.
+
+  Parameters:
+  - <a id="fx.sparks.waterfall_mist.opts" name="fx.sparks.waterfall_mist.opts"></a>**`opts`** (table). Where the mist is and which way it faces.
+
+    Keys:
+    - <a id="fx.sparks.waterfall_mist.opts.pos" name="fx.sparks.waterfall_mist.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position. Must lie inside the level.
+    - <a id="fx.sparks.waterfall_mist.opts.angle" name="fx.sparks.waterfall_mist.opts.angle"></a>**`angle`** ([trx.math.Angle](MATH.md#math.Angle)). The way the waterfall faces.
+
+  Example:
+  ```lua
+  trx.fx.sparks.waterfall_mist({ pos = trx.lara.item.pos, angle = 0 })
   ```

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -824,16 +824,24 @@ api.container = declarator("container", "containers", {
     end
 
     -- A collection is declared as the module that is indexed, or as the member
-    -- of it the collection is read through: one segment or two, where every
-    -- other declaration names a member and so has one more.
+    -- of it the collection is read through, which may sit inside a namespace:
+    -- one segment, two, or three.
     local parts = segments(name)
     need(
-      #parts == 1 or #parts == 2,
-      "a collection is declared as 'module' or 'module.member', got: %s",
+      #parts >= 1 and #parts <= 3,
+      "a collection is declared as 'module', 'module.member' or "
+        .. "'module.namespace.member', got: %s",
       name
     )
     container.module = parts[1]
-    container.member = parts[2]
+    container.member = #parts > 1 and table.concat(parts, ".", 2) or nil
+    -- The table it hangs off and the name it hangs there under, which is the
+    -- module's own table unless a namespace stands between the two.
+    container.holder = parts[1]
+    container.holder_name = parts[#parts]
+    if #parts == 3 then
+      container.holder = parts[1] .. "." .. parts[2]
+    end
 
     -- The table the collection is indexed on: the module's own where the module
     -- is indexed, and a member of it where the module hands a collection out.
@@ -845,7 +853,18 @@ api.container = declarator("container", "containers", {
       owner.table = module_table(name)
     else
       owner.table = owner.table or {}
-      rawset(module_table(container.module), container.member, owner.table)
+      local holder = module_table(container.module)
+      if #parts == 3 then
+        holder = rawget(holder, parts[2])
+        need(
+          type(holder) == "table",
+          "%s needs api.namespace('%s.%s') declared first",
+          name,
+          parts[1],
+          parts[2]
+        )
+      end
+      rawset(holder, container.holder_name, owner.table)
     end
     owner.container = container
     install_meta(owner)
@@ -1357,10 +1376,10 @@ api.enum = declarator("enum", "enums", {
 api.const = declarator("const", "constants", {
   declare = function(entry, path, spec, need)
     need(spec.value ~= nil, "%s has no value; is it exported from C?", path)
-    local where = placed(path, need)
+    local where = placed(path, need, true)
     entry.where = where
 
-    rawset(module_table(where.module), where.name, spec.value)
+    rawset(table_of(where, need), where.name, spec.value)
     return spec.value
   end,
 
@@ -1530,9 +1549,10 @@ local function audit_reachable()
       declared[owner] = declared[owner] or {}
       declared[owner][entry.where.name] = true
     elseif made_by(entry, api.container) and entry.member ~= nil then
-      -- The table a collection is read through is a member of its module.
-      declared[entry.module] = declared[entry.module] or {}
-      declared[entry.module][entry.member] = true
+      -- The table a collection is read through is a member of the module, or
+      -- of a namespace inside it.
+      declared[entry.holder] = declared[entry.holder] or {}
+      declared[entry.holder][entry.holder_name] = true
     end
   end
 

--- a/src/lua/api/fx.lua
+++ b/src/lua/api/fx.lua
@@ -352,3 +352,1458 @@ api.const("fx.MAX_FOG", {
     .. "fog of their own, which takes its slots first, so fewer than this "
     .. "reach the screen where a level is already using them.",
 })
+
+api.define("fx.explosion", {
+  description = [[
+Shows the explosion a rocket or a grenade leaves behind, without the damage.
+
+TR1, TR2 and TR4 draw the explosion sprite the level carries. TR3 has none, and
+gets a fireball of sparks instead. Under water the effect uses the drowned
+version, which throws a burst of bubbles and lifts a splash where the water
+ends.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the explosion is and whether it is heard.",
+      fields = {
+        pos_field,
+        {
+          name = "sound",
+          type = "boolean",
+          optional = true,
+          default = true,
+          description = "Whether the explosion sound plays with it.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.explosion({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.explosion(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.sound == nil or opts.sound
+    )
+  end,
+})
+
+api.define("fx.fire", {
+  description = [[
+Burns a fire at a point for this frame. Make the call every frame to keep the
+fire alight.
+
+TR4 only. The other games have no such fire, so the call does nothing there.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the fire is and how it burns.",
+      fields = {
+        pos_field,
+        {
+          name = "size",
+          type = "integer",
+          optional = true,
+          default = 1,
+          description = "How big it burns: `0` small, `1` medium, `2` big.",
+        },
+        {
+          name = "fade",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How far it is dimmed, `0` being full strength.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.events.after_control(function()
+  trx.fx.fire({ pos = trx.lara.item.pos, size = 2 })
+end)]],
+  },
+  impl = function(opts)
+    raw.fire(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.size or 1,
+      opts.fade or 0
+    )
+  end,
+})
+
+api.define("fx.splash", {
+  description = [[
+Breaks the water at an item, the way a body falling in does. The item says
+where the splash is; the water it lands in says how big.]],
+  params = {
+    {
+      name = "item",
+      type = "items.Item",
+      description = "The item the splash rises around.",
+    },
+  },
+  examples = { [[trx.fx.splash(trx.lara.item)]] },
+  impl = function(item)
+    raw.splash(item.num)
+  end,
+})
+
+api.define("fx.wade_splash", {
+  description = "Breaks the water around an item wading through it.",
+  params = {
+    {
+      name = "item",
+      type = "items.Item",
+      description = "The item doing the wading.",
+    },
+    {
+      name = "depth",
+      type = "math.Distance",
+      description = "How deep the water stands about it.",
+    },
+  },
+  examples = { [[trx.fx.wade_splash(trx.lara.item, 512)]] },
+  impl = function(item, depth)
+    raw.wade_splash(item.num, depth)
+  end,
+})
+
+api.define("fx.ripple", {
+  description = [[
+Spreads a ring on the water surface. The ring widens and fades on its own.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the ring is and how it spreads.",
+      fields = {
+        pos_field,
+        {
+          name = "size",
+          type = "integer",
+          optional = true,
+          default = 8,
+          description = "How wide it starts, from 1 to 255.",
+        },
+        {
+          name = "slow",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it spreads at half speed.",
+        },
+        {
+          name = "dark",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is drawn dark rather than bright.",
+        },
+        {
+          name = "blood",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is drawn in the blood color.",
+        },
+        {
+          name = "jitter",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether the ring wavers as it spreads.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.ripple({ pos = trx.lara.item.pos, size = 16 })]],
+  },
+  impl = function(opts)
+    raw.ripple(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.size or 8,
+      opts.slow,
+      opts.dark,
+      opts.blood,
+      opts.jitter
+    )
+  end,
+})
+
+api.define("fx.small_splash", {
+  description = "Throws a handful of drops off the water surface.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the drops are and how many of them.",
+      fields = {
+        pos_field,
+        {
+          name = "count",
+          type = "integer",
+          optional = true,
+          default = 1,
+          description = "How many drops, from 1 to 255.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.small_splash({ pos = trx.lara.item.pos, count = 8 })]],
+  },
+  impl = function(opts)
+    raw.small_splash(opts.pos.x, opts.pos.y, opts.pos.z, opts.count or 1)
+  end,
+})
+
+api.define("fx.underwater_blood", {
+  description = [[
+Spreads a cloud of blood under water, the way a hit that lands there does.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the cloud is and how wide it spreads.",
+      fields = {
+        pos_field,
+        {
+          name = "size",
+          type = "integer",
+          optional = true,
+          default = 8,
+          description = "How wide it spreads, from 1 to 255.",
+        },
+        {
+          name = "dark",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is drawn in the darker TR3 gold color.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.underwater_blood({ pos = trx.lara.item.pos, size = 32 })]],
+  },
+  impl = function(opts)
+    raw.underwater_blood(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.size or 8,
+      opts.dark
+    )
+  end,
+})
+
+api.define("fx.footprint", {
+  description = [[
+Leaves a footprint under an item, on the floor the item stands on. The floor
+material decides whether one is left at all.]],
+  params = {
+    {
+      name = "item",
+      type = "items.Item",
+      description = "The item the print is taken from.",
+    },
+    {
+      name = "left_foot",
+      type = "boolean",
+      description = "Whether it is the left foot rather than the right.",
+    },
+  },
+  examples = { [[trx.fx.footprint(trx.lara.item, true)]] },
+  impl = function(item, left_foot)
+    raw.footprint(item.num, left_foot)
+  end,
+})
+
+api.define("fx.knockback", {
+  description = [[
+Spreads a ring of force out from a point, as a blast does. The ring is drawn
+and widens on its own.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the ring starts.",
+      fields = { pos_field },
+    },
+  },
+  examples = { [[trx.fx.knockback({ pos = trx.lara.item.pos })]] },
+  impl = function(opts)
+    raw.knockback(opts.pos.x, opts.pos.y, opts.pos.z)
+  end,
+})
+
+local SparkType = api.enum("fx.SparkType", {
+  backing = "SPARK_SPRITE_TYPE",
+  description = "Which spark-set sprite a spark is drawn with.",
+  values = {
+    EXPLOSION = "The soft round puff fire, smoke and explosions are drawn with.",
+    SMALL_SPLASH = "A single drop of water.",
+    BIG_SPLASH = "A sheet of water.",
+    RIPPLE = "A ring on the water surface.",
+    PARTICLE = "The plain speck, which is also what a footprint is drawn with.",
+    SHIELD = "The bubble drawn around a shielded target.",
+    ROPE = "A length of rope.",
+    DRIVE = "The forward gear light of a vehicle.",
+    REVERSE = "The reverse gear light of a vehicle.",
+    RICOCHET = "The spark struck off a wall by a shot.",
+    BLOOD = "A drop of blood.",
+  },
+})
+
+local DrawType = api.enum("fx.DrawType", {
+  backing = "DRAW_TYPE",
+  description = "How a sprite is laid over what is behind it.",
+  values = {
+    OPAQUE = "It covers what is behind it.",
+    BLEND = "It is mixed with what is behind it.",
+    BLEND_ADD = "It is added to what is behind it, so it lightens.",
+    BLEND_SUB = "It is taken from what is behind it, so it darkens.",
+    REFLECTIVE_OPAQUE = "Opaque, and carrying the room reflection.",
+    REFLECTIVE_BLEND_ADD = "Added, and carrying the room reflection.",
+  },
+})
+
+api.type("fx.Spark", {
+  backing = "SPARK",
+  description = [[
+A spark is one particle from the spark pool: a sprite that lives for a set
+number of frames, moving, resizing and fading on its own as it does.
+
+TR3 and TR4 only. The earlier games carry no spark set, so nothing spawns one
+and the pool stays empty.
+
+A spark that runs out of life leaves its slot to the next one asked for. A
+handle held across that becomes stale, and field access raises an error.]],
+  fields = {
+    life = {
+      from = "life",
+      type = "integer",
+      description = "Frames of life left. It reaches zero and the spark ends.",
+    },
+    life_span = {
+      from = "s_life",
+      type = "integer",
+      description = "Frames of life it started with, which the fades are "
+        .. "measured against.",
+    },
+    pos = {
+      from = "pos",
+      type = "math.Vec3",
+      description = "Where it sits, in the world, or from what it is attached "
+        .. "to. Read `trx.fx.Spark.world_pos` for the position it is drawn at.",
+    },
+    vel = {
+      from = "vel",
+      type = "math.Vec3",
+      description = "How far it moves each frame.",
+    },
+    width = {
+      from = "size.width",
+      type = "integer",
+      description = "How wide it is drawn now.",
+    },
+    height = {
+      from = "size.height",
+      type = "integer",
+      description = "How tall it is drawn now.",
+    },
+    start_width = {
+      from = "src_size.width",
+      type = "integer",
+      description = "The width it grows from.",
+    },
+    start_height = {
+      from = "src_size.height",
+      type = "integer",
+      description = "The height it grows from.",
+    },
+    end_width = {
+      from = "dst_size.width",
+      type = "integer",
+      description = "The width it grows to.",
+    },
+    end_height = {
+      from = "dst_size.height",
+      type = "integer",
+      description = "The height it grows to.",
+    },
+    color = {
+      from = "color",
+      type = "math.Color",
+      description = "The color it is drawn in now.",
+    },
+    start_color = {
+      from = "src_color",
+      type = "math.Color",
+      description = "The color it fades from.",
+    },
+    end_color = {
+      from = "dst_color",
+      type = "math.Color",
+      description = "The color it fades to.",
+    },
+    fade_speed = {
+      from = "col_fade_speed",
+      type = "integer",
+      description = "How fast it travels from one color to the other.",
+    },
+    fade_to_black = {
+      from = "fade_to_black",
+      type = "integer",
+      description = "How many frames of life are left when it starts to "
+        .. "darken toward black.",
+    },
+    scalar = {
+      from = "scalar",
+      type = "integer",
+      description = "How strongly the size is scaled with distance.",
+    },
+    gravity = {
+      from = "gravity",
+      type = "integer",
+      description = "How much it is pulled down each frame.",
+    },
+    max_y_vel = {
+      from = "max_y_vel",
+      type = "integer",
+      description = "As fast as gravity may carry it down.",
+    },
+    friction = {
+      from = "friction",
+      type = "integer",
+      description = "How fast it is slowed each frame.",
+    },
+    rot_angle = {
+      from = "rot_angle",
+      type = "integer",
+      description = "How far it is turned about the view, from 0 to 4095.",
+    },
+    rot_add = {
+      from = "rot_add",
+      type = "integer",
+      description = "How far it turns each frame.",
+    },
+    extras = {
+      from = "extras",
+      type = "integer",
+      description = "How many further sparks it leaves behind as it ends.",
+    },
+    node_num = {
+      from = "node_num",
+      type = "integer",
+      description = "Which of the sixteen body points it hangs off, where it "
+        .. "is attached to one.",
+    },
+    room_num = {
+      from = "room_num",
+      type = "rooms.Num",
+      writable = false,
+      description = "The room it was spawned in.",
+    },
+    draw_type = {
+      from = "draw_type",
+      type = "fx.DrawType",
+      writable = false,
+      description = "How it is laid over what is behind it.",
+    },
+    scales = {
+      from = "scales",
+      type = "boolean",
+      description = "Whether it travels from its start size to its end size.",
+    },
+    rotates = {
+      from = "rotates",
+      type = "boolean",
+      description = "Whether it turns as it lives.",
+    },
+    is_blood = {
+      from = "is_blood",
+      type = "boolean",
+      description = "Whether it counts as blood, which the pool sheds first "
+        .. "when it runs short of slots.",
+    },
+    is_outside = {
+      from = "is_outside",
+      type = "boolean",
+      description = "Whether the wind carries it.",
+    },
+    is_underwater = {
+      from = "is_underwater",
+      type = "boolean",
+      description = "Whether it drifts like an underwater particle.",
+    },
+    is_green = {
+      from = "is_green",
+      type = "boolean",
+      description = "Whether it is drawn in the green of the poison gas.",
+    },
+    uses_alt_sprite = {
+      from = "uses_alt_sprite",
+      type = "boolean",
+      description = "Whether it is drawn with the second sprite of its kind.",
+    },
+  },
+
+  extensions = {
+    room = {
+      type = "rooms.Room",
+      description = "The room it was spawned in.",
+      impl = function(spark)
+        return trx.rooms[spark.room_num]
+      end,
+    },
+    world_pos = {
+      type = "math.Vec3",
+      description = "Where it is drawn, which is where it sits unless it is "
+        .. "attached to something that carries it.",
+      impl = function(spark)
+        return raw.get_spark_world_pos(spark)
+      end,
+    },
+    item = {
+      type = "items.Item",
+      nullable = true,
+      description = "The item it is attached to, and `nil` where it hangs on "
+        .. "nothing.",
+      impl = function(spark)
+        local num = raw.get_spark_item(spark)
+        return num and trx.items[num] or nil
+      end,
+    },
+  },
+
+  methods = {
+    is_valid = {
+      returns = {
+        type = "boolean",
+        description = "False once the spark has ended.",
+      },
+      description = [[Reports whether the handle still names a live spark.
+
+A spark that runs out of life leaves its slot to the next one asked for.]],
+    },
+    kill = {
+      description = "Ends the spark now and frees its slot.",
+    },
+  },
+})
+
+api.namespace("fx.sparks", {
+  description = [[
+The spark pool: the particles TR3 and TR4 draw their smoke, flames, sparks and
+splashes with.
+
+TR1 and TR2 carry no spark set. There the pool stays empty, and everything here
+returns nothing rather than raising.]],
+})
+
+api.const("fx.sparks.MAX_COUNT", {
+  value = raw.spark_max_count(),
+  type = "integer",
+  description = "How many sparks the pool holds. A spark spawned after that "
+    .. "takes the slot of the one with the least life left.",
+})
+
+api.container("fx.sparks.pool", {
+  description = [[The spark pool, counted from 1. `#trx.fx.sparks.pool` is
+`trx.fx.sparks.MAX_COUNT` rather than how many sparks are alive: a slot holding
+no live spark reads as `nil`.]],
+  key = { type = "integer" },
+  value = { type = "fx.Spark", nullable = true },
+  examples = {
+    [[for _, spark in pairs(trx.fx.sparks.pool) do
+  spark.color = trx.math.color(255, 0, 0)
+end]],
+  },
+  get = function(idx)
+    return raw.get_spark(idx - 1)
+  end,
+  count = raw.spark_max_count,
+})
+
+api.type("fx.Wind", {
+  record = true,
+  description = "How far the wind carries a spark each frame.",
+  fields = {
+    x = { type = "math.Distance", description = "The east-west axis." },
+    z = { type = "math.Distance", description = "The north-south axis." },
+  },
+})
+
+api.property("fx.sparks.wind", {
+  type = "fx.Wind",
+  description = [[
+The wind that carries the sparks marked `trx.fx.Spark.is_outside`.
+
+The engine works this out again every frame from the breeze setting, so a value
+written here holds for that frame alone.]],
+  get = function()
+    local x, z = raw.get_smoke_wind()
+    return { x = x, z = z }
+  end,
+  set = function(wind)
+    raw.set_smoke_wind(wind.x, wind.z)
+  end,
+})
+
+local spark_pos_field = {
+  name = "pos",
+  type = "math.Vec3",
+  description = "World position. Must lie inside the level.",
+}
+
+local spark_vel_field = {
+  name = "vel",
+  type = "math.Vec3",
+  optional = true,
+  description = "How far it moves each frame. Defaults to standing still.",
+}
+
+api.define("fx.sparks.spawn", {
+  description = [[
+Puts one spark in the world and hands it back, so a script can draw with the
+pool the game draws its own smoke and flames with.
+
+The spark lives for the frames it is given, moving, resizing and fading on its
+own, and then frees its slot. Nothing has to be called each frame to keep it up.
+
+Returns `nil` where the level carries no spark set, which is every TR1 and TR2
+level.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "What the spark is and how it behaves.",
+      fields = {
+        spark_pos_field,
+        spark_vel_field,
+        {
+          name = "sprite_type",
+          type = "fx.SparkType",
+          optional = true,
+          default = SparkType.PARTICLE,
+          description = "Which sprite it is drawn with.",
+        },
+        {
+          name = "life",
+          type = "integer",
+          optional = true,
+          default = 16,
+          description = "How many frames it lives, from 1 to 255.",
+        },
+        {
+          name = "color",
+          type = "math.Color",
+          optional = true,
+          description = "The color it starts in. Defaults to white.",
+        },
+        {
+          name = "end_color",
+          type = "math.Color",
+          optional = true,
+          description = "The color it fades to. Defaults to the color it "
+            .. "starts in, so it holds one color.",
+        },
+        {
+          name = "fade_speed",
+          type = "integer",
+          optional = true,
+          default = 8,
+          description = "How fast it travels between the two colors.",
+        },
+        {
+          name = "fade_to_black",
+          type = "integer",
+          optional = true,
+          default = 8,
+          description = "How many frames of life are left when it starts to "
+            .. "darken toward black.",
+        },
+        {
+          name = "width",
+          type = "integer",
+          optional = true,
+          default = 4,
+          description = "How wide it starts, from 0 to 255.",
+        },
+        {
+          name = "height",
+          type = "integer",
+          optional = true,
+          default = 4,
+          description = "How tall it starts, from 0 to 255.",
+        },
+        {
+          name = "end_width",
+          type = "integer",
+          optional = true,
+          description = "The width it grows to, for a spark that scales. "
+            .. "Defaults to the width it starts at.",
+        },
+        {
+          name = "end_height",
+          type = "integer",
+          optional = true,
+          description = "The height it grows to, for a spark that scales. "
+            .. "Defaults to the height it starts at.",
+        },
+        {
+          name = "scales",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it travels from its start size to its end "
+            .. "size over its life.",
+        },
+        {
+          name = "scalar",
+          type = "integer",
+          optional = true,
+          default = 2,
+          description = "How strongly the size is scaled with distance.",
+        },
+        {
+          name = "gravity",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How much it is pulled down each frame.",
+        },
+        {
+          name = "max_y_vel",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "As fast as gravity may carry it down.",
+        },
+        {
+          name = "friction",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How fast it is slowed each frame.",
+        },
+        {
+          name = "rot_angle",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How far it starts turned about the view, from 0 to "
+            .. "4095.",
+        },
+        {
+          name = "rot_add",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How far it turns each frame, for a spark that turns.",
+        },
+        {
+          name = "rotates",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it turns as it lives.",
+        },
+        {
+          name = "extras",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How many further sparks it leaves behind as it ends.",
+        },
+        {
+          name = "draw_type",
+          type = "fx.DrawType",
+          optional = true,
+          default = DrawType.BLEND_ADD,
+          description = "How it is laid over what is behind it.",
+        },
+        {
+          name = "is_outside",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether the wind carries it.",
+        },
+        {
+          name = "is_underwater",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it drifts like an underwater particle.",
+        },
+        {
+          name = "is_green",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is drawn in the green of the poison gas.",
+        },
+        {
+          name = "uses_alt_sprite",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is drawn with the second sprite of its "
+            .. "kind.",
+        },
+      },
+    },
+  },
+  returns = {
+    type = "fx.Spark",
+    nullable = true,
+    description = "The spark, or `nil` where the level carries no spark set.",
+  },
+  examples = {
+    [[trx.fx.sparks.spawn({
+  pos = trx.lara.item.pos,
+  vel = { x = 0, y = -8, z = 0 },
+  sprite_type = trx.fx.SparkType.EXPLOSION,
+  life = 48,
+  color = trx.math.color(255, 200, 64),
+  end_color = trx.math.color(64, 0, 0),
+  width = 16,
+  end_width = 48,
+  scales = true,
+})]],
+  },
+  impl = raw.spawn_spark,
+})
+
+api.define("fx.sparks.explosion", {
+  description = "Throws the fireball of sparks an explosion is drawn with.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the fireball is and how strongly it bursts.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "extras",
+          type = "integer",
+          optional = true,
+          default = 3,
+          description = "How many further sparks each one leaves behind as it "
+            .. "ends, from 0 to 3.",
+        },
+        {
+          name = "light",
+          type = "integer",
+          optional = true,
+          default = -2,
+          description = "How the fireball lights the room around it: `-2` "
+            .. "bright, `-1` dim, `0` not at all.",
+        },
+        {
+          name = "underwater",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it uses the underwater burst.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.explosion({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_explosion(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.extras or 3,
+      opts.light or -2,
+      opts.underwater
+    )
+  end,
+})
+
+api.define("fx.sparks.explosion_smoke", {
+  description = "Lifts the smoke an explosion leaves behind.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the smoke is and which part of the burst it is.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "underwater",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it lifts as it does under water.",
+        },
+        {
+          name = "ending",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is the thinner smoke that closes the "
+            .. "burst rather than the smoke that opens it.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.explosion_smoke({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_explosion_smoke(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.underwater,
+      opts.ending
+    )
+  end,
+})
+
+api.define("fx.sparks.explosion_bubble", {
+  description = "Throws the burst of bubbles an explosion under water makes.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the bubbles rise.",
+      fields = { spark_pos_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.explosion_bubble({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_explosion_bubble(opts.pos.x, opts.pos.y, opts.pos.z)
+  end,
+})
+
+local flame_variant_field = {
+  name = "variant",
+  type = "integer",
+  optional = true,
+  default = 0,
+  description = "Which colors it burns in: `0` orange, `2` pale, `254` green.",
+}
+
+api.define("fx.sparks.fire_flame", {
+  description = [[
+Throws one tongue of flame, the way a burning body does. Make the call every
+frame to keep a fire burning.
+
+No flame is thrown more than twenty sectors from Lara.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the flame is and what color it burns.",
+      fields = { spark_pos_field, flame_variant_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.fire_flame({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_fire_flame(opts.pos.x, opts.pos.y, opts.pos.z, opts.variant or 0)
+  end,
+})
+
+api.define("fx.sparks.fire_smoke", {
+  description = "Lifts one puff of the smoke a fire gives off.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the smoke is and which flame color it follows.",
+      fields = { spark_pos_field, flame_variant_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.fire_smoke({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_fire_smoke(opts.pos.x, opts.pos.y, opts.pos.z, opts.variant or 0)
+  end,
+})
+
+api.define("fx.sparks.static_flame", {
+  description = "Throws one tongue of the flame a standing fire burns with.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the flame is and how big it burns.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "size",
+          type = "integer",
+          optional = true,
+          default = 32,
+          description = "How big it burns.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.static_flame({ pos = trx.lara.item.pos, size = 64 })]],
+  },
+  impl = function(opts)
+    raw.spark_static_flame(opts.pos.x, opts.pos.y, opts.pos.z, opts.size or 32)
+  end,
+})
+
+api.define("fx.sparks.side_flame", {
+  description = "Throws a tongue of flame sideways, as a jet does.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the jet is and which way it burns.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "angle",
+          type = "math.Angle",
+          description = "The way the flame is thrown.",
+        },
+        {
+          name = "speed",
+          type = "integer",
+          optional = true,
+          default = 32,
+          description = "How hard it is thrown.",
+        },
+        {
+          name = "pilot",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is the small pilot flame rather than the "
+            .. "jet itself.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.side_flame({
+  pos = trx.lara.item.pos,
+  angle = trx.lara.item.rot.y,
+})]],
+  },
+  impl = function(opts)
+    raw.spark_side_flame(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.angle,
+      opts.speed or 32,
+      opts.pilot
+    )
+  end,
+})
+
+api.define("fx.sparks.flamethrower_flame", {
+  description = "Throws the flame a flamethrower leaves where its jet lands.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the flame lands.",
+      fields = { spark_pos_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.flamethrower_flame({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_flamethrower_flame(opts.pos.x, opts.pos.y, opts.pos.z)
+  end,
+})
+
+api.define("fx.sparks.flamethrower_smoke", {
+  description = "Lifts the smoke a flamethrower jet leaves behind.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the smoke is.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "underwater",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it lifts as it does under water.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.flamethrower_smoke({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_flamethrower_smoke(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.underwater
+    )
+  end,
+})
+
+api.define("fx.sparks.gun_smoke", {
+  description = "Lifts the smoke a fired weapon leaves at its muzzle.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the smoke is and which weapon left it.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "weapon",
+          type = "catalog.weapons",
+          description = "Which weapon it is drawn for. `UNKNOWN`, `UNARMED`, "
+            .. "and out-of-range values raise.",
+        },
+        {
+          name = "shade",
+          type = "integer",
+          optional = true,
+          default = 64,
+          description = "How light the smoke is, from 0 to 255.",
+        },
+        {
+          name = "initial",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether it is the first puff of a shot, which is "
+            .. "denser than the ones that follow.",
+        },
+        {
+          name = "vel",
+          type = "math.Vec3",
+          optional = true,
+          description = "Which way the smoke is pushed. Left out, it lifts "
+            .. "straight up.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.gun_smoke({
+  pos = trx.lara.item.pos,
+  weapon = trx.catalog.weapons.pistols,
+  initial = true,
+})]],
+  },
+  impl = function(opts)
+    local vel = opts.vel
+    raw.spark_gun_smoke(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.weapon,
+      opts.shade or 64,
+      opts.initial,
+      vel and vel.x,
+      vel and vel.y,
+      vel and vel.z
+    )
+  end,
+})
+
+api.define("fx.sparks.dart_smoke", {
+  description = "Lifts the trail of smoke a flying dart leaves.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the smoke is and which way the dart flies.",
+      fields = {
+        spark_pos_field,
+        spark_vel_field,
+        {
+          name = "hit",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether the dart has landed, which puffs the smoke "
+            .. "out rather than trailing it.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.dart_smoke({ pos = trx.lara.item.pos, hit = true })]],
+  },
+  impl = function(opts)
+    local vel = opts.vel or { x = 0, z = 0 }
+    raw.spark_dart_smoke(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      vel.x,
+      vel.z,
+      opts.hit
+    )
+  end,
+})
+
+api.define("fx.sparks.rocket_smoke", {
+  description = "Lifts the trail of smoke a flying rocket leaves.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the smoke is and how light it lifts.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "shade",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = "How light the smoke turns as it fades, from 0 to 191.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.rocket_smoke({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_rocket_smoke(opts.pos.x, opts.pos.y, opts.pos.z, opts.shade or 0)
+  end,
+})
+
+api.define("fx.sparks.flare", {
+  description = "Throws the sparks a burning flare gives off.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the sparks are and which way they fly.",
+      fields = {
+        spark_pos_field,
+        spark_vel_field,
+        {
+          name = "smoke",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether smoke is lifted with them.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.flare({ pos = trx.lara.item.pos, smoke = true })]],
+  },
+  impl = function(opts)
+    local vel = opts.vel or { x = 0, y = 0, z = 0 }
+    raw.spark_flare(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      vel.x,
+      vel.y,
+      vel.z,
+      opts.smoke
+    )
+  end,
+})
+
+api.define("fx.sparks.shotgun", {
+  description = "Throws the sparks a shotgun blast strikes off what it hits.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the sparks are and which way they fly.",
+      fields = { spark_pos_field, spark_vel_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.shotgun({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    local vel = opts.vel or { x = 0, y = 0, z = 0 }
+    raw.spark_shotgun(opts.pos.x, opts.pos.y, opts.pos.z, vel.x, vel.y, vel.z)
+  end,
+})
+
+api.define("fx.sparks.ricochet", {
+  description = [[
+Strikes the sparks a shot makes where it lands on a wall.
+
+TR4 throws as many streaks as asked for and can lift smoke instead. TR3 throws
+one burst, and uses the count as its size.]],
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the shot lands and which way the sparks fly.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "angle",
+          type = "math.Angle",
+          description = "The way the sparks fly.",
+        },
+        {
+          name = "count",
+          type = "integer",
+          optional = true,
+          default = 3,
+          description = "How many streaks, from 1 to 255.",
+        },
+        {
+          name = "smoke_only",
+          type = "boolean",
+          optional = true,
+          default = false,
+          description = "Whether smoke is lifted rather than sparks struck. "
+            .. "TR4 only.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.ricochet({ pos = trx.lara.item.pos, angle = 0 })]],
+  },
+  impl = function(opts)
+    raw.spark_ricochet(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.angle,
+      opts.count or 3,
+      opts.smoke_only
+    )
+  end,
+})
+
+api.define("fx.sparks.bubble", {
+  description = "Lifts one bubble through the water.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the bubble is and how big it is.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "size",
+          type = "integer",
+          optional = true,
+          default = 8,
+          description = "How big it is at its smallest.",
+        },
+        {
+          name = "size_range",
+          type = "integer",
+          optional = true,
+          default = 8,
+          description = "How much bigger than that it may be drawn.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.bubble({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    raw.spark_bubble(
+      opts.pos.x,
+      opts.pos.y,
+      opts.pos.z,
+      opts.size or 8,
+      opts.size_range or 8
+    )
+  end,
+})
+
+api.define("fx.sparks.breath", {
+  description = "Puffs the cloud of breath a body gives off in the cold.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the breath is and which way it drifts.",
+      fields = { spark_pos_field, spark_vel_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.breath({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    local vel = opts.vel or { x = 0, y = 0, z = 0 }
+    raw.spark_breath(opts.pos.x, opts.pos.y, opts.pos.z, vel.x, vel.y, vel.z)
+  end,
+})
+
+api.define("fx.sparks.pickup_aid", {
+  description = "Throws the twinkle that marks a pickup worth reaching.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the twinkle is and which way it drifts.",
+      fields = { spark_pos_field, spark_vel_field },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.pickup_aid({ pos = trx.lara.item.pos })]],
+  },
+  impl = function(opts)
+    local vel = opts.vel or { x = 0, z = 0 }
+    raw.spark_pickup_aid(opts.pos.x, opts.pos.y, opts.pos.z, vel.x, vel.z)
+  end,
+})
+
+api.define("fx.sparks.waterfall_mist", {
+  description = "Lifts the mist that stands at the foot of a waterfall.",
+  params = {
+    {
+      name = "opts",
+      type = "table",
+      description = "Where the mist is and which way it faces.",
+      fields = {
+        spark_pos_field,
+        {
+          name = "angle",
+          type = "math.Angle",
+          description = "The way the waterfall faces.",
+        },
+      },
+    },
+  },
+  examples = {
+    [[trx.fx.sparks.waterfall_mist({ pos = trx.lara.item.pos, angle = 0 })]],
+  },
+  impl = function(opts)
+    raw.spark_waterfall_mist(opts.pos.x, opts.pos.y, opts.pos.z, opts.angle)
+  end,
+})

--- a/src/tests/lua/api/api.lua
+++ b/src/tests/lua/api/api.lua
@@ -1695,19 +1695,50 @@ end)
 test("a collection is declared as a module or a member of one", function()
   local api = fresh_env()
   api.module("things", { description = "..." })
-  local ok, err = pcall(api.container, "things.a.b", {
+  local ok, err = pcall(api.container, "things.a.b.c", {
     description = "Indexing.",
     key = { type = "integer", description = "A key." },
     value = { type = "string" },
     get = function() end,
   })
-  assert(not ok, "three segments deep")
+  assert(not ok, "four segments deep")
   -- The path the message names is the one that was written, not one with a
   -- segment added to borrow another declaration's parser.
   assert(
-    tostring(err):find("got: things.a.b", 1, true),
+    tostring(err):find("got: things.a.b.c", 1, true),
     "the message must name the path as written: " .. tostring(err)
   )
+end)
+
+test("a collection inside a namespace needs the namespace first", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  local spec = {
+    description = "Indexing.",
+    key = { type = "integer", description = "A key." },
+    value = { type = "string" },
+    get = function(idx)
+      return ("#%d"):format(idx)
+    end,
+    count = function()
+      return 2
+    end,
+  }
+
+  local ok, err = pcall(api.container, "things.group.samples", spec)
+  assert(not ok, "the namespace has to be declared first")
+  assert(
+    tostring(err):find("api.namespace('things.group')", 1, true),
+    "the message must name the namespace: " .. tostring(err)
+  )
+
+  local api2 = fresh_env()
+  api2.module("things", { description = "..." })
+  api2.namespace("things.group", { description = "A group." })
+  api2.container("things.group.samples", spec)
+  assert(trx.things.group.samples[1] == "#1", "the collection is indexed")
+  assert(#trx.things.group.samples == 2, "and counted")
+  api2.seal()
 end)
 
 -- Several collections on one module tie on the module they sit under, and the

--- a/src/trx/game/enum.c
+++ b/src/trx/game/enum.c
@@ -21,11 +21,13 @@
 #include <trx/game/objects/general/waterfall.h>
 #include <trx/game/objects/ids.h>
 #include <trx/game/objects/traps/scaled_spikes.h>
+#include <trx/game/output/types.h>
 #include <trx/game/rooms/enum.h>
 #include <trx/game/savegame/types.h>
 #include <trx/game/screenshot.h>
 #include <trx/game/shell/mod.h>
 #include <trx/game/sound/ids.h>
+#include <trx/game/sparks/enum.h>
 #include <trx/game/ui/elements/frame.h>
 #include <trx/game/ui/elements/stack.h>
 #include <trx/game/ui/regions.h>
@@ -251,6 +253,25 @@ static __attribute__((constructor)) void M_Init(void)
     ENUM_MAP(GF_LEVEL_TYPE, GFL_BONUS, "bonus");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_DUMMY, "dummy");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_CURRENT, "current");
+
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_EXPLOSION, "explosion");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_SMALL_SPLASH, "small_splash");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_BIG_SPLASH, "big_splash");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_RIPPLE, "ripple");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_PARTICLE, "particle");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_SHIELD, "shield");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_ROPE, "rope");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_DRIVE, "drive");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_REVERSE, "reverse");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_RICOCHET, "ricochet");
+    ENUM_MAP(SPARK_SPRITE_TYPE, SPARK_TYPE_BLOOD, "blood");
+
+    ENUM_MAP(DRAW_TYPE, DRAW_OPAQUE, "opaque");
+    ENUM_MAP(DRAW_TYPE, DRAW_BLEND, "blend");
+    ENUM_MAP(DRAW_TYPE, DRAW_BLEND_ADD, "blend_add");
+    ENUM_MAP(DRAW_TYPE, DRAW_BLEND_SUB, "blend_sub");
+    ENUM_MAP(DRAW_TYPE, DRAW_REFLECTIVE_OPAQUE, "reflective_opaque");
+    ENUM_MAP(DRAW_TYPE, DRAW_REFLECTIVE_BLEND_ADD, "reflective_blend_add");
 
     ENUM_MAP(WEATHER_TYPE, WEATHER_NONE, "none");
     ENUM_MAP(WEATHER_TYPE, WEATHER_RAIN, "rain");

--- a/src/trx/game/lua/capi/fx.c
+++ b/src/trx/game/lua/capi/fx.c
@@ -1,4 +1,10 @@
+#include <trx/core/colors.h>
 #include <trx/core/utils.h>
+#include <trx/game/effects.h>
+#include <trx/game/fx.h>
+#include <trx/game/fx/fire.h>
+#include <trx/game/gun/registry.h>
+#include <trx/game/items.h>
 #include <trx/game/level/settings.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
@@ -7,9 +13,34 @@
 #include <trx/game/output/lights.h>
 #include <trx/game/output/lights/fog_bulbs.h>
 #include <trx/game/rooms/common.h>
+#include <trx/game/sparks.h>
+#include <trx/game/sparks/spawners.h>
 #include <trx/game/spawn.h>
+#include <trx/version.h>
 
 #include <lauxlib.h>
+
+// A spark's flags sit in one word rather than in a bitfield, so each public one
+// is bridged as the boolean it stands for.
+#define M_SPARK_FLAG(name_, bit_)                                              \
+    static bool M_GetSpark##name_(                                             \
+        const void *const self, TRX_VALUE *const out)                          \
+    {                                                                          \
+        const SPARK *const spark = self;                                       \
+        *out = Value_Make_TVT_BOOL((spark->flags & (bit_)) != 0U);             \
+        return true;                                                           \
+    }                                                                          \
+    static const char *M_SetSpark##name_(                                      \
+        void *const self, const TRX_VALUE *const in)                           \
+    {                                                                          \
+        SPARK *const spark = self;                                             \
+        if (in->as_bool) {                                                     \
+            spark->flags |= (uint16_t)(bit_);                                  \
+        } else {                                                               \
+            spark->flags &= (uint16_t)~(bit_);                                 \
+        }                                                                      \
+        return nullptr;                                                        \
+    }
 
 typedef struct {
     XYZ_32 pos;
@@ -22,6 +53,58 @@ typedef struct {
     int16_t strength;
     int16_t angle;
 } M_BLOOD;
+
+M_SPARK_FLAG(Scales, SPARK_F_SCALE)
+M_SPARK_FLAG(IsBlood, SPARK_F_BLOOD)
+M_SPARK_FLAG(Rotates, SPARK_F_ROTATE)
+M_SPARK_FLAG(IsOutside, SPARK_F_OUTSIDE)
+M_SPARK_FLAG(UsesAltSprite, SPARK_F_ALT_SPRITE)
+M_SPARK_FLAG(IsUnderwater, SPARK_F_UNDERWATER)
+M_SPARK_FLAG(IsGreen, SPARK_F_GREEN)
+
+// clang-format off
+static const FIELD_DESC m_SparkFields[] = {
+    FIELD(SPARK, life),
+    FIELD(SPARK, s_life),
+    FIELD(SPARK, pos),
+    FIELD(SPARK, vel),
+    FIELD(SPARK, size.width),
+    FIELD(SPARK, size.height),
+    FIELD(SPARK, src_size.width),
+    FIELD(SPARK, src_size.height),
+    FIELD(SPARK, dst_size.width),
+    FIELD(SPARK, dst_size.height),
+    FIELD(SPARK, color),
+    FIELD(SPARK, src_color),
+    FIELD(SPARK, dst_color),
+    FIELD(SPARK, scalar),
+    FIELD(SPARK, col_fade_speed),
+    FIELD(SPARK, fade_to_black),
+    FIELD(SPARK, gravity),
+    FIELD(SPARK, max_y_vel),
+    FIELD(SPARK, friction),
+    FIELD_MODULAR(SPARK, rot_angle),
+    FIELD(SPARK, rot_add),
+    FIELD(SPARK, extras),
+    FIELD(SPARK, node_num),
+    FIELD_RO(SPARK, room_num),
+    FIELD_RO(SPARK, draw_type),
+
+    FIELD_FN("scales", TVT_BOOL, M_GetSparkScales, M_SetSparkScales),
+    FIELD_FN("is_blood", TVT_BOOL, M_GetSparkIsBlood, M_SetSparkIsBlood),
+    FIELD_FN("rotates", TVT_BOOL, M_GetSparkRotates, M_SetSparkRotates),
+    FIELD_FN("is_outside", TVT_BOOL, M_GetSparkIsOutside, M_SetSparkIsOutside),
+    FIELD_FN(
+        "uses_alt_sprite", TVT_BOOL, M_GetSparkUsesAltSprite,
+        M_SetSparkUsesAltSprite),
+    FIELD_FN(
+        "is_underwater", TVT_BOOL, M_GetSparkIsUnderwater,
+        M_SetSparkIsUnderwater),
+    FIELD_FN("is_green", TVT_BOOL, M_GetSparkIsGreen, M_SetSparkIsGreen),
+};
+// clang-format on
+
+TYPE_DEFINE(SPARK, m_SparkFields)
 
 static int32_t M_ReadChannel(lua_State *const L, const int32_t idx)
 {
@@ -109,6 +192,127 @@ static int M_L_BloodBath(lua_State *const L)
     Spawn_BloodBath(
         blood.pos.x, blood.pos.y, blood.pos.z, blood.strength, blood.angle,
         blood.room_num, count);
+    return 0;
+}
+
+// The room a world position falls in, or a raised error where it falls outside
+// the level: an effect the engine puts in a room has nowhere to go without one.
+static int16_t M_CheckRoom(lua_State *const L, const XYZ_32 pos)
+{
+    const int16_t room_num = Room_GetIndexFromPos(pos);
+    if (room_num == NO_ROOM) {
+        luaL_error(L, "position is outside the level");
+    }
+    return room_num;
+}
+
+static XYZ_32 M_ReadPos(lua_State *const L)
+{
+    return (XYZ_32) {
+        .x = luaL_checkinteger(L, 1),
+        .y = luaL_checkinteger(L, 2),
+        .z = luaL_checkinteger(L, 3),
+    };
+}
+
+static ITEM *M_CheckItem(lua_State *const L, const int arg)
+{
+    const int32_t item_num =
+        LUA_CheckRange(L, arg, Item_GetTotalCount(), "item");
+    return Item_Get(item_num);
+}
+
+// trxc.fx.explosion(x, y, z, with_sound)
+static int M_L_Explosion(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Spawn_Explosion(pos, M_CheckRoom(L, pos), lua_toboolean(L, 4));
+    return 0;
+}
+
+// trxc.fx.fire(x, y, z, size, fade)
+static int M_L_Fire(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    int32_t size = luaL_checkinteger(L, 4);
+    CLAMP(size, 0, 2);
+    FX_Fire_Add(pos, size, M_CheckRoom(L, pos), luaL_checkinteger(L, 5));
+    return 0;
+}
+
+// trxc.fx.splash(item_num)
+static int M_L_Splash(lua_State *const L)
+{
+    FX_Water_Splash(M_CheckItem(L, 1));
+    return 0;
+}
+
+// trxc.fx.wade_splash(item_num, depth)
+static int M_L_WadeSplash(lua_State *const L)
+{
+    FX_Water_WadeSplash(M_CheckItem(L, 1), luaL_checkinteger(L, 2));
+    return 0;
+}
+
+// trxc.fx.ripple(x, y, z, size, slow, dark, blood, jitter)
+static int M_L_Ripple(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    int32_t size = luaL_checkinteger(L, 4);
+    CLAMP(size, 1, 255);
+
+    uint32_t flags = FX_RIPPLE_ACTIVE;
+    if (lua_toboolean(L, 5)) {
+        flags |= FX_RIPPLE_SLOW;
+    }
+    if (lua_toboolean(L, 6)) {
+        flags |= FX_RIPPLE_DARK;
+    }
+    if (lua_toboolean(L, 7)) {
+        flags |= FX_RIPPLE_BLOOD;
+    }
+    if (lua_toboolean(L, 8)) {
+        flags |= FX_RIPPLE_JITTER;
+    }
+    FX_Water_SetupRipple(pos, size, flags);
+    return 0;
+}
+
+// trxc.fx.small_splash(x, y, z, count)
+static int M_L_SmallSplash(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    int32_t count = luaL_checkinteger(L, 4);
+    CLAMP(count, 1, 255);
+    Sparks_TriggerSmallSplash(pos, count);
+    return 0;
+}
+
+// trxc.fx.underwater_blood(x, y, z, size, dark)
+static int M_L_UnderwaterBlood(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    int32_t size = luaL_checkinteger(L, 4);
+    CLAMP(size, 1, 255);
+    if (lua_toboolean(L, 5)) {
+        FX_Water_TriggerUnderwaterBloodD(pos, size);
+    } else {
+        FX_Water_TriggerUnderwaterBlood(pos, size);
+    }
+    return 0;
+}
+
+// trxc.fx.footprint(item_num, is_left_foot)
+static int M_L_Footprint(lua_State *const L)
+{
+    FX_Footprint_Add(M_CheckItem(L, 1), lua_toboolean(L, 2));
+    return 0;
+}
+
+// trxc.fx.knockback(x, y, z)
+static int M_L_Knockback(lua_State *const L)
+{
+    FX_Ring_SpawnKnockBack(M_ReadPos(L));
     return 0;
 }
 
@@ -214,9 +418,452 @@ static int M_L_SetFogColor(lua_State *const L)
     return 0;
 }
 
+static void *M_ResolveSpark(const LUA_STRUCT_REF *const ref)
+{
+    return Sparks_FromHandle(ref->handle);
+}
+
+static void M_PushSpark(lua_State *const L, SPARK *const spark)
+{
+    if (spark == nullptr) {
+        lua_pushnil(L);
+        return;
+    }
+    LUA_Struct_Push(L, &TYPE_SPARK, M_ResolveSpark, Sparks_GetHandle(spark));
+}
+
+static SPARK *M_CheckSpark(lua_State *const L, const int arg)
+{
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, arg, &TYPE_SPARK);
+    return LUA_Struct_Deref(L, ref);
+}
+
+// An optional integer in an options table, clamped to what the member holds.
+static int32_t M_OptField(
+    lua_State *const L, const int arg, const char *const key,
+    const int32_t fallback, const int32_t lo, const int32_t hi)
+{
+    lua_getfield(L, arg, key);
+    int32_t value = fallback;
+    if (!lua_isnil(L, -1)) {
+        value = (int32_t)luaL_checkinteger(L, -1);
+        CLAMP(value, lo, hi);
+    }
+    lua_pop(L, 1);
+    return value;
+}
+
+static bool M_OptFlagField(
+    lua_State *const L, const int arg, const char *const key)
+{
+    lua_getfield(L, arg, key);
+    const bool value = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+    return value;
+}
+
+static RGB_888 M_OptColorField(
+    lua_State *const L, const int arg, const char *const key,
+    const RGB_888 fallback)
+{
+    lua_getfield(L, arg, key);
+    RGB_888 color = fallback;
+    if (!lua_isnil(L, -1)) {
+        color = LUA_CheckValue(L, -1, TVT_RGB_888).as_rgb;
+    }
+    lua_pop(L, 1);
+    return color;
+}
+
+static XYZ_32 M_OptXYZField(
+    lua_State *const L, const int arg, const char *const key)
+{
+    lua_getfield(L, arg, key);
+    const XYZ_32 value =
+        lua_isnil(L, -1) ? (XYZ_32) {} : LUA_CheckXYZAt(L, lua_gettop(L), arg);
+    lua_pop(L, 1);
+    return value;
+}
+
+// trxc.fx.spawn_spark(opts) -> spark or nil
+static int M_L_SpawnSpark(lua_State *const L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    // Everything the options table is refused over is read before a slot is
+    // taken, so a raised error leaves no half-built spark alive in the pool.
+    const int32_t sprite_type =
+        M_OptField(L, 1, "sprite_type", SPARK_TYPE_PARTICLE, 0, INT8_MAX);
+    const XYZ_32 pos = M_OptXYZField(L, 1, "pos");
+    const int16_t room_num = M_CheckRoom(L, pos);
+
+    SPARK *const spark =
+        Sparks_InitialiseSpriteSpark((SPARK_SPRITE_TYPE)sprite_type);
+    if (spark == nullptr) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    const int32_t life = M_OptField(L, 1, "life", 16, 1, UINT8_MAX);
+    const RGB_888 color = M_OptColorField(L, 1, "color", COLOR_RGB_888_WHITE);
+
+    spark->pos = pos;
+    spark->room_num = (uint8_t)room_num;
+    spark->vel = M_OptXYZField(L, 1, "vel");
+    spark->life = life;
+    spark->s_life = life;
+    spark->src_color = color;
+    spark->dst_color = M_OptColorField(L, 1, "end_color", color);
+    spark->src_size.width = M_OptField(L, 1, "width", 4, 0, UINT8_MAX);
+    spark->src_size.height = M_OptField(L, 1, "height", 4, 0, UINT8_MAX);
+    spark->dst_size.width =
+        M_OptField(L, 1, "end_width", spark->src_size.width, 0, UINT8_MAX);
+    spark->dst_size.height =
+        M_OptField(L, 1, "end_height", spark->src_size.height, 0, UINT8_MAX);
+    spark->size = spark->src_size;
+    spark->scalar = M_OptField(L, 1, "scalar", 2, 0, UINT8_MAX);
+    spark->col_fade_speed = M_OptField(L, 1, "fade_speed", 8, 0, UINT8_MAX);
+    spark->fade_to_black = M_OptField(L, 1, "fade_to_black", 8, 0, UINT8_MAX);
+    spark->gravity = M_OptField(L, 1, "gravity", 0, INT16_MIN, INT16_MAX);
+    spark->max_y_vel = M_OptField(L, 1, "max_y_vel", 0, INT8_MIN, INT8_MAX);
+    spark->friction = M_OptField(L, 1, "friction", 0, 0, UINT8_MAX);
+    spark->rot_angle = M_OptField(L, 1, "rot_angle", 0, 0, 0xFFF);
+    spark->rot_add = M_OptField(L, 1, "rot_add", 0, INT8_MIN, INT8_MAX);
+    spark->extras = M_OptField(L, 1, "extras", 0, 0, UINT8_MAX);
+    spark->dynamic = -1;
+    spark->draw_type = M_OptField(
+        L, 1, "draw_type", DRAW_BLEND_ADD, 0, DRAW_REFLECTIVE_BLEND_ADD);
+
+    if (M_OptFlagField(L, 1, "scales")) {
+        spark->flags |= SPARK_F_SCALE;
+    }
+    if (M_OptFlagField(L, 1, "rotates")) {
+        spark->flags |= SPARK_F_ROTATE;
+    }
+    if (M_OptFlagField(L, 1, "is_outside")) {
+        spark->flags |= SPARK_F_OUTSIDE;
+    }
+    if (M_OptFlagField(L, 1, "uses_alt_sprite")) {
+        spark->flags |= SPARK_F_ALT_SPRITE;
+    }
+    if (M_OptFlagField(L, 1, "is_underwater")) {
+        spark->flags |= SPARK_F_UNDERWATER;
+    }
+    if (M_OptFlagField(L, 1, "is_green")) {
+        spark->flags |= SPARK_F_GREEN;
+    }
+
+    Sparks_FinishSetup(spark);
+    M_PushSpark(L, spark);
+    return 1;
+}
+
+// trxc.fx.spark_max_count() -> int
+static int M_L_SparkMaxCount(lua_State *const L)
+{
+    lua_pushinteger(L, Sparks_GetMaxCount());
+    return 1;
+}
+
+// trxc.fx.get_spark(index) -> spark or nil
+static int M_L_GetSpark(lua_State *const L)
+{
+    int32_t idx;
+    if (!LUA_CheckBoundedInt(L, 1, 0, Sparks_GetMaxCount() - 1, &idx)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    SPARK *const spark = Sparks_GetSpark(idx);
+    M_PushSpark(L, spark->on ? spark : nullptr);
+    return 1;
+}
+
+// trxc.fx.get_spark_world_pos(spark) -> pos
+static int M_L_GetSparkWorldPos(lua_State *const L)
+{
+    LUA_PushXYZ(L, Sparks_GetWorldPos(M_CheckSpark(L, 1)));
+    return 1;
+}
+
+// trxc.fx.get_spark_item(spark) -> item number or nil
+static int M_L_GetSparkItem(lua_State *const L)
+{
+    const SPARK *const spark = M_CheckSpark(L, 1);
+    if ((spark->flags & SPARK_F_ITEM) == 0U) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushinteger(L, spark->item_num);
+    return 1;
+}
+
+// spark:kill()
+static int M_L_SparkKill(lua_State *const L)
+{
+    SPARK *const spark = M_CheckSpark(L, 1);
+    if (spark->dynamic != -1) {
+        Sparks_FreeDynamic(spark->dynamic);
+        spark->dynamic = -1;
+    }
+    spark->on = false;
+    spark->life = 0;
+    return 0;
+}
+
+// trxc.fx.get_smoke_wind() -> x, z
+static int M_L_GetSmokeWind(lua_State *const L)
+{
+    const XZ_32 wind = Sparks_GetSmokeWind();
+    lua_pushinteger(L, wind.x);
+    lua_pushinteger(L, wind.z);
+    return 2;
+}
+
+// trxc.fx.set_smoke_wind(x, z)
+static int M_L_SetSmokeWind(lua_State *const L)
+{
+    Sparks_SetSmokeWind((XZ_32) {
+        .x = luaL_checkinteger(L, 1),
+        .z = luaL_checkinteger(L, 2),
+    });
+    return 0;
+}
+
+// trxc.fx.spark_explosion(x, y, z, extras, dynamic, underwater)
+static int M_L_SparkExplosion(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    int32_t extras = luaL_checkinteger(L, 4);
+    CLAMP(extras, 0, 3);
+    int32_t dynamic = luaL_checkinteger(L, 5);
+    CLAMP(dynamic, -2, 0);
+    Sparks_TriggerExplosionSparks(
+        pos, extras, dynamic, lua_toboolean(L, 6) ? 1 : 0, M_CheckRoom(L, pos));
+    return 0;
+}
+
+// trxc.fx.spark_explosion_smoke(x, y, z, underwater, ending)
+static int M_L_SparkExplosionSmoke(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    const bool underwater = lua_toboolean(L, 4);
+    const int16_t room_num = M_CheckRoom(L, pos);
+    if (lua_toboolean(L, 5)) {
+        Sparks_TriggerExplosionSmokeEnd(pos, underwater, room_num);
+    } else {
+        Sparks_TriggerExplosionSmoke(pos, underwater, room_num);
+    }
+    return 0;
+}
+
+// trxc.fx.spark_explosion_bubble(x, y, z)
+static int M_L_SparkExplosionBubble(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerExplosionBubble(pos, M_CheckRoom(L, pos));
+    return 0;
+}
+
+// trxc.fx.spark_fire_flame(x, y, z, type)
+static int M_L_SparkFireFlame(lua_State *const L)
+{
+    Sparks_TriggerFireFlame(M_ReadPos(L), -1, luaL_checkinteger(L, 4));
+    return 0;
+}
+
+// trxc.fx.spark_fire_smoke(x, y, z, type)
+static int M_L_SparkFireSmoke(lua_State *const L)
+{
+    Sparks_TriggerFireSmoke(M_ReadPos(L), -1, luaL_checkinteger(L, 4));
+    return 0;
+}
+
+// trxc.fx.spark_static_flame(x, y, z, size)
+static int M_L_SparkStaticFlame(lua_State *const L)
+{
+    Sparks_TriggerStaticFlame(M_ReadPos(L), luaL_checkinteger(L, 4));
+    return 0;
+}
+
+// trxc.fx.spark_side_flame(x, y, z, angle, speed, pilot)
+static int M_L_SparkSideFlame(lua_State *const L)
+{
+    Sparks_TriggerSideFlame(
+        M_ReadPos(L), luaL_checkinteger(L, 4), luaL_checkinteger(L, 5),
+        lua_toboolean(L, 6));
+    return 0;
+}
+
+// trxc.fx.spark_flamethrower_flame(x, y, z)
+static int M_L_SparkFlamethrowerFlame(lua_State *const L)
+{
+    Sparks_TriggerFlamethrowerHitFlame(M_ReadPos(L));
+    return 0;
+}
+
+// trxc.fx.spark_flamethrower_smoke(x, y, z, underwater)
+static int M_L_SparkFlamethrowerSmoke(lua_State *const L)
+{
+    Sparks_TriggerFlamethrowerSmoke(M_ReadPos(L), lua_toboolean(L, 4));
+    return 0;
+}
+
+// trxc.fx.spark_gun_smoke(x, y, z, weapon, shade, initial, vx, vy, vz)
+static int M_L_SparkGunSmoke(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    const GAME_VECTOR at = { .pos = pos, .room_num = M_CheckRoom(L, pos) };
+    const lua_Integer gun_type = luaL_checkinteger(L, 4);
+    if (gun_type <= LGT_UNARMED || !Gun_Registry_IsValidType(gun_type)) {
+        return luaL_argerror(L, 4, "not a weapon");
+    }
+    const LARA_GUN_TYPE weapon = (LARA_GUN_TYPE)gun_type;
+    int32_t shade = luaL_checkinteger(L, 5);
+    CLAMP(shade, 0, 255);
+    const bool initial = lua_toboolean(L, 6);
+
+    if (lua_isnoneornil(L, 7)) {
+        Sparks_TriggerGunSmoke(at, initial, weapon, shade);
+        return 0;
+    }
+    const XYZ_32 vel = {
+        .x = luaL_checkinteger(L, 7),
+        .y = luaL_checkinteger(L, 8),
+        .z = luaL_checkinteger(L, 9),
+    };
+    Sparks_TriggerGunSmokeDirected(at, vel, initial, weapon, shade);
+    return 0;
+}
+
+// trxc.fx.spark_dart_smoke(x, y, z, vx, vz, hit)
+static int M_L_SparkDartSmoke(lua_State *const L)
+{
+    Sparks_TriggerDartSmoke(
+        M_ReadPos(L),
+        (XZ_32) {
+            .x = luaL_checkinteger(L, 4),
+            .z = luaL_checkinteger(L, 5),
+        },
+        lua_toboolean(L, 6));
+    return 0;
+}
+
+// trxc.fx.spark_rocket_smoke(x, y, z, spread)
+static int M_L_SparkRocketSmoke(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerRocketSmoke(
+        pos, luaL_checkinteger(L, 4), M_CheckRoom(L, pos));
+    return 0;
+}
+
+// trxc.fx.spark_flare(x, y, z, vx, vy, vz, smoke)
+static int M_L_SparkFlare(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerFlareSparks(
+        pos,
+        (XYZ_32) {
+            .x = luaL_checkinteger(L, 4),
+            .y = luaL_checkinteger(L, 5),
+            .z = luaL_checkinteger(L, 6),
+        },
+        lua_toboolean(L, 7));
+    return 0;
+}
+
+// trxc.fx.spark_shotgun(x, y, z, vx, vy, vz)
+static int M_L_SparkShotgun(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerShotgunSparks(
+        pos,
+        (XYZ_32) {
+            .x = luaL_checkinteger(L, 4),
+            .y = luaL_checkinteger(L, 5),
+            .z = luaL_checkinteger(L, 6),
+        });
+    return 0;
+}
+
+// trxc.fx.spark_ricochet(x, y, z, angle, count, smoke_only)
+static int M_L_SparkRicochet(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    const GAME_VECTOR at = { .pos = pos, .room_num = M_CheckRoom(L, pos) };
+    const int32_t angle = luaL_checkinteger(L, 4);
+    int32_t count = luaL_checkinteger(L, 5);
+    CLAMP(count, 1, 255);
+    if (g_TRVersion >= 4) {
+        Sparks_TriggerRicochetTR4(at, angle, count, lua_toboolean(L, 6));
+    } else {
+        Sparks_TriggerRicochetTR3(at, angle, count);
+    }
+    return 0;
+}
+
+// trxc.fx.spark_bubble(x, y, z, size, size_range)
+static int M_L_SparkBubble(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerBubble(
+        pos.x, pos.y, pos.z, luaL_checkinteger(L, 4), luaL_checkinteger(L, 5),
+        NO_EFFECT);
+    return 0;
+}
+
+// trxc.fx.spark_breath(x, y, z, vx, vy, vz)
+static int M_L_SparkBreath(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerBreath(
+        pos,
+        (XYZ_32) {
+            .x = luaL_checkinteger(L, 4),
+            .y = luaL_checkinteger(L, 5),
+            .z = luaL_checkinteger(L, 6),
+        },
+        M_CheckRoom(L, pos));
+    return 0;
+}
+
+// trxc.fx.spark_pickup_aid(x, y, z, vx, vz)
+static int M_L_SparkPickupAid(lua_State *const L)
+{
+    Sparks_TriggerPickupAid(
+        M_ReadPos(L),
+        (XZ_32) {
+            .x = luaL_checkinteger(L, 4),
+            .z = luaL_checkinteger(L, 5),
+        });
+    return 0;
+}
+
+// trxc.fx.spark_waterfall_mist(x, y, z, angle)
+static int M_L_SparkWaterfallMist(lua_State *const L)
+{
+    const XYZ_32 pos = M_ReadPos(L);
+    Sparks_TriggerWaterfallMist(pos.x, pos.y, pos.z, luaL_checkinteger(L, 4));
+    return 0;
+}
+
+static const luaL_Reg m_SparkMethods[] = {
+    { "kill", M_L_SparkKill },
+    { nullptr, nullptr },
+};
+
 static const luaL_Reg m_Module[] = {
     { "blood", M_L_Blood },
     { "blood_bath", M_L_BloodBath },
+    { "explosion", M_L_Explosion },
+    { "fire", M_L_Fire },
+    { "footprint", M_L_Footprint },
+    { "knockback", M_L_Knockback },
+    { "ripple", M_L_Ripple },
+    { "small_splash", M_L_SmallSplash },
+    { "splash", M_L_Splash },
+    { "underwater_blood", M_L_UnderwaterBlood },
+    { "wade_splash", M_L_WadeSplash },
     { "emit_light", M_L_EmitLight },
     { "emit_fog", M_L_EmitFog },
     { "fog_bulb_count", M_L_FogBulbCount },
@@ -224,6 +871,32 @@ static const luaL_Reg m_Module[] = {
     { "get_fog_bulb_room", M_L_GetFogBulbRoom },
     { "get_fog_color", M_L_GetFogColor },
     { "set_fog_color", M_L_SetFogColor },
+    { "get_smoke_wind", M_L_GetSmokeWind },
+    { "set_smoke_wind", M_L_SetSmokeWind },
+    { "get_spark", M_L_GetSpark },
+    { "get_spark_item", M_L_GetSparkItem },
+    { "get_spark_world_pos", M_L_GetSparkWorldPos },
+    { "spark_max_count", M_L_SparkMaxCount },
+    { "spawn_spark", M_L_SpawnSpark },
+    { "spark_breath", M_L_SparkBreath },
+    { "spark_bubble", M_L_SparkBubble },
+    { "spark_dart_smoke", M_L_SparkDartSmoke },
+    { "spark_explosion", M_L_SparkExplosion },
+    { "spark_explosion_bubble", M_L_SparkExplosionBubble },
+    { "spark_explosion_smoke", M_L_SparkExplosionSmoke },
+    { "spark_fire_flame", M_L_SparkFireFlame },
+    { "spark_fire_smoke", M_L_SparkFireSmoke },
+    { "spark_flamethrower_flame", M_L_SparkFlamethrowerFlame },
+    { "spark_flamethrower_smoke", M_L_SparkFlamethrowerSmoke },
+    { "spark_flare", M_L_SparkFlare },
+    { "spark_gun_smoke", M_L_SparkGunSmoke },
+    { "spark_pickup_aid", M_L_SparkPickupAid },
+    { "spark_ricochet", M_L_SparkRicochet },
+    { "spark_rocket_smoke", M_L_SparkRocketSmoke },
+    { "spark_shotgun", M_L_SparkShotgun },
+    { "spark_side_flame", M_L_SparkSideFlame },
+    { "spark_static_flame", M_L_SparkStaticFlame },
+    { "spark_waterfall_mist", M_L_SparkWaterfallMist },
     { nullptr, nullptr },
 };
 
@@ -231,6 +904,7 @@ static void M_Create(lua_State *const L)
 {
     LUA_RegisterModule(L, "fx", m_Module);
     LUA_Struct_Register(L, &TYPE_FOG_BULB, nullptr);
+    LUA_Struct_Register(L, &TYPE_SPARK, m_SparkMethods);
 
     LUA_GetModule(L, "fx");
     lua_pushinteger(L, OUTPUT_MAX_PENDING_LIGHTS);

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -1,6 +1,7 @@
 #include <trx/game/sparks/manager.h>
 
 #include <trx/config.h>
+#include <trx/core/handle.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/core/utils.h>
@@ -23,6 +24,11 @@ typedef struct {
 } M_SPARK_DYNAMIC;
 
 static SPARK m_Sparks[M_MAX_SPARKS];
+static uint32_t m_SparkGens[M_MAX_SPARKS];
+static HANDLE_REGISTRY m_SparkHandles = {
+    .gens = m_SparkGens,
+    .capacity = M_MAX_SPARKS,
+};
 static M_SPARK_DYNAMIC m_Dynamics[M_MAX_SPARK_DYNAMICS];
 static int32_t m_NextSpark = 0;
 static XZ_32 m_SmokeWind = {};
@@ -56,6 +62,7 @@ static int32_t M_GetFreeSpark(void)
     for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
         if (!m_Sparks[idx].on) {
             m_NextSpark = (idx + 1) & 0xBF;
+            Handle_RegistryBump(&m_SparkHandles, idx);
             return idx;
         }
         idx = idx == (M_MAX_SPARKS - 1) ? 0 : idx + 1;
@@ -73,6 +80,7 @@ static int32_t M_GetFreeSpark(void)
     }
 
     m_NextSpark = (free + 1) & 0xBF;
+    Handle_RegistryBump(&m_SparkHandles, free);
     return free;
 }
 
@@ -310,6 +318,28 @@ SPARK *Sparks_GetSpark(const int32_t idx)
     return &m_Sparks[idx];
 }
 
+int32_t Sparks_GetMaxCount(void)
+{
+    return M_MAX_SPARKS;
+}
+
+TRX_HANDLE Sparks_GetHandle(const SPARK *const spark)
+{
+    if (spark == nullptr) {
+        return (TRX_HANDLE) { .id = -1 };
+    }
+    return Handle_RegistryMint(&m_SparkHandles, (int32_t)(spark - m_Sparks));
+}
+
+SPARK *Sparks_FromHandle(const TRX_HANDLE handle)
+{
+    if (!Handle_RegistryIsLive(&m_SparkHandles, handle)) {
+        return nullptr;
+    }
+    SPARK *const spark = &m_Sparks[handle.id];
+    return spark->on ? spark : nullptr;
+}
+
 SPARK *Sparks_InitialiseSpriteSpark(const SPARK_SPRITE_TYPE type)
 {
     const int32_t sprite_idx = Sparks_GetSpriteIndex(type);
@@ -446,6 +476,7 @@ void Sparks_Reset(void)
     for (int32_t i = 0; i < M_MAX_SPARK_DYNAMICS; i++) {
         m_Dynamics[i].on = false;
     }
+    Handle_RegistryBumpAll(&m_SparkHandles);
     m_NextSpark = 0;
     m_SmokeWind = (XZ_32) {};
     m_HairWindZ = 0;

--- a/src/trx/game/sparks/manager.h
+++ b/src/trx/game/sparks/manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/handle.h>
 #include <trx/core/result.h>
 #include <trx/game/sparks/types.h>
 
@@ -29,6 +30,14 @@ XYZ_32 Sparks_GetWorldPos(const SPARK *spark);
 
 SPARK *Sparks_GetFreeSpark(void);
 SPARK *Sparks_GetSpark(int32_t idx);
+int32_t Sparks_GetMaxCount(void);
+
+// Identity of the spark holding a pool slot. Taking the slot for another spark
+// retires the handles that named the previous one, as does a level change.
+TRX_HANDLE Sparks_GetHandle(const SPARK *spark);
+// Resolves a handle to a live spark, or nullptr where the slot has been taken
+// for another spark, or holds one whose life has run out.
+SPARK *Sparks_FromHandle(TRX_HANDLE handle);
 SPARK *Sparks_InitialiseSpriteSpark(SPARK_SPRITE_TYPE type);
 int32_t Sparks_GetSpriteIndex(SPARK_SPRITE_TYPE offset);
 void Sparks_Sync(SPARK *spark);

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -771,20 +771,25 @@ void Sparks_TriggerUnderwaterExplosion(const ITEM *item)
     if (item == nullptr) {
         return;
     }
+    Sparks_TriggerUnderwaterExplosionAt(item->pos, item->room_num);
+}
 
-    Sparks_TriggerExplosionBubble(item->pos, item->room_num);
-    Sparks_TriggerExplosionSparks(item->pos, 2, -2, 1, item->room_num);
+void Sparks_TriggerUnderwaterExplosionAt(
+    const XYZ_32 pos, const int16_t room_num)
+{
+    Sparks_TriggerExplosionBubble(pos, room_num);
+    Sparks_TriggerExplosionSparks(pos, 2, -2, 1, room_num);
 
     for (int32_t i = 0; i < 3; i++) {
-        Sparks_TriggerExplosionSparks(item->pos, 2, -1, 1, item->room_num);
+        Sparks_TriggerExplosionSparks(pos, 2, -1, 1, room_num);
     }
 
-    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(pos, room_num);
     if (water_height == NO_HEIGHT) {
         return;
     }
 
-    int32_t y = item->pos.y - water_height;
+    int32_t y = pos.y - water_height;
     if (y >= 2048) {
         return;
     }
@@ -792,9 +797,9 @@ void Sparks_TriggerUnderwaterExplosion(const ITEM *item)
     const int32_t wh = 2048 - y;
     y = wh >> 6;
 
-    const ROOM *const room = Room_Get(item->room_num);
+    const ROOM *const room = Room_Get(room_num);
     FX_Water_SetupSplash(&(FX_WATER_SPLASH_SETUP) {
-        .pos = { .x = item->pos.x, .y = room->max_ceiling, .z = item->pos.z },
+        .pos = { .x = pos.x, .y = room->max_ceiling, .z = pos.z },
         .inner_y_size = -96,
         .inner_xz_vel = 160,
         .inner_gravity = 96,

--- a/src/trx/game/sparks/spawners.h
+++ b/src/trx/game/sparks/spawners.h
@@ -15,6 +15,7 @@ void Sparks_TriggerSmallSplash(XYZ_32 pos, int32_t count);
 void Sparks_TriggerBreath(XYZ_32 pos, XYZ_32 vel, int16_t room_num);
 
 void Sparks_TriggerUnderwaterExplosion(const ITEM *item);
+void Sparks_TriggerUnderwaterExplosionAt(XYZ_32 pos, int16_t room_num);
 void Sparks_TriggerExplosionBubble(XYZ_32 pos, int16_t room_num);
 void Sparks_TriggerExplosionSparks(
     XYZ_32 pos, int32_t extras, int32_t dynamic, int32_t uw, int16_t room_num);

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -134,6 +134,42 @@ void Spawn_RicochetRay(
     Spawn_Ricochet(hit_pos);
 }
 
+void Spawn_Explosion(
+    const XYZ_32 pos, const int16_t room_num, const bool with_sound)
+{
+    const bool is_underwater = M_IsUnderwaterAt(pos, room_num);
+
+    if (g_TRVersion >= 3) {
+        if (is_underwater) {
+            Sparks_TriggerUnderwaterExplosionAt(pos, room_num);
+        } else {
+            Sparks_TriggerExplosionSparks(pos, 3, -2, 0, room_num);
+            for (int32_t i = 0; i < 2; i++) {
+                Sparks_TriggerExplosionSparks(pos, 3, -1, 0, room_num);
+            }
+        }
+    } else {
+        const int16_t effect_num = Effect_Create(room_num);
+        if (effect_num != NO_EFFECT) {
+            EFFECT *const effect = Effect_Get(effect_num);
+            effect->pos = pos;
+            effect->speed = 0;
+            effect->frame_num = 0;
+            effect->counter = 0;
+            effect->object_id = O_EXPLOSION_1;
+        }
+    }
+
+    if (!with_sound) {
+        return;
+    }
+    const XYZ_32 *const sfx_pos = g_TRVersion >= 3 ? &pos : nullptr;
+    const uint32_t flags =
+        g_TRVersion >= 3 ? (0x1800000 | SPM_PITCH) : SPM_NORMAL;
+    Sound_Effect(SFX_EXPLOSION_1, sfx_pos, flags);
+    Sound_Effect(SFX_EXPLOSION_2, sfx_pos, SPM_NORMAL);
+}
+
 void Spawn_Bubble(const XYZ_32 *const pos, const int16_t room_num)
 {
     if (g_TRVersion == 3) {

--- a/src/trx/game/spawn.h
+++ b/src/trx/game/spawn.h
@@ -12,6 +12,11 @@ void Spawn_Ricochet(GAME_VECTOR pos);
 // `count` is the number of streaks to spawn, and only applies to TR4.
 void Spawn_RicochetRay(GAME_VECTOR start, GAME_VECTOR hit_pos, int32_t count);
 
+// The explosion a rocket or a grenade leaves behind, without the damage: the
+// sprite effect in TR1/2, and a spark fireball in TR3/4, which has no
+// explosion sprite. Under water the effect is the drowned one.
+void Spawn_Explosion(XYZ_32 pos, int16_t room_num, bool with_sound);
+
 void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
 void Spawn_BubbleEx(
     const XYZ_32 *pos, int16_t room_num, int32_t size, int32_t size_range);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds the effects the engine already draws to trx.fx: an explosion, a fire, a splash, a ripple, a footprint, blood under water, and the ring of force a blast spreads.

Adds trx.fx.sparks for the particle pool TR3 and TR4 draw their smoke, flames, sparks and splashes with. A script spawns one particle at a time, reads and changes every particle alive, and sets the wind that carries them.

A collection can now be declared inside a namespace, which is what trx.fx.sparks.pool needs.