### PR TITLE
camera/los_camera: force look update in crouch transition

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Fixed the photo mode camera drifting upwards and overshooting when it is moved while pitched up or down (TRX1142)
 - Fixed the photo mode camera flickering and refusing to turn over when it is pitched past straight up or down, and turning in coarse steps while aimed near vertical (TRX1152)
 - Fixed photo mode showing the same animation frame while advancing the game a quarter of a frame at a time (TRX1353, regression from 1.9)
+- Fixed the TR3 and TR4 look cameras not updating when holding look during the transition from standing to crouching and vice-versa (OG bug) (TRX1325)
 
 **Developer console**
 - Added the `/outfit` console command, which shows or changes what Lara is wearing (TRX1070)

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -44,6 +44,14 @@ static M_IDEAL m_LastIdeal = {};
 static M_IDEAL m_LastLookIdeal = {};
 static int32_t m_Snaps = 0;
 
+static const LARA_ANIMATION_ID m_ForceLookAnims[] = {
+    // clang-format off
+    LA_STAND_TO_CROUCH,
+    LA_CROUCH_TO_STAND,
+    NO_CATALOG_ID,
+    // clang-format on
+};
+
 static CAMERA_LOOK_SETTINGS m_LookSettings = {
     // clang-format off
     .head_turn         = +2 * DEG_1,
@@ -260,6 +268,8 @@ static bool M_UpdateLaraState(void)
                 m_LastState.lara.torso_rot, lara->torso_rot);
         same_camera_state &= m_LastState.target_angle == current_angle
             && m_LastState.target_elevation == current_elevation;
+    } else {
+        same_lara_state &= !Lara_HasAnimation(m_ForceLookAnims);
     }
     if (same_lara_state && same_camera_state) {
         return false;

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -497,6 +497,27 @@ bool Lara_IsWet(void)
     return false;
 }
 
+bool Lara_HasAnimation(const LARA_ANIMATION_ID *const test_arr)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    if (lara_item == nullptr) {
+        return false;
+    }
+
+    if (Lara_GetAnimationObject() != O_LARA) {
+        return false;
+    }
+
+    const LARA_ANIMATION_ID current_anim =
+        LA_U(Item_GetRelativeAnim(lara_item));
+    for (int32_t i = 0; test_arr[i] != NO_CATALOG_ID; i++) {
+        if (test_arr[i] == current_anim) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool Lara_HasState(const LARA_STATE_ID *const test_arr)
 {
     const LARA_INFO *const lara_info = Lara_GetLaraInfo();

--- a/src/trx/game/lara/misc.h
+++ b/src/trx/game/lara/misc.h
@@ -28,6 +28,7 @@ int32_t Lara_GetWaterDepth(XYZ_32 pos, int16_t room_num);
 // Whether Lara holds a machine gun and is in either anim state: 0 (start
 // aim); 2 (firing); or 4 (stopping firing).
 bool Lara_IsMachineGunActive(void);
+bool Lara_HasAnimation(const LARA_ANIMATION_ID *test_arr);
 bool Lara_HasState(const LARA_STATE_ID *test_arr);
 bool Lara_HasExtraState(const LARA_EXTRA_STATE *test_arr);
 void Lara_SwitchToExtraState(LARA_EXTRA_STATE goal_state);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This forces the look camera to update while Lara is in particular crouch transition animations. Her state, position, etc cannot be relied on in this case as none of those values change.

I'll log a follow-up task to make further use of `Lara_HasAnimation`; I think we have a few places that'd benefit.

Resolves TRX1325.