### PR TITLE
tools/te: fix custom levels with no interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,7 +191,7 @@ repos:
     entry: tools/lint/gen/te_symlinks
     language: python
     pass_filenames: false
-    files: ^(data/trx/ship/cfg/|tools/lint/gen/te_symlinks$)
+    files: ^(data/trx/ship/(cfg|modules|scripts|games)/|tools/lint/gen/te_symlinks$)
 
 - repo: https://github.com/JohnnyMorganz/StyLua
   rev: v2.3.0

--- a/data/te/tr1/Engine/games/tr1-custom/scripts/_game.lua
+++ b/data/te/tr1/Engine/games/tr1-custom/scripts/_game.lua
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/scripts/_game.lua

--- a/data/te/tr1/Engine/modules/assault.lua
+++ b/data/te/tr1/Engine/modules/assault.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/assault.lua

--- a/data/te/tr1/Engine/modules/legend.lua
+++ b/data/te/tr1/Engine/modules/legend.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/legend.lua

--- a/data/te/tr1/Engine/modules/overlay/init.lua
+++ b/data/te/tr1/Engine/modules/overlay/init.lua
@@ -1,0 +1,1 @@
+../../../../../trx/ship/modules/overlay/init.lua

--- a/data/te/tr1/Engine/modules/overlay/photo_mode.lua
+++ b/data/te/tr1/Engine/modules/overlay/photo_mode.lua
@@ -1,0 +1,1 @@
+../../../../../trx/ship/modules/overlay/photo_mode.lua

--- a/data/te/tr1/Engine/modules/save_crystal.lua
+++ b/data/te/tr1/Engine/modules/save_crystal.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/save_crystal.lua

--- a/data/te/tr1/Engine/modules/water_color.lua
+++ b/data/te/tr1/Engine/modules/water_color.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/water_color.lua

--- a/data/te/tr1/Engine/scripts/weapons.lua
+++ b/data/te/tr1/Engine/scripts/weapons.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/scripts/weapons.lua

--- a/data/te/tr2/Engine/games/tr2-custom/scripts/_game.lua
+++ b/data/te/tr2/Engine/games/tr2-custom/scripts/_game.lua
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/scripts/_game.lua

--- a/data/te/tr2/Engine/modules/assault.lua
+++ b/data/te/tr2/Engine/modules/assault.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/assault.lua

--- a/data/te/tr2/Engine/modules/legend.lua
+++ b/data/te/tr2/Engine/modules/legend.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/legend.lua

--- a/data/te/tr2/Engine/modules/overlay/init.lua
+++ b/data/te/tr2/Engine/modules/overlay/init.lua
@@ -1,0 +1,1 @@
+../../../../../trx/ship/modules/overlay/init.lua

--- a/data/te/tr2/Engine/modules/overlay/photo_mode.lua
+++ b/data/te/tr2/Engine/modules/overlay/photo_mode.lua
@@ -1,0 +1,1 @@
+../../../../../trx/ship/modules/overlay/photo_mode.lua

--- a/data/te/tr2/Engine/modules/save_crystal.lua
+++ b/data/te/tr2/Engine/modules/save_crystal.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/save_crystal.lua

--- a/data/te/tr2/Engine/modules/water_color.lua
+++ b/data/te/tr2/Engine/modules/water_color.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/water_color.lua

--- a/data/te/tr2/Engine/scripts/weapons.lua
+++ b/data/te/tr2/Engine/scripts/weapons.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/scripts/weapons.lua

--- a/data/te/tr3/Engine/games/tr3-custom/scripts/_game.lua
+++ b/data/te/tr3/Engine/games/tr3-custom/scripts/_game.lua
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/scripts/_game.lua

--- a/data/te/tr3/Engine/games/tr3/modules/quest_items.lua
+++ b/data/te/tr3/Engine/games/tr3/modules/quest_items.lua
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/modules/quest_items.lua

--- a/data/te/tr3/Engine/modules/assault.lua
+++ b/data/te/tr3/Engine/modules/assault.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/assault.lua

--- a/data/te/tr3/Engine/modules/legend.lua
+++ b/data/te/tr3/Engine/modules/legend.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/legend.lua

--- a/data/te/tr3/Engine/modules/overlay/init.lua
+++ b/data/te/tr3/Engine/modules/overlay/init.lua
@@ -1,0 +1,1 @@
+../../../../../trx/ship/modules/overlay/init.lua

