### PR TITLE
inventory: refuse an entry that names no object

### DIFF
--- a/src/trx/game/inventory.c
+++ b/src/trx/game/inventory.c
@@ -407,9 +407,12 @@ void Inv_RemoveAllItems(void)
 bool Inv_CanAddItem(const OBJECT_ID object_id)
 {
     const OBJECT_ID inv_object_id = Inv_GetItemOption(object_id);
-    const OBJECT *const object =
-        Object_Get(inv_object_id == NO_OBJECT ? object_id : inv_object_id);
-    return object->loaded;
+    const OBJECT_ID wanted =
+        inv_object_id == NO_OBJECT ? object_id : inv_object_id;
+    if (wanted == NO_OBJECT) {
+        return false;
+    }
+    return Object_Get(wanted)->loaded;
 }
 
 bool Inv_AddItem(const OBJECT_ID object_id)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the game stopped on an assertion as Lara's inventory was set up. An entry naming no object asked the object table for one anyway, which is fatal; it now counts as an entry she cannot carry.