### PR TITLE
output/shadows: fix shadow jumping when shimmying

### DIFF
--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -223,7 +223,7 @@ static void M_GetPlacement(
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(*anchor_pos, &room_num);
     const int32_t height = Room_GetHeight(sector, *anchor_pos);
-    if (height != NO_HEIGHT) {
+    if (height != NO_HEIGHT && height >= *floor - STEP_L) {
         *floor = height;
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where Lara's shadow jumped up onto the ledge for a frame while she shimmied around a corner or moved from a climb to a hang. Her shadow now keeps to the ground below her.

Resolves TRX1224