### PR TITLE
output/shaders: fix TR3 shader link failure

### DIFF
--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -364,6 +364,10 @@ void main(void) {
 
     // Apply flat shading AFTER modulation
     gOut.color = vec4(lit * modulate, inColor.a);
+
+    // Only TR4 lights the submerged part of a mesh separately.
+    gOut.colorSub = gOut.color.rgb;
+    gOut.addSub = gOut.add;
 #else
     gOut.add = vec3(0.0);
     float shade_mul = 1.0;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -164,6 +164,7 @@
 - Fixed the debug portal and bounding box lines becoming thinner at higher supersampling values (TRX1251)
 - Fixed missing reflections on transparent TR4 surfaces, such as Werner's glasses (TRX1294)
 - Fixed TR3 colored light objects appearing white in TR1 and TR2 levels (#6517 / TRX1377, regression from 1.10)
+- Fixed TR3 levels refusing to start with a message that TRX cannot draw the game
 
 **TR1**
 - Added the ability for Lara to burn in swamp rooms marked with death sectors (#6539 / TRX1395)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where TR3 levels refused to start, with a message that TRX cannot draw the game. The mesh vertex shader left the submerged color outputs unwritten in the TR3 path, which strict drivers reject at link time.