### PR TITLE
inventory_ring: light TR4 items as the OG does

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -216,6 +216,7 @@
 - Added inventory option models (TRX1357)
 - Added TR4 support to the Windows installer (TRX1333)
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
+- Changed the inventory item lighting to match the original game (TRX1371)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)
 - Fixed Lara flinching when she bumps into Von Croy (TRX1095)

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -27,6 +27,12 @@
 #define M_SHADE_NORMAL SHADE_LOW
 #define M_SHADE_SELECTED SHADE_NEUTRAL
 
+// The TR4 brightness an inventory item ramps between as the selection moves,
+// and the level that leaves the item at its plain color.
+#define M_TR4_BRIGHT_NORMAL 32.0f
+#define M_TR4_BRIGHT_SELECTED 160.0f
+#define M_TR4_BRIGHT_NEUTRAL 128.0f
+
 static XYZ_32 M_VectorViewFromWorld(const XYZ_32 v_world)
 {
     return Matrix_MulVec32_M(&g_ViewMatrix, v_world);
@@ -166,7 +172,8 @@ static void M_DrawItem(
     MATRIX draw_manual_rot = inv_item->prev_manual_rot;
     Matrix_Slerp3x3_M(&draw_manual_rot, &inv_item->manual_rot, interp_rate);
 
-    int32_t shade = M_SHADE_NORMAL;
+    // 0 when the item is the selected one, 1 when it is not.
+    float unselected = 1.0f;
     if (ring->status != RNG_FADING_OUT && ring->status != RNG_DONE) {
         if (ring->rotating) {
             float t = (ring->rot_count / (float)INV_RING_ROTATE_DURATION);
@@ -176,12 +183,20 @@ static void M_DrawItem(
             } else if (inv_item != ring->list[ring->rotate_to_object]) {
                 t = 1.0f;
             }
-            shade = LERP((float)M_SHADE_SELECTED, (float)M_SHADE_NORMAL, t);
+            unselected = t;
         } else if (inv_item == ring->list[ring->current_object]) {
-            shade = M_SHADE_SELECTED;
+            unselected = 0.0f;
         }
     }
+    const int32_t shade =
+        LERP((float)M_SHADE_SELECTED, (float)M_SHADE_NORMAL, unselected);
     Output_SetLightAdder(shade);
+    if (g_TRVersion == 4) {
+        const float bright =
+            LERP(M_TR4_BRIGHT_SELECTED, M_TR4_BRIGHT_NORMAL, unselected)
+            / M_TR4_BRIGHT_NEUTRAL;
+        Output_CalculateStaticLightRGB_F((RGB_F) { bright, bright, bright });
+    }
 
     Matrix_TranslateRel(0, draw_y_trans, draw_z_trans);
 

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -16,6 +16,7 @@
 #include <trx/game/objects/general/save_crystal.h>
 #include <trx/game/objects/links.h>
 #include <trx/game/objects/names.h>
+#include <trx/game/output/lights.h>
 #include <trx/game/output/state.h>
 #include <trx/game/overlay.h>
 #include <trx/game/sound.h>
@@ -337,7 +338,12 @@ void InvRing_Light(const INV_RING *const ring)
     Output_SetLightDivider(0x6000);
     Output_RotateLight(angles[1], angles[0]);
 
-    if (g_TRVersion >= 3) {
+    if (g_TRVersion == 4) {
+        // The OG lights an inventory item by a flat brightness alone, with no
+        // room lights (newinv.cpp phd_PutPolygonsPickup). InvRing_Draw sets
+        // the per-item level; this leaves a neutral one behind for the rest.
+        Output_CalculateStaticLightRGB_F((RGB_F) { 1.0f, 1.0f, 1.0f });
+    } else if (g_TRVersion == 3) {
         // OG Inv_RingLight() LightCol columns are (sun, spot, dynamic):
         // sun = (3312, 1664, 0);
         // spot = (3312, 3312, 3312);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Lights TR4 inventory items with flat brightness that changes with the selection, as in the original game. Previously, they used TR3's three-light setup, which the TR4 renderer ignores, and retained the light list from the last level item drawn.

Resolves TRX1371