### PR TITLE
Keep bars hidden for the entire cutscene, including fades

### DIFF
--- a/data/trx/ship/modules/overlay/init.lua
+++ b/data/trx/ship/modules/overlay/init.lua
@@ -72,11 +72,11 @@ local state = {
   opening = signal.new(false),
 }
 
--- Lara's own bars are hers to show, so they go while she is not in charge of
--- herself and while a cutscene has the screen.
+-- Show Lara's bars only when she controls herself and the cutscene is not
+-- active. A cutscene keeps the screen through its fades.
 state.lara_bars = state.ui_enabled
   & lara.signals.is_controllable
-  & ~trx.cutscenes.signals.is_playing
+  & ~trx.cutscenes.signals.is_active
 
 -- How low a bar has to be before it flashes, which TR1 puts lower than the
 -- rest. It is read as a bar asks, because which game is running is not settled

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -303,6 +303,7 @@
 - Added the `trx.ui.widgets.Digits` widget, which lays a line of text out as an object's sprites
 - Added a new Lua module, `trx.waypoints`, for how far along a level's own progression Lara has got, which TR4 marks out and its guides follow; it is saved with the game and reports the furthest she has ever reached as well as where she is now
 - Added `trx.lara.speech_face`, for the face Lara talks with, which follows the outfit she is wearing rather than the one a level carries
+- Added `trx.cutscenes.is_active`, which says when a cutscene has the screen, including during its fades (TRX1414)
 - Added `trx.cutscenes.set_lara_shadow_bounds()`, for the box a cutscene gives Lara's shadow, so a scene can make it read as something she rides in (TRX911)
 - Added `trx.mod.Mod.can_switch`, which says whether `trx.mod.switch` accepts the mod, so a single level loaded on its own is told apart from a mod a player picks
 - Added `trx.strings.dash_case()`, which spells a name the way the console shows one

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -10387,8 +10387,20 @@
       "writable": false
     },
     {
+      "description": "Signals when a cutscene has the screen, including during its fades.",
+      "path": "cutscenes.signals.is_active",
+      "type": "signal.Signal",
+      "writable": false
+    },
+    {
       "description": "Whether a cutscene is on screen.",
       "path": "cutscenes.is_playing",
+      "type": "boolean",
+      "writable": false
+    },
+    {
+      "description": "Whether a cutscene has the screen, including during its fades. Use this\nto keep an interface off while the cutscene is active.",
+      "path": "cutscenes.is_active",
       "type": "boolean",
       "writable": false
     },

