### PR TITLE
cutseq: holster Lara's weapons before a scene

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -200,6 +200,7 @@
 - Fixed a crash while an in-game cutscene poses Lara (TRX1059)
 - Fixed characters sliding across the room, and Lara's braid trailing behind her, when an in-game cutscene moves them to a new place (TRX1270)
 - Fixed the level showing for a moment when an in-game cutscene ends (TRX1252)
+- Fixed Lara keeping her weapons drawn, and her flare in hand, while the screen fades into an in-game cutscene (TRX1349)
 - Fixed Lara's shadow and the flames around her when she burns staying where an in-game cutscene began, rather than following her (TRX911)
 - Fixed the light the flames cast staying where an in-game cutscene began while Lara burns, rather than following her (TRX1197)
 - Fixed Von Croy's shadow floating at the height of his knees during the scenes he plays in Angkor Wat (TRX911)

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -14,6 +14,9 @@
 #include <trx/game/flyby_mode.h>
 #include <trx/game/game/state.h>
 #include <trx/game/game_flow.h>
+#include <trx/game/gun/common.h>
+#include <trx/game/gun/flare.h>
+#include <trx/game/gun/rifle.h>
 #include <trx/game/input.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
@@ -46,6 +49,12 @@
 // place in a single frame, so the pose interpolation must not sweep the actor
 // across the gap.
 #define M_CUT_DISTANCE (WALL_L / 2)
+
+// Ticks the black screen waits for Lara to put away what she holds. The
+// original engine gives her the same count before it starts the scene
+// regardless, so an animation that cannot finish - one she is crawling
+// through, for instance - does not hold the game.
+#define M_HOLSTER_TIMEOUT 50
 
 typedef enum {
     M_PHASE_INACTIVE,
@@ -104,6 +113,9 @@ static struct {
     uint64_t played_mask;
     int32_t fov;
     float letterbox;
+    // Counts down while the black screen waits for Lara to put away what she
+    // holds.
+    int32_t holster_timeout;
     FADER fader;
 } m_State = {
     .num = M_NO_CUTSCENE,
@@ -225,6 +237,53 @@ static void M_TeleportLara(const XYZ_32 pos, const int16_t y_rot)
     Interpolation_CommitLara();
 }
 
+// Puts away what Lara holds, as the original engine does when a cutscene
+// triggers: the weapons go back into their holsters, and a flare is thrown
+// away rather than dropped.
+static void M_RequestHolster(void)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const bool holds_flare = Gun_IsFlareType(lara->gun_type);
+    if (!holds_flare
+        && (lara->gun_status == LGS_ARMLESS
+            || lara->gun_status == LGS_HANDS_BUSY)) {
+        return;
+    }
+    lara->gun_status = LGS_UNDRAW;
+}
+
+// Reports whether Lara's hands are free, so that the scene can begin.
+static bool M_IsHolsterFinished(void)
+{
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    return lara->gun_status == LGS_HANDS_BUSY
+        || (lara->gun_status == LGS_ARMLESS && !lara->flare.control);
+}
+
+// Empties Lara's hands before the scene starts, as the original engine does.
+// Where the wait above timed out, she still holds what the undraw did not
+// finish putting away.
+static void M_ClearLaraHands(void)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (Gun_IsRifleType(lara->gun_type)) {
+        while (lara->gun_item_num != NO_ITEM) {
+            Gun_Rifle_Undraw(lara->gun_type);
+        }
+    }
+    Gun_Flare_Clear();
+    Gun_SetLaraHandLMesh(LGT_UNARMED);
+    Gun_SetLaraHandRMesh(LGT_UNARMED);
+    lara->gun_type = LGT_UNARMED;
+    lara->request_gun_type = LGT_UNARMED;
+    lara->gun_status = LGS_ARMLESS;
+    lara->target = nullptr;
+    lara->left_arm.lock = 0;
+    lara->right_arm.lock = 0;
+    lara->left_arm.frame_num = 0;
+    lara->right_arm.frame_num = 0;
+}
+
 static bool M_Begin(const int32_t num)
 {
     // Read into a local, so a descriptor that turns out to be malformed does
@@ -308,6 +367,7 @@ static bool M_Begin(const int32_t num)
     CutSeq_SetPlayed(num, true);
     m_State.lara_shadow_bounds.is_present = false;
 
+    M_ClearLaraHands();
     M_TeleportLara(info->origin, 0);
     M_SetLaraPose(&m_State.actors[0].pose_curr);
 
@@ -531,6 +591,8 @@ void CutSeq_Request(const int32_t num, const bool fade_out)
     }
     m_State.pending_num = num;
     m_State.phase = M_PHASE_FADE_OUT;
+    m_State.holster_timeout = M_HOLSTER_TIMEOUT;
+    M_RequestHolster();
     if (fade_out) {
         Fader_InitFromCurrent(&m_State.fader, 1.0f, M_FADE_DURATION);
     } else {
@@ -725,6 +787,10 @@ void CutSeq_Control(void)
     switch (m_State.phase) {
     case M_PHASE_FADE_OUT:
         if (!Fader_IsActive(&m_State.fader)) {
+            if (m_State.holster_timeout > 0 && !M_IsHolsterFinished()) {
+                m_State.holster_timeout--;
+                return;
+            }
             const int32_t num = m_State.pending_num;
             m_State.pending_num = M_NO_CUTSCENE;
             if (!M_Begin(num)) {

--- a/src/trx/game/gun/flare.c
+++ b/src/trx/game/gun/flare.c
@@ -454,6 +454,17 @@ void Gun_Flare_Undraw(void)
     M_SetArm(frame_num_1);
 }
 
+void Gun_Flare_Clear(void)
+{
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (Gun_Flare_IsMeshActive()) {
+        Gun_SetLaraHandLMesh(LGT_UNARMED);
+    }
+    lara_info->flare.control = false;
+    lara_info->flare.age = M_NO_AGE;
+    lara_info->flare.frame_num = 0;
+}
+
 void Gun_Flare_Dispose(const bool thrown)
 {
     const ITEM *const lara_item = Lara_GetItem();

--- a/src/trx/game/gun/flare.h
+++ b/src/trx/game/gun/flare.h
@@ -8,3 +8,7 @@ void Gun_Flare_Control(void);
 void Gun_Flare_Draw(void);
 void Gun_Flare_Undraw(void);
 void Gun_Flare_Dispose(bool thrown);
+
+// Takes the flare out of Lara's hand and forgets how far it had burned,
+// leaving nothing behind in the level.
+void Gun_Flare_Clear(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A cutscene trigger sends Lara's weapons back into their holsters and makes her throw away a flare she holds, while the screen fades to black. The black screen waits for her hands to come free, for at most 50 ticks, and the scene then takes the weapon or the flare out of her hands where the undraw did not finish. Before this, she kept everything in hand until the scene began and it vanished, and a lit flare was lost rather than thrown.

The original game skips the holstering for one of its scenes, and lets a few crawling states through without waiting. Neither is carried over: the wait times out instead.

Resolves TRX1349