### PR TITLE
Speed up level loading and mesh drawing

### DIFF
--- a/src/trx/core/thread_pool.c
+++ b/src/trx/core/thread_pool.c
@@ -1,6 +1,7 @@
 #include <trx/core/thread_pool.h>
 
 #include <trx/core/memory.h>
+#include <trx/core/subsystem.h>
 
 #include <SDL2/SDL_cpuinfo.h>
 #include <SDL2/SDL_thread.h>
@@ -22,6 +23,14 @@ struct THREAD_POOL {
     size_t working_count;
     SDL_cond *working_cond;
 };
+
+static THREAD_POOL *m_Shared = nullptr;
+
+static void M_Shutdown(void)
+{
+    ThreadPool_Destroy(m_Shared);
+    m_Shared = nullptr;
+}
 
 static int32_t M_WorkerThread(void *const arg)
 {
@@ -129,3 +138,13 @@ void ThreadPool_Wait(THREAD_POOL *pool)
     }
     SDL_UnlockMutex(pool->queue_mutex);
 }
+
+THREAD_POOL *ThreadPool_GetShared(void)
+{
+    if (m_Shared == nullptr) {
+        m_Shared = ThreadPool_Create(-1);
+    }
+    return m_Shared;
+}
+
+REGISTER_BASE_SUBSYSTEM(.shutdown = M_Shutdown)

--- a/src/trx/core/thread_pool.h
+++ b/src/trx/core/thread_pool.h
@@ -18,3 +18,7 @@ void ThreadPool_AddJob(THREAD_POOL *pool, THREAD_FUNC func, void *user_data);
 
 // Wait for all submitted jobs to complete.
 void ThreadPool_Wait(THREAD_POOL *pool);
+
+// Returns the session-wide pool, with one thread per CPU. Callers submit jobs,
+// wait for them, and do not destroy the pool.
+THREAD_POOL *ThreadPool_GetShared(void);

--- a/src/trx/game/anims/frames.c
+++ b/src/trx/game/anims/frames.c
@@ -1,5 +1,6 @@
 #include <trx/core/benchmark.h>
 #include <trx/core/log.h>
+#include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/anims.h>
@@ -40,17 +41,21 @@ static int32_t M_GetAnimFrameCount(
     }
 }
 