--- a/data/te/tr3/Engine/modules/overlay/photo_mode.lua
+++ b/data/te/tr3/Engine/modules/overlay/photo_mode.lua
@@ -1,0 +1,1 @@
+../../../../../trx/ship/modules/overlay/photo_mode.lua

--- a/data/te/tr3/Engine/modules/save_crystal.lua
+++ b/data/te/tr3/Engine/modules/save_crystal.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/save_crystal.lua

--- a/data/te/tr3/Engine/modules/water_color.lua
+++ b/data/te/tr3/Engine/modules/water_color.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/water_color.lua

--- a/data/te/tr3/Engine/scripts/weapons.lua
+++ b/data/te/tr3/Engine/scripts/weapons.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/scripts/weapons.lua

--- a/tools/lint/gen/game_strings
+++ b/tools/lint/gen/game_strings
@@ -757,11 +757,14 @@ class RunContext:
         ]
         # The test fixtures name keys that exist to be looked up in a test, and
         # keys that exist to be missing. Neither says anything about what the
-        # game ships.
+        # game ships. The TombEditor tree links to the files the game ships, so
+        # it declares nothing of its own.
         lua_files = [
             path
             for path in versioned_files
-            if path.suffix == ".lua" and SRC_DIR / "tests" not in path.parents
+            if path.suffix == ".lua"
+            and SRC_DIR / "tests" not in path.parents
+            and DATA_DIR / "te" not in path.parents
         ]
         self.enum_value_types = get_enum_value_types(source_files)
         self.config_aliases = get_config_aliases(CommonPaths.src_dir / "config/map.def")

--- a/tools/lint/gen/te_symlinks
+++ b/tools/lint/gen/te_symlinks
@@ -98,21 +98,44 @@ def create_symlink(path: Path, target: str) -> None:
     path.symlink_to(target)
 
 
+def mirror_links(source_dir: Path, target_dir: Path) -> None:
+    for source_path in sorted(source_dir.rglob("*")):
+        if source_path.is_dir():
+            continue
+        if source_path.parent.name == 'presets':
+            continue
+        rel_path = source_path.relative_to(source_dir)
+        target_path = target_dir / rel_path
+        target_rel = source_path.relative_to(target_path.parent, walk_up=True)
+        create_symlink(target_path, str(target_rel))
+
+
 def create_cfg_links() -> None:
     source_dir = ROOT / "data" / "trx" / "ship" / "cfg"
     for game in TE_GAMES:
         target_dir = ROOT / "data" / "te" / game / "Engine" / "cfg"
-        for source_path in sorted(source_dir.rglob("*")):
-            if source_path.is_dir():
-                continue
-            if source_path.parent.name == 'presets':
-                continue
-            rel_path = source_path.relative_to(source_dir)
-            target_path = target_dir / rel_path
-            target_rel = source_path.relative_to(
-                target_path.parent, walk_up=True
-            )
-            create_symlink(target_path, str(target_rel))
+        mirror_links(source_dir, target_dir)
+
+
+def create_engine_script_links() -> None:
+    ship_dir = ROOT / "data" / "trx" / "ship"
+    for game in TE_GAMES:
+        engine_dir = ROOT / "data" / "te" / game / "Engine"
+        mirror_links(ship_dir / "modules", engine_dir / "modules")
+        mirror_links(ship_dir / "scripts", engine_dir / "scripts")
+
+
+def create_game_script_links() -> None:
+    games_dir = ROOT / "data" / "trx" / "ship" / "games"
+    for game, custom in GAME_LINKS:
+        base_dir = ROOT / "data" / "te" / game / "Engine" / "games"
+        source_path = games_dir / game / "scripts" / "_game.lua"
+        target_path = base_dir / custom / "scripts" / "_game.lua"
+        target_rel = source_path.relative_to(target_path.parent, walk_up=True)
+        create_symlink(target_path, str(target_rel))
+        # The game script names its own game's modules, so those keep the
+        # directory the name points at.
+        mirror_links(games_dir / game / "modules", base_dir / game / "modules")
 
 
 def create_game_links() -> None:
@@ -136,6 +159,8 @@ def create_injection_links() -> None:
 def main() -> None:
     remove_te_symlinks()
     create_cfg_links()
+    create_engine_script_links()
+    create_game_script_links()
     create_game_links()
     create_injection_links()
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where a game built from the Tomb Editor download had no interface and no weapons. Before this, the symlink tree held only the configuration and the catalogs, so the shared modules and the startup scripts never reached the engine.

Resolves TRX1409