### PR TITLE
phase/executor: fix jitter while the game quits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -164,6 +164,7 @@
 - Fixed the debug portal and bounding box lines becoming thinner at higher supersampling values (TRX1251)
 - Fixed missing reflections on transparent TR4 surfaces, such as Werner's glasses (TRX1294)
 - Fixed TR3 colored light objects appearing white in TR1 and TR2 levels (#6517 / TRX1377, regression from 1.10)
+- Fixed the picture jittering between two frames while the game fades out to quit (TRX1405)
 
 **TR1**
 - Added the ability for Lara to burn in swamp rooms marked with death sectors (#6539 / TRX1395)

--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -314,7 +314,8 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
             }
         }
 
-        if (!Shell_ShouldPauseForFocusLoss() && Interpolation_IsActive()) {
+        if (!Shell_ShouldPauseForFocusLoss() && !m_Exiting
+            && Interpolation_IsActive()) {
             Interpolation_SetRate(0.5);
             Output_SetTime(m_CurrentFrame - 0.5f);
             M_Draw(phase);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the picture jumps between two frames while the game fades out to quit. The executor kept drawing an interpolated half frame after the world stopped, causing the last two frames to alternate during the fade.

Resolves TRX1405