### PR TITLE
output/sources/ui: flatten TR4 pickup lighting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -227,6 +227,7 @@
 - Added TR4 support to the Windows installer (TRX1333)
 - Changed a flip to move the group of rooms the trigger names, rather than every flip room in the level (TRX173)
 - Changed the inventory item lighting to match the original game (TRX1371)
+- Changed the lighting of the rotating pickups in the interface to match the original game (TRX1402)
 - Fixed animations that move an item sideways playing with the item standing still, such as TR4's guide shimmy (TRX1062)
 - Fixed creatures walking through squares a pushable block stands on (TRX1060)
 - Fixed Lara flinching when she bumps into Von Croy (TRX1095)

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -155,7 +155,11 @@ static void M_Draw3DPickups(const M_PRIV *const p)
         Matrix_Scale((1 << W2V_SHIFT) * scale);
 
         // Set up lighting for the pickup mesh.
-        if (g_TRVersion >= 3) {
+        if (g_TRVersion == 4) {
+            // The OG lights a HUD pickup by a flat brightness alone, with no
+            // room lights (output.cpp S_DrawPickup).
+            Output_CalculateStaticLightRGB_F((RGB_F) { 1.0f, 1.0f, 1.0f });
+        } else if (g_TRVersion == 3) {
             // Port of OG TR3's SetPickupLight().
             // ambient = (64, 64, 64)
             // sun     = (3072, 1680, 640)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

TR4 lights the rotating pickup in the interface by a flat brightness alone, the way the original game does. Before this, it used TR3's pickup light rig, which lit the item from the side in warm and blue tones and made it read differently from the same item in the inventory.

Resolves TRX1402