### PR TITLE
lara+stats: handle distance travelled overflows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -118,6 +118,8 @@
 - Changed the save crystal behavior to give Lara a crystal when starting a game, if the mode is set to Saving (pickups), in line with the TR3 PS1 version (Gameplay → General → Crystal mode) (TRX1101)
 - Changed the option for Lara's braid to introduce an "auto" mode, which will automatically hide the braid for regular TR1 outfits, and show it for TR2+ outfits (Graphic options → General → Lara's braid) (#6446 / TRX1300)
 - Removed support for saves from TRX 1.0, and TR1X/TR2X era
+- Fixed not being able to load saves with overflowed values for Lara's distance travelled (TRX1368)
+- Fixed the distance travelled statistic to ignore when Lara is out of bounds to avoid skewing the value (OG bug) (TRX1368)
 
 **Music and sound**
 - Added an option to have Lara's sliding SFX stop as soon as she leaves a slope (#6294 / TRX1155)

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -977,6 +977,20 @@ static void M_HandleStartState(const LARA_EXTRA_STATE start_state)
     lara_item->rot = old_rot;
 }
 
+static void M_CalculateDistanceTravelled(
+    const ITEM *const item, LARA_INFO *const lara)
+{
+    // Performing certain glitches can cause Lara to travel enormous distances
+    // in the Y direction. Thwart this to avoid overflows and inaccurate stats.
+    XYZ_32 pos = item->pos;
+    if (pos.y <= NO_HEIGHT || pos.y > MAX_HEIGHT) {
+        pos.y = lara->last_pos.y;
+    }
+
+    Stats_AddDistanceTravelled(pos, lara->last_pos);
+    lara->last_pos = pos;
+}
+
 void Lara_Control_Initialise(
     const GF_LEVEL_TYPE level_type, const LARA_EXTRA_STATE start_state)
 {
@@ -1089,7 +1103,5 @@ void Lara_Control(void)
     Camera_MoveManual();
     M_HandleEnvironment();
     Lara_Breath_Control(item);
-
-    Stats_AddDistanceTravelled(item->pos, lara_info->last_pos);
-    lara_info->last_pos = item->pos;
+    M_CalculateDistanceTravelled(item, lara_info);
 }

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -1013,8 +1013,9 @@ static RESULT M_ReadResumeInfo(
     MUST(JSON_READ(io, "ammo_hits", &resume->stats.ammo_hits));
     MUST(JSON_READ(io, "ammo_used", &resume->stats.ammo_used));
     MUST(JSON_READ(io, "medipacks_used", &resume->stats.medipacks_used));
-    MUST(
-        JSON_READ(io, "distance_travelled", &resume->stats.distance_travelled));
+    int32_t distance;
+    MUST(JSON_READ(io, "distance_travelled", &distance));
+    resume->stats.distance_travelled = (uint32_t)distance;
     MUST(JSON_READ(io, "kills", &resume->stats.counts[STATS_CAT_KILLS]));
     SHOULD(
         JSON_READ(io, "crystals", &resume->stats.counts[STATS_CAT_CRYSTALS]));

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -265,7 +265,8 @@ void Stats_AddDistanceTravelled(const XYZ_32 pos, const XYZ_32 last_pos)
 {
     LEVEL_STATS *const stats = Stats_GetLevelStats(Game_GetCurrentLevel());
     if (stats != nullptr) {
-        stats->distance_travelled += XYZ_32_GetDistance(pos, last_pos);
+        stats->distance_travelled +=
+            (uint32_t)XYZ_32_GetDistance(pos, last_pos);
     }
 }
 

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -142,7 +142,7 @@ static const char *M_FormatTime(
     }
 }
 
-static const char *M_FormatDistance(int32_t distance)
+static const char *M_FormatDistance(uint32_t distance)
 {
     distance /= 445;
     if (distance < 1000) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures distance travelled is always treated as an unsigned value, so in extreme cases it will wrap safely back to 0. When Lara is performing certain glitches that put her Y position out of bounds, the stats will continue to use her previous Y position to avoid skewing the results.

Test recording in the ticket.

Resolves TRX1368.
