### PR TITLE
Let a body burst pick its flame color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -324,6 +324,7 @@
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)
 - Changed `trx.game.trx_version` to `trx.game.TRX_VERSION`
 - Changed `trx.game.end_level()` to end the level silently, leaving the "Level complete!" message to the `/endlevel` console command
+- Changed `trx.items.Item:die()` and `trx.items.Item:shatter()` to let scripts choose the flame color for flying body parts
 - Changed a color setting to read as a `trx.math.Color` rather than as hex text, and to be written with either (TRX1091)
 - Changed the `trx.weapons` functions that take a weapon id to be deprecated, the weapon itself now answering what it is available as, what it is carried as, and what it is fed (TRX1091)
 - Fixed creatures taking wrong routes where crossing to the next square needs a jump or a monkey swing (TRX1061)

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -12689,7 +12689,7 @@
             },
             {
               "default": 0,
-              "description": "Flame color for flying body parts, as\n`trx.fx.sparks.fire_flame` defines it: `0` orange, `2` pale, and\n`254` green.",
+              "description": "Flame color for flying body parts, as\n`trx.fx.sparks.fire_flame` defines it: `0` orange, `2` pale, and\n`254` green. Only TR3 and TR4 body parts burn; TR1 and TR2 ignore\nthis.",
               "name": "flame_variant",
               "optional": true,
               "type": "integer"
@@ -13110,7 +13110,7 @@
             },
             {
               "default": 0,
-              "description": "Flame color for flying body parts, as\n`trx.fx.sparks.fire_flame` defines it.",
+              "description": "Flame color for flying body parts, as\n`trx.fx.sparks.fire_flame` defines it. Only TR3 and TR4 body parts\nburn; TR1 and TR2 ignore this.",
               "name": "flame_variant",
               "optional": true,
               "type": "integer"

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -12686,6 +12686,13 @@
               "name": "explode",
               "optional": true,
               "type": "boolean"
+            },
+            {
+              "default": 0,
+              "description": "Flame color for flying body parts, as\n`trx.fx.sparks.fire_flame` defines it: `0` orange, `2` pale, and\n`254` green.",
+              "name": "flame_variant",
+              "optional": true,
+              "type": "integer"
             }
           ]
         },
@@ -13098,6 +13105,13 @@
               "default": 0,
               "description": "Splash damage dealt to nearby items.",
               "name": "damage",
