### PR TITLE
installer: fix failing install from a disc image

### DIFF
--- a/tools/installer/TRX_Installer/CueFile.cs
+++ b/tools/installer/TRX_Installer/CueFile.cs
@@ -7,6 +7,22 @@ public class CueFile
 {
     public readonly List<CueTrack> TrackList = new();
 
+    // Reads a cue sheet, or returns null when the file is not a usable cue
+    // sheet. Use this to probe a file whose format is not known in advance;
+    // the constructor reports the reason with an exception instead.
+    public static CueFile? TryLoad(string cueFilePath)
+    {
+        try
+        {
+            CueFile cueFile = new(cueFilePath);
+            return cueFile.TrackList.Count > 0 ? cueFile : null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
     public CueFile(string cueFilePath)
     {
         _cueFilePath = cueFilePath;

--- a/tools/installer/TRX_Installer/DiscImageInstallSource.cs
+++ b/tools/installer/TRX_Installer/DiscImageInstallSource.cs
@@ -1,23 +1,28 @@
 using DiscUtils.Iso9660;
 using DiscUtils.Streams;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace TRX_Installer;
 
 internal class DiscImageInstallSource : IInstallSource
 {
+    // Reports whether the directory holds a disc image this source can read.
+    public static bool CanInstallFrom(string sourceDirectory)
+    {
+        return FindCueFile(sourceDirectory) is not null
+            || FindRawImage(sourceDirectory) is not null;
+    }
+
     public async Task InstallAsync(
         string sourceDirectory,
         string targetDirectory,
         string gameId,
         IInstallerProgress progress)
     {
-        string cuePath = Path.Combine(sourceDirectory, "game.dat");
-        string isoPath = Path.Combine(sourceDirectory, "game.iso");
-        CueFile cueFile = new(cuePath);
-        CueTrack firstTrack = cueFile.TrackList.First();
-        firstTrack.Write(isoPath, null);
+        (string isoPath, bool isTemporary) = PrepareIso(
+            sourceDirectory, Path.Combine(sourceDirectory, "game.iso"));
 
         try
         {
@@ -54,11 +59,152 @@ internal class DiscImageInstallSource : IInstallSource
         }
         finally
         {
-            if (File.Exists(isoPath))
+            if (isTemporary && File.Exists(isoPath))
             {
                 File.Delete(isoPath);
             }
         }
+    }
+
+    // Layout of the sectors in a disc image. A plain ISO stores 2048 data
+    // bytes per sector, while a raw image stores 2352 bytes per sector and
+    // keeps the data at a fixed offset that depends on the sector mode.
+    private enum DiscImageKind
+    {
+        Unknown,
+        Iso,
+        RawMode1,
+        RawMode2,
+    }
+
+    private static readonly string[] ImageFileNames = ["GAME.GOG", "game.dat"];
+    private static readonly string[] ImageFilePatterns = ["*.iso", "*.bin", "*.gog", "*.dat", "*.img"];
+
+    // Returns the path to an image that CDReader can read, and whether that
+    // image is a temporary file the caller must delete. A cue sheet gives the
+    // position of the data track, and its first track goes to targetPath. A
+    // raw image without a cue sheet goes to targetPath sector by sector. A
+    // plain ISO needs no conversion and is read where it lies.
+    private static (string path, bool isTemporary) PrepareIso(
+        string sourceDirectory, string targetPath)
+    {
+        CueFile? cueFile = FindCueFile(sourceDirectory);
+        if (cueFile is not null)
+        {
+            cueFile.TrackList.First().Write(targetPath, null);
+            return (targetPath, true);
+        }
+
+        string? imagePath = FindRawImage(sourceDirectory);
+        if (imagePath is null)
+        {
+            throw new ApplicationException(
+                $"Could not find a disc image in {sourceDirectory}. "
+                + "Expected a cue sheet with a matching image, an ISO image, "
+                + "or a raw CD image.");
+        }
+
+        DiscImageKind kind = GetImageKind(imagePath);
+        if (kind == DiscImageKind.Iso)
+        {
+            return (imagePath, false);
+        }
+
+        long length = new FileInfo(imagePath).Length;
+        CueTrack track = new(
+            imagePath,
+            1,
+            kind == DiscImageKind.RawMode2 ? "MODE2/2352" : "MODE1/2352",
+            "00:00:00")
+        {
+            Stop = length,
+            StopSector = length / CueTrack.SectorLength,
+        };
+        track.Write(targetPath, null);
+        return (targetPath, true);
+    }
+
+    private static CueFile? FindCueFile(string sourceDirectory)
+    {
+        return EnumerateCandidates(sourceDirectory, ["*.cue"])
+            .Select(CueFile.TryLoad)
+            .FirstOrDefault(cueFile => cueFile is not null);
+    }
+
+    private static string? FindRawImage(string sourceDirectory)
+    {
+        return EnumerateCandidates(sourceDirectory, ImageFilePatterns)
+            .FirstOrDefault(path => GetImageKind(path) != DiscImageKind.Unknown);
+    }
+
+    // Lists the files to probe, with the names the original releases use
+    // first, and never the temporary image this source writes itself.
+    private static IEnumerable<string> EnumerateCandidates(
+        string sourceDirectory, string[] patterns)
+    {
+        if (!Directory.Exists(sourceDirectory))
+        {
+            yield break;
+        }
+
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        IEnumerable<string> paths = ImageFileNames
+            .Select(name => Path.Combine(sourceDirectory, name))
+            .Concat(patterns.SelectMany(pattern =>
+                Directory.EnumerateFiles(sourceDirectory, pattern)));
+
+        foreach (string path in paths)
+        {
+            if (Path.GetFileName(path).Equals("game.iso", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            if (File.Exists(path) && seen.Add(Path.GetFullPath(path)))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    private static DiscImageKind GetImageKind(string path)
+    {
+        try
+        {
+            using FileStream stream = File.OpenRead(path);
+            if (HasVolumeDescriptor(stream, 16 * 2048 + 1))
+            {
+                return DiscImageKind.Iso;
+            }
+            if (HasVolumeDescriptor(stream, 16 * CueTrack.SectorLength + 16 + 1))
+            {
+                return DiscImageKind.RawMode1;
+            }
+            if (HasVolumeDescriptor(stream, 16 * CueTrack.SectorLength + 24 + 1))
+            {
+                return DiscImageKind.RawMode2;
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        return DiscImageKind.Unknown;
+    }
+
+    // Reports whether the primary volume descriptor of an ISO 9660 file
+    // system starts at the given offset.
+    private static bool HasVolumeDescriptor(FileStream stream, long offset)
+    {
+        byte[] buffer = new byte[5];
+        if (stream.Length < offset + buffer.Length)
+        {
+            return false;
+        }
+        stream.Seek(offset, SeekOrigin.Begin);
+        return stream.Read(buffer, 0, buffer.Length) == buffer.Length
+            && Encoding.ASCII.GetString(buffer) == "CD001";
     }
 
     private static IEnumerable<string> GetFilesToExtract(DiscUtils.DiscDirectoryInfo root)

--- a/tools/installer/TRX_Installer/InstallComponentFactory.cs
+++ b/tools/installer/TRX_Installer/InstallComponentFactory.cs
@@ -26,16 +26,12 @@ internal static class InstallComponentFactory
                     "Steam",
                     GetSteamDirectories("Tomb Raider (I)"),
                     _discImage,
-                    sourceDirectory =>
-                        File.Exists(Path.Combine(sourceDirectory, "GAME.GOG"))
-                        || File.Exists(Path.Combine(sourceDirectory, "game.dat"))),
+                    DiscImageInstallSource.CanInstallFrom),
                 new InstallSourceOption(
                     "GOG",
                     GetGOGDirectories("Tomb Raider 1"),
                     _discImage,
-                    sourceDirectory =>
-                        File.Exists(Path.Combine(sourceDirectory, "GAME.GOG"))
-                        || File.Exists(Path.Combine(sourceDirectory, "game.dat"))),
+                    DiscImageInstallSource.CanInstallFrom),
                 new InstallSourceOption(
                     "Disc",
                     DriveInfo.GetDrives()


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the installer stopped with "no tracks were found" and installed no game files, when the source directory held a disc image that is not a cue sheet. Before this, the installer always read game.dat as a cue sheet, and it accepted a directory that it could not read.

The installer now identifies a cue sheet, an ISO image and a raw CD image. It reports the directory that it inspected when it finds none of them.