### PR TITLE
objects/shoal: fix fish losing water color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -174,6 +174,7 @@
 - Fixed underwater blood clouds appearing in the air when the security lasers hurt Lara at the water surface (OG bug) (#6323 / TRX1180)
 - Fixed the ceiling spikes not stopping on a pushable block until Lara finishes pushing it (OG bug) (#6308 / TRX1169)
 - Fixed the piranhas in It's a Madhouse! being invisible if attacking Lara while she collects the Aviary Key (#6345 / TRX1200)
+- Fixed fish losing their water color (TRX1385, regression from 1.8)
 - Fixed the specks drifting in water being too small and all one size
 - Fixed crystal 206 in Thames Wharf not being triggered if the alternative route is used to reach it (#6349 / TRX1202)
 - Fixed Lara being embedded in the floor at the beginning of Temple Ruins, which causes the camera to pop after the first frame (TRX1028)

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -10,6 +10,7 @@
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
 #include <trx/game/output/sources/poly_fx.h>
+#include <trx/game/output/water.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
@@ -537,6 +538,9 @@ static bool M_Draw(const ITEM *const item)
         return false;
     }
 
+    // Use the anchor room because the item can leave the shoal's water.
+    Output_Water_SetupFromRoom(Room_Get(p->anchor.room_num));
+
     const XYZ_32 base_pos = p->anchor.pos;
     const double ratio = Interpolation_GetWorldRate();
     const bool do_interp =
@@ -656,6 +660,8 @@ static bool M_Draw(const ITEM *const item)
                 sprite_idx, tri_world, tri_color, DRAW_BLEND);
         }
     }
+
+    Output_Water_SetupFromRoom(Room_Get(item->room_num));
 
     if (Interpolation_IsActive() && ratio >= 1.0) {
         for (int32_t i = 0; i < M_FISH_PER_SHOAL + 1; i++) {

--- a/src/trx/game/output/water.h
+++ b/src/trx/game/output/water.h
@@ -32,6 +32,8 @@ typedef struct {
 // water states of the room and camera.
 void Output_Water_SetupAboveWater(bool is_camera_underwater);
 void Output_Water_SetupBelowWater(bool is_camera_underwater);
+// Sets the water effects for a room and the current camera state.
+void Output_Water_SetupFromRoom(const ROOM *room);
 
 // Reports whether objects receive the water colour.
 bool Output_Water_IsShadeEnabled(void);

--- a/src/trx/game/output/water/common.c
+++ b/src/trx/game/output/water/common.c
@@ -1,7 +1,9 @@
 #include <trx/debug.h>
+#include <trx/game/camera.h>
 #include <trx/game/output/state.h>
 #include <trx/game/output/water.h>
 #include <trx/game/output/water/priv.h>
+#include <trx/game/rooms.h>
 #include <trx/version.h>
 
 typedef struct {
@@ -64,6 +66,11 @@ void Output_Water_SetupAboveWater(const bool is_camera_underwater)
 void Output_Water_SetupBelowWater(const bool is_camera_underwater)
 {
     M_Setup(true, is_camera_underwater);
+}
+
+void Output_Water_SetupFromRoom(const ROOM *const room)
+{
+    M_Setup(room->flags.underwater, g_Camera.underwater);
 }
 
 bool Output_Water_IsShadeEnabled(void)

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -102,15 +102,6 @@ static void M_EnsureRoomsToDraw(void)
     m_RoomsToDraw = Vector_CreateAtCapacity(sizeof(int16_t), 100);
 }
 
-static inline void M_SetupWaterStatus(const ROOM *const room)
-{
-    if (room->flags.underwater) {
-        Output_Water_SetupBelowWater(g_Camera.underwater);
-    } else {
-        Output_Water_SetupAboveWater(g_Camera.underwater);
-    }
-}
-
 static void M_SetBounds(
     const PORTAL *const portal, int32_t room_num, const ROOM *parent);
 
@@ -366,7 +357,7 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
         });
     }
 
-    M_SetupWaterStatus(Room_Get(item->room_num));
+    Output_Water_SetupFromRoom(Room_Get(item->room_num));
 
     // A fading body scales down the tint already in force rather than
     // replacing it, so it keeps the water color it is lying in.
@@ -395,7 +386,7 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
 static void M_DrawSingleRoom(const ROOM *const room)
 {
     Output_SetCurrentRoom(room);
-    M_SetupWaterStatus(room);
+    Output_Water_SetupFromRoom(room);
 
     OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
     g_PhdLeft = bind->bound_left;
@@ -418,7 +409,7 @@ static void M_DrawSingleRoom(const ROOM *const room)
     Matrix_TranslateAbs32(room->pos);
     Output_DrawRoom(room, false);
 
-    M_SetupWaterStatus(room);
+    Output_Water_SetupFromRoom(room);
 
     Matrix_Push();
     Matrix_TranslateAbs32(room->pos);
@@ -446,10 +437,10 @@ static void M_DrawSingleRoom(const ROOM *const room)
         if (clip != CLIP_NOT_VISIBLE) {
             const ROOM *const owner = Room_Get(mesh->room_num);
             M_DrawSet_Add(&m_DrawnStatics, mesh->draw_num);
-            M_SetupWaterStatus(owner);
+            Output_Water_SetupFromRoom(owner);
             Output_CalculateStaticMeshLight(mesh->pos, mesh->shade, owner);
             Object_DrawMesh(obj->mesh_idx, clip, false);
-            M_SetupWaterStatus(room);
+            Output_Water_SetupFromRoom(room);
             if (g_Config.debug.enable_debug_bounding_boxes) {
                 Output_DrawCuboid(&obj->draw_bounds);
             }
@@ -458,7 +449,7 @@ static void M_DrawSingleRoom(const ROOM *const room)
     }
 
     M_DrawSet_ForEach(&room->drawn_items, M_DrawRoomItem, nullptr);
-    M_SetupWaterStatus(room);
+    Output_Water_SetupFromRoom(room);
 
     g_PhdLeft = Viewport_GetMinX(VIEWPORT_GAME);
     g_PhdTop = Viewport_GetMinY(VIEWPORT_GAME);
@@ -567,7 +558,7 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     const ITEM *const lara_item = Lara_GetItem();
     if (lara_item != nullptr && Object_Get(O_LARA)->loaded) {
         const ROOM *const lara_room = Room_Get(lara_item->room_num);
-        M_SetupWaterStatus(lara_room);
+        Output_Water_SetupFromRoom(lara_room);
         Output_SetCurrentRoom(lara_room);
         Lara_Draw(lara_item);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where fish could lose their water color and appear in plain daylight colors while underwater. Before this, fish could keep the wrong color after leaving the water that contained them.

Resolves TRX1385