### PR TITLE
lara: fix clamping under low ceilings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed Lara being able to monkey roll too close to sector edges, resulting in her falling after the animation completes (#6459 / TRX1314, regression from 1.10)
 - Fixed Lara beginning to monkey roll for one frame despite being too close to the edge of a sector (#6459 / TRX1314, regression from 1.10)
 - Fixed Lara not being able to crawl backwards in certain sloped crawlspaces (OG bug) (TRX1322)
+- Fixed Lara being able to crouch/crawl into spaces with very low ceilings where she can become clamped, such as RX-Tech Mines room 159 (OG bug) (#6477 / TRX1331)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Added the `/golden` console command, which casts Lara in gold (TRX1070)
 - Added the `/fmv` console command, which plays one of the game's movies
 - Added the `/copy` console command, which copies another command's output to the clipboard (#6372 / TRX1226)
+- Improved the `/teleport` console command to avoid Lara ending up in a clamped position under low ceilings (TRX1346)
 - Changed the `/flip` console command to take a flip group, so `/flip 3` moves that group alone while `/flip` on its own moves them all (TRX173)
 - Changed the `/mod` console command to complete the names of the mods it can switch to
 - Changed the `/set` console command to complete the values a setting accepts, such as its enum values or on and off (TRX1174)

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -1,5 +1,6 @@
 #include <trx/game/lara/cheat.h>
 
+#include <trx/config.h>
 #include <trx/core/vector.h>
 #include <trx/game/camera.h>
 #include <trx/game/console.h>
@@ -321,32 +322,42 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
 
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     const int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
-    if (height == NO_HEIGHT) {
+    const int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
+    if (height == NO_HEIGHT || ceiling == NO_HEIGHT) {
         return false;
     }
 
+    const ROOM *const room = Room_Get(room_num);
+    const int32_t water_height = Room_GetWaterHeight(pos, room_num);
+    const bool pos_submerged = room->flags.underwater
+        || (water_height != NO_HEIGHT && water_height > 0);
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+
+    if (!pos_submerged && lara_info->water_status != LWS_CHEAT) {
+        const int32_t required_space = g_Config.gameplay.enable_crawling
+                && (lara_info->gun_status == LGS_ARMLESS
+                    || !Gun_IsRifleType(lara_info->gun_type))
+            ? STEPUP_HEIGHT
+            : LARA_HEIGHT;
+        if (height - ceiling < required_space) {
+            return false;
+        }
+    }
+
     ITEM *const lara_item = Lara_GetItem();
-    lara_item->pos.x = pos.x;
-    lara_item->pos.y = pos.y;
-    lara_item->pos.z = pos.z;
+    lara_item->pos = pos;
     lara_item->floor = height;
 
     const int16_t item_num = Item_GetIndex(lara_item);
     Item_UpdateRoom(item_num, room_num);
 
-    LARA_INFO *const lara_info = Lara_GetLaraInfo();
     if (lara_info->gun_status == LGS_HANDS_BUSY) {
         lara_info->gun_status = LGS_ARMLESS;
     }
 
     Lara_Vehicle_Dismount();
     if (lara_info->extra_anim) {
-        const ROOM *const room = Room_Get(lara_item->room_num);
-        const bool room_submerged = room->flags.underwater;
-        const int32_t water_height =
-            Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
-
-        if (room_submerged || (water_height != NO_HEIGHT && water_height > 0)) {
+        if (pos_submerged) {
             lara_info->water_status = LWS_UNDERWATER;
             lara_item->current_anim_state = LS(LS_SWIM);
             lara_item->goal_anim_state = LS(LS_SWIM);
@@ -368,6 +379,13 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
         lara_info->extra_anim = false;
         M_ResetGunStatus();
         M_ReinitialiseGunMeshes();
+    }
+
+    if (lara_info->water_status != LWS_UNDERWATER
+        && lara_info->water_status != LWS_CHEAT && !lara_info->is_crouched
+        && height - ceiling < LARA_HEIGHT) {
+        lara_item->goal_anim_state = LS(LS_CROUCH_IDLE);
+        Lara_Animate(lara_item);
     }
 
     lara_info->hit_effect_count = 0;

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -79,6 +79,25 @@ static bool M_IsBadDestination(const ITEM *const item, const int16_t angle)
     return room->flags.swamp || room->flags.underwater;
 }
 
+static void M_CrouchShift(ITEM *const item, COLL_INFO *const coll)
+{
+    if (g_Config.gameplay.wall_glitch_mode == WALL_GLITCH_FIXED) {
+        const XYZ_32 pos = XYZ_32_OffsetYaw(
+            item->pos, Lara_GetLaraInfo()->move_angle, STEP_L / 8);
+        int16_t room_num = item->room_num;
+        const SECTOR *const sector = Room_GetSector(pos, &room_num);
+        const int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+        const int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
+        if (ABS(height - ceiling) < ABS(M_CROUCH_CEILING_THRESHOLD)) {
+            item->pos = coll->old_pos;
+            return;
+        }
+    }
+
+    Lara_Col_Shift(coll);
+    item->pos.y += coll->side_mid.floor;
+}
+
 static void M_Crouch(ITEM *const item, COLL_INFO *const coll)
 {
     item->gravity = false;
@@ -104,8 +123,7 @@ static void M_Crouch(ITEM *const item, COLL_INFO *const coll)
     }
 
     lara->keep_crouched = coll->side_mid.ceiling >= M_CROUCH_CEILING_THRESHOLD;
-    Lara_Col_Shift(coll);
-    item->pos.y += coll->side_mid.floor;
+    M_CrouchShift(item, coll);
 
     const bool crouch_active = g_Config.gameplay.enable_toggle_crouch
         ? !(lara->crouching && g_InputDB.crouch)
@@ -196,9 +214,7 @@ static void M_CrouchTurn(ITEM *const item, COLL_INFO *const coll)
     }
 
     lara->keep_crouched = coll->side_mid.ceiling >= M_CROUCH_CEILING_THRESHOLD;
-
-    Lara_Col_Shift(coll);
-    item->pos.y += coll->side_mid.floor;
+    M_CrouchShift(item, coll);
 }
 
 static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
@@ -232,9 +248,7 @@ static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
     }
 
     lara->keep_crouched = coll->side_mid.ceiling >= M_CROUCH_CEILING_THRESHOLD;
-
-    Lara_Col_Shift(coll);
-    item->pos.y += coll->side_mid.floor;
+    M_CrouchShift(item, coll);
 
     const bool crouch_active = g_Config.gameplay.enable_toggle_crouch
         ? lara->crouching
@@ -356,8 +370,7 @@ static void M_CrawlForward(ITEM *const item, COLL_INFO *const coll)
     } else if (Lara_Col_Fallen(item, coll)) {
         lara->gun_status = LGS_ARMLESS;
     } else {
-        Lara_Col_Shift(coll);
-        item->pos.y += coll->side_mid.floor;
+        M_CrouchShift(item, coll);
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids Lara being able to crouch/crawl over steps where the destination position would result in her becoming clamped. The logic only applies if `wall_glitch_mode` is set to `fixed`.

Teleporting to a low ceiling space will also now move Lara into a crouching state if it's viable to do so. Otherwise, teleport positions are tested to ensure she has enough room to stand and move freely. This only applies to being on land and not in the fly cheat.

Resolves #6477 / TRX1331 / TRX1346.
