### PR TITLE
lua/api/math: say a length in sectors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -89,6 +89,7 @@
 - Added an object families file, so a mod can say which objects count as pickups, doors, creatures and the rest without a new build
 - Added a `trx.path` module, so a script can work with filesystem paths, join one with `/`, inspect its parts, find the game's own files, and read and write under the game's directories
 - Added a `trx.json` module, so a script can read and write JSON as text or files
+- Added `trx.math.from_sectors()` and `trx.math.to_sectors()`, so a script can say a length the way a level is laid out
 - Added an object links file, so a mod can say which pickup an inventory icon stands for, which slot a key goes into, and which box a weapon's rounds come in
 - Added `trx.objects.declare()`, so a script can define how its own object starts, updates, casts a shadow and saves its position
 - Added `trx.objects.borrow_content()`, so an object with no models of its own can use another object's meshes and animations

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6964,6 +6964,42 @@
       }
     },
     {
+      "description": "Says a length in sectors, which is how a level is laid out, in the units the\nengine measures the world in. A part of a sector is a length of its own, so\n`0.5` is half a sector.",
+      "examples": [
+        "-- how far the uzis reach, eight sectors out\ntrx.weapons.get(trx.catalog.weapons.uzis).target_dist =\n  trx.math.from_sectors(8)"
+      ],
+      "params": [
+        {
+          "description": "A length in sectors.",
+          "name": "value",
+          "type": "number"
+        }
+      ],
+      "path": "math.from_sectors",
+      "returns": {
+        "description": "The same length.",
+        "type": "math.Distance"
+      }
+    },
+    {
+      "description": "Says a length in sectors, which is what it reads as on a level's own grid. A length that is not a whole number of sectors reads as a fraction.",
+      "examples": [
+        "local sectors = trx.math.to_sectors(trx.lara.item.pos.y)"
+      ],
+      "params": [
+        {
+          "description": "The length to say.",
+          "name": "value",
+          "type": "math.Distance"
+        }
+      ],
+      "path": "math.to_sectors",
+      "returns": {
+        "description": "The same length in sectors.",
+        "type": "number"
+      }
+    },
+    {
       "description": "Restarts the game into another mod. The switch happens once the game flow picks it up, not on the call.",
       "examples": [
         "trx.mod.switch(\"arabian-nights\")"

--- a/docs/trx/lua/reference/MATH.md
+++ b/docs/trx/lua/reference/MATH.md
@@ -171,3 +171,33 @@ Fixed-point trigonometry, matching the engine's own tables. Using these rather t
     z = corner.z + trx.math.WALL_L,
   })
   ```
+
+- <a id="math.from_sectors" name="math.from_sectors"></a>[lua]`trx.math.from_sectors(value)`  
+  Says a length in sectors, which is how a level is laid out, in the units the
+  engine measures the world in. A part of a sector is a length of its own, so
+  `0.5` is half a sector.
+
+  Parameters:
+  - <a id="math.from_sectors.value" name="math.from_sectors.value"></a>**`value`** (number). A length in sectors.
+
+  Returns: [trx.math.Distance](#math.Distance). The same length.
+
+  Example:
+  ```lua
+  -- how far the uzis reach, eight sectors out
+  trx.weapons.get(trx.catalog.weapons.uzis).target_dist =
+    trx.math.from_sectors(8)
+  ```
+
+- <a id="math.to_sectors" name="math.to_sectors"></a>[lua]`trx.math.to_sectors(value)`  
+  Says a length in sectors, which is what it reads as on a level's own grid. A length that is not a whole number of sectors reads as a fraction.
+
+  Parameters:
+  - <a id="math.to_sectors.value" name="math.to_sectors.value"></a>**`value`** ([trx.math.Distance](#math.Distance)). The length to say.
+
+  Returns: number. The same length in sectors.
+
+  Example:
+  ```lua
+  local sectors = trx.math.to_sectors(trx.lara.item.pos.y)
+  ```

--- a/src/lua/api/math.lua
+++ b/src/lua/api/math.lua
@@ -310,6 +310,61 @@ trx.zones.box(corner, {
   end,
 })
 
+api.define("math.from_sectors", {
+  description = [[
+    Says a length in sectors, which is how a level is laid out, in the units the
+    engine measures the world in. A part of a sector is a length of its own, so
+    `0.5` is half a sector.
+  ]],
+  params = {
+    {
+      name = "value",
+      type = "number",
+      description = "A length in sectors.",
+    },
+  },
+  returns = {
+    type = "math.Distance",
+    description = "The same length.",
+  },
+  examples = {
+    [[-- how far the uzis reach, eight sectors out
+trx.weapons.get(trx.catalog.weapons.uzis).target_dist =
+  trx.math.from_sectors(8)]],
+  },
+  impl = function(value)
+    if type(value) ~= "number" then
+      error("value must be a number", 3)
+    end
+    return math.floor(value * raw.WALL_L + 0.5)
+  end,
+})
+
+api.define("math.to_sectors", {
+  description = "Says a length in sectors, which is what it reads as on a level's own grid. A "
+    .. "length that is not a whole number of sectors reads as a fraction.",
+  params = {
+    {
+      name = "value",
+      type = "math.Distance",
+      description = "The length to say.",
+    },
+  },
+  returns = {
+    type = "number",
+    description = "The same length in sectors.",
+  },
+  examples = {
+    [[local sectors = trx.math.to_sectors(trx.lara.item.pos.y)]],
+  },
+  impl = function(value)
+    if type(value) ~= "number" then
+      error("value must be a number", 3)
+    end
+    return value / raw.WALL_L
+  end,
+})
+
 api.const("math.DEG_1", {
   value = raw.DEG_1,
   type = "math.Angle",

--- a/src/tests/lua/api/math.lua
+++ b/src/tests/lua/api/math.lua
@@ -4,6 +4,7 @@
 
 local h = require("harness")
 local test = h.test
+local raises = h.raises
 
 local DEG_90 = trx.math.DEG_90
 
@@ -39,6 +40,20 @@ test("atan takes z before x", function()
     "straight along +x is a quarter turn"
   )
   assert(trx.math.atan(1024, 1024) == trx.math.DEG_45)
+end)
+
+test("a length says itself in sectors and back", function()
+  assert(trx.math.from_sectors(8) == 8 * trx.math.WALL_L)
+  assert(trx.math.from_sectors(0.5) == trx.math.WALL_L // 2)
+  assert(trx.math.from_sectors(-2) == -2 * trx.math.WALL_L)
+  assert(trx.math.to_sectors(trx.math.WALL_L) == 1)
+  assert(trx.math.to_sectors(trx.math.WALL_L // 2) == 0.5)
+  raises(function()
+    trx.math.from_sectors("8")
+  end)
+  raises(function()
+    trx.math.to_sectors({})
+  end)
 end)
 
 test("round_to_sector snaps to the corner west and north", function()


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds trx.math.from_sectors and trx.math.to_sectors, so a script can say a length the way a level is laid out rather than multiplying by the size of a sector.