### PR TITLE
lua: let a directory answer to its name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -275,6 +275,7 @@
 - Added `trx.fx.fog_bulbs` and `trx.fx.fog_color`, so a script can read level fog bulbs and set the distance fog color (TRX658)
 - Added more world effects to `trx.fx`: explosions, fires, splashes, ripples, footprints, underwater blood and blast rings
 - Added `trx.fx.sparks`, so a script can throw the particles the games use for smoke, flames, sparks and splashes, and read or change every live particle
+- Changed `require()` to also look for `<module>/init.lua`, so modules can grow into multiple files without changing how callers require them.
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)

--- a/src/tests/trx/game/lua/common.c
+++ b/src/tests/trx/game/lua/common.c
@@ -359,6 +359,33 @@ TEST(a_required_script_may_sit_in_a_subdirectory)
     M_Done();
 }
 
+// A directory with an init.lua answers to the name of the directory, so a
+// module that outgrows one file keeps the name its callers write.
+TEST(a_directory_with_an_init_script_answers_to_its_name)
+{
+    M_Booted();
+    M_WriteGameScript("my_group/init", "return { name = 'grouped' }\n");
+    M_WriteCommonScript("their_group/init", "return { name = 'pooled' }\n");
+
+    M_CheckEval("assert(require('tr1.my_group').name == 'grouped')");
+    M_CheckEval("assert(require('common.their_group').name == 'pooled')");
+
+    M_Done();
+}
+
+// The file wins, so a directory beside a script of the same name cannot take
+// the name over.
+TEST(a_script_answers_before_the_directory_beside_it)
+{
+    M_Booted();
+    M_WriteGameScript("my_group", "return { name = 'file' }\n");
+    M_WriteGameScript("my_group/init", "return { name = 'directory' }\n");
+
+    M_CheckEval("assert(require('tr1.my_group').name == 'file')");
+
+    M_Done();
+}
+
 // The name is the whole of what keeps a require inside the directory it names,
 // there being no other check between it and the filesystem.
 TEST(a_name_that_could_reach_outside_is_refused)

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -284,19 +284,29 @@ static const char *M_ResolveScript(
     // The dots the script wrote are the directories the file sits in.
     const char *const path_stem = luaL_gsub(L, stem, ".", "/");
 
-    const char *rel;
-    GAME_DYNAMIC_PATH source;
-    if (M_HasRoot(name, root_len, M_COMMON_ROOT)) {
-        source = GAME_DYNAMIC_PATH_COMMON_MODULE_FILE;
-        rel = lua_pushfstring(L, "%s.lua", path_stem);
-    } else {
-        source = GAME_DYNAMIC_PATH_GAME_MODULE_FILE;
+    const bool is_common = M_HasRoot(name, root_len, M_COMMON_ROOT);
+    const GAME_DYNAMIC_PATH source = is_common
+        ? GAME_DYNAMIC_PATH_COMMON_MODULE_FILE
+        : GAME_DYNAMIC_PATH_GAME_MODULE_FILE;
+
+    const char *mod = nullptr;
+    if (!is_common) {
         lua_pushlstring(L, name, root_len);
-        const char *const mod = lua_tostring(L, -1);
-        rel = lua_pushfstring(L, "%s/modules/%s.lua", mod, path_stem);
+        mod = lua_tostring(L, -1);
     }
 
-    const char *const path = GamePath_PeekResolve(source, rel);
+    // A name is the file it spells out, or the init.lua of a directory of that
+    // name. A module that grows into several files keeps the name its callers
+    // already write.
+    const char *path = nullptr;
+    for (int32_t i = 0; i < 2 && path == nullptr; i++) {
+        const char *const tail =
+            lua_pushfstring(L, i == 0 ? "%s.lua" : "%s/init.lua", path_stem);
+        const char *const rel =
+            is_common ? tail : lua_pushfstring(L, "%s/modules/%s", mod, tail);
+        path = GamePath_PeekResolve(source, rel);
+    }
+
     lua_settop(L, base);
     return path;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A `require()` call now finds either a matching script, or the init.lua of a matching directory. This allows a module to grow into several files without renaming itself or updating scripts that require it.
A matching file takes precedence over a directory with the same name.