### PR TITLE
lara: improve environment picking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Fixed Lara briefly teleporting above the water line if she is stepping backwards from 2-click to 3-click wading depth (TRX1309, regression from 1.0)
 - Fixed Lara's arms twitching when stopped against walls in shallow water with either forward or backward input pressed against the wall (OG bug) (#6254 / TRX1121)
 - Fixed Lara assuming a fully underwater animation in custom levels if she begins at wading or water surface depths (OG bug) (TRX1312)
+- Fixed Lara embedding in the ceiling in custom levels if she begins at crawlspace height (OG bug) (#6547 / TRX1401)
+- Fixed exiting the fly cheat not always putting Lara into the correct animation for her environment (#6547 / TRX1401)
 - Fixed Lara slipping into wading-depth water when walking down steps in a water room (OG bug) (TRX1307)
 - Fixed Lara being able to monkey roll too close to sector edges, resulting in her falling after the animation completes (#6459 / TRX1314, regression from 1.10)
 - Fixed Lara beginning to monkey roll for one frame despite being too close to the edge of a sector (#6459 / TRX1314, regression from 1.10)

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -272,20 +272,8 @@ bool Lara_Cheat_ExitFlyMode(void)
         return false;
     }
 
-    const ROOM *const room = Room_Get(lara_item->room_num);
-    const int32_t water_height =
-        Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
-
-    if (room->flags.underwater
-        || (water_height != NO_HEIGHT && water_height > 0
-            && !room->flags.swamp)) {
-        lara_info->water_status = LWS_UNDERWATER;
-    } else {
-        lara_info->water_status =
-            room->flags.swamp ? LWS_WADE : LWS_ABOVE_WATER;
-        Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
-        lara_item->goal_anim_state = LS(LS_STOP);
-        lara_item->current_anim_state = LS(LS_STOP);
+    Lara_Control_SelectEnvironment();
+    if (lara_info->water_status != LWS_UNDERWATER) {
         lara_item->rot.x = 0;
         lara_item->rot.z = 0;
         lara_info->head_rot.x = 0;

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -42,6 +42,16 @@
 #define M_LEAN_MAX_UW       (LARA_LEAN_MAX * 2)  // = 4004
 // clang-format on
 
+static const LARA_STATE_ID m_StartSwimStates[] = {
+    // clang-format off
+    LS_SWIM,
+    LS_GLIDE,
+    LS_TREAD,
+    LS_WATER_ROLL,
+    NO_CATALOG_ID,
+    // clang-format on
+};
+
 static int32_t m_OpenDoorsCheatCooldown = 0;
 
 extern bool Skidoo_Control(void);
@@ -958,9 +968,10 @@ static void M_HandleEnvironment(void)
 static void M_HandleStartState(const LARA_EXTRA_STATE start_state)
 {
     ITEM *const lara_item = Lara_GetItem();
-    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
     const XYZ_16 old_rot = lara_item->rot;
 
+    lara_info->water_status = LWS_ABOVE_WATER;
     Lara_SwitchToExtraState(start_state);
     if (g_Config.gameplay.enable_cinematics) {
         Camera_InvokeCinematic(lara_item, 0, 0);
@@ -994,38 +1005,49 @@ static void M_CalculateDistanceTravelled(
 void Lara_Control_Initialise(
     const GF_LEVEL_TYPE level_type, const LARA_EXTRA_STATE start_state)
 {
-    ITEM *const lara_item = Lara_GetItem();
-    LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_info->water_status = LWS_ABOVE_WATER;
-
     if ((level_type == GFL_NORMAL || level_type == GFL_BONUS)
         && start_state != LS_EXTRA_BREATH) {
         M_HandleStartState(start_state);
         return;
     }
+    Lara_Control_SelectEnvironment();
+}
 
-    if (Room_Get(lara_item->room_num)->flags.underwater) {
+void Lara_Control_SelectEnvironment(void)
+{
+    ITEM *const lara_item = Lara_GetItem();
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+
+    lara_info->water_status = LWS_ABOVE_WATER;
+    LARA_ANIMATION_ID goal_anim = LA_STAND_STILL;
+
+    const ROOM *const room = Room_Get(lara_item->room_num);
+    if (room->flags.underwater) {
         const int32_t water_depth =
             Lara_GetWaterDepth(lara_item->pos, lara_item->room_num);
-        const int32_t water_height =
-            Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
+        const int32_t water_height = Room_GetWaterHeightEx(
+            lara_item->pos, lara_item->room_num,
+            (ROOM_WATER_HEIGHT_ARGS) {
+                .fix_tilts = true,
+                .require_air_above = true,
+            });
         const int32_t water_height_diff = water_height == NO_HEIGHT
             ? NO_HEIGHT
             : lara_item->pos.y - water_height;
-        if (water_depth > LARA_SWIM_DEPTH || !g_Config.gameplay.enable_wading) {
-            if (water_height_diff > LARA_SWIM_DEPTH) {
+        if (water_height == NO_HEIGHT || water_depth > LARA_SWIM_DEPTH
+            || !g_Config.gameplay.enable_wading) {
+            if (water_height == NO_HEIGHT || water_height_diff >= STEP_L) {
                 lara_info->water_status = LWS_UNDERWATER;
-                lara_item->goal_anim_state = LS(LS_TREAD);
-                lara_item->current_anim_state = LS(LS_TREAD);
-                Item_SwitchToAnim(lara_item, LA(LA_UNDERWATER_IDLE), 0);
+                if (Lara_HasState(m_StartSwimStates)) {
+                    return;
+                }
+                goal_anim = LA_UNDERWATER_IDLE;
             } else {
                 lara_info->water_status = LWS_SURFACE;
                 lara_item->pos.y = 1 + water_height;
-                lara_item->goal_anim_state = LS(LS_SURF_TREAD);
-                lara_item->current_anim_state = LS(LS_SURF_TREAD);
-                Item_SwitchToAnim(lara_item, LA(LA_ONWATER_IDLE), 0);
+                goal_anim = LA_ONWATER_IDLE;
             }
-            return;
+            goto finish;
         } else if (
             g_Config.gameplay.enable_wading
             && water_height_diff > M_WADE_DEPTH) {
@@ -1033,9 +1055,26 @@ void Lara_Control_Initialise(
         }
     }
 
-    lara_item->goal_anim_state = LS(LS_STOP);
-    lara_item->current_anim_state = LS(LS_STOP);
-    Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
+    if (room->flags.swamp) {
+        lara_info->water_status = LWS_WADE;
+    } else if (g_Config.gameplay.enable_crawling) {
+        int16_t room_num = lara_item->room_num;
+        const SECTOR *const sector = Room_GetSector(lara_item->pos, &room_num);
+        const int32_t height = Room_GetHeight(sector, lara_item->pos);
+        const int32_t ceiling = Room_GetCeiling(sector, lara_item->pos);
+        if (height != NO_HEIGHT && height - ceiling < LARA_HEIGHT) {
+            goal_anim = LA_CROUCH_IDLE;
+            lara_item->pos.y = height;
+        }
+    }
+
+finish:
+    if (goal_anim != LA_U(Item_GetRelativeAnim(lara_item))) {
+        Item_SwitchToAnim(lara_item, LA(goal_anim), 0);
+        const ANIM *const anim = Item_GetAnim(lara_item);
+        lara_item->current_anim_state = anim->current_anim_state;
+        lara_item->goal_anim_state = anim->current_anim_state;
+    }
 }
 
 void Lara_Control(void)

--- a/src/trx/game/lara/control.h
+++ b/src/trx/game/lara/control.h
@@ -5,4 +5,5 @@
 
 void Lara_Control_Initialise(
     GF_LEVEL_TYPE level_type, LARA_EXTRA_STATE start_state);
+void Lara_Control_SelectEnvironment(void);
 void Lara_Control(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This improves Lara's environment selection on level start and updates the fly cheat exit to utilise the same function. It resolves Lara becoming embedded in shallow pools and in crawlspaces.

Resolves #6547 / TRX1401.

Tests:
- [x] OG level-start cases from #6460
- [x] Custom level-start cases (link in the ticket)
- [x] Exit the fly cheat in shallow water - Lara should stand
- [x] Exit the fly cheat at wading depth - Lara should stand, or splash and then stand (depending on whether or not she's at floor height)
- [x] Exit the fly cheat just below the water surface (up to one click) - Lara should surface
- [x] Exit the fly cheat just above the water surface - Lara should fall
- [x] Exit the fly cheat far above the water surface - Lara should fall
- [x] Exit the fly cheat in deeper water - Lara should remain in the swimming animation with the same tilt
- [x] Exit the fly cheat on land with room to stand - Lara should stand or fall (depending on whether or not she's at floor height)
- [x] Exit the fly cheat in a crawlspace - Lara should crouch
- [x] Exit the fly cheat in a swamp - Lara should stand and begin to sink as normal
- [x] Exit the fly cheat above a swamp - Lara should fall as normal
