### PR TITLE
cutscene: fix actors that do not reset

### DIFF
--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -155,8 +155,22 @@ static void M_RestoreLaraCutsceneState(void)
 
 static bool M_IsCutsceneActor(const ITEM *const item)
 {
-    return (item->object_id >= O_PLAYER_1 && item->object_id <= O_PLAYER_10)
-        || item->object_id == O_LARA;
+    switch (item->object_id) {
+    case O_LARA:
+    case O_PLAYER_1:
+    case O_PLAYER_2:
+    case O_PLAYER_3:
+    case O_PLAYER_4:
+    case O_PLAYER_5:
+    case O_PLAYER_6:
+    case O_PLAYER_7:
+    case O_PLAYER_8:
+    case O_PLAYER_9:
+    case O_PLAYER_10:
+        return true;
+    default:
+        return false;
+    }
 }
 
 static void M_ResetActorAnimation(ITEM *const item)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where cutscene actors 5 to 10 kept their animation when a cutscene restarted, and unrelated objects were reset in their place. Before this, the actor check used a range, but the actor object IDs are not contiguous.