### PR TITLE
objects/propeller: make collidable on activation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -111,6 +111,7 @@
 - Fixed Lara clipping into or underneath lifts if she tries to step on top of or into one from an exterior floor whose height matches the lift ceiling or floor (OG bug) (#3905 / TRX1014)
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
+- Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
 
 **Saves and settings**
 - Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)

--- a/src/trx/game/objects/traps/propeller.c
+++ b/src/trx/game/objects/traps/propeller.c
@@ -57,6 +57,7 @@ void Propeller_Control(const int16_t item_num)
 
     if (Item_IsTriggerActive(item) && !item->trigger.spent) {
         item->goal_anim_state = M_STATE_ON;
+        item->is_collidable = true;
 
         if ((item->touch_bits & 6) != 0) {
             const ITEM *const lara_item = Lara_GetItem();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes propellers not being collidable if they are stopped and then later reactivated. This doesn't happen in OG because of the animation setup - ultimately the data does not have any state changes to reactivate. I have created a test level however to showcase that the requested feature is already possible by altering the animation setup - link in the ticket.

Resolves #6494 / TRX1351.
Ref: #6396