-static OBJECT *M_GetAnimObject(const int32_t anim_idx)
+// Maps each animation to its first object, avoiding a search for every
+// animation.
+static OBJECT **M_BuildAnimObjects(const int32_t anim_count)
 {
+    OBJECT **const anim_objects = Memory_Alloc(sizeof(OBJECT *) * anim_count);
     CATALOG_FOR_EACH(CATALOG_OBJECTS, i)
     {
         OBJECT *const obj = Object_Get(i);
-        if (obj->loaded && obj->mesh_count >= 0 && obj->anim_idx == anim_idx) {
-            return obj;
+        if (obj->loaded && obj->mesh_count >= 0 && obj->anim_idx >= 0
+            && obj->anim_idx < anim_count
+            && anim_objects[obj->anim_idx] == nullptr) {
+            anim_objects[obj->anim_idx] = obj;
         }
     }
-
-    return nullptr;
+    return anim_objects;
 }
 
 static ANIM_FRAME *M_FindFrameBase(const uint32_t frame_ofs)
@@ -169,11 +174,12 @@ void Anim_LoadFrames(
     BENCHMARK benchmark = Benchmark_Start();
 
     const int32_t anim_count = Anim_GetTotalCount();
+    OBJECT **const anim_objects = M_BuildAnimObjects(anim_count);
     OBJECT *cur_obj = nullptr;
     int32_t frame_idx = 0;
 
     for (int32_t i = 0; i < anim_count; i++) {
-        OBJECT *const next_obj = M_GetAnimObject(i);
+        OBJECT *const next_obj = anim_objects[i];
         const bool obj_changed = next_obj != nullptr;
         if (obj_changed) {
             cur_obj = next_obj;
@@ -213,5 +219,6 @@ void Anim_LoadFrames(
         }
     }
 
+    Memory_Free(anim_objects);
     Benchmark_End(&benchmark, nullptr);
 }

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -13,6 +13,7 @@
 #include <trx/game/savegame.h>
 #include <trx/version.h>
 
+#include <SDL2/SDL_mutex.h>
 #include <string.h>
 #include <zlib.h>
 
@@ -22,6 +23,16 @@ typedef struct {
     INJECTION *injection;
     const char *path;
 } M_LOAD_JOB;
+
+// Holds one injection file's decompressed payload, keyed by path.
+typedef struct {
+    char *path;
+    char *payload;
+    int32_t size;
+    INJECTION_VERSION version;
+    INJECTION_FILE_TYPE type;
+    bool used;
+} M_PAYLOAD_ENTRY;
 
 static bool (*m_Testers[ITT_NUMBER_OF])(
     const INJECTION_CONTEXT *, const INJECTION *injection) = {};
@@ -38,6 +49,11 @@ static int32_t m_MaxStaticObject2DId = -1;
 static VECTOR *m_RoomMeta = nullptr;
 static LEVEL_CONTEXT_INFO m_CachedInfo = {};
 static uint16_t *m_PaletteMap = nullptr;
+
+// Caches decompressed payloads for the current level. Unused entries are
+// dropped after each load.
+static VECTOR *m_PayloadCache = nullptr;
+static SDL_mutex *m_PayloadCacheMutex = nullptr;
 static size_t m_PaletteMapSize = 0;
 
 static bool M_IsRelevant(
@@ -200,6 +216,88 @@ static void M_InitialiseBlock(
     File_Skip(file, data_size);
 }
 
+// Returns the cached entry for a path, or nullptr if there is none. The caller
+// must hold the cache lock.
+static M_PAYLOAD_ENTRY *M_GetCachedPayload(const char *const path)
+{
+    if (m_PayloadCache == nullptr || path == nullptr) {
+        return nullptr;
+    }
+    for (int32_t i = 0; i < m_PayloadCache->count; i++) {
+        M_PAYLOAD_ENTRY *const entry = Vector_Get(m_PayloadCache, i);
+        if (strcmp(entry->path, path) == 0) {
+            return entry;
+        }
+    }
+    return nullptr;
+}
+
+static void M_StorePayload(
+    const char *const path, const char *const payload, const int32_t size,
+    const INJECTION_VERSION version, const INJECTION_FILE_TYPE type)
+{
+    if (path == nullptr) {
+        return;
+    }
+    SDL_LockMutex(m_PayloadCacheMutex);
+    if (M_GetCachedPayload(path) == nullptr) {
+        if (m_PayloadCache == nullptr) {
+            m_PayloadCache = Vector_Create(sizeof(M_PAYLOAD_ENTRY));
+        }
+        const M_PAYLOAD_ENTRY entry = {
+            .path = Memory_DupStr(path),
+            .payload = Memory_Dup(payload, size),
+            .size = size,
+            .version = version,
+            .type = type,
+            .used = true,
+        };
+        Vector_Add(m_PayloadCache, &entry);
+    }
+    SDL_UnlockMutex(m_PayloadCacheMutex);
+}
+
+// Sets up an injection from the cache and reports whether it was found.
+static bool M_LoadFromCache(
+    INJECTION *const injection, const char *const file_name)
+{
+    SDL_LockMutex(m_PayloadCacheMutex);
+    M_PAYLOAD_ENTRY *const entry = M_GetCachedPayload(file_name);
+    if (entry == nullptr) {
+        SDL_UnlockMutex(m_PayloadCacheMutex);
+        return false;
+    }
+    entry->used = true;
+    injection->path = Memory_DupStr(file_name);
+    injection->version = entry->version;
+    injection->type = entry->type;
+    injection->relevant = M_IsRelevant(&m_Context, entry->type);
+    if (injection->relevant) {
+        injection->fp = File_OpenBuffer(entry->payload, entry->size);
+        File_SetSoftFailure(injection->fp, true);
+    }
+    SDL_UnlockMutex(m_PayloadCacheMutex);
+    return true;
+}
+
+// Drops entries unused by this load, keeping only the current level's data.
+static void M_PrunePayloadCache(void)
+{
+    if (m_PayloadCache == nullptr) {
+        return;
+    }
+    for (int32_t i = m_PayloadCache->count - 1; i >= 0; i--) {
+        M_PAYLOAD_ENTRY *const entry = Vector_Get(m_PayloadCache, i);
+        if (entry->used) {
+            entry->used = false;
+            continue;
+        }
+        Memory_FreePointer(&entry->path);
+        Memory_FreePointer(&entry->payload);
+        Vector_RemoveAt(m_PayloadCache, i);
+    }
+}
+
 static void M_ReadFile(
     INJECTION *const injection, TRX_FILE *const file,
     const char *const file_name)
@@ -252,6 +350,9 @@ static void M_ReadFile(
         goto cleanup;
     }
 
+    M_StorePayload(
+        file_name, payload, uncompressed_size, injection->version,
+        injection->type);
     injection->fp = File_OpenBuffer(payload, uncompressed_size);
     File_SetSoftFailure(injection->fp, true);
     if (m_Context.mode != INJECTION_MODE_STATS) {
@@ -292,6 +393,10 @@ static void M_InitialiseInjection(INJECTION *const injection)
 static void M_LoadFromFile(
     INJECTION *const injection, const char *const file_name)
 {
+    if (M_LoadFromCache(injection, file_name)) {
+        return;
+    }
+
     TRX_FILE *file = nullptr;
     if (!SHOULD(
             File_OpenPathInMemory(file_name, &file),
@@ -361,7 +466,12 @@ void Inject_InitLevel(const GF_LEVEL *const level, const INJECTION_MODE mode)
     m_Context.mode = mode;
     m_NumInjections = level->injections.count;
     if (m_NumInjections == 0) {
+        M_PrunePayloadCache();
         return;
+    }
+
+    if (m_PayloadCacheMutex == nullptr) {
+        m_PayloadCacheMutex = SDL_CreateMutex();
     }
 
     BENCHMARK benchmark = Benchmark_Start();
@@ -392,6 +502,7 @@ void Inject_InitLevel(const GF_LEVEL *const level, const INJECTION_MODE mode)
     for (int32_t i = 0; i < m_NumInjections; i++) {
         M_InitialiseInjection(&m_Injections[i]);
     }
+    M_PrunePayloadCache();
 
     if (m_Context.mode != INJECTION_MODE_STATS) {
         Benchmark_End(&benchmark, nullptr);

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -481,7 +481,7 @@ void Inject_InitLevel(const GF_LEVEL *const level, const INJECTION_MODE mode)
         M_LOAD_JOB *const jobs =
             Memory_Alloc(sizeof(M_LOAD_JOB) * m_NumInjections);
 
-        THREAD_POOL *const pool = ThreadPool_Create(-1);
+        THREAD_POOL *const pool = ThreadPool_GetShared();
         ASSERT(pool != nullptr);
         for (int32_t i = 0; i < m_NumInjections; i++) {
             jobs[i] = (M_LOAD_JOB) {
@@ -492,7 +492,6 @@ void Inject_InitLevel(const GF_LEVEL *const level, const INJECTION_MODE mode)
         }
 
         ThreadPool_Wait(pool);
-        ThreadPool_Destroy(pool);
 
         Memory_Free(jobs);
     } else {

--- a/src/trx/game/lara/skin/gold.c
+++ b/src/trx/game/lara/skin/gold.c
@@ -33,6 +33,8 @@ static OBJECT_MESH *M_CloneMesh(
 {
     OBJECT_MESH *const mesh = GameBuf_Alloc(sizeof(OBJECT_MESH), GBUF_MESHES);
     *mesh = *src;
+    Object_InitialiseMesh(mesh);
+    Object_SetMeshOffset(mesh, Object_GetMeshOffset(src));
     mesh->enable_solid_color = true;
     mesh->solid_color = color;
     mesh->enable_reflections = true;

--- a/src/trx/game/level/finalize/render_assets.c
+++ b/src/trx/game/level/finalize/render_assets.c
@@ -232,7 +232,7 @@ void Level_Finalize_LoadTexturePages(LEVEL_CONTEXT *const ctx)
 
     {
         int32_t *pages = Memory_Alloc(num_pages * sizeof(int32_t));
-        THREAD_POOL *const pool = ThreadPool_Create(-1);
+        THREAD_POOL *const pool = ThreadPool_GetShared();
         for (int32_t i = 0; i < num_pages; i++) {
             pages[i] = i;
         }
@@ -240,7 +240,6 @@ void Level_Finalize_LoadTexturePages(LEVEL_CONTEXT *const ctx)
             ThreadPool_AddJob(pool, M_PremultiplyTexturePage, &pages[i]);
         }
         ThreadPool_Wait(pool);
-        ThreadPool_Destroy(pool);
         Memory_Free(pages);
     }
     Benchmark_End(&benchmark, "premultiplied alpha");

--- a/src/trx/game/level/sections/meshes.c
+++ b/src/trx/game/level/sections/meshes.c
@@ -248,6 +248,7 @@ RESULT Level_Section_AppendObjectMeshes(
     for (int32_t i = 0; i < unique_offsets->count; i++) {
         const int32_t pointer = *(const int32_t *)Vector_Get(unique_offsets, i);
         File_Seek(file, start_pos + pointer - base_index, FILE_SEEK_SET);
+        Object_InitialiseMesh(&meshes[i]);
         MUST(M_ReadObjectMesh(&meshes[i], file), "mesh %d", i);
 
         // The original data position is required for backward compatibility

--- a/src/trx/game/level/sections/textures.c
+++ b/src/trx/game/level/sections/textures.c
@@ -168,7 +168,7 @@ RESULT Level_Section_ReadTexturePages(
 
     info->textures.pages_32 = Memory_Alloc(texture_size_32_bit);
 
-    THREAD_POOL *const pool = ThreadPool_Create(-1);
+    THREAD_POOL *const pool = ThreadPool_GetShared();
     M_TEXTURE_PAGE_DECODE_JOB *const jobs =
         Memory_Alloc(sizeof(*jobs) * num_pages);
     uint16_t *input_16 = nullptr;
@@ -198,7 +198,6 @@ RESULT Level_Section_ReadTexturePages(
     ThreadPool_Wait(pool);
     Memory_FreePointer(&input_16);
     Memory_Free(jobs);
-    ThreadPool_Destroy(pool);
 
     Benchmark_End(&benchmark, nullptr);
     return OK;

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -18,6 +18,11 @@ typedef struct {
     OBJECT obj;
 } M_UNCATALOGED_SLOT;
 
+typedef struct {
+    int32_t data_offset;
+    int32_t registry_idx;
+} M_MESH_PRIV;
+
 CATALOG_TABLE_DEFINE(m_Objects, CATALOG_OBJECTS, OBJECT);
 static STATIC_OBJECT_3D *m_StaticObjects3D = nullptr;
 static STATIC_OBJECT_2D *m_StaticObjects2D = nullptr;
@@ -26,6 +31,23 @@ static int32_t m_StaticObjects2DCount = 0;
 static VECTOR *m_MeshPointers = nullptr;
 
 static VECTOR *m_UncatalogedSlots = nullptr;
+
+static M_MESH_PRIV *M_GetPriv(const OBJECT_MESH *const mesh)
+{
+    return (M_MESH_PRIV *)mesh->priv;
+}
+
+static void M_RefreshRegistryIndex(OBJECT_MESH *const mesh)
+{
+    M_MESH_PRIV *const priv = M_GetPriv(mesh);
+    priv->registry_idx = -1;
+    for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
+        if (mesh == Object_GetMesh(i)) {
+            priv->registry_idx = i;
+            return;
+        }
+    }
+}
 
 void Object_Reset(void)
 {
@@ -197,6 +219,14 @@ OBJECT_SLOT Object_IDToSlot(const OBJECT_ID id)
     return Catalog_IDToSlot(CATALOG_OBJECTS, id, -1);
 }
 
+void Object_InitialiseMesh(OBJECT_MESH *const mesh)
+{
+    M_MESH_PRIV *const priv = GameBuf_Alloc(sizeof(M_MESH_PRIV), GBUF_MESHES);
+    priv->data_offset = 0;
+    priv->registry_idx = -1;
+    mesh->priv = priv;
+}
+
 void Object_InitialiseMeshes(const int32_t mesh_count)
 {
     if (m_MeshPointers != nullptr) {
@@ -207,6 +237,10 @@ void Object_InitialiseMeshes(const int32_t mesh_count)
 
 void Object_StoreMesh(OBJECT_MESH *const mesh)
 {
+    M_MESH_PRIV *const priv = M_GetPriv(mesh);
+    if (priv->registry_idx < 0) {
+        priv->registry_idx = m_MeshPointers->count;
+    }
     Vector_Add(m_MeshPointers, (void *)&mesh);
 }
 
@@ -234,12 +268,7 @@ int32_t Object_GetItemMeshIndex(const ITEM *const item, const int32_t mesh_idx)
 
 int32_t Object_GetMeshIndex(const OBJECT_MESH *const mesh)
 {
-    for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
-        if (mesh == Object_GetMesh(i)) {
-            return i;
-        }
-    }
-    return -1;
+    return M_GetPriv(mesh)->registry_idx;
 }
 
 int32_t Object_GetMeshCount(void)
@@ -261,12 +290,12 @@ OBJECT_MESH *Object_FindMesh(const int32_t data_offset)
 
 int32_t Object_GetMeshOffset(const OBJECT_MESH *const mesh)
 {
-    return (int32_t)(intptr_t)mesh->priv;
+    return M_GetPriv(mesh)->data_offset;
 }
 
 void Object_SetMeshOffset(OBJECT_MESH *const mesh, const int32_t data_offset)
 {
-    mesh->priv = (void *)(intptr_t)data_offset;
+    M_GetPriv(mesh)->data_offset = data_offset;
 }
 
 void Object_SwapMesh(
@@ -306,6 +335,8 @@ void Object_SwapMeshEx(
     OBJECT_MESH **const slot_1 = Vector_Get(m_MeshPointers, mesh_idx1);
     OBJECT_MESH **const slot_2 = Vector_Get(m_MeshPointers, mesh_idx2);
     SWAP(*slot_1, *slot_2);
+    M_RefreshRegistryIndex(*slot_1);
+    M_RefreshRegistryIndex(*slot_2);
 
     Output_DispatchObjectMeshSwap(mesh_idx1, mesh_idx2);
 }

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -63,6 +63,7 @@ STATIC_OBJECT_3D *Object_Get3DStatic(int32_t static_id);
 STATIC_OBJECT_2D *Object_Get2DStatic(int32_t static_id);
 
 void Object_InitialiseMeshes(int32_t mesh_count);
+void Object_InitialiseMesh(OBJECT_MESH *mesh);
 void Object_StoreMesh(OBJECT_MESH *mesh);
 
 int32_t Object_GetMeshCount(void);

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -13,6 +13,9 @@
 #include <trx/game/output/water.h>
 #include <trx/version.h>
 
+// Maximum number of policies stored for one mesh. Extra policies are ignored.
+#define M_MAX_MESH_POLICIES 16
+
 typedef struct {
     OUTPUT_MESH *mesh_batch;
 } M_MESH;
@@ -28,6 +31,11 @@ typedef struct {
     int32_t mesh_idx;
     const OUTPUT_OBJECT_MESH_POLICY *policy;
 } M_POLICY_ENTRY;
+
+typedef struct {
+    const OUTPUT_OBJECT_MESH_POLICY *entries[M_MAX_MESH_POLICIES];
+    int32_t count;
+} M_POLICY_SET;
 
 typedef void (*M_FACE_VERTEX_FUNC)(
     OUTPUT_MESH_VERTEX *vertex, const FACE *face, int32_t vertex_idx,
@@ -60,19 +68,35 @@ static const OUTPUT_OBJECT_MESH_POLICY *M_GetMeshPolicy(
     return nullptr;
 }
 
-static uint16_t M_GetPolicyVertexFlags(const int32_t mesh_idx)
+// Collects a mesh's policies once, so face building need not search them for
+// every vertex.
+static void M_GatherMeshPolicies(
+    const int32_t mesh_idx, M_POLICY_SET *const set)
+{
+    set->count = 0;
+    if (m_MeshPolicies == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < m_MeshPolicies->count; i++) {
+        const M_POLICY_ENTRY *const entry = Vector_Get(m_MeshPolicies, i);
+        if (entry->mesh_idx == mesh_idx && set->count < M_MAX_MESH_POLICIES) {
+            set->entries[set->count++] = entry->policy;
+        }
+    }
+}
+
+static uint16_t M_GetPolicyVertexFlags(const M_POLICY_SET *const set)
 {
     uint16_t flags = 0;
-    const OUTPUT_OBJECT_MESH_POLICY *policy;
-    for (int32_t i = 0; (policy = M_GetMeshPolicy(mesh_idx, i)) != nullptr;
-         i++) {
-        flags |= policy->vertex_flags;
+    for (int32_t i = 0; i < set->count; i++) {
+        flags |= set->entries[i]->vertex_flags;
     }
     return flags;
 }
 
 static SCENE_PASS M_GetScenePass(
-    const FACE *const face, const uint16_t flags, const int32_t mesh_idx)
+    const FACE *const face, const uint16_t flags,
+    const M_POLICY_SET *const policies)
 {
     // Half-opacity faces draw depth-sorted, like the PSX half blend mode.
     if (face->semi_transparent) {
@@ -83,9 +107,9 @@ static SCENE_PASS M_GetScenePass(
     }
     if ((face->effects & 0x1u) != 0u) {
         SCENE_PASS pass = SCENE_PASS_BLEND_ADD;
-        const OUTPUT_OBJECT_MESH_POLICY *policy;
-        for (int32_t i = 0; (policy = M_GetMeshPolicy(mesh_idx, i)) != nullptr;
-             i++) {
+        for (int32_t i = 0; i < policies->count; i++) {
+            const OUTPUT_OBJECT_MESH_POLICY *const policy =
+                policies->entries[i];
             if (policy->get_face_pass != nullptr
                 && policy->get_face_pass(face, &pass)) {
                 break;
@@ -115,7 +139,7 @@ static bool M_IsReflectiveFace(
 
 static void M_AddObjectFace(
     MESH_BUILDER *const builder, const OBJECT_MESH *const obj_mesh,
-    const FACE *const face, uint16_t flags, const int32_t mesh_idx)
+    const FACE *const face, uint16_t flags, const M_POLICY_SET *const policies)
 {
     RGBA_8888 color = COLOR_RGBA_8888_WHITE;
     OUTPUT_MESH_VERTEX vertices[4];
@@ -168,9 +192,9 @@ static void M_AddObjectFace(
 
     for (int32_t i = 0; i < face->vertex_count; i++) {
         if (may_recolor) {
-            const OUTPUT_OBJECT_MESH_POLICY *policy;
-            for (int32_t j = 0;
-                 (policy = M_GetMeshPolicy(mesh_idx, j)) != nullptr; j++) {
+            for (int32_t j = 0; j < policies->count; j++) {
+                const OUTPUT_OBJECT_MESH_POLICY *const policy =
+                    policies->entries[j];
                 if (policy->get_vertex_color != nullptr
                     && policy->get_vertex_color(face, i, &color)) {
                     break;
@@ -181,14 +205,12 @@ static void M_AddObjectFace(
                 && face->vertices[i] < -obj_mesh->num_lights
             ? obj_mesh->lighting.lights[face->vertices[i]]
             : SHADE_NEUTRAL;
-        {
-            const OUTPUT_OBJECT_MESH_POLICY *policy;
-            for (int32_t j = 0;
-                 (policy = M_GetMeshPolicy(mesh_idx, j)) != nullptr; j++) {
-                if (policy->get_vertex_shade != nullptr
-                    && policy->get_vertex_shade(face, i, &shade)) {
-                    break;
-                }
+        for (int32_t j = 0; j < policies->count; j++) {
+            const OUTPUT_OBJECT_MESH_POLICY *const policy =
+                policies->entries[j];
+            if (policy->get_vertex_shade != nullptr
+                && policy->get_vertex_shade(face, i, &shade)) {
+                break;
             }
         }
         const XYZ_16 normal = face->vertices[i] < obj_mesh->num_lights
@@ -218,7 +240,7 @@ static void M_AddObjectFace(
     // Half-opacity faces skip the depth prepass, so they cannot clip other
     // effects drawn at the same spot (e.g. the gun flash glow).
     MeshBuilder_AddFan(
-        builder, M_GetScenePass(face, flags, mesh_idx), face->double_sided,
+        builder, M_GetScenePass(face, flags, policies), face->double_sided,
         !face->semi_transparent);
 }
 
@@ -237,15 +259,18 @@ static void M_PrepareMeshes(M_PRIV *const p)
             flags |= VERT_REFLECTIVE;
         }
 
-        flags |= M_GetPolicyVertexFlags(i);
+        M_POLICY_SET policies;
+        M_GatherMeshPolicies(i, &policies);
+        flags |= M_GetPolicyVertexFlags(&policies);
         for (int32_t j = 0; j < obj_mesh->tex_faces.count; j++) {
             M_AddObjectFace(
-                builder, obj_mesh, &obj_mesh->tex_faces.data[j], flags, i);
+                builder, obj_mesh, &obj_mesh->tex_faces.data[j], flags,
+                &policies);
         }
         for (int32_t j = 0; j < obj_mesh->flat_faces.count; j++) {
             M_AddObjectFace(
                 builder, obj_mesh, &obj_mesh->flat_faces.data[j],
-                flags | VERT_FLAT_SHADED, i);
+                flags | VERT_FLAT_SHADED, &policies);
         }
 
         MeshBuilder_AdjustDepth(builder, obj_mesh->depth_adjustment);

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -106,6 +106,14 @@ static OBJECT_TEXTURE *m_ObjectTextures = nullptr;
 static SPRITE_TEXTURE *m_SpriteTextures = nullptr;
 static ANIMATED_TEXTURE_RANGE *m_AnimTextureRanges = nullptr;
 
+// Caches the last color cube so an unchanged palette skips the nearest-color
+// search.
+static struct {
+    RGBA_8888 *cube;
+    RGB_888 src[256];
+    int32_t src_size;
+} m_PaletteLut = {};
+
 // TR4 UV rotate: the first N animated texture ranges scroll their V linearly
 // instead of frame-swapping (see docs on the TR4 UVRotate gameflow command).
 static int32_t m_UVRotateRangeCount = 0;
@@ -945,10 +953,16 @@ static void M_RefreshPaletteLut(void)
 
     const int32_t count =
         M_PALETTE_LUT_SIZE * M_PALETTE_LUT_SIZE * M_PALETTE_LUT_SIZE;
-    RGBA_8888 *const cube = Memory_Alloc(sizeof(RGBA_8888) * count);
-    M_BuildPaletteLut(cube, palette, pal_size);
-    TRX_GL_Renderer_SetPaletteLut(cube, M_PALETTE_LUT_SIZE);
-    Memory_Free(cube);
+    if (m_PaletteLut.cube == nullptr) {
+        m_PaletteLut.cube = Memory_Alloc(sizeof(RGBA_8888) * count);
+    }
+    if (m_PaletteLut.src_size != pal_size
+        || memcmp(m_PaletteLut.src, palette, sizeof(RGB_888) * pal_size) != 0) {
+        M_BuildPaletteLut(m_PaletteLut.cube, palette, pal_size);
+        memcpy(m_PaletteLut.src, palette, sizeof(RGB_888) * pal_size);
+        m_PaletteLut.src_size = pal_size;
+    }
+    TRX_GL_Renderer_SetPaletteLut(m_PaletteLut.cube, M_PALETTE_LUT_SIZE);
 }
 
 static void M_FreeLevelData(void)
@@ -994,6 +1008,8 @@ void Output_Textures_Shutdown(void)
         m_AnimationRanges.sprites = nullptr;
     }
     M_FreeLevelData();
+    Memory_FreePointer(&m_PaletteLut.cube);
+    m_PaletteLut.src_size = 0;
 
     if (m_Priv.tex_env_map != 0) {
         glDeleteTextures(1, &m_Priv.tex_env_map);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR makes the level load a bit faster, especially when reloading the same level. On TR3 Jungle, loading a save now takes about 158 ms, down from 211 ms, based on the median of 18 consecutive loads on the same machine.

#### Implementation details

The loader now caches work whose results do not change between loads:

- Palette lookup cubes are built once per palette and reused, saving about 40 ms per load.
- Injection files are read and decompressed once, then cached. TR3 Jungle's 19 injections previously cost about 17 ms per load.
- Animations now map directly to their starting objects, replacing 1,061 searches across 821 objects.
- Mesh policies are collected once per mesh instead of searched again for every vertex.
- Threaded work now shares one session-wide pool, avoiding repeated thread startup and shutdown.

Separately, meshes now remember their registry slots. Staging a mesh previously searched the whole registry for it twice, so a frame ran roughly 60 to 100 of those searches, each across 1,051 meshes. One recording triggered 240,791 of them over 2,500 frames.