### PR TITLE
shell/flow: fix skips killing music

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,9 @@
 - Fixed TR1's moored boat sharing its name with TR2's speedboat, so a command that took `boat` could act on either
 - Fixed the TR3 SWAT 2 and SWAT 3 enemies being named as SWAT 1, so a command that took either of them acted on the wrong enemy
 
+**Recordings**
+- Fixed recordings losing music after `skip start` (TRX1429)
+
 **Weapons and ammunition**
 - Added an option to keep Lara firing the M16/MP5 from her hip while the action key is held, rather than shouldering the gun the moment she stops moving (Gameplay → Controls → M16/MP5 aiming variants) (#3861 / TRX1048)
 - Fixed Lara taking out a two-handed weapon in wading-depth water only to put it away at once (OG bug) (#6253 / TRX1120)

--- a/src/trx/game/clock/common.c
+++ b/src/trx/game/clock/common.c
@@ -89,6 +89,11 @@ void Clock_EnableWait(void)
     m_Disabled = false;
 }
 
+bool Clock_IsRealTime(void)
+{
+    return !m_Disabled;
+}
+
 void Clock_EnableFixedFPS(const int32_t fps)
 {
     if (fps <= 0) {

--- a/src/trx/game/clock/common.h
+++ b/src/trx/game/clock/common.h
@@ -9,6 +9,10 @@ void Clock_DisableWait(void);
 // Restores the waiting Clock_DisableWait turned off.
 void Clock_EnableWait(void);
 
+// Reports whether frames are paced to real time. Frames run as fast as possible
+// when pacing is disabled.
+bool Clock_IsRealTime(void);
+
 // Counts time in frames: every Clock_WaitTick moves the clock on by 1/fps. Zero
 // goes back to real time, carrying on from where the frame count reached.
 void Clock_EnableFixedFPS(int32_t fps);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -7,6 +7,7 @@
 #include <trx/core/memory.h>
 #include <trx/core/subsystem.h>
 #include <trx/core/vector.h>
+#include <trx/game/clock.h>
 #include <trx/game/const.h>
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
@@ -659,6 +660,11 @@ RESULT Music_SetSpeed(const double speed)
 RESULT Music_SyncTimestamp(const double timestamp)
 {
     MUST(M_CheckMainStream());
+    // Do not seek while frames run as fast as possible. The track cannot keep
+    // up, so syncing it would seek every few frames.
+    if (!Clock_IsRealTime()) {
+        return OK;
+    }
     return Audio_Stream_SyncTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -87,7 +87,8 @@ double Music_GetTimestamp(void);
 // music plays.
 RESULT Music_SeekTimestamp(double timestamp);
 
-// Seeks to the given timestamp if the drift is too big.
+// Seeks to the given timestamp when the drift is too large. Does nothing while
+// frames run as fast as possible because the track cannot keep up.
 RESULT Music_SyncTimestamp(double timestamp);
 
 // Play the current track at the given rate, so a sped-up cutscene carries its

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -105,7 +105,7 @@ RESULT Output_Init(void)
 
 bool Output_IsHeadless(void)
 {
-    return Shell_GetArgs()->headless;
+    return Shell_GetArgs()->headless || Shell_IsDrawingSkipped();
 }
 
 const OUTPUT_UNIFORMS *Output_GetUniforms(void)

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -548,7 +548,7 @@ static void M_StopSkipping(void)
         return;
     }
     p->skipping = false;
-    Shell_SetHeadless(false);
+    Shell_SetDrawingSkipped(false);
 }
 
 static bool M_ParseSkipStartEvent(const char *const event_str)
@@ -557,10 +557,9 @@ static bool M_ParseSkipStartEvent(const char *const event_str)
         return false;
     }
     M_PRIV *const p = &m_Priv;
-    // A run already told to draw nothing must not start drawing at skip end.
-    if (!p->skipping && !Shell_GetArgs()->headless) {
+    if (!p->skipping) {
         p->skipping = true;
-        Shell_SetHeadless(true);
+        Shell_SetDrawingSkipped(true);
     }
     return true;
 }

--- a/src/trx/game/shell/common.h
+++ b/src/trx/game/shell/common.h
@@ -35,8 +35,10 @@ bool Shell_GetPrevHeadless(void);
 bool Shell_GetPrevQuiet(void);
 const SHELL_ARGS *Shell_GetArgs(void);
 
-// Stop or resume drawing the game while it keeps running its logic frames.
-void Shell_SetHeadless(bool headless);
+// Stops or resumes drawing while the game keeps running its logic frames.
+// Audio, the window, and other systems continue to run.
+void Shell_SetDrawingSkipped(bool skipped);
+bool Shell_IsDrawingSkipped(void);
 
 bool Shell_IsFullscreen(void);
 SHELL_SIZE Shell_GetDefaultSize(void);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -35,6 +35,9 @@ static char *m_PendingMod = nullptr;
 static bool m_PrevHeadless = false;
 static bool m_PrevQuiet = false;
 
+// Set while a replay runs a stretch with the drawing off.
+static bool m_DrawingSkipped = false;
+
 // Given back before the config module goes down, so a mod switch does not
 // leave a copy behind.
 static int32_t m_ConfigListener = -1;
@@ -323,22 +326,25 @@ const SHELL_ARGS *Shell_GetArgs(void)
     return m_Session != nullptr ? m_Session->args : nullptr;
 }
 
-void Shell_SetHeadless(const bool headless)
+void Shell_SetDrawingSkipped(const bool skipped)
 {
-    ASSERT(m_Session != nullptr);
-    SHELL_ARGS *const args = (SHELL_ARGS *)m_Session->args;
-    if (args->headless == headless) {
+    if (m_DrawingSkipped == skipped) {
         return;
     }
 
-    args->headless = headless;
+    m_DrawingSkipped = skipped;
     // The clock counts frames either way; only the pacing changes here.
-    if (headless) {
+    if (skipped) {
         Clock_DisableWait();
     } else {
         Clock_EnableWait();
         Clock_SyncTick();
     }
+}
+
+bool Shell_IsDrawingSkipped(void)
+{
+    return m_DrawingSkipped;
 }
 
 SDL_Window *Shell_GetWindow(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Recording skips now keep music playing while drawing is disabled.

Before this, skip start made the entire session headless which stopped music, notably killing the cutscene levels audio.

Resolves TRX1429