### PR TITLE
fx/ring: let blasts tilt rings

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -5694,12 +5694,19 @@
       ],
       "params": [
         {
-          "description": "Where the ring starts.",
+          "description": "Where the ring starts and how far it may lean.",
           "fields": [
             {
               "description": "World position.",
               "name": "pos",
               "type": "math.Vec3"
+            },
+            {
+              "default": 0,
+              "description": "Maximum tilt for each ring in either direction. `0` keeps them level.",
+              "name": "tilt",
+              "optional": true,
+              "type": "math.Angle"
             }
           ],
           "name": "opts",

--- a/docs/trx/lua/reference/FX.md
+++ b/docs/trx/lua/reference/FX.md
@@ -471,10 +471,11 @@ end
   and widens on its own.
 
   Parameters:
-  - <a id="fx.knockback.opts" name="fx.knockback.opts"></a>**`opts`** (table). Where the ring starts.
+  - <a id="fx.knockback.opts" name="fx.knockback.opts"></a>**`opts`** (table). Where the ring starts and how far it may lean.
 
     Keys:
     - <a id="fx.knockback.opts.pos" name="fx.knockback.opts.pos"></a>**`pos`** ([trx.math.Vec3](MATH.md#math.Vec3)). World position.
+    - <a id="fx.knockback.opts.tilt" name="fx.knockback.opts.tilt"></a>**`tilt`** ([trx.math.Angle](MATH.md#math.Angle), optional, default `0`). Maximum tilt for each ring in either direction. `0` keeps them level.
 
   Example:
   ```lua

--- a/src/lua/api/fx.lua
+++ b/src/lua/api/fx.lua
@@ -637,13 +637,23 @@ and widens on its own.]],
     {
       name = "opts",
       type = "table",
-      description = "Where the ring starts.",
-      fields = { pos_field },
+      description = "Where the ring starts and how far it may lean.",
+      fields = {
+        pos_field,
+        {
+          name = "tilt",
+          type = "math.Angle",
+          optional = true,
+          default = 0,
+          description = "Maximum tilt for each ring in either direction. `0` "
+            .. "keeps them level.",
+        },
+      },
     },
   },
   examples = { [[trx.fx.knockback({ pos = trx.lara.item.pos })]] },
   impl = function(opts)
-    raw.knockback(opts.pos.x, opts.pos.y, opts.pos.z)
+    raw.knockback(opts.pos.x, opts.pos.y, opts.pos.z, opts.tilt or 0)
   end,
 })
 

--- a/src/trx/game/fx/ring.c
+++ b/src/trx/game/fx/ring.c
@@ -507,7 +507,7 @@ FX_RING *FX_Ring_PeekRing(const FX_RING_TYPE type, const int32_t idx)
     return &m_Rings[type][idx];
 }
 
-void FX_Ring_SpawnKnockBack(const XYZ_32 pos)
+void FX_Ring_SpawnKnockBack(const XYZ_32 pos, const int16_t tilt)
 {
     for (int32_t i = 0; i < M_MAX_RINGS; i++) {
         FX_RING *const ring = &m_Rings[FX_RING_TYPE_KNOCKBACK][i];
@@ -517,8 +517,11 @@ void FX_Ring_SpawnKnockBack(const XYZ_32 pos)
         ring->pos.x = pos.x;
         ring->pos.y = pos.y - 512 + (i << 7);
         ring->pos.z = pos.z;
-        ring->rot.x = 0;
-        ring->rot.z = 0;
+        // Give each ring a random tilt up to the requested angle.
+        ring->rot.x =
+            tilt == 0 ? 0 : (int16_t)(Random_GetDraw() % (tilt * 2)) - tilt;
+        ring->rot.z =
+            tilt == 0 ? 0 : (int16_t)(Random_GetDraw() % (tilt * 2)) - tilt;
         ring->radius = ((i == 1) + 2) << 8;
         FX_Ring_Sync(ring);
     }

--- a/src/trx/game/fx/ring.h
+++ b/src/trx/game/fx/ring.h
@@ -31,7 +31,10 @@ typedef enum {
 } FX_RING_TYPE;
 
 void FX_Ring_Draw(void);
-void FX_Ring_SpawnKnockBack(XYZ_32 pos);
+
+// Spawn rings pushed out by a blast, with an optional tilt in either direction.
+void FX_Ring_SpawnKnockBack(XYZ_32 pos, int16_t tilt);
+
 void FX_Ring_BounceKnockBack(void);
 
 void FX_Ring_Sync(FX_RING *ring);

--- a/src/trx/game/lua/capi/fx.c
+++ b/src/trx/game/lua/capi/fx.c
@@ -312,7 +312,8 @@ static int M_L_Footprint(lua_State *const L)
 // trxc.fx.knockback(x, y, z)
 static int M_L_Knockback(lua_State *const L)
 {
-    FX_Ring_SpawnKnockBack(M_ReadPos(L));
+    const XYZ_32 pos = M_ReadPos(L);
+    FX_Ring_SpawnKnockBack(pos, (int16_t)luaL_optinteger(L, 4, 0));
     return 0;
 }
 

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -812,7 +812,7 @@ static void M_Control(const int16_t item_num)
         };
         if (XYZ_32_GetLength(delta) < 2816) {
             p->knockback_active = true;
-            FX_Ring_SpawnKnockBack(item->pos);
+            FX_Ring_SpawnKnockBack(item->pos, 0);
         }
     } else if (p->knockback_active) {
         const FX_RING *const ring = FX_Ring_PeekRing(FX_RING_TYPE_KNOCKBACK, 1);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Blasts can now tilt the rings they throw, and Lua scripts can set the maximum tilt for each ring. A missing value keeps the rings level.