### PR TITLE
phase/executor: exit at once without a fade

### DIFF
--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -67,16 +67,16 @@ static GF_COMMAND M_HandleOverride(void)
     return (GF_COMMAND) { .action = GF_NOOP };
 }
 
+// Starts the exit and reports whether a fade must finish before the phase ends.
 static bool M_BeginExit(void)
 {
-    if (m_Exiting) {
-        return false;
+    if (!m_Exiting) {
+        m_Exiting = true;
+        if (g_Config.visuals.enable_exit_fade_effects) {
+            Fader_InitFromCurrentHold(&m_ExitFader, 1.0f, 0.333f, 0.1f);
+        }
     }
-    m_Exiting = true;
-    if (g_Config.visuals.enable_exit_fade_effects) {
-        Fader_InitFromCurrentHold(&m_ExitFader, 1.0f, 0.333f, 0.1f);
-    }
-    return true;
+    return Fader_IsActive(&m_ExitFader);
 }
 
 static void M_DrawFadeToBlackTransition(const float opacity)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The game now leaves the phase as soon as the exit starts where the fade on game exit is off. Before this, the phase ran one more frame with nothing left to draw.
(Unreleased cosmetic regression)