### PR TITLE
lua/ui: fix stack spacing ignoring text size

### DIFF
--- a/src/lua/api/ui/widgets.lua
+++ b/src/lua/api/ui/widgets.lua
@@ -715,13 +715,15 @@ Widgets that are not shown take no room and leave no gap.]],
           shown = shown + 1
         end
       end
-      along = along + math.max(0, shown - 1) * (w.spacing or 0)
+      along = along
+        + math.max(0, shown - 1) * (w.spacing or 0) * raw.drawn_text_scale()
       if is_horizontal(w) then
         return along, across
       end
       return across, along
     end, function(w, x, y, bw, bh)
       local at = is_horizontal(w) and x or y
+      local spacing = (w.spacing or 0) * raw.drawn_text_scale()
       for _, child in ipairs(w.children) do
         if child:is_shown() then
           local cw, ch = child:measure()
@@ -733,7 +735,7 @@ Widgets that are not shown take no room and leave no gap.]],
               offset = bh - ch
             end
             child:paint(at, y + offset, cw, ch)
-            at = at + cw + (w.spacing or 0)
+            at = at + cw + spacing
           else
             local offset = 0
             if w.align == trx.ui.HAlign.CENTER then
@@ -742,7 +744,7 @@ Widgets that are not shown take no room and leave no gap.]],
               offset = bw - cw
             end
             child:paint(x + offset, at, cw, ch)
-            at = at + ch + (w.spacing or 0)
+            at = at + ch + spacing
           end
         end
       end

--- a/src/trx/game/lua/capi/ui.c
+++ b/src/trx/game/lua/capi/ui.c
@@ -125,9 +125,7 @@ static int32_t M_CheckSpriteIdx(lua_State *const L)
     return object->mesh_idx + sprite_num;
 }
 
-// Returns the number of sprites for object_id.
-// Returns 0 when object_id is not loaded, allowing widgets to test for
-// drawable sprites without raising an error.
+// trxc.ui.sprite_count(object_id) -> number
 static int M_L_UISpriteCount(lua_State *const L)
 {
     const OBJECT *const object = Object_Get(LUA_CheckObjectID(L, 1));
@@ -135,9 +133,7 @@ static int M_L_UISpriteCount(lua_State *const L)
     return 1;
 }
 
-// Returns the bounds of sprite_num in object_id as x0, y0, x1, y1.
-// Returns bounds relative to the drawing position, so x0 and y0 are usually
-// negative, in canvas units at scale 1.
+// trxc.ui.sprite_bounds(object_id, sprite_num) -> x0, y0, x1, y1
 static int M_L_UISpriteBounds(lua_State *const L)
 {
     const SPRITE_TEXTURE *const sprite =
@@ -152,8 +148,7 @@ static int M_L_UISpriteBounds(lua_State *const L)
     return 4;
 }
 
-// Draws sprite_num from object_id at the specified position, scale and
-// colour.
+// trxc.ui.sprite(object_id, sprite_num, x, y, z, scale, color)
 static int M_L_UISprite(lua_State *const L)
 {
     M_CheckPainting(L);
@@ -353,8 +348,6 @@ static void M_PushRamp(
 }
 
 // trxc.ui.bar_theme(type) -> table or nil
-//
-// Returns the current bar theme from player settings.
 static int M_L_UIBarTheme(lua_State *const L)
 {
     const lua_Integer type = luaL_checkinteger(L, 1);
@@ -398,7 +391,14 @@ static int M_L_UIBarScale(lua_State *const L)
     return 1;
 }
 
-// Returns the UI text scale.
+// trxc.ui.drawn_text_scale() -> number
+static int M_L_UIDrawnTextScale(lua_State *const L)
+{
+    lua_pushnumber(L, UI_Scaler_GetTextScale());
+    return 1;
+}
+
+// trxc.ui.text_scale() -> number
 static int M_L_UITextScale(lua_State *const L)
 {
     lua_pushnumber(L, UI_Scaler_GetScale(UI_SCALER_TARGET_TEXT));
@@ -414,6 +414,7 @@ static const luaL_Reg m_Module[] = {
     { "bar_theme", M_L_UIBarTheme },
     { "bar_scale", M_L_UIBarScale },
     { "text_scale", M_L_UITextScale },
+    { "drawn_text_scale", M_L_UIDrawnTextScale },
     { "reserve", M_L_UIReserve },
     { "slot_box", M_L_UISlotBox },
     { "measure_text", M_L_UIMeasureText },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where stack spacing ignored the player's text scale. Script widgets now use the same scaled spacing as engine widgets. The drawn text size is available to scripts as `trxc.ui.drawn_text_scale`; it combines the player's scale with the scale applied by a dialog.