### PR TITLE
interpolation: fix photo mode frame stepping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Fixed the Inverted look option not applying to the binoculars (#6431 / TRX1291)
 - Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down (TRX1142)
 - Fixed the photo mode camera flickering and refusing to turn over when it is pitched past straight up or down, and turning in coarse steps while aimed near vertical (TRX1152)
+- Fixed photo mode showing the same animation frame while advancing the game a quarter of a frame at a time (TRX1353, regression from 1.9)
 
 **Developer console**
 - Added the `/outfit` console command, which shows or changes what Lara is wearing (TRX1070)

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -8,6 +8,7 @@
 #include <trx/game/game/state.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
+#include <trx/game/photo_mode.h>
 #include <trx/game/rooms.h>
 #include <trx/game/shell.h>
 #include <trx/game/viewport.h>
@@ -438,7 +439,10 @@ bool Interpolation_IsActive(void)
 
 double Interpolation_GetWorldRate(void)
 {
-    if (!Interpolation_IsActive() || !Game_IsPlaying()) {
+    // Photo mode steps the world itself and keeps its own rate, so the frozen
+    // gameplay state must not force the rate back to 1.0.
+    if (!Interpolation_IsActive()
+        || (!Game_IsPlaying() && !PhotoMode_IsActive())) {
         return 1.0;
     }
     return m_WorldRate;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Photo mode blends the animation frames while the game is advanced a quarter of a frame at a time. Before this, all four steps showed the same pose and only the fourth one moved it, while item positions kept moving smoothly.

The blend rate now stays available while photo mode is active. It is still held at rest for the inventory and the pause screen, which do not advance the game.

Resolves TRX1353