### PR TITLE
inventory_ring: declare items from Lua

### DIFF
--- a/data/te/tr1/Engine/modules/inv_ring.lua
+++ b/data/te/tr1/Engine/modules/inv_ring.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/inv_ring.lua

--- a/data/te/tr1/Engine/modules/weapons.lua
+++ b/data/te/tr1/Engine/modules/weapons.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/weapons.lua

--- a/data/te/tr1/Engine/scripts/inv_ring.lua
+++ b/data/te/tr1/Engine/scripts/inv_ring.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/scripts/inv_ring.lua

--- a/data/te/tr2/Engine/modules/inv_ring.lua
+++ b/data/te/tr2/Engine/modules/inv_ring.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/inv_ring.lua

--- a/data/te/tr2/Engine/modules/weapons.lua
+++ b/data/te/tr2/Engine/modules/weapons.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/weapons.lua

--- a/data/te/tr2/Engine/scripts/inv_ring.lua
+++ b/data/te/tr2/Engine/scripts/inv_ring.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/scripts/inv_ring.lua

--- a/data/te/tr3/Engine/modules/inv_ring.lua
+++ b/data/te/tr3/Engine/modules/inv_ring.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/inv_ring.lua

--- a/data/te/tr3/Engine/modules/weapons.lua
+++ b/data/te/tr3/Engine/modules/weapons.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/modules/weapons.lua

--- a/data/te/tr3/Engine/scripts/inv_ring.lua
+++ b/data/te/tr3/Engine/scripts/inv_ring.lua
@@ -1,0 +1,1 @@
+../../../../trx/ship/scripts/inv_ring.lua

--- a/data/trx/ship/modules/inv_ring.lua
+++ b/data/trx/ship/modules/inv_ring.lua
@@ -1,0 +1,11 @@
+-- Declares the inventory-ring items from the game's ring file.
+
+local found = trx.path.resolve("common_config", "inv_ring.json5")
+local specs = found ~= nil and trx.json.read_file(found) or nil
+if specs == nil then
+  return
+end
+
+for _, spec in ipairs(specs) do
+  trx.inventory.declare_ring_item(spec)
+end

--- a/data/trx/ship/modules/weapons.lua
+++ b/data/trx/ship/modules/weapons.lua
@@ -1,0 +1,17 @@
+-- Declares the weapons from the game's weapons file. Unsupported weapons,
+-- such as those fixed to vehicles, keep their settings but are not handled.
+
+local found = trx.path.resolve("common_config", "weapons.json5")
+local specs = found ~= nil and trx.json.read_file(found) or nil
+if specs == nil then
+  return
+end
+
+for key, spec in pairs(specs) do
+  local weapon = trx.catalog.weapons[key]
+  if weapon == nil then
+    trx.log.warning(("unknown weapon '%s'"):format(key))
+  else
+    trx.weapons.declare(weapon, spec)
+  end
+end

--- a/data/trx/ship/scripts/inv_ring.lua
+++ b/data/trx/ship/scripts/inv_ring.lua
@@ -1,0 +1,1 @@
+require("common.inv_ring")

--- a/data/trx/ship/scripts/weapons.lua
+++ b/data/trx/ship/scripts/weapons.lua
@@ -1,18 +1,1 @@
--- Declares the weapons listed in the game's weapons file. Unsupported kinds,
--- such as weapons fixed to vehicles, keep their settings but are not handled
--- by the engine.
-
-local found = trx.path.resolve("common_config", "weapons.json5")
-local specs = found ~= nil and trx.json.read_file(found) or nil
-if specs == nil then
-  return
-end
-
-for key, spec in pairs(specs) do
-  local weapon = trx.catalog.weapons[key]
-  if weapon == nil then
-    trx.log.warning(("the game does not define weapon '%s'"):format(key))
-  else
-    trx.weapons.declare(weapon, spec)
-  end
-end
+require("common.weapons")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -324,8 +324,10 @@
 - Added `trx.fx.fog_bulbs` and `trx.fx.fog_color`, so a script can read level fog bulbs and set the distance fog color (TRX658)
 - Added more world effects to `trx.fx`: explosions, fires, splashes, ripples, footprints, underwater blood and blast rings
 - Added `trx.fx.sparks`, so a script can throw the particles the games use for smoke, flames, sparks and splashes, and read or change every live particle