--- a/docs/trx/lua/reference/CUTSCENES.md
+++ b/docs/trx/lua/reference/CUTSCENES.md
@@ -40,7 +40,10 @@ end)
   nothing in it can be triggered or listened to; naming a frame is how a
   script acts part-way through one, as the original game does. *(read-only)*
 - <a id="cutscenes.signals.is_playing" name="cutscenes.signals.is_playing"></a>**`trx.cutscenes.signals.is_playing`** ([trx.signal.Signal](SIGNAL.md#signal.Signal)). Says when a cutscene takes the screen, and when it gives it back. *(read-only)*
+- <a id="cutscenes.signals.is_active" name="cutscenes.signals.is_active"></a>**`trx.cutscenes.signals.is_active`** ([trx.signal.Signal](SIGNAL.md#signal.Signal)). Signals when a cutscene has the screen, including during its fades. *(read-only)*
 - <a id="cutscenes.is_playing" name="cutscenes.is_playing"></a>**`trx.cutscenes.is_playing`** (boolean). Whether a cutscene is on screen. *(read-only)*
+- <a id="cutscenes.is_active" name="cutscenes.is_active"></a>**`trx.cutscenes.is_active`** (boolean). Whether a cutscene has the screen, including during its fades. Use this
+  to keep an interface off while the cutscene is active. *(read-only)*
 - <a id="cutscenes.count" name="cutscenes.count"></a>**`trx.cutscenes.count`** (integer). How many cutscenes this game can play. `0` where it has none, which is every game but TR4 and a TR4 install with no `cutseq.pak` beside its levels. *(read-only)*
 - <a id="cutscenes.actor_count" name="cutscenes.actor_count"></a>**`trx.cutscenes.actor_count`** (integer). How many actors the running cutscene has, or `0` if none is running. *(read-only)*
 - <a id="cutscenes.fov" name="cutscenes.fov"></a>**`trx.cutscenes.fov`** ([trx.math.Angle](MATH.md#math.Angle)). Field of view a cutscene plays at. TR4 uses 11488, against 14560 for ordinary play.

--- a/src/lua/api/cutscenes.lua
+++ b/src/lua/api/cutscenes.lua
@@ -325,10 +325,34 @@ api.property("cutscenes.signals.is_playing", {
   end,
 })
 
+local cutscene_active = nil
+
+api.property("cutscenes.signals.is_active", {
+  type = "signal.Signal",
+  description = "Signals when a cutscene has the screen, including during its fades.",
+  get = function()
+    if cutscene_active == nil then
+      cutscene_active = trx.signal.polled(function()
+        return trx.cutscenes.is_active
+      end)
+    end
+    return cutscene_active
+  end,
+})
+
 api.property("cutscenes.is_playing", {
   type = "boolean",
   description = "Whether a cutscene is on screen.",
   get = raw.is_playing,
+})
+
+api.property("cutscenes.is_active", {
+  type = "boolean",
+  description = [[
+    Whether a cutscene has the screen, including during its fades. Use this
+    to keep an interface off while the cutscene is active.
+  ]],
+  get = raw.is_active,
 })
 
 api.property("cutscenes.count", {

--- a/src/tests/fakes/cutseq.c
+++ b/src/tests/fakes/cutseq.c
@@ -24,6 +24,12 @@ bool CutSeq_IsPlaying(void)
     return m_IsPlaying;
 }
 
+// The fake scene has no fades.
+bool CutSeq_IsActive(void)
+{
+    return m_IsPlaying;
+}
+
 int32_t CutSeq_GetCurrent(void)
 {
     return -1;

--- a/src/trx/game/cutseq/playback.c
+++ b/src/trx/game/cutseq/playback.c
@@ -192,12 +192,15 @@ static float M_GetDefaultLetterbox(void)
                                                         : M_DEFAULT_LETTERBOX;
 }
 
-// Reports whether a scene may be cut short. The title plays its scenes as
-// scenery behind the menu, where there is nothing for the player to get past.
 static bool M_IsSkippable(void)
 {
     const GF_LEVEL *const level = GF_GetCurrentLevel();
     return level == nullptr || level->type != GFL_TITLE;
+}
+
+static bool M_IsBusy(void)
+{
+    return m_State.phase != M_PHASE_INACTIVE;
 }
 
 static void M_ReleaseNodes(void)
@@ -550,18 +553,13 @@ int32_t CutSeq_GetCount(void)
 
 bool CutSeq_IsActive(void)
 {
-    return m_State.phase != M_PHASE_INACTIVE;
+    return M_IsBusy() || Fader_GetCurrentValue(&m_State.fader) > 0.0f;
 }
 
 bool CutSeq_IsPlaying(void)
 {
     return m_State.phase == M_PHASE_PLAYING
         || m_State.phase == M_PHASE_FADE_END;
-}
-
-bool CutSeq_IsFading(void)
-{
-    return Fader_IsActive(&m_State.fader);
 }
 
 int32_t CutSeq_GetCurrent(void)
@@ -578,7 +576,7 @@ void CutSeq_Request(const int32_t num, const bool fade_out)
 {
     // Lara is a cutscene's first actor, so a level that never placed her - a
     // title that only shows scenery - has nothing to play.
-    if (CutSeq_IsActive() || num < 0 || num >= CutSeq_GetCount()
+    if (M_IsBusy() || num < 0 || num >= CutSeq_GetCount()
         || Lara_GetItem() == nullptr) {
         return;
     }
@@ -616,7 +614,7 @@ void CutSeq_HandleTrigger(const int32_t num)
     // A pad answers every frame Lara stands on it, so the once-only rule comes
     // first - it decides whether there is a trigger to answer at all, and a
     // script that wants a scene again clears its played mark.
-    if (CutSeq_IsActive() || CutSeq_IsPlayed(num)) {
+    if (M_IsBusy() || CutSeq_IsPlayed(num)) {
         return;
     }
 

--- a/src/trx/game/cutseq/playback.h
+++ b/src/trx/game/cutseq/playback.h
@@ -24,15 +24,19 @@
 void CutSeq_Load(void);
 
 bool CutSeq_IsAvailable(void);
+
 // How many cutscenes this game can play; 0 when it has none. Every number a
 // caller passes below is a valid one only while it is under this.
 int32_t CutSeq_GetCount(void);
+
+// Whether a cutscene has the screen, fades included. It holds through the fade
+// into a scene, through the scene, and through the black that follows it, and
+// ends once the level is back in view or the next scene, the end of the level
+// or another place to go has taken the screen.
 bool CutSeq_IsActive(void);
 bool CutSeq_IsPlaying(void);
-// Whether the cutscene's own fade is still on screen. It runs on past the
-// scene, bringing the level back into view once the scene has been torn down.
-bool CutSeq_IsFading(void);
 int32_t CutSeq_GetCurrent(void);
+
 // Which frame of the running scene is on screen, or -1 when none is. A scene
 // has no other clock: its actors are pose tracks rather than items, so a
 // script with something to do part-way through has only the frame to name it
@@ -48,6 +52,7 @@ void CutSeq_Request(int32_t num, bool fade_out);
 // The number need not be one the pak can play; see CUTSEQ_MAX_TRIGGERS.
 bool CutSeq_IsPlayed(int32_t num);
 void CutSeq_SetPlayed(int32_t num, bool played);
+
 // The whole played-once bitmask, for the paths that carry it as one value:
 // the savegame, and the start of a playthrough.
 uint64_t CutSeq_GetPlayedMask(void);

--- a/src/trx/game/lua/capi/cutscenes.c
+++ b/src/trx/game/lua/capi/cutscenes.c
@@ -84,6 +84,13 @@ static int M_L_CutscenesIsPlaying(lua_State *const L)
     return 1;
 }
 
+// trxc.cutscenes.is_active() → bool
+static int M_L_CutscenesIsActive(lua_State *const L)
+{
+    lua_pushboolean(L, CutSeq_IsActive());
+    return 1;
+}
+
 // trxc.cutscenes.is_played(num) → bool
 static int M_L_CutscenesIsPlayed(lua_State *const L)
 {
@@ -231,6 +238,7 @@ static const luaL_Reg m_Module[] = {
     { "get_current", M_L_CutscenesGetCurrent },
     { "get_frame_num", M_L_CutscenesGetFrameNum },
     { "is_playing", M_L_CutscenesIsPlaying },
+    { "is_active", M_L_CutscenesIsActive },
     { "get_count", M_L_CutscenesGetCount },
     { "get_actor_count", M_L_CutscenesGetActorCount },
     { "set_actor_visible", M_L_CutscenesSetActorVisible },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Lara's bars now stay hidden for the entire cutscene, including fades. Previously, they could appear over black screens between chained cutscenes, such as the TR4 ending.

Cutscenes now also report when they hold the screen:

```lua
trx.cutscenes.is_active
trx.cutscenes.signals.is_active
```

Resolves TRX1414

#### Testing

##### TR4

- [x] Sprint before the ending, then skip the first two cutscenes: no bars appear between them.
- [x] Play the ending without skipping: no bars appear.
- [x] Sprint before an in-game cutscene: the sprint bar disappears during the fade and returns afterward.