+              "optional": true,
+              "type": "integer"
+            },
+            {
+              "default": 0,
+              "description": "Flame color for flying body parts, as\n`trx.fx.sparks.fire_flame` defines it.",
+              "name": "flame_variant",
               "optional": true,
               "type": "integer"
             }

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -204,7 +204,8 @@ end
       - <a id="items.Item.die.explode" name="items.Item.die.explode"></a>**`explode`** (boolean, optional, default `false`). Whether to burst the meshes as it dies.
       - <a id="items.Item.die.flame_variant" name="items.Item.die.flame_variant"></a>**`flame_variant`** (integer, optional, default `0`). Flame color for flying body parts, as
         [`trx.fx.sparks.fire_flame`](FX.md#fx.sparks.fire_flame) defines it: `0` orange, `2` pale, and
-        `254` green.
+        `254` green. Only TR3 and TR4 body parts burn; TR1 and TR2 ignore
+        this.
 
     - <a id="items.Item.distance_to" name="items.Item.distance_to"></a>[lua]`item:distance_to(pos)`  
       Distance from this item to a world position.
@@ -478,7 +479,8 @@ end
       Parameters:
       - <a id="items.Item.shatter.damage" name="items.Item.shatter.damage"></a>**`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
       - <a id="items.Item.shatter.flame_variant" name="items.Item.shatter.flame_variant"></a>**`flame_variant`** (integer, optional, default `0`). Flame color for flying body parts, as
-        [`trx.fx.sparks.fire_flame`](FX.md#fx.sparks.fire_flame) defines it.
+        [`trx.fx.sparks.fire_flame`](FX.md#fx.sparks.fire_flame) defines it. Only TR3 and TR4 body parts
+        burn; TR1 and TR2 ignore this.
 
     - <a id="items.Item.take_damage" name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
       Hurts the item the way a weapon does, and reports through

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -197,11 +197,14 @@ end
     - <a id="items.Item.destroy" name="items.Item.destroy"></a>[lua]`item:destroy()`  
       Removes the item from the game. Any other handle to it becomes stale.
 
-    - <a id="items.Item.die" name="items.Item.die"></a>[lua]`item:die([explode])`  
+    - <a id="items.Item.die" name="items.Item.die"></a>[lua]`item:die([explode], [flame_variant])`  
       Runs the object's creature death handling: the corpse stays, and [`explode`](#items.Item.die.explode) bursts its meshes as a rocket or grenade would. For creatures; [`destroy`](#items.Item.destroy) simply removes any item from the game.
 
       Parameters:
       - <a id="items.Item.die.explode" name="items.Item.die.explode"></a>**`explode`** (boolean, optional, default `false`). Whether to burst the meshes as it dies.
+      - <a id="items.Item.die.flame_variant" name="items.Item.die.flame_variant"></a>**`flame_variant`** (integer, optional, default `0`). Flame color for flying body parts, as
+        [`trx.fx.sparks.fire_flame`](FX.md#fx.sparks.fire_flame) defines it: `0` orange, `2` pale, and
+        `254` green.
 
     - <a id="items.Item.distance_to" name="items.Item.distance_to"></a>[lua]`item:distance_to(pos)`  
       Distance from this item to a world position.
@@ -469,11 +472,13 @@ end
       - <a id="items.Item.set_property.name" name="items.Item.set_property.name"></a>**`name`** (string). Which property, as the object declares it.
       - <a id="items.Item.set_property.value" name="items.Item.set_property.value"></a>**`value`** (any). What to write, of the type the property is declared with.
 
-    - <a id="items.Item.shatter" name="items.Item.shatter"></a>[lua]`item:shatter([damage])`  
+    - <a id="items.Item.shatter" name="items.Item.shatter"></a>[lua]`item:shatter([damage], [flame_variant])`  
       Bursts the item's meshes into flying debris, the visual [`die`](#items.Item.die) produces with [`die.explode`](#items.Item.die.explode), on its own. It does not kill or remove the item.
 
       Parameters:
       - <a id="items.Item.shatter.damage" name="items.Item.shatter.damage"></a>**`damage`** (integer, optional, default `0`). Splash damage dealt to nearby items.
+      - <a id="items.Item.shatter.flame_variant" name="items.Item.shatter.flame_variant"></a>**`flame_variant`** (integer, optional, default `0`). Flame color for flying body parts, as
+        [`trx.fx.sparks.fire_flame`](FX.md#fx.sparks.fire_flame) defines it.
 
     - <a id="items.Item.take_damage" name="items.Item.take_damage"></a>[lua]`item:take_damage(damage)`  
       Hurts the item the way a weapon does, and reports through

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -730,6 +730,17 @@ end)]],
           default = false,
           description = "Whether to burst the meshes as it dies.",
         },
+        {
+          name = "flame_variant",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = [[
+            Flame color for flying body parts, as
+            `trx.fx.sparks.fire_flame` defines it: `0` orange, `2` pale, and
+            `254` green.
+          ]],
+        },
       },
       description = "Runs the object's creature death handling: the corpse stays, and `trx.items.Item.die.explode` "
         .. "bursts its meshes as a rocket or grenade would. For creatures; `trx.items.Item:destroy` simply removes "
@@ -764,6 +775,16 @@ lara:take_damage(lara.hit_points)]],
           optional = true,
           default = 0,
           description = "Splash damage dealt to nearby items.",
+        },
+        {
+          name = "flame_variant",
+          type = "integer",
+          optional = true,
+          default = 0,
+          description = [[
+            Flame color for flying body parts, as
+            `trx.fx.sparks.fire_flame` defines it.
+          ]],
         },
       },
       description = "Bursts the item's meshes into flying debris, the visual `trx.items.Item:die` produces with "

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -738,7 +738,8 @@ end)]],
           description = [[
             Flame color for flying body parts, as
             `trx.fx.sparks.fire_flame` defines it: `0` orange, `2` pale, and
-            `254` green.
+            `254` green. Only TR3 and TR4 body parts burn; TR1 and TR2 ignore
+            this.
           ]],
         },
       },
@@ -783,7 +784,8 @@ lara:take_damage(lara.hit_points)]],
           default = 0,
           description = [[
             Flame color for flying body parts, as
-            `trx.fx.sparks.fire_flame` defines it.
+            `trx.fx.sparks.fire_flame` defines it. Only TR3 and TR4 body parts
+            burn; TR1 and TR2 ignore this.
           ]],
         },
       },

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -846,7 +846,8 @@ bool Creature_IsAlly(const ITEM *const item)
 void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
 {
     const bool explode = args.explode;
-    FAKE_RECORD("creature_die", FV(explode));
+    const int16_t flame_variant = args.flame_variant;
+    FAKE_RECORD("creature_die", FV(explode), FV(flame_variant));
     m_Items[item_num].hit_points = 0;
 }
 
@@ -866,7 +867,8 @@ void Item_TakeDamage(
 int32_t Item_Shatter(const int16_t item_num, const ITEM_SHATTER_ARGS args)
 {
     const int16_t damage = args.damage;
-    FAKE_RECORD("shatter", FV(damage));
+    const int16_t flame_variant = args.flame_variant;
+    FAKE_RECORD("shatter", FV(damage), FV(flame_variant));
     return 0;
 }
 

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -843,8 +843,9 @@ bool Creature_IsAlly(const ITEM *const item)
     return false;
 }
 
-void Creature_Die(const int16_t item_num, const bool explode)
+void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
 {
+    const bool explode = args.explode;
     FAKE_RECORD("creature_die", FV(explode));
     m_Items[item_num].hit_points = 0;
 }
@@ -862,9 +863,9 @@ void Item_TakeDamage(
     }
 }
 
-int32_t Item_Shatter(
-    const int16_t item_num, const int32_t mesh_bits, const int16_t damage)
+int32_t Item_Shatter(const int16_t item_num, const ITEM_SHATTER_ARGS args)
 {
+    const int16_t damage = args.damage;
     FAKE_RECORD("shatter", FV(damage));
     return 0;
 }

--- a/src/tests/lua/api/items.lua
+++ b/src/tests/lua/api/items.lua
@@ -641,6 +641,13 @@ test("die runs the object's death handling; destroy does not", function()
   )
 
   fake.reset()
+  trx.items[0]:die(true, 254)
+  assert(
+    fake.calls().creature_die.flame_variant == 254,
+    "die() should pass the flame variant"
+  )
+
+  fake.reset()
   trx.items[0]:destroy()
   assert(
     fake.calls().creature_die.count == 0,
@@ -680,6 +687,12 @@ test("shatter bursts the meshes on their own", function()
 
   trx.items[0]:shatter(5)
   assert(fake.calls().shatter.damage == 5, "the damage should pass through")
+
+  trx.items[0]:shatter(0, 254)
+  assert(
+    fake.calls().shatter.flame_variant == 254,
+    "shatter() should pass the flame variant"
+  )
 end)
 
 test("is_one_shot reads and sets the trigger flag", function()

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1060,7 +1060,7 @@ bool Creature_Animate(
 
     Item_Animate(item);
     if (item->is_finished) {
-        Creature_Die(item_num, false);
+        Creature_Die(item_num, (CREATURE_DIE_ARGS) {});
         return false;
     }
 
@@ -1451,8 +1451,9 @@ void Creature_TestBoxDamage(const int16_t item_num)
     Item_TakeDamage(item, M_BOX_DAMAGE, IDF_NO_HIT_STATUS, nullptr);
 }
 
-void Creature_Die(const int16_t item_num, const bool explode)
+void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
 {
+    const bool explode = args.explode;
     ITEM *const item = Item_Get(item_num);
 
     switch (item->object_id) {
@@ -1467,7 +1468,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
 
     case O_SKIDOO_ARMED:
         if (explode) {
-            Item_Shatter(item_num, -1, 0);
+            Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
             ITEM *const vehicle_item = Item_Get(item_num);
             M_Kill(vehicle_item);
             Item_SetVisible(vehicle_item, false);
@@ -1477,7 +1478,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
 
     case O_SKIDOO_DRIVER:
         if (explode) {
-            Item_Shatter(item_num, -1, 0);
+            Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
         }
         M_Kill(item);
         const int16_t vehicle_item_num = SkidooDriver_GetSkidooItemNum(item);
@@ -1496,7 +1497,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
     item->is_collidable = false;
     M_Kill(item);
     if (explode) {
-        Item_Shatter(item_num, -1, 0);
+        Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
         Item_Destroy(item_num);
     } else {
         Item_RemoveSimulated(item_num);

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1454,6 +1454,7 @@ void Creature_TestBoxDamage(const int16_t item_num)
 void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
 {
     const bool explode = args.explode;
+    const int16_t flame_variant = args.flame_variant;
     ITEM *const item = Item_Get(item_num);
 
     switch (item->object_id) {
@@ -1468,7 +1469,10 @@ void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
 
     case O_SKIDOO_ARMED:
         if (explode) {
-            Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
+            Item_Shatter(
+                item_num,
+                (ITEM_SHATTER_ARGS) { .mesh_bits = -1,
+                                      .flame_variant = flame_variant });
             ITEM *const vehicle_item = Item_Get(item_num);
             M_Kill(vehicle_item);
             Item_SetVisible(vehicle_item, false);
@@ -1478,7 +1482,10 @@ void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
 
     case O_SKIDOO_DRIVER:
         if (explode) {
-            Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
+            Item_Shatter(
+                item_num,
+                (ITEM_SHATTER_ARGS) { .mesh_bits = -1,
+                                      .flame_variant = flame_variant });
         }
         M_Kill(item);
         const int16_t vehicle_item_num = SkidooDriver_GetSkidooItemNum(item);
@@ -1497,7 +1504,10 @@ void Creature_Die(const int16_t item_num, const CREATURE_DIE_ARGS args)
     item->is_collidable = false;
     M_Kill(item);
     if (explode) {
-        Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
+        Item_Shatter(
+            item_num,
+            (ITEM_SHATTER_ARGS) { .mesh_bits = -1,
+                                  .flame_variant = flame_variant });
         Item_Destroy(item_num);
     } else {
         Item_RemoveSimulated(item_num);

--- a/src/trx/game/creature/common.h
+++ b/src/trx/game/creature/common.h
@@ -45,7 +45,16 @@ bool Creature_Animate(int16_t item_num, int16_t angle, int16_t tilt);
 void Creature_SpecialKill(
     ITEM *item, int32_t kill_anim, int32_t kill_state, int32_t lara_kill_state);
 void Creature_TestBoxDamage(int16_t item_num);
-void Creature_Die(int16_t item_num, bool explode);
+
+typedef struct {
+    // Burst the creature's meshes into flying body parts. Without this, the
+    // corpse stays.
+    bool explode;
+} CREATURE_DIE_ARGS;
+
+// Kills the creature and removes it from play.
+void Creature_Die(int16_t item_num, CREATURE_DIE_ARGS args);
+
 int32_t Creature_Vault(
     int16_t item_num, int16_t angle, int32_t vault, int32_t shift);
 

--- a/src/trx/game/creature/common.h
+++ b/src/trx/game/creature/common.h
@@ -50,6 +50,9 @@ typedef struct {
     // Burst the creature's meshes into flying body parts. Without this, the
     // corpse stays.
     bool explode;
+
+    // Set the flame variant for flying body parts. Zero is ordinary fire.
+    int16_t flame_variant;
 } CREATURE_DIE_ARGS;
 
 // Kills the creature and removes it from play.

--- a/src/trx/game/effects/manager.c
+++ b/src/trx/game/effects/manager.c
@@ -121,6 +121,7 @@ int16_t Effect_Create(const int16_t room_num)
     effect->shade = SHADE_NEUTRAL;
     effect->flag1 = 0;
     effect->flag2 = 0;
+    effect->flame_variant = 0;
     effect->interp.is_new = true;
 
     return effect_num;

--- a/src/trx/game/effects/types.h
+++ b/src/trx/game/effects/types.h
@@ -16,6 +16,8 @@ typedef struct {
     int16_t frame_num;
     int16_t counter;
     int16_t shade;
+    // Store the flame variant for a flying body part. Zero is ordinary fire.
+    int16_t flame_variant;
 
     int32_t flag1, flag2;
 

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -307,6 +307,7 @@ int32_t Item_Shatter(const int16_t item_num, const ITEM_SHATTER_ARGS args)
 
             effect->counter =
                 is_tr3 ? ((damage << 2) | (Random_GetControl() & 3)) : damage;
+            effect->flame_variant = args.flame_variant;
             effect->object_id = O_BODY_PART;
             effect->frame_num = Object_GetItemMeshIndex(item, walk.joint);
             effect->shade = Output_GetLightAdder() - 0x300;

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -226,9 +226,10 @@ void Item_ResetMeshBits(ITEM *const item)
     item->mesh_bits = UINT32_MAX;
 }
 
-int32_t Item_Shatter(
-    const int16_t item_num, const int32_t mesh_bits, const int16_t damage)
+int32_t Item_Shatter(const int16_t item_num, const ITEM_SHATTER_ARGS args)
 {
+    const int32_t mesh_bits = args.mesh_bits;
+    const int16_t damage = args.damage;
     ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
     if (!obj->loaded) {

--- a/src/trx/game/items/utils.h
+++ b/src/trx/game/items/utils.h
@@ -67,6 +67,9 @@ typedef struct {
     // values deal damage and disable them. Zero deals no damage and disables
     // them.
     int16_t damage;
+
+    // Set the flame variant for flying body parts. Zero is ordinary fire.
+    int16_t flame_variant;
 } ITEM_SHATTER_ARGS;
 
 int32_t Item_Shatter(int16_t item_num, ITEM_SHATTER_ARGS args);

--- a/src/trx/game/items/utils.h
+++ b/src/trx/game/items/utils.h
@@ -46,17 +46,30 @@ void Item_TakeDamage(
 // decides rather than a weapon. Does nothing to an item already at zero.
 void Item_TakeFatalDamage(ITEM *item, const ITEM *sender);
 
+// One bit per mesh index, for an ITEM mesh_bits mask.
+#define ITEM_MESH(idx_) ((int32_t)(1u << (idx_)))
+
+// Every mesh from lo_ to hi_, both included.
+#define ITEM_MESH_RANGE(lo_, hi_)                                              \
+    ((int32_t)((~0u >> (31 - ((hi_) - (lo_)))) << (lo_)))
+
 bool Item_IsMeshVisible(const ITEM *item, int32_t mesh_num);
 void Item_SetMeshVisible(ITEM *item, int32_t mesh_num, bool visible);
 void Item_SetMeshVisibleMask(ITEM *item, uint32_t mesh_mask, bool visible);
 void Item_ResetMeshBits(ITEM *item);
 
-// Mesh_bits: which meshes to affect.
-// Damage:
-// * Positive values - deal damage, enable body part explosions.
-// * Negative values - deal damage, disable body part explosions.
-// * Zero - don't deal any damage, disable body part explosions.
-int32_t Item_Shatter(int16_t item_num, int32_t mesh_bits, int16_t damage);
+typedef struct {
+    // Set the meshes to burst. -1 bursts every mesh. Use the complement of
+    // the meshes to spare for a narrower set.
+    int32_t mesh_bits;
+
+    // Positive values deal damage and enable body part explosions. Negative
+    // values deal damage and disable them. Zero deals no damage and disables
+    // them.
+    int16_t damage;
+} ITEM_SHATTER_ARGS;
+
+int32_t Item_Shatter(int16_t item_num, ITEM_SHATTER_ARGS args);
 
 bool Item_ShouldSpawnBlood(const ITEM *item);
 

--- a/src/trx/game/lara/cheat_keys.c
+++ b/src/trx/game/lara/cheat_keys.c
@@ -61,7 +61,9 @@ static void M_ExplodeLara(void)
 {
     const LARA_INFO *const lara_info = Lara_GetLaraInfo();
     ITEM *const lara_item = Lara_GetItem();
-    Item_Shatter(lara_info->item_num, -1, 1);
+    Item_Shatter(
+        lara_info->item_num,
+        (ITEM_SHATTER_ARGS) { .mesh_bits = -1, .damage = 1 });
     Sound_Effect(SFX_EXPLOSION_1, &lara_item->pos, SPM_NORMAL);
     Lara_Kill();
     Item_SetVisible(lara_item, false);

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -621,7 +621,8 @@ static int M_L_ItemsDie(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     LUA_Struct_Deref(L, ref);
-    Creature_Die(ref->handle.id, lua_toboolean(L, 2));
+    Creature_Die(
+        ref->handle.id, (CREATURE_DIE_ARGS) { .explode = lua_toboolean(L, 2) });
     return 0;
 }
 
@@ -642,7 +643,12 @@ static int M_L_ItemsShatter(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     LUA_Struct_Deref(L, ref);
-    Item_Shatter(ref->handle.id, -1, (int16_t)luaL_optinteger(L, 2, 0));
+    Item_Shatter(
+        ref->handle.id,
+        (ITEM_SHATTER_ARGS) {
+            .mesh_bits = -1,
+            .damage = (int16_t)luaL_optinteger(L, 2, 0),
+        });
     return 0;
 }
 

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -622,7 +622,11 @@ static int M_L_ItemsDie(lua_State *const L)
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     LUA_Struct_Deref(L, ref);
     Creature_Die(
-        ref->handle.id, (CREATURE_DIE_ARGS) { .explode = lua_toboolean(L, 2) });
+        ref->handle.id,
+        (CREATURE_DIE_ARGS) {
+            .explode = lua_toboolean(L, 2),
+            .flame_variant = (int16_t)luaL_optinteger(L, 3, 0),
+        });
     return 0;
 }
 
@@ -648,6 +652,7 @@ static int M_L_ItemsShatter(lua_State *const L)
         (ITEM_SHATTER_ARGS) {
             .mesh_bits = -1,
             .damage = (int16_t)luaL_optinteger(L, 2, 0),
+            .flame_variant = (int16_t)luaL_optinteger(L, 3, 0),
         });
     return 0;
 }

--- a/src/trx/game/objects/creatures/atlantean.c
+++ b/src/trx/game/objects/creatures/atlantean.c
@@ -88,8 +88,11 @@ static void M_Control(const int16_t item_num)
 
     if (item->hit_points <= 0) {
         Item_Shatter(
-            item_num, -1,
-            m_EnableExplosions ? p->part_damage : -p->part_damage);
+            item_num,
+            (ITEM_SHATTER_ARGS) {
+                .mesh_bits = -1,
+                .damage = m_EnableExplosions ? p->part_damage : -p->part_damage,
+            });
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
         LOT_DisableBaddieAI(item_num);
         Item_Destroy(item_num);

--- a/src/trx/game/objects/creatures/centaur.c
+++ b/src/trx/game/objects/creatures/centaur.c
@@ -140,7 +140,9 @@ static void M_Control(const int16_t item_num)
 
     if (item->is_finished) {
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
-        Item_Shatter(item_num, -1, p->part_damage);
+        Item_Shatter(
+            item_num,
+            (ITEM_SHATTER_ARGS) { .mesh_bits = -1, .damage = p->part_damage });
         Item_Destroy(item_num);
         Item_SetFinished(item, true);
     }

--- a/src/trx/game/objects/creatures/centaur_statue.c
+++ b/src/trx/game/objects/creatures/centaur_statue.c
@@ -59,7 +59,7 @@ static void M_Control(const int16_t item_num)
 
     if (y > -WALL_L && y < WALL_L
         && SQUARE(x) + SQUARE(z) < SQUARE(STATUE_EXPLODE_DIST)) {
-        Item_Shatter(item_num, -1, 0);
+        Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
         Item_Destroy(item_num);
         Item_SetFinished(item, true);
 

--- a/src/trx/game/objects/creatures/claw_mutant.c
+++ b/src/trx/game/objects/creatures/claw_mutant.c
@@ -189,7 +189,7 @@ static void M_Control(const int16_t item_num)
             Item_SwitchToAnim(item, M_ANIM_DEATH, 0);
             item->current_anim_state = M_STATE_DEATH;
         } else if (Item_TestFrameEqual(item, -1)) {
-            Creature_Die(item_num, true);
+            Creature_Die(item_num, (CREATURE_DIE_ARGS) { .explode = true });
             for (int32_t i = 0; i < 3; i++) {
                 const int32_t dynamic = i == 0 ? -2 : -1;
                 Sparks_TriggerExplosionSparks(item->pos, 3, dynamic, 2, 0);

--- a/src/trx/game/objects/creatures/jelly.c
+++ b/src/trx/game/objects/creatures/jelly.c
@@ -33,7 +33,7 @@ static void M_Control(const int16_t item_num)
     CREATURE *const creature = item->creature_data;
 
     if (item->hit_points <= 0) {
-        if (Item_Shatter(item_num, -1, 0)) {
+        if (Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 })) {
             LOT_DisableBaddieAI(item_num);
             Item_Destroy(item_num);
             Item_SetFinished(item, true);

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -246,7 +246,7 @@ static void M_Control(const int16_t item_num)
             item->current_anim_state = M_STATE_DEATH;
         } else if (
             TribeBoss_IsLizardActive() && Item_GetRelativeFrame(item) == 50) {
-            Creature_Die(item_num, true);
+            Creature_Die(item_num, (CREATURE_DIE_ARGS) { .explode = true });
         }
     } else {
         AI_INFO info;

--- a/src/trx/game/objects/creatures/pod.c
+++ b/src/trx/game/objects/creatures/pod.c
@@ -83,7 +83,9 @@ static void M_Control(const int16_t item_num)
             item->goal_anim_state = M_STATE_EXPLODE;
             item->mesh_bits = 0xFFFFFF;
             item->is_collidable = false;
-            Item_Shatter(item_num, 0xFFFE00, 0);
+            Item_Shatter(
+                item_num,
+                (ITEM_SHATTER_ARGS) { .mesh_bits = ~ITEM_MESH_RANGE(0, 8) });
 
             const M_PRIV *const p = item->priv;
             if (p->bug_item_num != NO_ITEM) {

--- a/src/trx/game/objects/creatures/spider.c
+++ b/src/trx/game/objects/creatures/spider.c
@@ -134,7 +134,8 @@ static void M_Control(const int16_t item_num)
         default:
             break;
         }
-    } else if (Item_Shatter(item_num, -1, 0)) {
+    } else if (
+        Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 })) {
         LOT_DisableBaddieAI(item_num);
         Item_Destroy(item_num);
         Item_SetFinished(item, true);

--- a/src/trx/game/objects/creatures/torso.c
+++ b/src/trx/game/objects/creatures/torso.c
@@ -224,7 +224,9 @@ static void M_Control(const int16_t item_num)
 
     if (item->is_finished) {
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
-        Item_Shatter(item_num, -1, p->part_damage);
+        Item_Shatter(
+            item_num,
+            (ITEM_SHATTER_ARGS) { .mesh_bits = -1, .damage = p->part_damage });
         Room_TestTriggers(item);
 
         Item_Destroy(item_num);

--- a/src/trx/game/objects/creatures/xian_knight.c
+++ b/src/trx/game/objects/creatures/xian_knight.c
@@ -96,7 +96,7 @@ static void M_Control(const int16_t item_num)
             Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
             item->mesh_bits = -1;
             item->object_id = O_XIAN_KNIGHT_STATUE;
-            Item_Shatter(item_num, -1, 0);
+            Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
             item->object_id = O_XIAN_KNIGHT;
             LOT_DisableBaddieAI(item_num);
             Item_Destroy(item_num);

--- a/src/trx/game/objects/creatures/xian_spearman.c
+++ b/src/trx/game/objects/creatures/xian_spearman.c
@@ -139,7 +139,7 @@ static void M_Control(const int16_t item_num)
             Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
             item->mesh_bits = -1;
             item->object_id = O_XIAN_SPEARMAN_STATUE;
-            Item_Shatter(item_num, -1, 0);
+            Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
             item->object_id = O_XIAN_SPEARMAN;
             LOT_DisableBaddieAI(item_num);
             Item_Destroy(item_num);

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -106,7 +106,8 @@ static void M_Control_TR3(const int16_t effect_num)
     const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
     if (!(time4 & 0xC)) {
         if (effect->counter & 1) {
-            Sparks_TriggerFireFlame(effect->pos, effect_num, 0);
+            Sparks_TriggerFireFlame(
+                effect->pos, effect_num, effect->flame_variant);
         }
 
         if (effect->counter & 2) {
@@ -130,7 +131,8 @@ static void M_Control_TR3(const int16_t effect_num)
             for (int32_t i = 0; i < 3; i++) {
                 if (effect->counter & 1) {
                     Sparks_TriggerFireFlame(
-                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1, 0);
+                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1,
+                        effect->flame_variant);
                 }
                 if (effect->counter & 2) {
                     Sparks_TriggerFireSmoke(
@@ -151,7 +153,8 @@ static void M_Control_TR3(const int16_t effect_num)
             for (int32_t i = 0; i < 3; i++) {
                 if (effect->counter & 1) {
                     Sparks_TriggerFireFlame(
-                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1, 0);
+                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1,
+                        effect->flame_variant);
                 }
                 if (effect->counter & 2) {
                     Sparks_TriggerFireSmoke(
@@ -213,7 +216,7 @@ static void M_Control_TR4(const int16_t effect_num)
 
     const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
     if ((time4 & 0xC) == 0 && (effect->counter & 3) != 0 && do_burn_effects) {
-        Sparks_TriggerFireFlame(effect->pos, effect_num, 0);
+        Sparks_TriggerFireFlame(effect->pos, effect_num, effect->flame_variant);
     }
 
     int16_t room_num = effect->room_num;

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -162,7 +162,7 @@ static bool M_TryExplodeItem(
         Gun_SmashItem(target_item_num);
     } else if (
         target_item->hit_points <= 0 && M_CanExplodeTarget(target_item)) {
-        Creature_Die(target_item_num, true);
+        Creature_Die(target_item_num, (CREATURE_DIE_ARGS) { .explode = true });
     }
     return true;
 }

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -163,7 +163,7 @@ static bool M_TryExplodeItem(
         Gun_SmashItem(target_item_num);
     } else if (
         target_item->hit_points <= 0 && M_CanExplodeTarget(target_item)) {
-        Creature_Die(target_item_num, true);
+        Creature_Die(target_item_num, (CREATURE_DIE_ARGS) { .explode = true });
     }
     return true;
 }

--- a/src/trx/game/objects/general/smashable.c
+++ b/src/trx/game/objects/general/smashable.c
@@ -79,7 +79,9 @@ static void M_Control2(const int16_t item_num)
 
     item->mesh_bits = ~1;
     item->is_collidable = false;
-    Item_Shatter(item_num, 65278, 0);
+    Item_Shatter(
+        item_num,
+        (ITEM_SHATTER_ARGS) { .mesh_bits = ~(ITEM_MESH(0) | ITEM_MESH(8)) });
 
     if (item->object_id == O_SMASHABLE_2) {
         Sound_Effect(SFX_BRITTLE_GROUND_BREAK, &item->pos, SPM_NORMAL);
@@ -169,7 +171,9 @@ void Smashable_Smash(const int16_t item_num)
 
     item->is_collidable = false;
     item->mesh_bits = ~1;
-    Item_Shatter(item_num, 0b11111110'11111110, 0);
+    Item_Shatter(
+        item_num,
+        (ITEM_SHATTER_ARGS) { .mesh_bits = ~(ITEM_MESH(0) | ITEM_MESH(8)) });
 
     if (item->object_id == O_SMASHABLE_1) {
         Sound_Effect(SFX_GLASS_BREAK, &item->pos, SPM_NORMAL);

--- a/src/trx/game/objects/traps/falling_block.c
+++ b/src/trx/game/objects/traps/falling_block.c
@@ -224,7 +224,8 @@ static void M_ControlSimulated(ITEM *const item)
         item->current_anim_state = TRAP_FINISHED;
 
         const int32_t item_num = Item_GetIndex(item);
-        Item_Shatter(item_num, -1, 2465);
+        Item_Shatter(
+            item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1, .damage = 2465 });
         Item_Destroy(item_num);
     } else {
         item->rot.x = (Random_GetControl() & 0x3FF) - 0x200;

--- a/src/trx/game/objects/traps/gondola.c
+++ b/src/trx/game/objects/traps/gondola.c
@@ -14,7 +14,9 @@ static void M_Control(const int16_t item_num)
     case GONDOLA_STATE_FLOATING:
         if (item->goal_anim_state == GONDOLA_STATE_CRASH) {
             item->mesh_bits = 0xFF;
-            Item_Shatter(item_num, 240, 0);
+            Item_Shatter(
+                item_num,
+                (ITEM_SHATTER_ARGS) { .mesh_bits = ~ITEM_MESH_RANGE(0, 3) });
         }
         break;
 

--- a/src/trx/game/objects/traps/mine.c
+++ b/src/trx/game/objects/traps/mine.c
@@ -36,7 +36,8 @@ static void M_DetonateAll(
     ITEM *const boat_item = Item_Get(boat_item_num);
     if (Lara_Vehicle_GetIndex() == boat_item_num) {
         ITEM *const lara_item = Lara_GetItem();
-        Item_Shatter(Item_GetIndex(lara_item), -1, 0);
+        Item_Shatter(
+            Item_GetIndex(lara_item), (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
         Lara_Kill();
         lara_item->trigger.spent = true;
     }
@@ -45,7 +46,7 @@ static void M_DetonateAll(
     if (obj->loaded) {
         boat_item->object_id = O_BOAT_BITS;
         boat_item->mesh_bits = (1 << obj->mesh_count) - 1;
-        Item_Shatter(boat_item_num, -1, 0);
+        Item_Shatter(boat_item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
     }
     Item_Destroy(boat_item_num);
     boat_item->object_id = O_BOAT;

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -137,7 +137,7 @@ static void M_Control(const int16_t item_num)
     }
 
     if (item->hit_points <= 0) {
-        Item_Shatter(item_num, -1, 0);
+        Item_Shatter(item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
         LOT_DisableBaddieAI(item_num);
         Item_Destroy(item_num);
         item->trigger.spent = true;

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -354,7 +354,8 @@ static void M_Explode(ITEM *const item)
     }
 
     const int16_t vehicle_item_num = Lara_Vehicle_GetIndex();
-    Item_Shatter(vehicle_item_num, -2, 0);
+    Item_Shatter(
+        vehicle_item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = ~ITEM_MESH(0) });
     Item_Destroy(vehicle_item_num);
     Item_SetFinished(item, true);
     Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
@@ -1505,7 +1506,8 @@ bool QuadBike_Control(void)
                 lara_item->current_anim_state = LS(LS_STOP);
                 Item_SwitchToAnim(lara_item, LA(LA_FREEFALL_LAND), 0);
             } else {
-                Item_Shatter(lara->item_num, -1, 0);
+                Item_Shatter(
+                    lara->item_num, (ITEM_SHATTER_ARGS) { .mesh_bits = -1 });
                 Lara_Kill();
                 lara_item->trigger.spent = true;
             }

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -701,7 +701,9 @@ void Skidoo_Explode(const ITEM *const skidoo)
         effect->object_id = O_EXPLOSION_1;
     }
 
-    Item_Shatter(Item_GetIndex(skidoo), ~(SKIDOO_GUN_MESH - 1), 0);
+    Item_Shatter(
+        Item_GetIndex(skidoo),
+        (ITEM_SHATTER_ARGS) { .mesh_bits = ~ITEM_MESH_RANGE(0, 1) });
     Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
     Lara_Vehicle_SetIndex(NO_ITEM);
 }

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -791,6 +791,7 @@ static RESULT M_ReadEffect(JSON_READ_IO *const io)
     MUST(JSON_READ(io, "shade", &effect->shade));
     SHOULD(JSON_READ_OPT(io, "flag1", &effect->flag1));
     SHOULD(JSON_READ_OPT(io, "flag2", &effect->flag2));
+    SHOULD(JSON_READ_OPT(io, "flame_variant", &effect->flame_variant));
     return OK;
 }
 

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -427,6 +427,7 @@ void SG_File_DumpEffects(JSON_WRITE_IO *const io)
         JSONW_WRITE(io, "shade", effect->shade);
         JSONW_WRITE(io, "flag1", effect->flag1);
         JSONW_WRITE(io, "flag2", effect->flag2);
+        JSONW_WRITE(io, "flame_variant", effect->flame_variant);
         JSONW_POP_AND_APPEND(io);
     }
     JSONW_POP_AND_SET(io, "effects");


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Flying body parts can now burn in a chosen flame color:

```lua
trx.items[0]:die(true, 254) -- green
trx.items[0]:shatter(0, 2)  -- pale
```

If omitted, the normal flame is used. The variant uses `trx.fx.sparks.fire_flame` values and is saved with the game.

This works in TR3 and TR4. TR1 and TR2 body parts do not burn.

Internally, `Item_Shatter` and `Creature_Die` now use option structs, and mesh masks use `ITEM_MESH` / `ITEM_MESH_RANGE` instead of raw values.