+- Added `trx.inventory.declare_ring_item()`, so a script can add a custom object to the inventory ring
 - Changed `require()` to also look for `<module>/init.lua`, so modules can grow into multiple files without changing how callers require them.
 - Changed the in-game overlay to be drawn by a script rather than by the engine, so what it shows and where it sits can be changed without a build
+- Changed the inventory ring to be declared by a script, so its contents can be changed without a build
 - Changed `trx.cutscenes` to hand over the cutscene itself, so `trx.cutscenes[30]` says whether it has played, plays it, and narrows the cutscene events to it; the cutscene events hand one over too, and the functions that take a number are deprecated (TRX1199)
 - Changed `trx.cutscenes.play()` to take whether to fade out first, so a scene that opens a level begins on the black screen the level loaded behind (TRX1063)
 - Changed `trx.game.trx_version` to `trx.game.TRX_VERSION`

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1359,10 +1359,13 @@ If you install everything correctly, your game directory should look more or les
 │   │   ├── init.lua
 │   │   └── photo_mode.lua
 │   ├── assault.lua
+│   ├── inv_ring.lua
 │   ├── legend.lua
 │   ├── save_crystal.lua
-│   └── water_color.lua
+│   ├── water_color.lua
+│   └── weapons.lua
 ├── scripts
+│   ├── inv_ring.lua
 │   └── weapons.lua
 └── TRX.exe</code></pre>
 </details>
@@ -2757,10 +2760,13 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   ├── init.lua
     │   │   │   └── photo_mode.lua
     │   │   ├── assault.lua
+    │   │   ├── inv_ring.lua
     │   │   ├── legend.lua
     │   │   ├── save_crystal.lua
-    │   │   └── water_color.lua
+    │   │   ├── water_color.lua
+    │   │   └── weapons.lua
     │   ├── scripts
+    │   │   ├── inv_ring.lua
     │   │   └── weapons.lua
     │   └── icon.icns
     ├── _CodeSignature

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -7014,6 +7014,20 @@
       }
     },
     {
+      "description": "Adds an object to the inventory ring and sets how it is drawn and rotated.\n\nThe ring declares every item, including the shipped items. A script can add a\nminted object or change a shipped item without changing a game file. Declaring\nthe same object again changes its existing entry. The ring draws the object in\nthe declaration; use the pickup for an object that represents itself.",
+      "examples": [
+        "trx.inventory.declare_ring_item({\n  object_id = \"mymod:lantern_item\",\n  frames_total = 1,\n  anim_direction = 1,\n  anim_speed = 1,\n  meshes_sel = -1,\n  meshes_drawn = -1,\n  inv_pos = 20,\n})"
+      ],
+      "params": [
+        {
+          "description": "The entry's `object_id`, frame counts, rotations and offsets.\nAn omitted value keeps the ring's default.\n<!--noref: object_id-->",
+          "name": "spec",
+          "type": "table"
+        }
+      ],
+      "path": "inventory.declare_ring_item"
+    },
+    {
       "description": "Retrieves an item by number or by name.",
       "examples": [
         "local item = trx.items[0]\nitem.name = \"lara\"\nlocal lara = trx.items[\"lara\"]"

--- a/docs/trx/lua/reference/INVENTORY.md
+++ b/docs/trx/lua/reference/INVENTORY.md
@@ -208,3 +208,30 @@ end
       - <a id="inventory.Inventory.take.count" name="inventory.Inventory.take.count"></a>**`count`** (integer, optional). How many. Defaults to 1; below 1 raises.
 
       Returns: integer. How many came out.
+
+### Functions
+
+- <a id="inventory.declare_ring_item" name="inventory.declare_ring_item"></a>[lua]`trx.inventory.declare_ring_item(spec)`  
+  Adds an object to the inventory ring and sets how it is drawn and rotated.
+
+  The ring declares every item, including the shipped items. A script can add a
+  minted object or change a shipped item without changing a game file. Declaring
+  the same object again changes its existing entry. The ring draws the object in
+  the declaration; use the pickup for an object that represents itself.
+
+  Parameters:
+  - <a id="inventory.declare_ring_item.spec" name="inventory.declare_ring_item.spec"></a>**`spec`** (table). The entry's `object_id`, frame counts, rotations and offsets.
+    An omitted value keeps the ring's default.
+
+  Example:
+  ```lua
+  trx.inventory.declare_ring_item({
+    object_id = "mymod:lantern_item",
+    frames_total = 1,
+    anim_direction = 1,
+    anim_speed = 1,
+    meshes_sel = -1,
+    meshes_drawn = -1,
+    inv_pos = 20,
+  })
+  ```

--- a/src/lua/api/inventory.lua
+++ b/src/lua/api/inventory.lua
@@ -248,3 +248,40 @@ end]],
     return raw.get_current():entry_count()
   end,
 })
