### PR TITLE
shell: size the viewport from the game window

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -164,6 +164,7 @@
 - Fixed the debug portal and bounding box lines becoming thinner at higher supersampling values (TRX1251)
 - Fixed missing reflections on transparent TR4 surfaces, such as Werner's glasses (TRX1294)
 - Fixed TR3 colored light objects appearing white in TR1 and TR2 levels (#6517 / TRX1377, regression from 1.10)
+- Fixed the top of the picture being cut off in fullscreen on macOS (#6551 / TRX1407)
 
 **TR1**
 - Added the ability for Lara to burn in swamp rooms marked with death sectors (#6539 / TRX1395)

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -127,12 +127,6 @@ bool Shell_IsFullscreen(void)
     return (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0;
 }
 
-SHELL_SIZE Shell_GetCurrentSize(void)
-{
-    return Shell_IsFullscreen() ? Shell_GetCurrentDisplaySize()
-                                : Shell_GetWindowSize();
-}
-
 SHELL_SIZE Shell_GetDefaultSize(void)
 {
     return (SHELL_SIZE) { SHELL_HEADLESS_WIDTH, SHELL_HEADLESS_HEIGHT };
@@ -149,23 +143,6 @@ SHELL_SIZE Shell_GetWindowSize(void)
         SDL_GetWindowSize(window, &result.w, &result.h);
     }
     return result;
-}
-
-SHELL_SIZE Shell_GetCurrentDisplaySize(void)
-{
-    if (Shell_GetArgs()->headless) {
-        return Shell_GetDefaultSize();
-    }
-    int32_t display_idx = 0;
-    SDL_Window *const window = Shell_GetWindow();
-    if (window != nullptr) {
-        display_idx = SDL_GetWindowDisplayIndex(window);
-    }
-    SDL_DisplayMode dm;
-    if (SDL_GetCurrentDisplayMode(display_idx, &dm) == 0) {
-        return (SHELL_SIZE) { .w = dm.w, .h = dm.h };
-    }
-    return (SHELL_SIZE) { .w = -1, .h = -1 };
 }
 
 void Shell_ScheduleExit(void)

--- a/src/trx/game/shell/common.h
+++ b/src/trx/game/shell/common.h
@@ -41,5 +41,3 @@ void Shell_SetHeadless(bool headless);
 bool Shell_IsFullscreen(void);
 SHELL_SIZE Shell_GetDefaultSize(void);
 SHELL_SIZE Shell_GetWindowSize(void);
-SHELL_SIZE Shell_GetCurrentSize(void);
-SHELL_SIZE Shell_GetCurrentDisplaySize(void);

--- a/src/trx/game/shell/config.c
+++ b/src/trx/game/shell/config.c
@@ -24,14 +24,14 @@ static SHELL_SIZE m_ViewportSize = { .w = -1, .h = -1 };
 
 static bool M_MustUpdateRendererViewport(void)
 {
-    const SHELL_SIZE size = Shell_GetCurrentSize();
+    const SHELL_SIZE size = Shell_GetWindowSize();
     return m_ViewportSize.w != size.w || m_ViewportSize.h != size.h;
 }
 
 void Shell_RefreshRendererViewport(void)
 {
     Viewport_Reset();
-    m_ViewportSize = Shell_GetCurrentSize();
+    m_ViewportSize = Shell_GetWindowSize();
 }
 
 void Shell_SyncToWindow(void)

--- a/src/trx/game/viewport.c
+++ b/src/trx/game/viewport.c
@@ -157,7 +157,7 @@ VIEWPORT_RECT Viewport_GetRect(const VIEWPORT_SPACE space)
 
 void Viewport_Reset(void)
 {
-    const SHELL_SIZE size = Shell_GetCurrentSize();
+    const SHELL_SIZE size = Shell_GetWindowSize();
     VIEWPORT_RECT *const window = &m_Rects[VIEWPORT_WINDOW];
     VIEWPORT_RECT *const target = &m_Rects[VIEWPORT_TARGET];
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where the top of the picture was cut off in fullscreen on macOS. Before this, the viewport in fullscreen came from the display mode rather than from the window the game draws into, so the two disagreed wherever the system keeps part of the screen for itself.

Resolves #6551 / TRX1407