### PR TITLE
lara+effects: burn Lara in TR1/2 swamp rooms

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -158,11 +158,13 @@
 - Fixed TR3 colored light objects appearing white in TR1 and TR2 levels (#6517 / TRX1377, regression from 1.10)
 
 **TR1**
+- Added the ability for Lara to burn in swamp rooms marked with death sectors (#6539 / TRX1395)
 - Changed Lara to retain her equipment when turning to gold on the Midas Hand, with the equipment also turning to gold (TRX1073)
 - Fixed Lara's arm remaining in the flare pose if holding one on the Midas Hand (TRX1073)
 - Fixed a rare chance of exploded body parts getting stuck indefinitely at ceiling height (OG bug) (TRX1301)
 
 **TR2**
+- Added the ability for Lara to burn in swamp rooms marked with death sectors (#6539 / TRX1395)
 - Fixed a desync in the Tibetan Foothills demo if breeze mode is set to TR3 (TRX1388, regression from 1.10)
 
 **TR3**

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -246,7 +246,13 @@ void Lara_TouchLava(void)
 
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (lara_info->burn || lara_info->water_status != LWS_ABOVE_WATER) {
+    if (lara_info->burn) {
+        return;
+    }
+
+    if (lara_info->water_status != LWS_ABOVE_WATER
+        && (lara_info->water_status != LWS_WADE
+            || !Room_Get(lara_item->room_num)->flags.swamp)) {
         return;
     }
 

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -449,7 +449,8 @@ static void M_TR12_Control(const int16_t effect_num)
 
         const int32_t water_height =
             Room_GetWaterHeight(effect->pos, effect->room_num);
-        if ((water_height != NO_HEIGHT && effect->pos.y > water_height)
+        if ((water_height != NO_HEIGHT && effect->pos.y > water_height
+             && !M_IsLavaSwamp(effect->pos, effect->room_num))
             || lara_info->water_status == LWS_CHEAT) {
             effect->counter = 0;
             Effect_Destroy(Effect_GetIndex(effect));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This updates TR1/2 swamp rooms marked with death sectors to set and keep Lara on fire, similar to TR3.

Resolves #6539 / TRX1395.
