### PR TITLE
catalog/table: fix crash after custom objects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 - Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
+- Fixed the game crashing on a level loaded after one that named objects of its own
 
 **Saves and settings**
 - Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)

--- a/src/trx/game/catalog/table.c
+++ b/src/trx/game/catalog/table.c
@@ -39,6 +39,23 @@ static void *M_Claim(CATALOG_TABLE *const table, const CATALOG_ID id)
     return M_Peek(table, id);
 }
 
+// Clears all records from this ID to the end of the table.
+static void M_ClearFrom(CATALOG_TABLE *const table, const int32_t first_id)
+{
+    for (int32_t chunk_idx = 0; chunk_idx < table->chunk_count; chunk_idx++) {
+        const int32_t first = chunk_idx * CATALOG_TABLE_CHUNK;
+        const int32_t last = first + CATALOG_TABLE_CHUNK;
+        if (last <= first_id) {
+            continue;
+        }
+        const int32_t start = MAX(first, first_id);
+        memset(
+            (char *)table->chunks[chunk_idx]
+                + (size_t)(start - first) * table->elem_size,
+            0, (size_t)(last - start) * table->elem_size);
+    }
+}
+
 void CatalogTable_Link(CATALOG_TABLE *const table)
 {
     table->next = m_Tables;
@@ -89,6 +106,11 @@ void CatalogTable_FreeAll(void)
     }
 }
 
+void CatalogTable_Reset(CATALOG_TABLE *const table)
+{
+    M_ClearFrom(table, Catalog_GetBuiltInCount(table->context));
+}
+
 void CatalogTable_Free(CATALOG_TABLE *const table)
 {
     const int32_t keep = Catalog_GetBuiltInCount(table->context);
@@ -101,14 +123,6 @@ void CatalogTable_Free(CATALOG_TABLE *const table)
         Memory_FreePointer(&table->chunks);
         return;
     }
-    // Drop only records after the built-in identities because the final chunk
-    // may contain both built-in and minted records.
-    const int32_t first = (table->chunk_count - 1) * CATALOG_TABLE_CHUNK;
-    for (int32_t id = MAX(first, keep); id < first + CATALOG_TABLE_CHUNK;
-         id++) {
-        memset(
-            (char *)table->chunks[table->chunk_count - 1]
-                + (size_t)(id - first) * table->elem_size,
-            0, table->elem_size);
-    }
+    // Keep the final chunk because it can hold built-in records too.
+    M_ClearFrom(table, keep);
 }

--- a/src/trx/game/catalog/table.h
+++ b/src/trx/game/catalog/table.h
@@ -55,3 +55,7 @@ void CatalogTable_Add(CATALOG_TABLE *table, CATALOG_ID id, const void *record);
 void CatalogTable_FreeAll(void);
 
 void CatalogTable_Free(CATALOG_TABLE *table);
+
+// Clear minted identity records while keeping their storage. Minted identities
+// live until the session ends.
+void CatalogTable_Reset(CATALOG_TABLE *table);

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -50,7 +50,7 @@ void Object_Reset(void)
         m_UncatalogedSlots = nullptr;
     }
 
-    CatalogTable_Free(&m_Objects);
+    CatalogTable_Reset(&m_Objects);
 }
 
 void Object_InitialiseStaticObjects3D(const int32_t count)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where a level can crash after a previous level creates custom object identities. Before this, a level reset released the records and storage for identities that still lived until the session ended. A reset now clears those records but keeps their storage.