### PR TITLE
objects: link script objects

### DIFF
--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -13946,6 +13946,25 @@
           }
         },
         {
+          "description": "Links this object to another object. Use the relation name that\nthe game uses, such as `gun_to_ammo`. <!--noref: gun_to_ammo--> This lets the game use\nrelations between objects created by a script.",
+          "examples": [
+            "trx.objects[gun]:link(\"gun_to_ammo\", ammo)"
+          ],
+          "name": "link",
+          "params": [
+            {
+              "description": "The relation to add, such as `gun_to_ammo`. <!--noref: gun_to_ammo-->",
+              "name": "link",
+              "type": "string"
+            },
+            {
+              "description": "The object to link.",
+              "name": "other",
+              "type": "catalog.objects"
+            }
+          ]
+        },
+        {
           "description": "Takes the object out of a family.",
           "name": "remove_family",
           "params": [

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -100,6 +100,20 @@ trx.objects.wolf.properties.max_hit_points = 30
 
       Returns: a list of string.
 
+    - <a id="objects.Object.link" name="objects.Object.link"></a>[lua]`object:link(link, other)`  
+      Links this object to another object. Use the relation name that
+      the game uses, such as `gun_to_ammo`. This lets the game use
+      relations between objects created by a script.
+
+      Parameters:
+      - <a id="objects.Object.link.link" name="objects.Object.link.link"></a>**`link`** (string). The relation to add, such as `gun_to_ammo`.
+      - <a id="objects.Object.link.other" name="objects.Object.link.other"></a>**`other`** ([trx.catalog.objects](CATALOG.md#catalog.objects)). The object to link.
+
+      Example:
+      ```lua
+      trx.objects[gun]:link("gun_to_ammo", ammo)
+      ```
+
     - <a id="objects.Object.remove_family" name="objects.Object.remove_family"></a>[lua]`object:remove_family(family)`  
       Takes the object out of a family.
 

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -174,6 +174,28 @@ trx.objects.barrel:add_family("mymod:explosive")
 for _, id in ipairs(trx.objects.query:family("mymod:explosive"):ids()) do ... end]],
       },
     },
+    link = {
+      params = {
+        {
+          name = "link",
+          type = "string",
+          description = "The relation to add, such as `gun_to_ammo`. "
+            .. "<!--noref: gun_to_ammo-->",
+        },
+        {
+          name = "other",
+          type = "catalog.objects",
+          description = "The object to link.",
+        },
+      },
+      description = [[Links this object to another object. Use the relation name that
+the game uses, such as `gun_to_ammo`. <!--noref: gun_to_ammo--> This lets the game use
+relations between objects created by a script.]],
+      examples = {
+        [[trx.objects[gun]:link("gun_to_ammo", ammo)]],
+      },
+    },
+
     remove_family = {
       params = {
         {

--- a/src/tests/fakes/items.c
+++ b/src/tests/fakes/items.c
@@ -23,6 +23,7 @@
 #include <trx/game/items.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/families.h>
+#include <trx/game/objects/links.h>
 #include <trx/game/objects/names.h>
 #include <trx/game/objects/property.h>
 #include <trx/game/pathing/lot.h>
@@ -725,6 +726,20 @@ const char *ObjectProperty_GetObjectName(
     const OBJECT *const obj, const int32_t i)
 {
     return i == 0 ? "max_hit_points" : nullptr;
+}
+
+OBJECT_LINK ObjectLink_FromName(const char *const name)
+{
+    FAKE_RECORD("link_from_name", FV(name));
+    return strcmp(name, "gun_to_ammo") == 0 ? OBJ_LINK_GUN_TO_AMMO
+                                            : OBJ_LINK_NUMBER_OF;
+}
+
+RESULT ObjectLink_Add(
+    const OBJECT_ID from, const OBJECT_LINK link, const OBJECT_ID to)
+{
+    FAKE_RECORD("link_add", FV(from), FV(link), FV(to));
+    return OK;
 }
 
 void ObjectFamily_Add(const OBJECT_ID object_id, const OBJECT_FAMILY family)

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -8,6 +8,7 @@
 #include <trx/game/lua/utils.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/families.h>
+#include <trx/game/objects/links.h>
 #include <trx/game/objects/names.h>
 #include <trx/game/objects/setup.h>
 #include <trx/game/objects/types.h>
@@ -365,6 +366,22 @@ static int M_L_AddFamily(lua_State *const L)
     return 0;
 }
 
+// obj:link(name, other)
+static int M_L_AddLink(lua_State *const L)
+{
+    const LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_OBJECT);
+    const char *const name = luaL_checkstring(L, 2);
+    const OBJECT_LINK link = ObjectLink_FromName(name);
+    if (link == OBJ_LINK_NUMBER_OF) {
+        return luaL_error(L, "unknown object link '%s'", name);
+    }
+    const OBJECT_ID to = LUA_CheckObjectID(L, 3);
+    if (!IS_OK(ObjectLink_Add((OBJECT_ID)ref->handle.id, link, to))) {
+        return luaL_error(L, "could not link the objects");
+    }
+    return 0;
+}
+
 static int M_L_RemoveFamily(lua_State *const L)
 {
     const LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_OBJECT);
@@ -376,6 +393,7 @@ static const luaL_Reg m_Methods[] = {
     { "get_names", M_L_GetNames },
     { "get_default_names", M_L_GetDefaultNames },
     { "add_family", M_L_AddFamily },
+    { "link", M_L_AddLink },
     { "remove_family", M_L_RemoveFamily },
     { nullptr, nullptr },
 };

--- a/src/trx/game/objects/links.c
+++ b/src/trx/game/objects/links.c
@@ -112,6 +112,24 @@ static void M_Shutdown(void)
     }
 }
 
+RESULT ObjectLink_Add(
+    const OBJECT_ID from, const OBJECT_LINK link, const OBJECT_ID to)
+{
+    FAIL_IF(link >= OBJ_LINK_NUMBER_OF, "there is no link %d", link);
+    FAIL_IF(from == NO_OBJECT || to == NO_OBJECT, "a link needs two objects");
+    if (m_Links[link] == nullptr) {
+        m_Links[link] = Vector_Create(sizeof(M_PAIR));
+    }
+    const M_PAIR pair = { .from = from, .to = to };
+    Vector_Add(m_Links[link], (void *)&pair);
+    return OK;
+}
+
+OBJECT_LINK ObjectLink_FromName(const char *const name)
+{
+    return M_FromName(name);
+}
+
 OBJECT_ID ObjectLink_Get(const OBJECT_ID from, const OBJECT_LINK link)
 {
     return ObjectLink_GetAt(from, link, 0);

--- a/src/trx/game/objects/links.h
+++ b/src/trx/game/objects/links.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/result.h>
 #include <trx/game/objects/ids.h>
 
 // Define engine-wide links from one object identity to multiple objects.
@@ -9,6 +10,12 @@ typedef enum {
 #undef X_OBJECT_LINK
     OBJ_LINK_NUMBER_OF,
 } OBJECT_LINK;
+
+// Link one object to another.
+RESULT ObjectLink_Add(OBJECT_ID from, OBJECT_LINK link, OBJECT_ID to);
+
+// Return the link with the given name, or OBJ_LINK_NUMBER_OF if none exists.
+OBJECT_LINK ObjectLink_FromName(const char *name);
 
 // Return the first linked object, or NO_OBJECT if no link exists.
 OBJECT_ID ObjectLink_Get(OBJECT_ID from, OBJECT_LINK link);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Links objects created by scripts to the relations used by the game. This lets game systems find related objects such as ammunition for a gun.