+
+api.define("inventory.declare_ring_item", {
+  description = [[
+Adds an object to the inventory ring and sets how it is drawn and rotated.
+
+The ring declares every item, including the shipped items. A script can add a
+minted object or change a shipped item without changing a game file. Declaring
+the same object again changes its existing entry. The ring draws the object in
+the declaration; use the pickup for an object that represents itself.]],
+  params = {
+    {
+      name = "spec",
+      type = "table",
+      description = [[The entry's `object_id`, frame counts, rotations and offsets.
+An omitted value keeps the ring's default.
+<!--noref: object_id-->]],
+    },
+  },
+  examples = {
+    [[trx.inventory.declare_ring_item({
+  object_id = "mymod:lantern_item",
+  frames_total = 1,
+  anim_direction = 1,
+  anim_speed = 1,
+  meshes_sel = -1,
+  meshes_drawn = -1,
+  inv_pos = 20,
+})]],
+  },
+  impl = function(spec)
+    assert(
+      type(spec) == "table",
+      "trx.inventory.declare_ring_item expects a table"
+    )
+    return raw.declare_ring_item(spec)
+  end,
+})

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -848,6 +848,7 @@ unit_tests += {
   'src': ['harness/stubs_console.c', 'fakes/game.c', 'fakes/lara.c', 'fakes/items.c'],
   'engine': [
     'game/lua/capi/catalog.c',
+    'game/inventory_ring/vars.c',
     'game/lua/capi/inventory.c',
     'game/lua/capi/items.c',
     'game/lua/capi/weapons.c',
@@ -1001,6 +1002,7 @@ unit_tests += {
   'engine': [
     'game/lua/capi/catalog.c',
     'game/lua/capi/game.c',
+    'game/inventory_ring/vars.c',
     'game/lua/capi/inventory.c',
     'game/lua/capi/items.c',
     'game/lua/capi/lara.c',
@@ -1120,6 +1122,7 @@ unit_tests += {
     'game/lua/capi/events.c',
     'game/lua/capi/game.c',
     'game/lua/capi/input.c',
+    'game/inventory_ring/vars.c',
     'game/lua/capi/inventory.c',
     'game/lua/capi/items.c',
     'game/lua/capi/lara.c',

--- a/src/trx/game/inventory_ring/vars.c
+++ b/src/trx/game/inventory_ring/vars.c
@@ -1,12 +1,7 @@
 #include <trx/game/inventory_ring/vars.h>
 
-#include <trx/core/json/util/file.h>
 #include <trx/core/memory.h>
-#include <trx/core/result.h>
 #include <trx/core/subsystem.h>
-#include <trx/debug.h>
-#include <trx/game/catalog/manager.h>
-#include <trx/game/shell.h>
 
 INVENTORY_MODE g_InvRing_Mode = INV_TITLE_MODE;
 CAMERA_INFO g_InvRing_OldCamera = {};
@@ -29,81 +24,11 @@ static void M_Shutdown(void)
         Vector_Free(g_InvRing_Items);
         g_InvRing_Items = nullptr;
     }
-}
-
-static RESULT M_ReadItems(JSON_ARRAY *const arr, const char *const path)
-{
-#define L_READ_INT(key, target) target = JSON_ObjectGetInt(obj, key, target);
-
-    ASSERT(g_InvRing_Items != nullptr);
-
-    for (size_t i = 0; i < arr->length; i++) {
-        JSON_OBJECT *const obj = JSON_ArrayGetObject(arr, i);
-        const char *const name =
-            JSON_ObjectGetString(obj, "object_id", JSON_INVALID_STRING);
-        const CATALOG_ID id = Catalog_KeyToID(CATALOG_OBJECTS, name, NO_OBJECT);
-        FAIL_IF(id == NO_OBJECT, "%s: unknown object_id '%s'", path, name);
-        INVENTORY_ITEM *const item = Memory_Alloc(sizeof(*item));
-        item->object_id = id;
-        L_READ_INT("frames_total", item->frames_total);
-        L_READ_INT("current_frame", item->current_frame);
-        L_READ_INT("goal_frame", item->goal_frame);
-        L_READ_INT("open_frame", item->open_frame);
-        L_READ_INT("anim_direction", item->anim_direction);
-        L_READ_INT("anim_speed", item->anim_speed);
-        L_READ_INT("anim_count", item->anim_count);
-        L_READ_INT("x_rot_pt_sel", item->x_rot_pt_sel);
-        L_READ_INT("x_rot_pt", item->x_rot_pt);
-        L_READ_INT("x_rot_sel", item->x_rot_sel);
-        L_READ_INT("x_rot_nosel", item->x_rot_nosel);
-        L_READ_INT("x_rot", item->x_rot);
-        L_READ_INT("y_rot_sel", item->y_rot_sel);
-        L_READ_INT("y_rot", item->y_rot);
-        L_READ_INT("y_trans_sel", item->y_trans_sel);
-        L_READ_INT("y_trans", item->y_trans);
-        L_READ_INT("z_trans_sel", item->z_trans_sel);
-        L_READ_INT("z_trans", item->z_trans);
-        L_READ_INT("meshes_sel", item->meshes_sel);
-        L_READ_INT("meshes_drawn", item->meshes_drawn);
-        L_READ_INT("inv_pos", item->inv_pos);
-        Vector_Add(g_InvRing_Items, &item);
-    }
-
-    return OK;
-#undef L_READ_INT
-}
-
-static RESULT M_LoadFrom(const char *const path)
-{
-    for (int32_t i = 0; i < g_InvRing_Items->count; i++) {
-        INVENTORY_ITEM *const item =
-            *(INVENTORY_ITEM **)Vector_Get(g_InvRing_Items, i);
-        Memory_Free(item);
-    }
-    Vector_Clear(g_InvRing_Items);
+    // The rings point at the entries and last longer than they do, because a
+    // mod switch restarts the game in place.
     for (int32_t i = 0; i < RT_NUMBER_OF; i++) {
-        g_InvRing_Source[i].count = 0;
+        g_InvRing_Source[i] = (INV_RING_SOURCE) {};
     }
-
-    JSON_VALUE *root = nullptr;
-    MUST(JSONFile_ReadRequired(path, &root));
-    JSON_ARRAY *const arr = JSON_ValueAsArray(root);
-    const RESULT result = arr == nullptr
-        ? FAIL("%s: the file must hold a list", path)
-        : M_ReadItems(arr, path);
-    JSON_ValueFree(root);
-    return result;
 }
 
-static RESULT M_Load(void)
-{
-    const char *path = nullptr;
-    RESULT result = GamePath_Resolve(
-        GAME_DYNAMIC_PATH_COMMON_CONFIG, "inv_ring.json5", &path);
-    if (IS_OK(result)) {
-        result = M_LoadFrom(path);
-    }
-    return result;
-}
-
-REGISTER_SUBSYSTEM(.init = M_Init, .load = M_Load, .shutdown = M_Shutdown)
+REGISTER_SUBSYSTEM(.init = M_Init, .shutdown = M_Shutdown)

--- a/src/trx/game/lua/capi/inventory.c
+++ b/src/trx/game/lua/capi/inventory.c
@@ -1,4 +1,6 @@
+#include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/vector.h>
 #include <trx/game/catalog/manager.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/gun.h>
@@ -6,11 +8,13 @@
 #include <trx/game/gun/registry.h>
 #include <trx/game/inventory.h>
 #include <trx/game/inventory_ring/types.h>
+#include <trx/game/inventory_ring/vars.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/struct.h>
 #include <trx/game/lua/utils.h>
+#include <trx/game/objects/common.h>
 #include <trx/game/savegame.h>
 
 #include <lauxlib.h>
@@ -379,9 +383,82 @@ static const luaL_Reg m_InventoryMethods[] = {
     { nullptr, nullptr },
 };
 
+static int32_t M_ReadRingInt(
+    lua_State *const L, const int idx, const char *const key,
+    const int32_t fallback)
+{
+    lua_getfield(L, idx, key);
+    const int32_t value =
+        lua_isnil(L, -1) ? fallback : (int32_t)luaL_checkinteger(L, -1);
+    lua_pop(L, 1);
+    return value;
+}
+
+static INVENTORY_ITEM *M_FindRingItem(const OBJECT_ID object_id)
+{
+    for (int32_t i = 0; i < g_InvRing_Items->count; i++) {
+        INVENTORY_ITEM *const item =
+            *(INVENTORY_ITEM **)Vector_Get(g_InvRing_Items, i);
+        if (item->object_id == object_id) {
+            return item;
+        }
+    }
+    return nullptr;
+}
+
+// trxc.inventory.declare_ring_item(spec)
+static int M_L_InvDeclareRingItem(lua_State *const L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_getfield(L, 1, "object_id");
+    const char *const name = luaL_checkstring(L, -1);
+    const OBJECT_ID object_id = Object_IdFromKey(name);
+    if (object_id == NO_OBJECT) {
+        luaL_error(L, "unknown object '%s'", name);
+    }
+    lua_pop(L, 1);
+
+    INVENTORY_ITEM *item = M_FindRingItem(object_id);
+    const bool is_new = item == nullptr;
+    if (is_new) {
+        item = Memory_Alloc(sizeof(*item));
+        item->object_id = object_id;
+    }
+
+#define M_READ(key, field) item->field = M_ReadRingInt(L, 1, key, item->field)
+    M_READ("frames_total", frames_total);
+    M_READ("current_frame", current_frame);
+    M_READ("goal_frame", goal_frame);
+    M_READ("open_frame", open_frame);
+    M_READ("anim_direction", anim_direction);
+    M_READ("anim_speed", anim_speed);
+    M_READ("anim_count", anim_count);
+    M_READ("x_rot_pt_sel", x_rot_pt_sel);
+    M_READ("x_rot_pt", x_rot_pt);
+    M_READ("x_rot_sel", x_rot_sel);
+    M_READ("x_rot_nosel", x_rot_nosel);
+    M_READ("x_rot", x_rot);
+    M_READ("y_rot_sel", y_rot_sel);
+    M_READ("y_rot", y_rot);
+    M_READ("y_trans_sel", y_trans_sel);
+    M_READ("y_trans", y_trans);
+    M_READ("z_trans_sel", z_trans_sel);
+    M_READ("z_trans", z_trans);
+    M_READ("meshes_sel", meshes_sel);
+    M_READ("meshes_drawn", meshes_drawn);
+    M_READ("inv_pos", inv_pos);
+#undef M_READ
+
+    if (is_new) {
+        Vector_Add(g_InvRing_Items, &item);
+    }
+    return 0;
+}
+
 static const luaL_Reg m_Module[] = {
     { "get_current", M_L_InvGetCurrent },
     { "get", M_L_InvGetLevel },
+    { "declare_ring_item", M_L_InvDeclareRingItem },
     { nullptr, nullptr },
 };
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds a Lua function for declaring inventory-ring items. This lets mods add objects to the ring without changing the game files.