### PR TITLE
lara/skin: fix weapons with no held model

### DIFF
--- a/src/trx/game/gun/types.h
+++ b/src/trx/game/gun/types.h
@@ -169,6 +169,9 @@ typedef struct {
 
     // Select the mesh source when the weapon brings its own model.
     WEAPON_MESH_INFO meshes;
+    // The weapon whose meshes this weapon uses when it has none of its own.
+    // NO_CATALOG_ID for a weapon that stands alone.
+    LARA_GUN_TYPE skin_source;
     // Whether a module implements this weapon. A row that none declares is
     // a gun type the engine carries but nothing drives, such as empty hands
     // or a gun fixed to a vehicle.

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -22,7 +22,9 @@
 #include <string.h>
 #include <uthash.h>
 
-// The color the shipped golden models are textured in, to the texel.
+// Limit how far a weapon can search through its base weapons.
+#define M_MAX_SKIN_STEPS 8
+// The color of the shipped golden models, down to the texel.
 #define M_DEFAULT_GOLD_COLOR ((RGB_888) { 0xFF, 0xEE, 0x8B })
 
 typedef struct {
@@ -594,10 +596,23 @@ REGISTER_SUBSYSTEM(.load = M_Load, .shutdown = M_Shutdown)
 LARA_SKIN_MESH_MAP Lara_Skin_GetGunMeshMap(
     const LARA_SKIN_GUN_MAP *const gun_map, const LARA_GUN_TYPE gun_type)
 {
-    for (int32_t i = 0; i < gun_map->count; i++) {
-        if (gun_map->entries[i].gun_type == gun_type) {
-            return gun_map->entries[i].mesh_map;
+    // Use the weapon's meshes, then try each base weapon. Stop after a fixed
+    // number of steps so a chain of bases cannot loop forever.
+    LARA_GUN_TYPE wanted = gun_type;
+    for (int32_t step = 0; step < M_MAX_SKIN_STEPS; step++) {
+        for (int32_t i = 0; i < gun_map->count; i++) {
+            if (gun_map->entries[i].gun_type == wanted) {
+                return gun_map->entries[i].mesh_map;
+            }
         }
+        if (!Gun_Registry_IsValidType(wanted)) {
+            break;
+        }
+        const LARA_GUN_TYPE source = Gun_Registry_Get(wanted)->skin_source;
+        if (source <= LGT_UNARMED || source == wanted) {
+            break;
+        }
+        wanted = source;
     }
     LARA_SKIN_MESH_MAP map;
     memset(&map, -1, sizeof(map));

--- a/src/trx/game/lua/capi/weapons_spec.c
+++ b/src/trx/game/lua/capi/weapons_spec.c
@@ -515,8 +515,8 @@ static RESULT M_ReadGroup(
     return OK;
 }
 
-// Takes the weapon another weapon is built on as it stands, keeping what the
-// engine gave this one where the two disagree.
+// Reads the weapon this weapon is based on and keeps its own settings where
+// they differ.
 static RESULT M_ReadBase(
     lua_State *const L, const int idx, WEAPON_INFO *const w)
 {
@@ -538,6 +538,7 @@ static RESULT M_ReadBase(
     const WEAPON_INFO own = *w;
     *w = *Gun_Registry_Get(base_id);
     w->gun_type = gun_type;
+    w->skin_source = base_id;
     w->is_declared = was_declared;
     w->equip_input_role = was_declared ? own.equip_input_role : (INPUT_ROLE)-1;
     w->save_ammo_key = was_declared ? own.save_ammo_key : nullptr;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes a bug where a weapon based on another weapon left Lara holding nothing when it defined no meshes of its own. Base weapon lookup stops after a fixed number of steps.