### PR TITLE
inv_ring: fix the title blood spawning in one spot

### DIFF
--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -34,6 +34,7 @@
 #include <trx/game/option/stats.h>
 #include <trx/game/output/overlay.h>
 #include <trx/game/overlay.h>
+#include <trx/game/random.h>
 #include <trx/game/savegame.h>
 #include <trx/game/shell.h>
 #include <trx/game/sound.h>
@@ -995,6 +996,12 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     // instead. What plays there is the title script's business.
     ring->live_scene =
         mode == INV_TITLE_MODE && g_GameFlow.main_menu_use_live_scene;
+    // The draw random number generator stands still outside live play, which
+    // holds every effect the scene draws on one value. A live scene runs, so
+    // it advances again for as long as the menu is up.
+    if (ring->live_scene) {
+        Random_FreezeDraw(false);
+    }
     ring->background_style = mode != INV_TITLE_MODE
         ? g_Config.ui.inventory_background_style
         : (ring->live_scene ? BK_NONE : BK_IMAGE);
@@ -1104,6 +1111,7 @@ void InvRing_Close(INV_RING *const ring)
         if (FlybyMode_IsActive()) {
             FlybyMode_Deactivate();
         }
+        Random_FreezeDraw(true);
     }
 
     if (g_Config.input.enable_buffering_inventory) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the blood in the TR4 title screen's mummy scene appeared in a single spot. Before this, the draw random number generator stayed frozen for as long as the menu was up once a level had been played, so every effect the scene drew stood on one value.

Resolves TRX1406.