### PR TITLE
tr4/data: fix a Lua error in Semerkhet

### DIFF
--- a/data/trx/ship/games/tr4/scripts/semer.lua
+++ b/data/trx/ship/games/tr4/scripts/semer.lua
@@ -19,7 +19,8 @@ trx.events.on_game_start(function()
   trx.items[211].properties.switch_mode = trx.items.SwitchMode.HIDDEN_PICKUP
   trx.items[213].properties.switch_mode = trx.items.SwitchMode.HIDDEN_REACH
   trx.items[53].properties.pickup_mode = trx.items.PickupMode.HIDDEN
-  trx.items[160].properties.pickup_mode = trx.items.PickupMode.HIDDEN
+  -- TODO: the burning torch has no TRX object yet
+  -- trx.items[160].properties.pickup_mode = trx.items.PickupMode.HIDDEN
   trx.items[188].properties.pickup_mode = trx.items.PickupMode.HIDDEN
   trx.items[192].properties.pickup_mode = trx.items.PickupMode.HIDDEN
   trx.items[212].properties.pickup_mode = trx.items.PickupMode.HIDDEN

--- a/data/trx/ship/games/tr4/scripts/semer2.lua
+++ b/data/trx/ship/games/tr4/scripts/semer2.lua
@@ -12,7 +12,8 @@ trx.events.on_game_start(function()
   trx.items[122].properties.switch_mode = trx.items.SwitchMode.HIDDEN_PICKUP
   trx.items[126].properties.switch_mode = trx.items.SwitchMode.HIDDEN_REACH
   trx.items[130].properties.switch_mode = trx.items.SwitchMode.HIDDEN_REACH
-  trx.items[113].properties.pickup_mode = trx.items.PickupMode.HIDDEN
+  -- TODO: The burning torch has no TRX object yet
+  -- trx.items[113].properties.pickup_mode = trx.items.PickupMode.HIDDEN
   trx.items[121].properties.pickup_mode = trx.items.PickupMode.HIDDEN
   trx.items[125].properties.pickup_mode = trx.items.PickupMode.HIDDEN
   trx.items[129].properties.pickup_mode = trx.items.PickupMode.HIDDEN


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a Lua error when loading Tomb of Semerkhet and Guardian of Semerkhet. Both levels set a pickup mode on a burning torch, which TRX does not support yet. The error prevented the remaining level setup, including pickup modes, switch modes, and waterfall settings.

Resolves TRX1425