### PR TITLE
Fix FMV and in-game cutscene input discrepancies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Changed the save, load, level select and mod dialogs to show scroll arrows in every game, as TR1 does (TRX547)
 - Changed vertex snapping to offer Disabled, 320x240, and Upscale Res modes (#6278 / TRX1137)
 - Changed screenshots taken inside photo mode to not include debug overlay elements
+- Changed the pause behavior to be consistent between FMVs and in-game cutscenes (#6537)
 - Fixed a setting description showing a question mark in place of a key that is bound to a combination, such as Alt+Enter (TRX1136)
 - Fixed ability to open the inventory ring while a flyby sequence has Lara's control (TRX1057)
 - Fixed several dialogs running past the screen edges or overlapping headings at large text sizes (#6293 / TRX1154)

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -255,6 +255,7 @@ static RESULT M_Play(const char *const file_name)
     const int32_t audio_id = M_OpenAudioStream(file_name);
     bool input_paused = false;
     bool paused = false;
+    bool resume_pending = false;
 
     g_OldInputDB = g_Input;
     Fader_InitTo(&render_ctx.pause_fader, 0.0f, 0.0f, 0.0f);
@@ -271,17 +272,41 @@ static RESULT M_Play(const char *const file_name)
         Input_Update();
         Shell_ProcessInput();
 
-        render_ctx.show_pause_overlay = input_paused;
-        M_SetPauseText(M_ShouldShowPauseText(&render_ctx));
-        Overlay_Control();
-        LUA_FireEvent(LUA_EVENT_TICK);
+        if ((!paused
+             && (g_InputDB.menu_skip || TouchOverlay_HasAnyFingerDown()))
+            || GF_GetOverrideCommand().action != GF_NOOP || Shell_IsExiting()) {
+            Video_Stop(video);
+            break;
+        } else if (
+            (g_InputDB.pause || (input_paused && g_InputDB.menu_back))
+            && !focus_paused) {
+            input_paused = !input_paused;
+            if (g_Config.ui.pause_fade_effects) {
+                Fader_InitFromCurrent(
+                    &render_ctx.pause_fader, input_paused ? 1.0f : 0.0f,
+                    M_FADE_TIME);
+                if (!input_paused) {
+                    resume_pending = true;
+                }
+            }
+        }
 
-        const bool should_pause = focus_paused || input_paused;
+        if (resume_pending && !Fader_IsActive(&render_ctx.pause_fader)) {
+            resume_pending = false;
+        }
+
+        const bool should_pause =
+            focus_paused || input_paused || resume_pending;
         if (should_pause != paused) {
             Video_SetPaused(video, should_pause);
             IGNORE(Audio_Stream_SetPaused(audio_id, should_pause));
             paused = should_pause;
         }
+
+        render_ctx.show_pause_overlay = input_paused;
+        M_SetPauseText(M_ShouldShowPauseText(&render_ctx));
+        Overlay_Control();
+        LUA_FireEvent(LUA_EVENT_TICK);
 
         IGNORE(Audio_Stream_SetVolume(audio_id, M_GetAudioVolume()));
         const double audio_ts = Audio_Stream_GetTimestamp(audio_id);
@@ -293,22 +318,6 @@ static RESULT M_Play(const char *const file_name)
 
         if (paused) {
             M_RedrawFrame(&render_ctx);
-        }
-
-        if ((g_InputDB.pause || (input_paused && g_InputDB.menu_back))
-            && !focus_paused) {
-            input_paused = !input_paused;
-            if (g_Config.ui.pause_fade_effects) {
-                Fader_InitFromCurrent(
-                    &render_ctx.pause_fader, input_paused ? 1.0f : 0.0f,
-                    M_FADE_TIME);
-            }
-        } else if (
-            (!paused
-             && (g_InputDB.menu_skip || TouchOverlay_HasAnyFingerDown()))
-            || GF_GetOverrideCommand().action != GF_NOOP || Shell_IsExiting()) {
-            Video_Stop(video);
-            break;
         }
     }
 

--- a/src/trx/game/phase/phase_pause.c
+++ b/src/trx/game/phase/phase_pause.c
@@ -4,6 +4,7 @@
 #include <trx/core/memory.h>
 #include <trx/game/const.h>
 #include <trx/game/fader.h>
+#include <trx/game/game/state.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/input.h>
 #include <trx/game/music.h>
@@ -134,11 +135,18 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
         break;
 
     case STATE_WAIT:
-        if (g_InputDB.pause) {
-            M_ReturnToGame(p);
-            return (PHASE_CONTROL) { .action = PHASE_ACTION_NO_WAIT };
-        } else if (g_InputDB.option) {
-            p->state = STATE_ASK;
+        if (Game_IsPlayable()) {
+            if (g_InputDB.pause) {
+                M_ReturnToGame(p);
+                return (PHASE_CONTROL) { .action = PHASE_ACTION_NO_WAIT };
+            } else if (g_InputDB.option) {
+                p->state = STATE_ASK;
+            }
+        } else {
+            if (g_InputDB.pause || g_InputDB.option) {
+                M_ReturnToGame(p);
+                return (PHASE_CONTROL) { .action = PHASE_ACTION_NO_WAIT };
+            }
         }
         break;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This makes the FMV and in-game cutscene pause logic more consistent:

- FMV audio and video only resume after the fadeout has ended, similar to how it is for in-game cutscenes (that is, after 7c0d534bb551c2311c866738cd9bb62595af42c4). Previously they resumed immediately when <kbd>P</kbd> was pressed.
- Pressing <kbd>esc</kbd> will take precedence over pressing pause in FMVs, similar to how it is for in-game cutscenes (this is noticeable when using slowdown)
- Pressing <kbd>esc</kbd> while paused during an in-game cutscene no longer prompts the player if they want to exit to title, similar to how it is for FMVs. This seems more logical to me since cutscenes only play at the very end or the very beginning of levels and can be skipped anyway, please tell me if this isn't a good change.

Fixes #6537