### PR TITLE
cmd/give: fix giving items with no icon

### DIFF
--- a/src/lua/commands/give.lua
+++ b/src/lua/commands/give.lua
@@ -69,7 +69,7 @@ local LEADBAR = trx.catalog.objects.LEAD_BAR_ITEM
 -- How many went in, so a cheat that found nothing to hand over can say so
 -- rather than announcing a backpack that never got heavier.
 local function add_once(seen, id, count)
-  local icon = trx.inventory:icon_of(id)
+  local icon = trx.inventory:icon_of(id) or id
   if seen[icon] then
     return 0
   end


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a Lua error where `/give` gave nothing for a pickup with no unique inventory icon. Pickups with no inventory icon are now identified by their own objects.