### PR TITLE
Fix Lara sliding instead of collapsing on a fatal landing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed Lara not being able to crawl backwards in certain sloped crawlspaces (OG bug) (TRX1322)
 - Fixed Lara being able to crouch/crawl into spaces with very low ceilings where she can become clamped, such as RX-Tech Mines room 159 (OG bug) (#6477 / TRX1331)
 - Fixed Lara attempting to continue to descend a ladder despite being at the bottom of it (OG bug) (#6461 / TRX1315)
+- Fixed Lara sliding instead of collapsing when a fall kills her on a slope (TRX1408, regression from T1M 2.15.2 / TR2X 0.10 / TRX 1.1)
 
 **UI**
 - Added a fullscreen setting, so the window mode can be switched from the menu rather than only with Alt+Enter (Graphic Options → Rendering) (#6187 / TRX1036)

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -731,15 +731,19 @@ LANDED_STATE Lara_Col_LandedBad(ITEM *const item)
     if (g_Config.debug.enable_invulnerability) {
         return LANDED_OK;
     } else if (land_speed <= DAMAGE_LENGTH) {
-        Lara_TakeDamage(
-            LARA_MAX_HITPOINTS * SQUARE(land_speed) / SQUARE(DAMAGE_LENGTH),
-            false);
-    } else {
-        Lara_Kill();
+        const bool alive = item->hit_points > 0;
+        const int16_t damage =
+            LARA_MAX_HITPOINTS * SQUARE(land_speed) / SQUARE(DAMAGE_LENGTH);
+        // Item_TakeDamage clamps at zero, while the test below needs the
+        // negative value that the plain subtraction leaves behind.
+        const int16_t hit_points = item->hit_points - damage;
+        Lara_TakeDamage(damage, false);
+        // #675: Original bug to keep. Correct operator would be <=
+        return alive && hit_points < 0 ? LANDED_BAD : LANDED_OK;
     }
 
-    // #675: Original bug to keep. Correct operator would be <=
-    return item->hit_points < 0 ? LANDED_BAD : LANDED_OK;
+    Lara_Kill();
+    return LANDED_BAD;
 }
 
 // clang-format off

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -1,4 +1,5 @@
 #include <trx/config.h>
+#include <trx/game/anims/common.h>
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/util.h>
@@ -21,6 +22,14 @@ static bool M_IsAbyssLanding(
     const ITEM *const item, const COLL_INFO *const coll)
 {
     return Room_IsAbyssHeight(item->pos.y + coll->side_mid.floor);
+}
+
+static int16_t M_GetLandedBadState(const ITEM *const item)
+{
+    // Some landing animations have no change to the death state, in which
+    // case Lara stands up instead of staying stuck in the landing.
+    return Anim_HasChange(Item_GetAnim(item), LS(LS_DEATH)) ? LS(LS_DEATH)
+                                                            : LS(LS_STOP);
 }
 
 static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
@@ -366,7 +375,7 @@ static void M_ForwardJump(ITEM *const item, COLL_INFO *const coll)
         }
         break;
     case LANDED_BAD:
-        item->goal_anim_state = LS(LS_DEATH);
+        item->goal_anim_state = M_GetLandedBadState(item);
         break;
     case LANDED_HANDLED:
         break;
@@ -421,7 +430,7 @@ static void M_SideBackJump(ITEM *const item, COLL_INFO *const coll)
         item->goal_anim_state = LS(LS_STOP);
         break;
     case LANDED_BAD:
-        item->goal_anim_state = LS(LS_DEATH);
+        item->goal_anim_state = M_GetLandedBadState(item);
         break;
     case LANDED_HANDLED:
         break;
@@ -452,7 +461,7 @@ static void M_FallBack(ITEM *const item, COLL_INFO *const coll)
         item->goal_anim_state = LS(LS_STOP);
         break;
     case LANDED_BAD:
-        item->goal_anim_state = LS(LS_DEATH);
+        item->goal_anim_state = M_GetLandedBadState(item);
         break;
     case LANDED_HANDLED:
         break;

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -859,14 +859,20 @@ static void M_SprintRoll(ITEM *const item, COLL_INFO *const coll)
     }
 
     if (coll->side_mid.floor <= 0 && item->fall_speed > 0) {
-        if (Lara_Col_LandedBad(item)) {
+        switch (Lara_Col_LandedBad(item)) {
+        case LANDED_OK:
+            if (lara->water_status == LWS_WADE || !g_Input.forward
+                || g_Input.slow) {
+                item->goal_anim_state = LS(LS_STOP);
+            } else {
+                item->goal_anim_state = LS(LS_RUN);
+            }
+            break;
+        case LANDED_BAD:
             item->goal_anim_state = LS(LS_DEATH);
-        } else if (
-            lara->water_status == LWS_WADE || !g_Input.forward
-            || g_Input.slow) {
-            item->goal_anim_state = LS(LS_STOP);
-        } else {
-            item->goal_anim_state = LS(LS_RUN);
+            break;
+        case LANDED_HANDLED:
+            break;
         }
 
         item->fall_speed = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes Lara sliding down a slope instead of crunching when taking a fatal landing.

#### Testing

- [x] Lara collapses where she lands when a fall takes her health to zero on a slope, in TR1, TR2 and TR3.
- [x] Lara slides as before when the same fall leaves her alive.
- [x] A fall that leaves Lara at exactly zero health still ends in the standing death, not the crunch (#675).
