### PR TITLE
gun: add a weapon fire delay

### DIFF
--- a/src/trx/game/gun/pistols.c
+++ b/src/trx/game/gun/pistols.c
@@ -68,6 +68,9 @@ static const M_FRAME_SETUP m_DesertEagleSetup = {
 
 static bool m_SoundRight = false;
 static bool m_SoundLeft = false;
+// Track the frames before each hand may fire again.
+static int16_t m_FireDelayRight = 0;
+static int16_t m_FireDelayLeft = 0;
 
 static bool M_EnableFastSound(const LARA_GUN_TYPE weapon_type)
 {
@@ -136,6 +139,13 @@ static void M_Animate(const LARA_GUN_TYPE weapon_type)
     bool sound_already = false;
     int16_t angles[2];
 
+    // Reset the delays when the trigger is released so the next shot fires
+    // immediately. Each hand has its own delay.
+    if (!g_Input.action) {
+        m_FireDelayRight = 0;
+        m_FireDelayLeft = 0;
+    }
+
     int32_t frame_r = lara->right_arm.frame_num;
     if (!lara->right_arm.lock && (!g_Input.action || lara->target != nullptr)) {
         if (Anim_TestAbsFrameRange(
@@ -154,7 +164,10 @@ static void M_Animate(const LARA_GUN_TYPE weapon_type)
                 frame_r, setup->aim.start, setup->aim.extend)) {
             frame_r++;
         } else if (frame_r == setup->aim.end) {
-            if (g_Input.action) {
+            if (g_Input.action && m_FireDelayRight > 0) {
+                m_FireDelayRight--;
+            } else if (g_Input.action) {
+                m_FireDelayRight = weapon->fire_delay;
                 angles[0] = lara->right_arm.rot.y + lara_item->rot.y;
                 angles[1] = lara->right_arm.rot.x;
                 if (!Gun_IsSinglePistolType(weapon_type)
@@ -208,7 +221,10 @@ static void M_Animate(const LARA_GUN_TYPE weapon_type)
         Anim_TestAbsFrameRange(frame_l, setup->aim.start, setup->aim.extend)) {
         frame_l++;
     } else if (frame_l == setup->aim.end) {
-        if (g_Input.action) {
+        if (g_Input.action && m_FireDelayLeft > 0) {
+            m_FireDelayLeft--;
+        } else if (g_Input.action) {
+            m_FireDelayLeft = weapon->fire_delay;
             angles[0] = lara->left_arm.rot.y + lara_item->rot.y;
             angles[1] = lara->left_arm.rot.x;
             if (Gun_FireWeapon(weapon_type, lara->target, lara_item, angles)) {

--- a/src/trx/game/gun/rifle.c
+++ b/src/trx/game/gun/rifle.c
@@ -41,6 +41,7 @@ typedef enum {
 
 static bool m_M16Firing = false;
 static bool m_ReloadHarpoon = false;
+static int16_t m_FireDelay = 0;
 static int32_t m_HarpoonShots = 0;
 
 static void M_SetTR3ProjectileShade(ITEM *const item)
@@ -506,6 +507,12 @@ static void M_Animate(const LARA_GUN_TYPE weapon_type)
     ITEM *const item = Item_Get(lara->gun_item_num);
     const WEAPON_INFO *const weapon = Gun_Registry_Get(weapon_type);
 
+    // Apply the delay only while the trigger remains held. Releasing and
+    // pressing the trigger again fires at once.
+    if (!g_Input.action) {
+        m_FireDelay = 0;
+    }
+
     switch (item->current_anim_state) {
     case LA_G_AIM:
         m_M16Firing = false;
@@ -547,7 +554,11 @@ static void M_Animate(const LARA_GUN_TYPE weapon_type)
             if (lara->water_status != LWS_UNDERWATER && !running
                 && !m_ReloadHarpoon) {
                 if (g_Input.action) {
-                    if (lara->target == nullptr || lara->left_arm.lock) {
+                    if (m_FireDelay > 0) {
+                        m_FireDelay--;
+                        item->goal_anim_state = LA_G_AIM;
+                    } else if (lara->target == nullptr || lara->left_arm.lock) {
+                        m_FireDelay = weapon->fire_delay;
                         M_Fire(weapon_type, false);
                         if (is_machine_gun) {
                             M_PlayMachineGunSound(weapon_type, false);

--- a/src/trx/game/gun/types.h
+++ b/src/trx/game/gun/types.h
@@ -191,6 +191,9 @@ typedef struct {
     // Whether it keeps firing while the trigger is held, which also lets
     // Lara fire it on the move.
     bool is_machine_gun;
+    // The number of frames between shots while the trigger is held. Zero uses
+    // the recoil animation to set the firing rate.
+    int16_t fire_delay;
     // Whether Lara may bring it out under water.
     bool is_usable_underwater;
     // Whether it throws an explosive that flies on its own, rather than

--- a/src/trx/game/lua/capi/weapons_spec.c
+++ b/src/trx/game/lua/capi/weapons_spec.c
@@ -578,6 +578,7 @@ static RESULT M_ReadFlat(
     INPUT_ROLE *const out_role, int *const out_fire_idx)
 {
     M_INT(L, idx, "damage", w->damage);
+    M_INT(L, idx, "fire_delay", w->fire_delay);
     M_INT(L, idx, "gun_height", w->gun_height);
     MUST(M_ReadBool(L, idx, "is_available", &w->is_available));
     MUST(M_ReadBool(L, idx, "is_default", &w->is_default));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds a fire delay that sets the number of frames between shots while the trigger is held. Releasing the trigger resets the delay, so pressing it again fires at once. Weapons without a delay keep their existing firing rate.