### PR TITLE
av/audio_reverb: fix silent SFX after mod switch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -129,6 +129,7 @@
 - Added an option to have Lara's sliding SFX stop as soon as she leaves a slope (#6294 / TRX1155)
 - Fixed crystal sound effects not playing if Lara collects one underwater (OG bug) (TRX1111)
 - Fixed looped sound effects, such as rolling boulders and the seaplane, clicking and crackling while they play (#6491 / TRX1348)
+- Fixed sound effects going silent after switching from TR4 to another game (TRX1335)
 
 **Rendering**
 - Added affine texture mapping, the uncorrected texturing of the PlayStation, so textures warp across large surfaces as the camera moves; the PlayStation presets turn it on (Graphic Options → Rendering → Affine texture mapping)

--- a/src/trx/av/audio_reverb.c
+++ b/src/trx/av/audio_reverb.c
@@ -767,6 +767,7 @@ void Audio_Reverb_Shutdown(void)
 
     M_DspReverb_Destroy(&m_Reverb);
     m_IsInitialised = false;
+    m_ReverbType = 0;
 }
 
 void Audio_Reverb_SetType(uint8_t reverb_type)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes sound effects going silent after switching from TR4 to another game, while music keeps playing. The reverb type persisted across audio sessions, causing the next session to mix sound effects at zero gain.

Resolves TRX1335