### PR TITLE
photo_mode: fix the FPS counter staying on screen

### DIFF
--- a/src/trx/config/option.h
+++ b/src/trx/config/option.h
@@ -39,6 +39,8 @@ typedef enum {
     CONFIG_HOLD_SCRIPT,
     // The demo's own settings, put back when it ends.
     CONFIG_HOLD_DEMO,
+    // What photo mode keeps out of the picture, put back when it closes.
+    CONFIG_HOLD_PHOTO_MODE,
     // A key the player is holding, put back when they let go.
     CONFIG_HOLD_INPUT,
 } CONFIG_HOLD_SOURCE;

--- a/src/trx/game/photo_mode.c
+++ b/src/trx/game/photo_mode.c
@@ -27,7 +27,6 @@
 
 typedef struct {
     PHOTO_MODE current_mode;
-    bool show_fps_counter;
     double rate;
     bool lara_pos_touched;
     XYZ_32 orig_lara_pos;
@@ -232,11 +231,12 @@ static void M_HandleCameraMode(M_PRIV *const p)
 void PhotoMode_Start(void)
 {
     M_PRIV *const p = &m_Priv;
-    p->show_fps_counter = g_Config.ui.enable_fps_counter;
     p->rate = 1.0;
     p->current_mode = PHOTO_MODE_CAMERA;
     p->lara_pos_touched = false;
-    CONFIG_SET(g_Config.ui.enable_fps_counter, false);
+    CONFIG_PUSH_HOLD(
+        g_Config.ui.enable_fps_counter, false, CONFIG_HOLD_PHOTO_MODE);
+    Config_Update();
 
     M_RememberLaraPos(p);
     Camera_PhotoMode_Enter();
@@ -251,7 +251,8 @@ void PhotoMode_End(void)
     Camera_PhotoMode_Exit();
     M_RestoreLaraPos(p);
 
-    CONFIG_SET(g_Config.ui.enable_fps_counter, p->show_fps_counter);
+    CONFIG_POP_HOLD(g_Config.ui.enable_fps_counter);
+    Config_Update();
     Music_Unpause();
     Sound_UnpauseAll();
     m_Active = false;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes an unreleased regression where entering the photo mode with the hints would not hide the FPS counter.
Resolves TRX1354

It is still possible to force it to appear, but the green path should be fixed. Fixing the other paths would likely happen when we port the photo mode UI into LUA.