### PR TITLE
shell: fix unreadable fatal error text

### DIFF
--- a/src/tests/trx/core/strings/common.c
+++ b/src/tests/trx/core/strings/common.c
@@ -62,3 +62,36 @@ TEST(file_name_takes_empty_text)
 {
     M_CheckFileName("", "");
 }
+
+static void M_CheckWrap(
+    const char *const input, const int32_t columns, const char *const expected)
+{
+    char *const result = String_Wrap(input, columns);
+    CHECK_EQ_STR(result, expected);
+    Memory_Free(result);
+}
+
+TEST(wrap_leaves_text_that_fits)
+{
+    M_CheckWrap("Lara has the shotgun", 40, "Lara has the shotgun");
+}
+
+TEST(wrap_breaks_between_words)
+{
+    M_CheckWrap("Lara has the shotgun", 12, "Lara has the\nshotgun");
+}
+
+TEST(wrap_keeps_a_break_that_is_there)
+{
+    M_CheckWrap("Lara\nhas the shotgun", 40, "Lara\nhas the shotgun");
+}
+
+TEST(wrap_breaks_a_word_longer_than_a_line)
+{
+    M_CheckWrap("/a/very/long/path", 8, "/a/very/\nlong/pat\nh");
+}
+
+TEST(wrap_takes_empty_text)
+{
+    M_CheckWrap("", 40, "");
+}

--- a/src/trx/core/strings/common.c
+++ b/src/trx/core/strings/common.c
@@ -223,6 +223,60 @@ bool String_ParseRGBA8888(const char *value, RGBA_8888 *const target)
         == 4;
 }
 
+char *String_Wrap(const char *const text, const int32_t columns)
+{
+    if (text == nullptr || columns <= 0) {
+        return nullptr;
+    }
+
+    const size_t len = strlen(text);
+    char *const out = Memory_Alloc(len + len / (size_t)columns + 2);
+    size_t out_len = 0;
+    int32_t column = 0;
+
+    const char *word = text;
+    while (*word != '\0') {
+        if (*word == '\n') {
+            out[out_len++] = *word++;
+            column = 0;
+            continue;
+        }
+        if (*word == ' ') {
+            if (column > 0 && column < columns) {
+                out[out_len++] = *word;
+                column++;
+            }
+            word++;
+            continue;
+        }
+
+        size_t word_len = 0;
+        while (word[word_len] != '\0' && word[word_len] != ' '
+               && word[word_len] != '\n') {
+            word_len++;
+        }
+        if (column > 0 && column + (int32_t)word_len > columns) {
+            if (out_len > 0 && out[out_len - 1] == ' ') {
+                out_len--;
+            }
+            out[out_len++] = '\n';
+            column = 0;
+        }
+        for (size_t i = 0; i < word_len; i++) {
+            if (column == columns) {
+                out[out_len++] = '\n';
+                column = 0;
+            }
+            out[out_len++] = word[i];
+            column++;
+        }
+        word += word_len;
+    }
+
+    out[out_len] = '\0';
+    return out;
+}
+
 VECTOR *String_Paginate(const char *const text, const int32_t max_lines)
 {
     VECTOR *const pages = Vector_Create(sizeof(char *));

--- a/src/trx/core/strings/common.h
+++ b/src/trx/core/strings/common.h
@@ -28,6 +28,11 @@ char *String_ToUpperPattern(const char *text);
 // from both ends. Returns an allocated string the caller frees.
 char *String_ToFileName(const char *text);
 
+// Wraps text to lines of at most `columns` characters. Existing line breaks
+// stay in place, and words longer than `columns` are split at the limit.
+// Returns an allocated string that the caller has to free.
+char *String_Wrap(const char *text, int32_t columns);
+
 VECTOR *String_Paginate(const char *text, int32_t max_lines);
 
 typedef bool STRING_RANGE_FUNC(int32_t value, void *user_data);

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -2,6 +2,7 @@
 #include <trx/config.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/debug.h>
 #include <trx/game/replay/test_replay.h>
 #include <trx/game/shell.h>
@@ -16,6 +17,9 @@
 #include <libavcodec/version.h>
 #include <libavutil/log.h>
 #include <stdio.h>
+
+// Limits the fatal error dialog width, in characters.
+#define M_DIALOG_COLUMNS 80
 
 static bool m_IsExiting = false;
 static bool m_IsFocused = true;
@@ -46,8 +50,11 @@ static void M_ShowFatalError(
             && (SDL_GetWindowFlags(window) & SDL_WINDOW_SHOWN) == 0) {
             window = nullptr;
         }
+        char *const wrapped = String_Wrap(dialog_message, M_DIALOG_COLUMNS);
         SDL_ShowSimpleMessageBox(
-            SDL_MESSAGEBOX_ERROR, "Tomb Raider Error", dialog_message, window);
+            SDL_MESSAGEBOX_ERROR, "Tomb Raider Error",
+            wrapped != nullptr ? wrapped : dialog_message, window);
+        Memory_Free(wrapped);
     }
     Shell_Terminate(1);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where fatal error text could run wider than the screen. Before this, long file paths could make the dialog too wide to read. The message now wraps to fit the screen.