### PR TITLE
game/phase/phase_pause: resume audio after fadeout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Changed vertex snapping to offer Disabled, 320x240, and Upscale Res modes (#6278 / TRX1137)
 - Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter (TRX1136)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control (TRX1057)
+- Fixed the game audio resuming before the fadeout effect has ended when unpausing with this option enabled (#6536)
 - Fixed several dialogs running past the screen edges or overlapping headings at large text sizes (#6293 / TRX1154)
 - Fixed the save and load dialogs covering the inventory headings at large text sizes
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10) (TRX1068)

--- a/src/trx/game/phase/phase_pause.c
+++ b/src/trx/game/phase/phase_pause.c
@@ -32,6 +32,7 @@ typedef struct {
     } ui;
     GF_ACTION action;
     FADER fader;
+    bool resume_pending;
 } M_PRIV;
 
 static void M_RemoveText(M_PRIV *const p)
@@ -69,8 +70,13 @@ static void M_PauseGame(M_PRIV *const p)
 
 static void M_ReturnToGame(M_PRIV *const p)
 {
-    Music_Unpause();
-    Sound_UnpauseAll();
+    if (g_Config.ui.pause_fade_effects) {
+        p->resume_pending = true;
+    } else {
+        Music_Unpause();
+        Sound_UnpauseAll();
+        p->resume_pending = false;
+    }
     M_FadeOut(p);
 }
 
@@ -93,6 +99,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     M_PRIV *const p = phase->priv;
 
     p->ui.is_ready = false;
+    p->resume_pending = false;
     UI_Pause_Init(&p->ui.state);
     M_PauseGame(p);
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
@@ -162,6 +169,11 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
 
     case STATE_FADE_OUT:
         if (!M_IsFadeActive(p)) {
+            if (p->resume_pending) {
+                Music_Unpause();
+                Sound_UnpauseAll();
+                p->resume_pending = false;
+            }
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
                 .gf_cmd = { .action = p->action },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes the audio resuming before the fadeout has ended if the fade effect is enabled for the pause screen.

Fixes https://github.com/LostArtefacts/TRX/issues/6536