### PR TITLE
savegame: fill demo loadout on start

### DIFF
--- a/src/tests/trx/game/savegame/resume.c
+++ b/src/tests/trx/game/savegame/resume.c
@@ -289,6 +289,8 @@ TEST(an_entry_belongs_to_its_level_and_the_demos_share_one)
 TEST(a_demo_arrives_armed_however_the_playthrough_stands)
 {
     M_SetUp();
+    SG_Resume_ResetEntry(&m_DemoLevels[0]);
+    SG_Resume_ApplyRulesToEntry(&m_DemoLevels[0]);
     const RESUME_INFO *const demo = SG_Resume_GetEntry(&m_DemoLevels[0]);
     CHECK(demo->flags.available);
     CHECK_EQ_INT(Inv_State_GetCount(&demo->inv, O_PISTOLS_ITEM), 1);

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -252,10 +252,8 @@ RESULT GF_InterpretSequence(
     }
 
     default:
-        if (level->type == GFL_GYM) {
+        if (level->type == GFL_GYM || level->type == GFL_DEMO) {
             SG_Resume_ResetEntry(level);
-            SG_Resume_ApplyRulesToEntry(level);
-        } else if (level->type == GFL_DEMO) {
             SG_Resume_ApplyRulesToEntry(level);
         } else if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
             SG_Resume_ApplyRulesToEntry(level);

--- a/src/trx/game/savegame/resume.c
+++ b/src/trx/game/savegame/resume.c
@@ -63,23 +63,6 @@ void SG_Resume_Init(void)
         sizeof(RESUME_INFO)
         * (GF_GetLevelTable(GFLT_MAIN)->count
            + GF_GetLevelTable(GFLT_DEMOS)->count));
-
-    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_DEMOS);
-    for (int32_t i = 0; i < level_table->count; i++) {
-        RESUME_INFO *const resume_info =
-            SG_Resume_GetEntry(&level_table->levels[i]);
-        resume_info->lara_hitpoints = LARA_MAX_HITPOINTS;
-        resume_info->flags.available = true;
-        const LARA_GUN_TYPE default_gun = Gun_GetDefaultType();
-        Inv_State_SetCount(&resume_info->inv, Gun_GetGunObject(default_gun), 1);
-        Inv_State_SetAmmo(
-            &resume_info->inv, default_gun, Gun_GetInitialRounds(default_gun));
-        resume_info->gun_status = LGS_ARMLESS;
-        resume_info->equipped_gun_type = default_gun;
-        resume_info->holsters_gun_type = default_gun;
-        resume_info->back_gun_type = LGT_UNARMED;
-        resume_info->prev_level = -1;
-    }
 }
 
 void SG_Resume_Shutdown(void)
@@ -217,6 +200,23 @@ void SG_Resume_ApplyRulesToEntry(const GF_LEVEL *const level)
     RESUME_INFO *const resume = SG_Resume_GetEntry(level);
     if (resume == nullptr) {
         return;
+    }
+
+    if (level->type == GFL_DEMO) {
+        resume->flags.available = true;
+        resume->lara_hitpoints = LARA_MAX_HITPOINTS;
+
+        // A demo starts with the default weapon and nothing else.
+        const LARA_GUN_TYPE default_gun = Gun_GetDefaultType();
+        resume->inv = (INVENTORY_STATE) {};
+        Inv_State_SetCount(&resume->inv, Gun_GetGunObject(default_gun), 1);
+        Inv_State_SetAmmo(
+            &resume->inv, default_gun, Gun_GetInitialRounds(default_gun));
+
+        resume->equipped_gun_type = default_gun;
+        resume->holsters_gun_type = default_gun;
+        resume->back_gun_type = LGT_UNARMED;
+        resume->gun_status = LGS_ARMLESS;
     }
 
     if (!g_Config.gameplay.disable_healing_between_levels


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A demo's loadout is now filled when the demo starts instead of when the game starts. This prevents an earlier demo's loadout from carrying over. Demos are reset and given their rules the same way as the gym.

Since demos never show or use their loadout beyond Lara's pistols which have infinite ammo, this does not affect players and is only a theoretical fix.