### PR TITLE
input/touch: fix trackpad overlay

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -261,6 +261,7 @@
 - Changed a game named with `--mod` to say why it cannot be played, rather than quietly starting a different one (TRX1083)
 - Changed a broken settings, strings or game data file to say what is wrong with it and where (TRX1112)
 - Changed Lara turning to gold on the Midas hand to gild the outfit she has on, rather than swap her for a golden model (TRX1070)
+- Fixed touch controls turning on and showing the on-screen overlay on machines with a trackpad but no touchscreen (TRX1417)
 - Fixed the game crashing when a language with a broken strings file is picked (TRX1112)
 - Fixed the game crashing when another game is switched to while Lara is riding a vehicle (TRX1148)
 - Fixed the game crashing when a screenshot is taken in certain levels (TRX1305)

--- a/src/trx/game/input/backends/touch.c
+++ b/src/trx/game/input/backends/touch.c
@@ -367,6 +367,11 @@ static void M_Init(void)
     M_InitDefaultBindings();
 }
 
+static bool M_IsDirectDevice(const SDL_TouchID touch_id)
+{
+    return SDL_GetTouchDeviceType(touch_id) == SDL_TOUCH_DEVICE_DIRECT;
+}
+
 static void M_Shutdown(void)
 {
     TouchOverlay_Shutdown();
@@ -374,8 +379,8 @@ static void M_Shutdown(void)
 
 static void M_ProcessEvent(const SDL_Event *const event)
 {
-    if (event->type == SDL_FINGERDOWN
-        && !g_Config.input.enable_touch_controls) {
+    if (event->type == SDL_FINGERDOWN && !g_Config.input.enable_touch_controls
+        && M_IsDirectDevice(event->tfinger.touchId)) {
         CONFIG_SET(g_Config.input.enable_touch_controls, true);
         TouchOverlay_SetVisible(true);
         SHOULD(Config_Write());
@@ -710,7 +715,15 @@ INPUT_ROLE Touch_GetPositionRole(const int32_t position)
 
 bool Touch_HasHardwareSupport(void)
 {
-    return SDL_GetNumTouchDevices() > 0;
+    // SDL counts trackpads as touch devices. Only a direct device, where the
+    // player touches the display, is a touchscreen.
+    const int32_t device_count = SDL_GetNumTouchDevices();
+    for (int32_t i = 0; i < device_count; i++) {
+        if (M_IsDirectDevice(SDL_GetTouchDevice(i))) {
+            return true;
+        }
+    }
+    return false;
 }
 
 INPUT_BACKEND_IMPL g_Input_Touch = {

--- a/src/trx/game/input/backends/touch.h
+++ b/src/trx/game/input/backends/touch.h
@@ -22,5 +22,6 @@ void Touch_SetPositionState(int32_t position, bool pressed);
 // Get the role currently bound to a touch position in the active layout.
 INPUT_ROLE Touch_GetPositionRole(int32_t position);
 
-// Whether the running platform exposes any touch input devices.
+// Whether the running platform has a touchscreen. SDL also reports trackpads
+// as touch devices.
 bool Touch_HasHardwareSupport(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where touch controls turned on and showed the overlay on machines with a trackpad but no touchscreen.

The game now counts only direct touch devices as touchscreens.

Resolves TRX1417