### PR TITLE
build: silence uninitialized value warnings

### DIFF
--- a/src/trx/core/json/util/read_io.c
+++ b/src/trx/core/json/util/read_io.c
@@ -397,7 +397,7 @@ RESULT JSON_ReadIO_ReadXZ32Current(
 RESULT JSON_ReadIO_ReadXYZ16Current(
     JSON_READ_IO *const io, void *const target_void)
 {
-    XYZ_32 tmp;
+    XYZ_32 tmp = {};
     MUST(JSON_ReadIO_ReadXYZ32Current(io, &tmp));
     if (tmp.x < INT16_MIN || tmp.x > INT16_MAX || tmp.y < INT16_MIN
         || tmp.y > INT16_MAX || tmp.z < INT16_MIN || tmp.z > INT16_MAX) {

--- a/src/trx/core/value.c
+++ b/src/trx/core/value.c
@@ -458,7 +458,7 @@ void Value_CopyPtr(
         Memory_Free(old);
         return;
     }
-    TRX_VALUE v;
+    TRX_VALUE v = {};
     Value_ReadPtr(type, src, &v);
     Value_WritePtr(type, dst, &v);
 }

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -648,7 +648,7 @@ static int32_t M_PickShift(
         spread += rx * rx + ry * ry;
     }
 
-    float costs[SEAM_MAX_VERTEX_PAIRS];
+    float costs[SEAM_MAX_VERTEX_PAIRS] = {};
     for (int32_t shift = 0; shift < n; shift++) {
         float cost = 0.0f;
         for (int32_t k = 0; k < n; k++) {

--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -452,7 +452,7 @@ static void M_GetFaceCorners(
 static bool M_GetFaceCells(
     const ROOM *const room, const FACE *const face, int32_t cells[4])
 {
-    XYZ_32 corners[4];
+    XYZ_32 corners[4] = {};
     M_GetFaceCorners(room, face, corners);
 
     int32_t min_x = corners[0].x;
@@ -733,7 +733,7 @@ static int32_t M_CollectMeshFacets(
                     index->face_stamp[f] = stamp;
 
                     const FACE *const face = &index->faces[f];
-                    XYZ_32 corners[4];
+                    XYZ_32 corners[4] = {};
                     M_GetFaceCorners(room, face, corners);
 
                     int32_t face_min_x = corners[0].x;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Zero-initializes four locals that GCC reports as possibly uninitialized. In each place a loop or a switch on a known tag always fills the local, but the compiler cannot prove it.