### PR TITLE
tr4/data: show logo on title start

### DIFF
--- a/data/trx/ship/games/tr4/scripts/title.lua
+++ b/data/trx/ship/games/tr4/scripts/title.lua
@@ -5,14 +5,16 @@ local logo = require("tr4.logo")
 local LOGO_WIDTH = 512
 local LOGO_HEIGHT = 256
 
-trx.ui.regions.place(
-  trx.ui.Region.TOP_CENTER,
-  trx.ui.widgets.Image({
-    path = logo.path,
-    w = LOGO_WIDTH,
-    h = LOGO_HEIGHT,
-  })
-)
+local function show_logo()
+  trx.ui.regions.place(
+    trx.ui.Region.TOP_CENTER,
+    trx.ui.widgets.Image({
+      path = logo.path,
+      w = LOGO_WIDTH,
+      h = LOGO_HEIGHT,
+    })
+  )
+end
 
 -- The title screen alternates flyby sequences with cutscenes: a trigger along
 -- a flyby's path starts one, and the cutscene hands over to the next sequence
@@ -101,6 +103,7 @@ local function set_lara_visible(visible)
 end
 
 trx.events.on_title_start(function()
+  show_logo()
   trx.cutscenes.forget_played()
   set_lara_visible(false)
   trx.camera.play_flyby(FIRST_FLYBY_NUM)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids the TR4 logo showing during starting FMVs.

Resolves TRX1343.
