### PR TITLE
lara/col/climb: fix repeated ladder descent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed Lara beginning to monkey roll for one frame despite being too close to the edge of a sector (#6459 / TRX1314, regression from 1.10)
 - Fixed Lara not being able to crawl backwards in certain sloped crawlspaces (OG bug) (TRX1322)
 - Fixed Lara being able to crouch/crawl into spaces with very low ceilings where she can become clamped, such as RX-Tech Mines room 159 (OG bug) (#6477 / TRX1331)
+- Fixed Lara attempting to continue to descend a ladder despite being at the bottom of it (OG bug) (#6461 / TRX1315)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -819,6 +819,23 @@ static bool M_IsDestinationBlocked(
         item->pos, pos, item->room_num, LARA_HEIGHT, LARA_RADIUS);
 }
 
+static bool M_CanHangDownLadder(ITEM *const item, const COLL_INFO *const coll)
+{
+    const XYZ_32 current_pos = item->pos;
+    item->pos.y += STEP_L;
+
+    COLL_INFO dest_coll = *coll;
+    dest_coll.bad_pos = NO_BAD_POS;
+    dest_coll.bad_neg = -STEPUP_HEIGHT;
+    dest_coll.bad_ceiling = 0;
+    Lara_Col_GetInfo(item, &dest_coll);
+
+    const bool result = Lara_Col_TestLadderHang(item, &dest_coll);
+
+    item->pos = current_pos;
+    return result;
+}
+
 static void M_Hang(ITEM *const item, COLL_INFO *const coll)
 {
     if (M_TryCornerShimmy(item, coll)) {
@@ -876,7 +893,8 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     } else if (
         g_Input.back && lara->climb_status
         && Item_TestAnimEqual(item, LA(LA_REACH_TO_HANG))
-        && Item_TestFrameEqual(item, M_LF_HANG)) {
+        && Item_TestFrameEqual(item, M_LF_HANG)
+        && M_CanHangDownLadder(item, coll)) {
         item->goal_anim_state = LS(LS_HANG);
         item->current_anim_state = LS(LS_HANG);
         Item_SwitchToAnim(item, LA(LA_LADDER_DOWN_HANGING), 0);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This adds a destination position collision test for Lara when descending a ladder in the hanging state, which allows blocking the switch to the downwards animation if hanging in that position will not be possible.

Test level in ticket.

Resolves #6461 / TRX1315.
