### PR TITLE
camera/binoculars: enforce mode during control

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Fixed the photo mode camera flickering and refusing to turn over when it is pitched past straight up or down, and turning in coarse steps while aimed near vertical (TRX1152)
 - Fixed photo mode showing the same animation frame while advancing the game a quarter of a frame at a time (TRX1353, regression from 1.9)
 - Fixed the TR3 and TR4 look cameras not updating when holding look during the transition from standing to crouching and vice-versa (OG bug) (TRX1325)
+- Fixed the binoculars camera being positioned behind Lara if the look input is held while selecting them (TRX1378, regression from 1.9)
 
 **Developer console**
 - Added the `/outfit` console command, which shows or changes what Lara is wearing (TRX1070)

--- a/src/trx/game/camera/binoculars.c
+++ b/src/trx/game/camera/binoculars.c
@@ -252,6 +252,7 @@ void Camera_Binoculars_Control(void)
         return;
     }
 
+    g_Camera.type = CAM_BINOCULARS;
     M_HandleLookInput();
     M_HandleZoomInput();
     m_TorchActive = g_Input.action;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This prevents the binoculars camera mode being overridden between requesting them and control beginning.

Resolves TRX1378.
