### PR TITLE
av/audio_sample: fix crackling looped sounds

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -117,6 +117,7 @@
 **Music and sound**
 - Added an option to have Lara's sliding SFX stop as soon as she leaves a slope (#6294 / TRX1155)
 - Fixed crystal sound effects not playing if Lara collects one underwater (OG bug) (TRX1111)
+- Fixed looped sound effects, such as rolling boulders and the seaplane, clicking and crackling while they play (#6491 / TRX1348)
 
 **Rendering**
 - Added affine texture mapping, the uncorrected texturing of the PlayStation, so textures warp across large surfaces as the camera moves; the PlayStation presets turn it on (Graphic Options → Rendering → Affine texture mapping)

--- a/src/trx/av/audio_decoder.c
+++ b/src/trx/av/audio_decoder.c
@@ -316,6 +316,39 @@ static void M_Filter(
     }
 }
 
+// Pushes the samples the resampler still holds through to the sink.
+static void M_FlushResampler(AUDIO_DECODER *const decoder)
+{
+    if (decoder->swr_ctx == nullptr) {
+        return;
+    }
+
+    while (true) {
+        const int32_t max_samples = swr_get_out_samples(decoder->swr_ctx, 0);
+        if (max_samples <= 0) {
+            break;
+        }
+
+        const int32_t floats = max_samples * decoder->channels;
+        float *const scratch = Memory_Alloc(floats * sizeof(float));
+        uint8_t *out_buffer = (uint8_t *)scratch;
+        const int32_t converted =
+            swr_convert(decoder->swr_ctx, &out_buffer, max_samples, nullptr, 0);
+        if (converted > 0) {
+            if (decoder->filter_graph != nullptr) {
+                M_Filter(decoder, scratch, converted);
+            } else {
+                M_Append(decoder, scratch, converted);
+            }
+        }
+        Memory_Free(scratch);
+
+        if (converted <= 0) {
+            break;
+        }
+    }
+}
+
 // Pushes the samples the stretcher still holds through to the sink.
 static void M_FlushFilter(AUDIO_DECODER *const decoder)
 {
@@ -598,6 +631,7 @@ int32_t AudioDecoder_Read(AUDIO_DECODER *const decoder, const float **const out)
         // let the codec hand back the frames it was still holding
         avcodec_send_packet(decoder->codec_ctx, nullptr);
         M_Drain(decoder);
+        M_FlushResampler(decoder);
         M_FlushFilter(decoder);
         decoder->is_drained = true;
         *out = decoder->buffer;

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -56,6 +56,9 @@ typedef struct {
     bool is_playing;
     float volume_l; // sample gain multiplier
     float volume_r; // sample gain multiplier
+    // Follows `volume_l`/`volume_r` over one callback chunk.
+    float current_volume_l;
+    float current_volume_r;
 
     float pitch;
     // `volume`/`pan` come from the game layer (src/trx/game/sound/common.c).
@@ -116,6 +119,15 @@ static double M_DecibelToMultiplier(double db_gain)
         // DirectSound-style centi-dB domain: gain = 10^(centi_dB/2000).
         return pow(10.0, db_gain / 2000.0);
     }
+}
+
+static float M_ReadMono(const AUDIO_SAMPLE *const sample, const int32_t idx)
+{
+    float result = 0.0f;
+    for (int32_t i = 0; i < sample->channels; i++) {
+        result += sample->sample_data[idx * sample->channels + i];
+    }
+    return result / (float)sample->channels;
 }
 
 static bool M_RecalculateChannelVolumes(int32_t sound_id)
@@ -433,6 +445,8 @@ int32_t Audio_Sample_Play(
         sound->sample = &m_LoadedSamples[sample_id];
 
         M_RecalculateChannelVolumes(sound_id);
+        sound->current_volume_l = sound->volume_l;
+        sound->current_volume_r = sound->volume_r;
 
         result = sound_id;
         break;
@@ -579,8 +593,14 @@ void Audio_Sample_Mix(float *dst_buffer, size_t len)
         int32_t samples_requested =
             len / sizeof(AUDIO_WORKING_FORMAT) / AUDIO_WORKING_CHANNELS;
         float src_sample_idx = sound->current_sample;
-        const float *src_buffer = sample->sample_data;
         float *dst_ptr = dst_buffer;
+
+        float gain_l = sound->current_volume_l;
+        float gain_r = sound->current_volume_r;
+        const float gain_step_l =
+            (sound->volume_l - gain_l) / (float)samples_requested;
+        const float gain_step_r =
+            (sound->volume_r - gain_r) / (float)samples_requested;
 
         while ((dst_ptr - dst_buffer) / AUDIO_WORKING_CHANNELS
                < samples_requested) {
@@ -590,22 +610,30 @@ void Audio_Sample_Mix(float *dst_buffer, size_t len)
                 if (!sample->is_decoded || !sound->is_looped) {
                     break;
                 }
-                src_sample_idx = 0.0f;
+                src_sample_idx -= (float)ready;
+                if ((int32_t)src_sample_idx >= ready) {
+                    src_sample_idx = 0.0f;
+                }
             }
 
-            // because we handle 3d sound ourselves, downmix to mono
-            float src_sample = 0.0f;
-            for (int32_t i = 0; i < sample->channels; i++) {
-                src_sample +=
-                    src_buffer[(int32_t)src_sample_idx * sample->channels + i];
+            const int32_t idx = (int32_t)src_sample_idx;
+            int32_t next_idx = idx + 1;
+            if (next_idx >= ready) {
+                next_idx = sound->is_looped && sample->is_decoded ? 0 : idx;
             }
-            src_sample /= (float)sample->channels;
+            const float frac = src_sample_idx - (float)idx;
+            const float src_sample = M_ReadMono(sample, idx) * (1.0f - frac)
+                + M_ReadMono(sample, next_idx) * frac;
 
-            *dst_ptr++ += src_sample * sound->volume_l;
-            *dst_ptr++ += src_sample * sound->volume_r;
+            *dst_ptr++ += src_sample * gain_l;
+            *dst_ptr++ += src_sample * gain_r;
+            gain_l += gain_step_l;
+            gain_r += gain_step_r;
             src_sample_idx += sound->pitch;
         }
 
+        sound->current_volume_l = gain_l;
+        sound->current_volume_r = gain_r;
         sound->current_sample = src_sample_idx;
         if (sample->is_decoded && !sound->is_looped
             && (int32_t)src_sample_idx >= ready) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes clicking and crackling in looped sound effects, especially rolling boulders and the seaplane idle.

The mixer now ramps gain changes across an audio chunk instead of applying new volume and pan values at once every logic tick. It now also interpolates between source frames and preserves the fractional overshoot when a looped sound wraps. Decoding now flushes the resampler at the end of a stream, preventing samples from losing their tails.

Resolves #6491 / TRX1348