### PR TITLE
inject: fix crash on missing objects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 - Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
+- Fixed the game crashing on a level that does not carry an object an injection names
 
 **Saves and settings**
 - Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)

--- a/src/trx/game/inject/data/anims.c
+++ b/src/trx/game/inject/data/anims.c
@@ -110,8 +110,16 @@ static void M_CommandEdits(
         const int32_t num_raw_cmds = File_ReadS32(injection->fp);
         const int32_t num_anim_cmds = File_ReadS32(injection->fp);
 
-        const OBJECT *const obj = Object_Get(obj_info.id);
-        if (ctx->mode == INJECTION_MODE_STATS || !obj->loaded) {
+        if (ctx->mode == INJECTION_MODE_STATS) {
+            continue;
+        }
+        OBJECT *obj;
+        if (!SHOULD(
+                Inject_GetObject(obj_info, &obj),
+                "animation commands stay unchanged")) {
+            continue;
+        }
+        if (!obj->loaded) {
             continue;
         }
 

--- a/src/trx/game/inject/data/objects.c
+++ b/src/trx/game/inject/data/objects.c
@@ -38,9 +38,8 @@ static void M_ReadObject(const INJECTION_CHUNK chunk)
     const LEVEL_CONTEXT_INFO cached_info = Inject_GetCachedInfo();
     const INJECTION_OBJECT_INFO obj_info =
         Inject_ReadObjectPtr(chunk.injection);
-    OBJECT *const obj = Object_TryGet(obj_info.id);
-    if (obj == nullptr) {
-        LOG_WARNING("Invalid object %d", obj_info.id);
+    OBJECT *obj;
+    if (!SHOULD(Inject_GetObject(obj_info, &obj), "object edit is skipped")) {
         File_Skip(chunk.injection->fp, 14);
         return;
     }

--- a/src/trx/game/inject/data/textures.c
+++ b/src/trx/game/inject/data/textures.c
@@ -87,10 +87,10 @@ static void M_HandleSpriteSequences(
         const int16_t mesh_idx = File_ReadS16(injection->fp);
 
         if (obj_info.type == OBJ_TYPE_OBJECT) {
-            OBJECT *const obj = Object_TryGet(obj_info.id);
-            if (obj == nullptr) {
-                LOG_WARNING("Invalid object %d", obj_info.id);
-            } else {
+            OBJECT *obj;
+            if (SHOULD(
+                    Inject_GetObject(obj_info, &obj),
+                    "sprite sequence stays unchanged")) {
                 obj->mesh_count = num_meshes;
                 obj->mesh_idx = mesh_idx + level_info->textures.sprite_count;
                 obj->loaded = true;

--- a/src/trx/game/inject/editors/anims.c
+++ b/src/trx/game/inject/editors/anims.c
@@ -14,8 +14,16 @@ static void M_FrameEdits(
         const int32_t anim_idx = File_ReadS32(injection->fp);
         const int32_t packed_rot = File_ReadS32(injection->fp);
 
-        const OBJECT *const obj = Object_Get(obj_info.id);
-        if (ctx->mode == INJECTION_MODE_STATS || !obj->loaded) {
+        if (ctx->mode == INJECTION_MODE_STATS) {
+            continue;
+        }
+        OBJECT *obj;
+        if (!SHOULD(
+                Inject_GetObject(obj_info, &obj),
+                "animation frame stays unchanged")) {
+            continue;
+        }
+        if (!obj->loaded) {
             continue;
         }
 
@@ -36,12 +44,15 @@ static void M_FrameReplacements(
         const INJECTION_OBJECT_INFO obj_info = Inject_ReadObjectPtr(injection);
         const int32_t num_anims = File_ReadS32(injection->fp);
 
-        const OBJECT *const obj = Object_Get(obj_info.id);
+        OBJECT *obj = nullptr;
+        const bool has_obj = ctx->mode == INJECTION_MODE_STATS
+            || SHOULD(Inject_GetObject(obj_info, &obj),
+                      "animation frames stay unchanged");
         for (int32_t j = 0; j < num_anims; j++) {
             const int32_t anim_idx = File_ReadS32(injection->fp);
             const int32_t num_frames = File_ReadS32(injection->fp);
 
-            if (ctx->mode == INJECTION_MODE_STATS) {
+            if (ctx->mode == INJECTION_MODE_STATS || !has_obj) {
                 File_Skip(injection->fp, num_frames * sizeof(int16_t));
             } else {
                 const ANIM *const anim = Object_GetAnim(obj, anim_idx);
@@ -61,10 +72,15 @@ static void M_AnimEdits(
 {
     for (int32_t i = 0; i < data_count; i++) {
         const INJECTION_OBJECT_INFO obj_info = Inject_ReadObjectPtr(injection);
-        const OBJECT *const obj = Object_Get(obj_info.id);
         const int32_t anim_idx = File_ReadS32(injection->fp);
         const int32_t velocity = File_ReadS32(injection->fp);
         if (ctx->mode == INJECTION_MODE_STATS) {
+            continue;
+        }
+        OBJECT *obj;
+        if (!SHOULD(
+                Inject_GetObject(obj_info, &obj),
+                "animation velocity stays unchanged")) {
             continue;
         }
 

--- a/src/trx/game/inject/editors/meshes.c
+++ b/src/trx/game/inject/editors/meshes.c
@@ -54,7 +54,12 @@ static BOUNDS_16 M_ReadBounds16(TRX_FILE *const file)
 
 static uint16_t *M_GetMeshTexture(const M_FACE_TEXTURE_EDIT *const edit)
 {
-    const OBJECT *const obj = Object_Get(edit->obj_info.id);
+    OBJECT *obj;
+    if (!SHOULD(
+            Inject_GetObject(edit->obj_info, &obj),
+            "face texture stays unchanged")) {
+        return nullptr;
+    }
     if (!obj->loaded) {
         return nullptr;
     }
@@ -109,7 +114,12 @@ static void M_ApplyMeshEdit(const M_MESH_EDIT *const edit)
 {
     OBJECT_MESH *mesh;
     if (edit->obj_info.type == OBJ_TYPE_OBJECT) {
-        const OBJECT *const obj = Object_Get(edit->obj_info.id);
+        OBJECT *obj;
+        if (!SHOULD(
+                Inject_GetObject(edit->obj_info, &obj),
+                "mesh stays unchanged")) {
+            return;
+        }
         if (!obj->loaded) {
             return;
         }

--- a/src/trx/game/inject/editors/textures.c
+++ b/src/trx/game/inject/editors/textures.c
@@ -52,8 +52,13 @@ static void M_SpriteEdits(
         int16_t x1 = File_ReadS16(injection->fp);
         int16_t y1 = File_ReadS16(injection->fp);
 
-        const OBJECT *const obj = Object_TryGet(obj_info.id);
-        if (obj == nullptr || !obj->loaded) {
+        OBJECT *obj;
+        if (!SHOULD(
+                Inject_GetObject(obj_info, &obj),
+                "sprite bounds stay unchanged")) {
+            continue;
+        }
+        if (!obj->loaded) {
             continue;
         }
         if (obj->mesh_idx < 0

--- a/src/trx/game/inject/types.h
+++ b/src/trx/game/inject/types.h
@@ -37,4 +37,6 @@ typedef struct {
 typedef struct {
     INJECT_OBJECT_TYPE type;
     int32_t id;
+    // Stores the slot from the injection for diagnostics.
+    int32_t slot;
 } INJECTION_OBJECT_INFO;

--- a/src/trx/game/inject/utils.c
+++ b/src/trx/game/inject/utils.c
@@ -1,6 +1,7 @@
 #include <trx/game/inject/utils.h>
 
 #include <trx/core/file.h>
+#include <trx/debug.h>
 #include <trx/game/objects/common.h>
 
 INJECTION_OBJECT_INFO Inject_ReadObjectPtr(const INJECTION *const injection)
@@ -9,6 +10,7 @@ INJECTION_OBJECT_INFO Inject_ReadObjectPtr(const INJECTION *const injection)
         .type = File_ReadS32(injection->fp),
         .id = File_ReadS32(injection->fp),
     };
+    obj_info.slot = obj_info.id;
 
     if (obj_info.type == OBJ_TYPE_OBJECT) {
         obj_info.id = Object_SlotToID(obj_info.id);
@@ -18,4 +20,14 @@ INJECTION_OBJECT_INFO Inject_ReadObjectPtr(const INJECTION *const injection)
     }
 
     return obj_info;
+}
+
+RESULT Inject_GetObject(
+    const INJECTION_OBJECT_INFO obj_info, OBJECT **const out_obj)
+{
+    ASSERT(out_obj != nullptr);
+    OBJECT *const obj = Object_TryGet(obj_info.id);
+    FAIL_IF(obj == nullptr, "level has no object in slot %d", obj_info.slot);
+    *out_obj = obj;
+    return OK;
 }

--- a/src/trx/game/inject/utils.h
+++ b/src/trx/game/inject/utils.h
@@ -2,5 +2,10 @@
 
 #include <trx/core/file.h>
 #include <trx/game/inject/types.h>
+#include <trx/game/objects/types.h>
 
 INJECTION_OBJECT_INFO Inject_ReadObjectPtr(const INJECTION *injection);
+
+// Return the object named by an injection. Report failure when the level does
+// not bind that slot to an object.
+RESULT Inject_GetObject(INJECTION_OBJECT_INFO obj_info, OBJECT **out_obj);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where an injection that names an absent object can crash a custom level. Before this, the edit read an unbound object identity and triggered an assertion. Such edits are skipped, and the log reports the requested slot.