### PR TITLE
lua/rooms: add a ceiling height query

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -8106,11 +8106,11 @@
           "type": "rooms.Num"
         },
         {
-          "description": "How to read the floor.",
+          "description": "How to read the height.",
           "fields": [
             {
               "default": true,
-              "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
+              "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.",
               "name": "fix_tilts",
               "optional": true,
               "type": "boolean"
@@ -8124,6 +8124,46 @@
       "path": "rooms.floor_height",
       "returns": {
         "description": "The height, with `nil` where there is no floor.",
+        "nullable": true,
+        "type": "math.Distance"
+      }
+    },
+    {
+      "description": "The height of the ceiling over a world position. Returns `nil` inside solid geometry or outside the level.",
+      "examples": [
+        "local ceiling = trx.lara.item.room:ceiling_height(trx.lara.item.pos)"
+      ],
+      "params": [
+        {
+          "description": "World position.",
+          "name": "pos",
+          "type": "math.Vec3"
+        },
+        {
+          "description": "The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with `trx.rooms.Room:floor_height`.",
+          "name": "room_num",
+          "optional": true,
+          "type": "rooms.Num"
+        },
+        {
+          "description": "How to read the height.",
+          "fields": [
+            {
+              "default": true,
+              "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.",
+              "name": "fix_tilts",
+              "optional": true,
+              "type": "boolean"
+            }
+          ],
+          "name": "opts",
+          "optional": true,
+          "type": "table"
+        }
+      ],
+      "path": "rooms.ceiling_height",
+      "returns": {
+        "description": "The height, with `nil` where there is no ceiling.",
         "nullable": true,
         "type": "math.Distance"
       }
@@ -14594,6 +14634,37 @@
       "handle": true,
       "methods": [
         {
+          "description": "Returns the ceiling height, using this room as the starting room.",
+          "name": "ceiling_height",
+          "params": [
+            {
+              "description": "World position.",
+              "name": "pos",
+              "type": "math.Vec3"
+            },
+            {
+              "description": "How to read the height.",
+              "fields": [
+                {
+                  "default": true,
+                  "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.",
+                  "name": "fix_tilts",
+                  "optional": true,
+                  "type": "boolean"
+                }
+              ],
+              "name": "opts",
+              "optional": true,
+              "type": "table"
+            }
+          ],
+          "returns": {
+            "description": "The height, with `nil` where there is no ceiling.",
+            "nullable": true,
+            "type": "math.Distance"
+          }
+        },
+        {
           "description": "As `trx.rooms.floor_height`, looking from this room.",
           "name": "floor_height",
           "params": [
@@ -14603,11 +14674,11 @@
               "type": "math.Vec3"
             },
             {
-              "description": "How to read the floor.",
+              "description": "How to read the height.",
               "fields": [
                 {
                   "default": true,
-                  "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.",
+                  "description": "Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.",
                   "name": "fix_tilts",
                   "optional": true,
                   "type": "boolean"

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -79,15 +79,27 @@ end
 
     Methods:
 
+    - <a id="rooms.Room.ceiling_height" name="rooms.Room.ceiling_height"></a>[lua]`room:ceiling_height(pos, [opts])`  
+      Returns the ceiling height, using this room as the starting room.
+
+      Parameters:
+      - <a id="rooms.Room.ceiling_height.pos" name="rooms.Room.ceiling_height.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+      - <a id="rooms.Room.ceiling_height.opts" name="rooms.Room.ceiling_height.opts"></a>**`opts`** (table, optional). How to read the height.
+
+        Keys:
+        - <a id="rooms.Room.ceiling_height.opts.fix_tilts" name="rooms.Room.ceiling_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.
+
+      Returns: [trx.math.Distance](MATH.md#math.Distance) or `nil`. The height, with `nil` where there is no ceiling.
+
     - <a id="rooms.Room.floor_height" name="rooms.Room.floor_height"></a>[lua]`room:floor_height(pos, [opts])`  
       As [`trx.rooms.floor_height`](#rooms.floor_height), looking from this room.
 
       Parameters:
       - <a id="rooms.Room.floor_height.pos" name="rooms.Room.floor_height.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
-      - <a id="rooms.Room.floor_height.opts" name="rooms.Room.floor_height.opts"></a>**`opts`** (table, optional). How to read the floor.
+      - <a id="rooms.Room.floor_height.opts" name="rooms.Room.floor_height.opts"></a>**`opts`** (table, optional). How to read the height.
 
         Keys:
-        - <a id="rooms.Room.floor_height.opts.fix_tilts" name="rooms.Room.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
+        - <a id="rooms.Room.floor_height.opts.fix_tilts" name="rooms.Room.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.
 
       Returns: [trx.math.Distance](MATH.md#math.Distance) or `nil`. The height, with `nil` where there is no floor.
 
@@ -279,16 +291,34 @@ end
   Parameters:
   - <a id="rooms.floor_height.pos" name="rooms.floor_height.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
   - <a id="rooms.floor_height.room_num" name="rooms.floor_height.room_num"></a>**`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with [`trx.rooms.Room:floor_height`](#rooms.Room.floor_height).
-  - <a id="rooms.floor_height.opts" name="rooms.floor_height.opts"></a>**`opts`** (table, optional). How to read the floor.
+  - <a id="rooms.floor_height.opts" name="rooms.floor_height.opts"></a>**`opts`** (table, optional). How to read the height.
 
     Keys:
-    - <a id="rooms.floor_height.opts.fix_tilts" name="rooms.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height the original games read there, which is what the geometry glitches of the vanilla levels rest on.
+    - <a id="rooms.floor_height.opts.fix_tilts" name="rooms.floor_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.
 
   Returns: [trx.math.Distance](MATH.md#math.Distance) or `nil`. The height, with `nil` where there is no floor.
 
   Example:
   ```lua
   local floor = trx.lara.item.room:floor_height(trx.lara.item.pos)
+  ```
+
+- <a id="rooms.ceiling_height" name="rooms.ceiling_height"></a>[lua]`trx.rooms.ceiling_height(pos, [room_num], [opts])`  
+  The height of the ceiling over a world position. Returns `nil` inside solid geometry or outside the level.
+
+  Parameters:
+  - <a id="rooms.ceiling_height.pos" name="rooms.ceiling_height.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+  - <a id="rooms.ceiling_height.room_num" name="rooms.ceiling_height.room_num"></a>**`room_num`** ([trx.rooms.Num](#rooms.Num), optional). The search crosses portals, so a neighbouring room's floor is found too. Without it, the room is looked up from the position, which takes the first room that contains it and passes over the flipped-away ones. Where rooms overlap, name the room, or ask the room itself with [`trx.rooms.Room:floor_height`](#rooms.Room.floor_height).
+  - <a id="rooms.ceiling_height.opts" name="rooms.ceiling_height.opts"></a>**`opts`** (table, optional). How to read the height.
+
+    Keys:
+    - <a id="rooms.ceiling_height.opts.fix_tilts" name="rooms.ceiling_height.opts.fix_tilts"></a>**`fix_tilts`** (boolean, optional, default `true`). Whether a floor tilt that lies inside a wall is taken into account. `false` gives the flat height read by the original games. Vanilla level geometry can depend on this behaviour.
+
+  Returns: [trx.math.Distance](MATH.md#math.Distance) or `nil`. The height, with `nil` where there is no ceiling.
+
+  Example:
+  ```lua
+  local ceiling = trx.lara.item.room:ceiling_height(trx.lara.item.pos)
   ```
 
 - <a id="rooms.find_valid_pos" name="rooms.find_valid_pos"></a>[lua]`trx.rooms.find_valid_pos(pos, room_num)`  

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -72,7 +72,7 @@ local FLOOR_HEIGHT_OPTS = {
   name = "opts",
   type = "table",
   optional = true,
-  description = "How to read the floor.",
+  description = "How to read the height.",
   fields = {
     {
       name = "fix_tilts",
@@ -80,8 +80,8 @@ local FLOOR_HEIGHT_OPTS = {
       optional = true,
       default = true,
       description = "Whether a floor tilt that lies inside a wall is taken into account. "
-        .. "`false` gives the flat height the original games read there, which is what the "
-        .. "geometry glitches of the vanilla levels rest on.",
+        .. "`false` gives the flat height read by the original games. Vanilla level geometry "
+        .. "can depend on this behaviour.",
     },
   },
 }
@@ -217,6 +217,18 @@ end)]],
       description = "As `trx.rooms.floor_height`, looking from this room.",
       impl = function(room, pos, opts)
         return raw.get_height(pos, room.num, opts)
+      end,
+    },
+    ceiling_height = {
+      params = { FLOOR_HEIGHT_POS, FLOOR_HEIGHT_OPTS },
+      returns = {
+        type = "math.Distance",
+        nullable = true,
+        description = "The height, with `nil` where there is no ceiling.",
+      },
+      description = "Returns the ceiling height, using this room as the starting room.",
+      impl = function(room, pos, opts)
+        return raw.get_ceiling(pos, room.num, opts)
       end,
     },
   },
@@ -400,6 +412,21 @@ api.define("rooms.floor_height", {
     [[local floor = trx.lara.item.room:floor_height(trx.lara.item.pos)]],
   },
   impl = raw.get_height,
+})
+
+api.define("rooms.ceiling_height", {
+  description = "The height of the ceiling over a world position. Returns `nil` inside solid "
+    .. "geometry or outside the level.",
+  params = FLOOR_HEIGHT_PARAMS,
+  returns = {
+    type = "math.Distance",
+    nullable = true,
+    description = "The height, with `nil` where there is no ceiling.",
+  },
+  examples = {
+    [[local ceiling = trx.lara.item.room:ceiling_height(trx.lara.item.pos)]],
+  },
+  impl = raw.get_ceiling,
 })
 
 api.define("rooms.find_valid_pos", {

--- a/src/tests/fakes/rooms.c
+++ b/src/tests/fakes/rooms.c
@@ -6,6 +6,7 @@
 #include <harness/fake_calls.h>
 
 #include <trx/core/handle.h>
+#include <trx/game/const.h>
 #include <trx/game/items/actions.h>
 #include <trx/game/rooms.h>
 
@@ -158,6 +159,15 @@ int32_t Room_GetHeightEx(
 {
     FAKE_RECORD("get_height", FV(fix_tilts));
     return pos.x < 0 ? NO_HEIGHT : 0;
+}
+
+// Return a ceiling one sector above the flat floor, or no ceiling outside the
+// fake level.
+int32_t Room_GetCeilingEx(
+    const SECTOR *const sector, const XYZ_32 pos, const bool fix_tilts)
+{
+    FAKE_RECORD("get_ceiling", FV(fix_tilts));
+    return pos.x < 0 ? NO_HEIGHT : -WALL_L;
 }
 
 bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)

--- a/src/trx/game/lua/capi/rooms.c
+++ b/src/trx/game/lua/capi/rooms.c
@@ -253,29 +253,29 @@ static int M_L_RoomsFindValidPos(lua_State *const L)
     return 2;
 }
 
-// trxc.rooms.get_height({x,y,z}, room_num, opts) -> floor height, or nil where
-// there is no floor
-static int M_L_RoomsGetHeight(lua_State *const L)
+// Resolve the room where a height query starts.
+static bool M_ResolveHeightRoom(
+    lua_State *const L, const XYZ_32 pos, int16_t *const out_room_num)
 {
-    const XYZ_32 pos = LUA_CheckXYZ(L, 1);
-
-    int16_t room_num;
     if (lua_isnoneornil(L, 2)) {
-        room_num = Room_GetIndexFromPos(pos);
+        const int16_t room_num = Room_GetIndexFromPos(pos);
         if (room_num == NO_ROOM) {
-            lua_pushnil(L);
-            return 1;
+            return false;
         }
-    } else {
-        // Room_GetSector walks from the room it is given, and Room_Get gives
-        // back nullptr for a room outside the level.
-        const lua_Integer room_arg = luaL_checkinteger(L, 2);
-        luaL_argcheck(
-            L, room_arg >= 0 && room_arg <= Room_GetCount() - 1, 2,
-            "unknown room");
-        room_num = (int16_t)room_arg;
+        *out_room_num = room_num;
+        return true;
     }
+    // Room_GetSector walks from the room it is given, and Room_Get gives
+    // back nullptr for a room outside the level.
+    const lua_Integer room_arg = luaL_checkinteger(L, 2);
+    luaL_argcheck(
+        L, room_arg >= 0 && room_arg <= Room_GetCount() - 1, 2, "unknown room");
+    *out_room_num = (int16_t)room_arg;
+    return true;
+}
 
+static bool M_ReadFixTilts(lua_State *const L)
+{
     bool fix_tilts = true;
     if (lua_istable(L, 3)) {
         lua_getfield(L, 3, "fix_tilts");
@@ -284,6 +284,20 @@ static int M_L_RoomsGetHeight(lua_State *const L)
         }
         lua_pop(L, 1);
     }
+    return fix_tilts;
+}
+
+// Get the floor height, or nil when the position has no floor.
+static int M_L_RoomsGetHeight(lua_State *const L)
+{
+    const XYZ_32 pos = LUA_CheckXYZ(L, 1);
+
+    int16_t room_num;
+    if (!M_ResolveHeightRoom(L, pos, &room_num)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    const bool fix_tilts = M_ReadFixTilts(L);
 
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     const int32_t height = Room_GetHeightEx(sector, pos, fix_tilts, NO_ITEM);
@@ -295,9 +309,32 @@ static int M_L_RoomsGetHeight(lua_State *const L)
     return 1;
 }
 
+// Get the ceiling height, or nil when the position has no ceiling.
+static int M_L_RoomsGetCeiling(lua_State *const L)
+{
+    const XYZ_32 pos = LUA_CheckXYZ(L, 1);
+
+    int16_t room_num;
+    if (!M_ResolveHeightRoom(L, pos, &room_num)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    const bool fix_tilts = M_ReadFixTilts(L);
+
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetCeilingEx(sector, pos, fix_tilts);
+    if (height == NO_HEIGHT) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, height);
+    }
+    return 1;
+}
+
 static const luaL_Reg m_Module[] = {
     { "get_flipped_room", M_L_RoomsGetFlippedRoom },
     { "get_height", M_L_RoomsGetHeight },
+    { "get_ceiling", M_L_RoomsGetCeiling },
     { "count", M_L_RoomsCount },
     { "get", M_L_RoomsGet },
     { "get_bounds", M_L_RoomsGetBounds },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Lua scripts can now read the ceiling height above a position. The query returns nil when no ceiling exists.