### PR TITLE
inventory_ring: fix an item at the screen edge

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fixed the game flashing over the black bars beside the picture when a frame is advanced in photo mode (regression from 1.10) (TRX1068)
 - Fixed dialogs sitting against a band of screen that no longer matched what the overlay was drawing there, which could leave them overlapping the heading or the item name
 - Fixed the inventory ring's button hints and item count overlapping the line of text the game puts at the foot of the screen
+- Fixed an item hanging at the edge of the screen while the inventory changes from one ring to another (TRX1404)
 - Fixed the icons beside the volume settings, which now show a note for the music and a speaker for the sound effects (TRX1040)
 - Fixed the statistics overlapping inventory text at large text sizes (#6295 / TRX1156)
 

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -23,7 +23,6 @@
 
 #include <math.h>
 
-#define M_CAMERA_2_RING 598
 #define M_SHADE_NORMAL SHADE_LOW
 #define M_SHADE_SELECTED SHADE_NEUTRAL
 
@@ -311,7 +310,7 @@ void InvRing_Draw(INV_RING *const ring)
     draw_ring.camera.pos.y = draw_camera_y;
     draw_ring.camera_pitch = draw_camera_pitch;
     draw_ring.ring_pos.rot.y = draw_ring_rot_y;
-    draw_ring.camera.pos.z = draw_radius + M_CAMERA_2_RING;
+    draw_ring.camera.pos.z = draw_radius + INV_RING_CAMERA_2_RING;
 
     if (ring->mode == INV_TITLE_MODE) {
         if (ring->live_scene) {

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/core/strings.h>
+#include <trx/core/utils.h>
 #include <trx/game/const.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/input.h>
@@ -138,6 +139,66 @@ static void M_MotionCameraPitch(INV_RING *const ring, const int16_t target)
     motion->camera_pitch_target = target;
     motion->camera_pitch_rate = target / ring->status_frames;
     motion->misc = target;
+}
+
+// Returns how high above the camera an item reaches once the ring has
+// collapsed onto its center, over every item in the ring and over every angle
+// the item can be turned to. The item turns about the vertical axis, which
+// leaves its height alone but carries its width and its depth toward the
+// camera or away from it, and an item nearer the camera stands higher in the
+// view. The corners of the bounding box give the reach, and the tilt the ring
+// holds the item at applies to each of them.
+static int16_t M_GetRingItemElevation(
+    const INV_RING *const ring, const int32_t cam_dist_y,
+    const int32_t cam_dist_z)
+{
+    int16_t result = 0;
+    for (int32_t i = 0; i < ring->number_of_objects; i++) {
+        const INVENTORY_ITEM *const inv_item = ring->list[i];
+        const OBJECT *const obj = Object_Get(inv_item->object_id);
+        if (!obj->loaded || obj->mesh_count < 0) {
+            continue;
+        }
+
+        const BOUNDS_16 *const bounds =
+            &obj->frame_base[inv_item->current_frame].bounds;
+        const XYZ_16 ends[2] = { bounds->min, bounds->max };
+
+        for (int32_t corner = 0; corner < 8; corner++) {
+            const XYZ_32 pos = XYZ_32_Rotate(
+                (XYZ_32) {
+                    .x = ends[corner & 1].x,
+                    .y = ends[(corner >> 1) & 1].y,
+                    .z = ends[(corner >> 2) & 1].z,
+                },
+                (XYZ_16) { .x = inv_item->x_rot });
+            const int32_t reach =
+                XYZ_32_GetLength((XYZ_32) { .x = pos.x, .z = pos.z });
+            const int32_t dist_z =
+                MAX(cam_dist_z - inv_item->z_trans - reach, 1);
+            const int16_t elevation =
+                Math_Atan(dist_z, cam_dist_y + inv_item->y_trans + pos.y);
+            result = MAX(result, elevation);
+        }
+    }
+    return result;
+}
+
+// Returns the pitch that takes a ring out of view before the switch hands over
+// to the next one. The ring collapses onto its center as it goes, so the pitch
+// has to lift the highest point any item reaches there past the edge of the
+// screen. The camera already looks below the ring center, which costs the
+// pitch that much before the ring starts to move off screen.
+static int16_t M_GetRingSwitchPitch(const INV_RING *const ring)
+{
+    const int32_t cam_dist_y = ring->ring_pos.pos.y - ring->camera.pos.y;
+    const int32_t cam_dist_z = INV_RING_CAMERA_2_RING;
+    const int16_t aim = Math_Atan(cam_dist_z, cam_dist_y + M_CAMERA_Y_OFFSET);
+    const int16_t half_fov = Output_GetVerticalHalfFOV(
+        FOV_VALUE_PASSPORT * DEG_1, FOV_MODE_PASSPORT);
+    const int16_t elevation =
+        M_GetRingItemElevation(ring, cam_dist_y, cam_dist_z);
+    return half_fov + elevation - aim;
 }
 
 static void M_MotionRotation(
@@ -526,11 +587,11 @@ void InvRing_SetStatusTransition(
             break;
         case RNG_MAIN2KEYS:
         case RNG_OPTION2MAIN:
-            M_MotionCameraPitch(ring, DEG_45);
+            M_MotionCameraPitch(ring, M_GetRingSwitchPitch(ring));
             break;
         case RNG_MAIN2OPTION:
         case RNG_KEYS2MAIN:
-            M_MotionCameraPitch(ring, -DEG_45);
+            M_MotionCameraPitch(ring, -M_GetRingSwitchPitch(ring));
             break;
         default:
             break;

--- a/src/trx/game/inventory_ring/priv.h
+++ b/src/trx/game/inventory_ring/priv.h
@@ -12,6 +12,7 @@
 #define INV_RING_CAMERA_HEIGHT (-0x100) // = -256
 #define INV_RING_CAMERA_START_HEIGHT (-0x600) // = -1536
 #define INV_RING_RADIUS 688
+#define INV_RING_CAMERA_2_RING 598
 
 typedef enum {
     INV_RING_ARROW_TL,

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -58,6 +58,49 @@ static bool m_IsSkyboxEnabled = false;
 static int32_t m_TintOverrideDepth = 0;
 static RGBA_F m_TintOverrideStack[8] = {};
 
+static void M_GetFocalLengths(
+    const int16_t fov_angle, const FOV_MODE fov_mode, const float aspect,
+    float *const out_f_x, float *const out_f_y)
+{
+    const float fov = fov_angle * M_PI / (float)DEG_180;
+
+    float f_x, f_y;
+    switch (fov_mode) {
+    case FOV_MODE_HORIZONTAL:
+        f_x = 1.0f / tanf(fov * 0.5f);
+        f_y = f_x * aspect;
+        break;
+    case FOV_MODE_VERTICAL:
+        f_y = 1.0f / tanf(fov * 0.5f);
+        f_x = f_y / aspect;
+        break;
+    case FOV_MODE_PC: {
+        const float persp = ((4.0f / 3.0f) / aspect);
+        f_x = persp / tanf(fov * 0.5f);
+        f_y = f_x * aspect;
+        break;
+    }
+    case FOV_MODE_PS1: {
+        const float persp = ((4.0f / 3.0f) / aspect) * (240.0f / 200.0f);
+        f_x = persp / tanf(fov * 0.5f);
+        f_y = f_x * aspect;
+        break;
+    }
+    case FOV_MODE_PS1_FIT: {
+        const float persp =
+            ((4.0f / 3.0f) / MAX(aspect, 16.0f / 10.0f)) * (240.0f / 200.0f);
+        f_x = persp / tanf(fov * 0.5f);
+        f_y = f_x * aspect;
+        break;
+    }
+    default:
+        ASSERT_FAIL();
+    }
+
+    *out_f_x = f_x;
+    *out_f_y = f_y;
+}
+
 float Output_GetTime(void)
 {
     return m_Time;
@@ -232,6 +275,16 @@ void Output_PopTintOverride(void)
     m_TintOverrideDepth--;
 }
 
+int16_t Output_GetVerticalHalfFOV(
+    const int16_t fov_angle, const FOV_MODE fov_mode)
+{
+    const float aspect = (float)Viewport_GetWidth(VIEWPORT_GAME)
+        / (float)Viewport_GetHeight(VIEWPORT_GAME);
+    float f_x, f_y;
+    M_GetFocalLengths(fov_angle, fov_mode, aspect, &f_x, &f_y);
+    return atanf(1.0f / f_y) * DEG_180 / M_PI;
+}
+
 void Output_GetPerspProjectionMatrix(GLfloat output[][4])
 {
     const float left = Viewport_GetMinX(VIEWPORT_GAME);
@@ -241,40 +294,10 @@ void Output_GetPerspProjectionMatrix(GLfloat output[][4])
     const float near = Output_GetNearZ() / (float)(1 << W2V_SHIFT);
     const float far = Output_GetFarZ() / (float)(1 << W2V_SHIFT);
     const float aspect = (float)(right - left) / (float)(bottom - top);
-    const float fov = Camera_GetInterpolatedFOV() * M_PI / (float)DEG_180;
 
     float f_x, f_y;
-    switch (Viewport_GetFOVMode()) {
-    case FOV_MODE_HORIZONTAL:
-        f_x = 1.0f / tanf(fov * 0.5f);
-        f_y = f_x * aspect;
-        break;
-    case FOV_MODE_VERTICAL:
-        f_y = 1.0f / tanf(fov * 0.5f);
-        f_x = f_y / aspect;
-        break;
-    case FOV_MODE_PC: {
-        const float persp = ((4.0f / 3.0f) / aspect);
-        f_x = persp / tanf(fov * 0.5f);
-        f_y = f_x * aspect;
-        break;
-    }
-    case FOV_MODE_PS1: {
-        const float persp = ((4.0f / 3.0f) / aspect) * (240.0f / 200.0f);
-        f_x = persp / tanf(fov * 0.5f);
-        f_y = f_x * aspect;
-        break;
-    }
-    case FOV_MODE_PS1_FIT: {
-        const float persp =
-            ((4.0f / 3.0f) / MAX(aspect, 16.0f / 10.0f)) * (240.0f / 200.0f);
-        f_x = persp / tanf(fov * 0.5f);
-        f_y = f_x * aspect;
-        break;
-    }
-    default:
-        ASSERT_FAIL();
-    }
+    M_GetFocalLengths(
+        Camera_GetInterpolatedFOV(), Viewport_GetFOVMode(), aspect, &f_x, &f_y);
 
     const float near_z = Output_GetNearZ();
     const float far_z = Output_GetFarZ();

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -11,6 +11,12 @@
 void Output_SetSkyboxEnabled(bool enabled);
 bool Output_IsSkyboxEnabled(void);
 
+// Returns half the angle the game viewport spans vertically, for the given
+// field of view and formula. The angle depends on the viewport shape, so a
+// narrow window sees more of the scene above and below the center than a wide
+// one does.
+int16_t Output_GetVerticalHalfFOV(int16_t fov_angle, FOV_MODE fov_mode);
+
 void Output_GetPerspProjectionMatrix(GLfloat output[][4]);
 void Output_GetOrthoProjectionMatrix(GLfloat output[][4]);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where an item stays at the edge of the screen while the inventory changes from one ring to another, then disappears at once. Before this, the camera pitched a fixed 45 degrees to take the ring out of view, which is not far enough on a viewport that sees more of the scene above and below the center.

The angle now follows the field of view the inventory draws with.

Resolves TRX1404