### PR TITLE
lara/skin: fix crash with missing outfits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 - Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
+- Fixed the game crashing on a level that does not carry an object an outfit names
 
 **Saves and settings**
 - Added smoke, sparks, mist and bubbles to saves (Gameplay → General → Save effects)

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -15,6 +15,7 @@
 #include <trx/game/gun/common.h>
 #include <trx/game/gun/registry.h>
 #include <trx/game/lara.h>
+#include <trx/game/lara/mesh.h>
 #include <trx/game/lara/skin/gold.h>
 #include <trx/version.h>
 
@@ -483,6 +484,8 @@ void Lara_Skin_Initialise(void)
         if (GF_GetCurrentLevel() != nullptr && Object_Get(O_LARA)->loaded) {
             LOG_WARNING("No skin swap objects here; no outfit applied");
         }
+        // Use the Lara meshes from the level when no outfit can be applied.
+        Lara_Mesh_SwapAll(O_LARA);
         return;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where levels that contain Lara but none of her outfit objects can crash. Before this, those levels left Lara without meshes, and her braid accessed one on the first frame. Lara now keeps the meshes loaded by the level when no outfit can be applied.