### PR TITLE
Fix Lara's braid after a load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed the tip of Lara's braid dropping away from the rest of it for a moment after a level or a save is loaded (TRX1304)
 - Fixed Lara's braid not being drawn on the first frame of a level (TRX1304)
+- Fixed Lara's braid hanging away from her head or keeping the previous outfit's shape after an outfit change (TRX1437)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 - Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
 - Fixed crashes in custom levels with incomplete object sets

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -122,6 +122,7 @@
 - Fixed Lara clipping into or underneath lifts if she tries to step on top of or into one from an exterior floor whose height matches the lift ceiling or floor (OG bug) (#3905 / TRX1014)
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
 - Fixed the tip of Lara's braid dropping away from the rest of it for a moment after a level or a save is loaded (TRX1304)
+- Fixed Lara's braid not being drawn on the first frame of a level (TRX1304)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 - Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
 - Fixed crashes in custom levels with incomplete object sets

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -121,6 +121,7 @@
 - Fixed Lara being killed by electric fences while immune (#6475)
 - Fixed Lara clipping into or underneath lifts if she tries to step on top of or into one from an exterior floor whose height matches the lift ceiling or floor (OG bug) (#3905 / TRX1014)
 - Fixed Lara's braid not colliding properly with her selected outfit, instead referencing the level's OG outfit (TRX1277, regression from 1.2)
+- Fixed the tip of Lara's braid dropping away from the rest of it for a moment after a level or a save is loaded (TRX1304)
 - Fixed being able to push pushblocks onto floors with triangular geometry (TRX1228, regression from 1.0)
 - Fixed propellers not being collidable if they are deactivated and then later reactivated (OG bug) (#6494 / TRX1351)
 - Fixed crashes in custom levels with incomplete object sets

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -15,6 +15,7 @@
 #include <trx/game/interpolation.h>
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
+#include <trx/game/lara/hair.h>
 #include <trx/game/lua/events.h>
 #include <trx/game/music.h>
 #include <trx/game/option/passport.h>
@@ -45,13 +46,15 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
 {
     Game_SetCurrentLevel(level);
 
+    const bool is_cutscene = level->type == GFL_CUTSCENE;
+
     g_OverlayFlag = 1;
     Camera_Initialise();
+    Lara_Hair_Control(is_cutscene);
     Interpolation_Remember();
     Interpolation_Interpolate();
 
     Sound_StopAll();
-    const bool is_cutscene = level->type == GFL_CUTSCENE;
     if (level->music_track != MX_INACTIVE
         && (is_cutscene || Music_GetCurrentLoopedTrack() == MX_INACTIVE)) {
         Music_PlayBySlot(level->music_track, is_cutscene ? MPM_ONCE : MPM_LOOP);

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -577,3 +577,8 @@ void Interpolation_CommitBraid(void)
 {
     M_CommitBraid();
 }
+
+void Interpolation_RememberBraid(void)
+{
+    M_RememberBraid();
+}

--- a/src/trx/game/interpolation.h
+++ b/src/trx/game/interpolation.h
@@ -15,6 +15,7 @@ void Interpolation_SetRate(double rate);
 void Interpolation_Interpolate(void);
 void Interpolation_Remember(void);
 void Interpolation_RememberItem(ITEM *item);
+void Interpolation_RememberBraid(void);
 
 // Instantly discard interpolation data
 void Interpolation_CommitLara(void);

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -7,6 +7,7 @@
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/game.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/mesh.h>
 #include <trx/game/lara/pose.h>
@@ -322,6 +323,11 @@ static void M_Control(
 
             Matrix_Pop();
         }
+
+        // The chain has just been built from scratch, so there is no earlier
+        // pose to blend from; without this the first frames drawn after a
+        // level load stretch the braid between the two.
+        Interpolation_RememberBraid();
         return;
     }
 

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -328,6 +328,7 @@ static void M_Control(
         // pose to blend from; without this the first frames drawn after a
         // level load stretch the braid between the two.
         Interpolation_RememberBraid();
+        Interpolation_CommitBraid();
         return;
     }
 

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -38,7 +38,6 @@ typedef struct {
 
 static bool m_IsFirstHair[M_MAX_BRAIDS];
 static SPHERE m_HairSpheres[M_HAIR_SPHERES];
-static XYZ_32 m_HairVelocity[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
 static HAIR_SEGMENT m_HairSegments[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
 
 // The braid weld state, kept between outfit applies.
@@ -352,16 +351,15 @@ static void M_Control(
     const XZ_32 smoke_wind = Sparks_GetSmokeWind();
     const int32_t hair_wind_z = Sparks_GetHairWindZ();
 
-    XYZ_32 *const velocity = m_HairVelocity[braid_idx];
     for (int32_t i = 1; i <= M_HAIR_SEGMENTS; i++) {
         HAIR_SEGMENT *const ps = &m_HairSegments[braid_idx][i - 1];
         HAIR_SEGMENT *const s = &m_HairSegments[braid_idx][i];
 
-        velocity[0] = s->pos;
+        const XYZ_32 old_pos = s->pos;
 
-        s->pos.x += velocity[i].x * 3 / 4;
-        s->pos.y += velocity[i].y * 3 / 4;
-        s->pos.z += velocity[i].z * 3 / 4;
+        s->pos.x += s->vel.x * 3 / 4;
+        s->pos.y += s->vel.y * 3 / 4;
+        s->pos.z += s->vel.z * 3 / 4;
 
         if (g_Config.visuals.breeze_mode == BREEZE_MODE_TR3) {
             if (lara_info->water_status == LWS_ABOVE_WATER
@@ -378,11 +376,11 @@ static void M_Control(
             }
 
             if (s->pos.y > height) {
-                s->pos.x = velocity[0].x;
+                s->pos.x = old_pos.x;
                 if (s->pos.y - height <= STEP_L) {
                     s->pos.y = height;
                 }
-                s->pos.z = velocity[0].z;
+                s->pos.z = old_pos.z;
             }
         } else {
             LARA_WATER_STATE water_status = lara_info->water_status;
@@ -446,9 +444,9 @@ static void M_Control(
         s->pos.y = g_MatrixPtr->_13 >> W2V_SHIFT;
         s->pos.z = g_MatrixPtr->_23 >> W2V_SHIFT;
 
-        velocity[i].x = s->pos.x - velocity[0].x;
-        velocity[i].y = s->pos.y - velocity[0].y;
-        velocity[i].z = s->pos.z - velocity[0].z;
+        s->vel.x = s->pos.x - old_pos.x;
+        s->vel.y = s->pos.y - old_pos.y;
+        s->vel.z = s->pos.z - old_pos.z;
 
         Matrix_Pop();
     }
@@ -810,7 +808,7 @@ void Lara_Hair_Initialise(void)
             m_HairSegments[i][j].rot.x = -DEG_90;
             m_HairSegments[i][j].rot.y = 0;
             m_HairSegments[i][j].rot.z = 0;
-            m_HairVelocity[i][j - 1] = (XYZ_32) {};
+            m_HairSegments[i][j].vel = (XYZ_32) {};
         }
     }
 }

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -38,6 +38,15 @@ typedef struct {
 } M_SEGMENT_SEAM;
 
 static bool m_IsFirstHair[M_MAX_BRAIDS];
+
+// The braid currently represented by the segment chain. Each outfit brings its
+// own pigtail count, segment meshes, and bone lengths, so changing any of them
+// leaves the chain describing a braid Lara no longer wears.
+static struct {
+    int32_t count;
+    const ANIM_BONE *bones[M_MAX_BRAIDS];
+    int32_t mesh_idx[M_MAX_BRAIDS];
+} m_Seated = {};
 static SPHERE m_HairSpheres[M_HAIR_SPHERES];
 static HAIR_SEGMENT m_HairSegments[M_MAX_BRAIDS][M_HAIR_SEGMENTS + 1];
 
@@ -797,15 +806,33 @@ static void M_CalculateRenderRolls(
     }
 }
 
+static bool M_HasBraidChanged(void)
+{
+    const LARA_SKIN_BRAID *const braid = Lara_Skin_GetBraid();
+    bool changed = braid->count != m_Seated.count;
+    m_Seated.count = braid->count;
+
+    for (int32_t i = 0; i < M_MAX_BRAIDS; i++) {
+        const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase(i);
+        const int32_t mesh_idx = Lara_Skin_GetBraidMeshIdx(i);
+        changed |= bones != m_Seated.bones[i];
+        changed |= mesh_idx != m_Seated.mesh_idx[i];
+        m_Seated.bones[i] = bones;
+        m_Seated.mesh_idx[i] = mesh_idx;
+    }
+    return changed;
+}
+
 void Lara_Hair_Initialise(void)
 {
     for (int32_t i = 0; i < M_MAX_BRAIDS; i++) {
+        m_IsFirstHair[i] = true;
+
         const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase(i);
         if (bones == nullptr) {
             continue;
         }
 
-        m_IsFirstHair[i] = true;
         m_HairSegments[i][0].rot.x = -DEG_90;
         m_HairSegments[i][0].rot.y = 0;
 
@@ -818,6 +845,15 @@ void Lara_Hair_Initialise(void)
             m_HairSegments[i][j].vel = (XYZ_32) {};
         }
     }
+}
+
+void Lara_Hair_Rebuild(void)
+{
+    if (!M_HasBraidChanged()) {
+        return;
+    }
+    Lara_Hair_Initialise();
+    Lara_Hair_Control(true);
 }
 
 void Lara_Hair_Control(const bool in_cutscene)

--- a/src/trx/game/lara/hair.h
+++ b/src/trx/game/lara/hair.h
@@ -16,15 +16,29 @@ typedef struct {
     } interp;
 } HAIR_SEGMENT;
 
+// Resets every braid segment to its bone offset, hanging straight down at rest,
+// and marks the chain as not yet built. The braid stays undrawn until the next
+// control pass chains it off her head.
 void Lara_Hair_Initialise(void);
-// Detects the ring adjacent braid segments share and enables welding it shut at
-// draw time. A no-op unless the outfit opts into joints and the segment meshes
-// share a ring; call whenever the outfit changes.
+
+// Finds the ring shared by adjacent braid segments and enables welding it shut
+// at draw time. A no-op unless the outfit opts into joints and the segment
+// meshes share a ring; call whenever the outfit changes.
 void Lara_Hair_InitJoints(const LARA_SKIN_OUTFIT *outfit);
+
+// Rebuilds the braid chain when the outfit brings a different braid. A no-op
+// while the pigtail count, segment meshes, and bones stay the same; call
+// whenever the outfit changes.
+void Lara_Hair_Rebuild(void);
+
 bool Lara_Hair_IsActive(void);
+
 void Lara_Hair_Control(bool in_cutscene);
+
 void Lara_Hair_Draw(void);
 
 int32_t Lara_Hair_GetBraidCount(void);
+
 int32_t Lara_Hair_GetSegmentCount(void);
+
 HAIR_SEGMENT *Lara_Hair_GetSegment(int32_t braid_idx, int32_t segment_idx);

--- a/src/trx/game/lara/hair.h
+++ b/src/trx/game/lara/hair.h
@@ -7,6 +7,7 @@
 typedef struct {
     XYZ_32 pos;
     XYZ_16 rot;
+    XYZ_32 vel;
     struct {
         struct {
             XYZ_32 pos;

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -633,6 +633,7 @@ void Lara_Skin_ApplyOutfit(void)
     M_UpdateSunglasses();
     Lara_Joints_Initialise(outfit);
     Lara_Hair_InitJoints(outfit);
+    Lara_Hair_Rebuild();
 }
 
 void Lara_Skin_SetMeshOverride(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This PR fixes three braid issues when loading a level or save:

- The braid tip no longer drops away for a few frames after loading.
- The braid is now visible on the first frame after loading.
- Braid velocity is now stored directly on each segment, fixing stale velocity during setup.

Resolves TRX1304.

#### Testing

- [x] Save and load while wading; the braid stays intact.
- [x] Load a level; the braid is visible on the first frame.
- [x] Switch outfits while wading, including one with two pigtails; the braid is placed correctly.
- [x] Walk, run, jump, and roll; the braid behaves as before.
- [x] Wade, surface swim, and dive; the braid behaves as before.