### PR TITLE
Load directory-scoped Lua scripts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,7 +101,8 @@
 - Added a `trx.json` module, so a script can read and write JSON as text or files
 - Added `trx.math.from_sectors()` and `trx.math.to_sectors()`, so a script can say a length the way a level is laid out
 - Added `trx.weapons.declare()`, `trx.weapons.patch()` and `trx.weapons.set_fire()`, so a script can add a weapon of its own or change one the game holds, with what it does when fired written in the script
-- Added a `scripts` directory beside the engine, holding the scripts it runs as a game starts; a script takes effect by being there, and the weapons a game holds are declared by one of them
+- Added a `scripts/` directory beside the engine for scripts that run when a game starts
+- Added support for scripts with several files, using an `init.lua` entry point in a directory of its own
 - Added an object links file, so a mod can say which pickup an inventory icon stands for, which slot a key goes into, and which box a weapon's rounds come in
 - Added `trx.objects.declare()`, so a script can define how its own object starts, updates, casts a shadow and saves its position
 - Added `trx.objects.borrow_content()`, so an object with no models of its own can use another object's meshes and animations

--- a/docs/trx/lua/GETTING_STARTED.md
+++ b/docs/trx/lua/GETTING_STARTED.md
@@ -45,6 +45,24 @@ An expansion that has nothing of its own to set up needs no file: the script of
 the game it extends runs instead. Shipping one replaces that script rather than
 adding to it, so anything worth keeping goes in a module both require.
 
+### Scripts in a directory of their own
+
+A script that belongs to no single game goes in the `scripts/` directory beside
+the engine. It runs when a game starts. A script made of several files goes in
+its own directory, with `init.lua` as its entry point:
+
+```text
+scripts/my_scripts/init.lua
+```
+
+The engine runs each `init.lua` it finds. A script takes effect when it is
+present. A directory without one does nothing. The scripts that ship with the
+engine run first, so a directory script can use what they have declared.
+
+The engine looks for a file beside the script first. For example,
+`trx.inject.declare` naming `my.bin` finds `scripts/my_scripts/my.bin` before
+the game's own injections. The script does not need to name its directory.
+
 ### Sharing code between scripts
 
 A script can put what it has in common with another in a file of its own and
@@ -56,6 +74,7 @@ local mine = require("tr1.my_module")            -- games/tr1/modules/my_module.
 local nested = require("tr1.my_group.my_module") -- games/tr1/modules/my_group/my_module.lua
 local other = require("tr1-ub.my_module")        -- any installed game, by its directory name
 local pooled = require("common.my_module")       -- modules/my_module.lua, beside the engine
+local own = require(".my_module")                -- the directory it runs from
 ```
 
 A module lives in `modules/`, alongside the `scripts/` the engine runs, and a
@@ -66,6 +85,10 @@ is named the way it appears in `games/`, so a script says which game it is
 reaching into and gets the same file whichever game is running. `trx` is
 reserved for the engine's own modules, which are the global `trx` table rather
 than something to require.
+
+A name that starts with `.` refers to the directory of the entry point.
+Renaming the directory does not change its `require` calls. Use this form only
+while `init.lua` is loading.
 
 A required script runs once, and every later call is handed what the first one
 returned:
@@ -85,9 +108,9 @@ required by `_game.lua` runs once for the game. The first require of a name
 decides which of the two it is, and every require after it is handed that
 module, so the game and a level never hold two copies of one name.
 
-Names hold letters, digits, `_`, `-` and the `.` that separates directories.
-Case does not count, so a name spelled two ways is one module. There is no way
-to name a file outside the directory the form points at.
+Names can contain letters, digits, `_`, `-` and `.` between directories. A
+relative name has one leading `.`. Case does not count, so two spellings name
+the same module. A name cannot reach outside its directory: `..` is not valid.
 
 ### Interactive commands
 

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -6604,7 +6604,7 @@
       "path": "game.screenshot"
     },
     {
-      "description": "Adds injections to every level, in addition to those named by its game flow.\n\nThe function runs before each level loads its content. It can read the current\nsettings and return a different list for each level.\n\nReturn file names, not paths. The game searches for them in the same order as\ngame-flow injections: in the mod first, then in the base game. Use\n`trx.path.resolve` to check whether a file exists first.",
+      "description": "Adds injections to every level, in addition to those named by its game flow.\n\nThe function runs before each level loads its content. It can read the current\nsettings and return a different list for each level.\n\nReturn file names, not paths. A file beside the script is searched first. Other\nfiles are searched in the same order as game-flow injections: in the mod first,\nthen in the base game. Use `trx.path.resolve` to check whether a file exists.",
       "examples": [
         "trx.inject.declare(function()\n  local files = { \"mymod_models.bin\" }\n  if trx.config.get(\"visuals.enable_ps1_crystals\") then\n    files[#files + 1] = \"wall_crystals.bin\"\n  end\n  return files\nend)"
       ],

--- a/docs/trx/lua/reference/INJECT.md
+++ b/docs/trx/lua/reference/INJECT.md
@@ -25,9 +25,9 @@ injections, so a mod can ship its content without changing a game flow.
   The function runs before each level loads its content. It can read the current
   settings and return a different list for each level.
 
-  Return file names, not paths. The game searches for them in the same order as
-  game-flow injections: in the mod first, then in the base game. Use
-  [`trx.path.resolve`](PATH.md#path.resolve) to check whether a file exists first.
+  Return file names, not paths. A file beside the script is searched first. Other
+  files are searched in the same order as game-flow injections: in the mod first,
+  then in the base game. Use [`trx.path.resolve`](PATH.md#path.resolve) to check whether a file exists.
 
   Parameters:
   - <a id="inject.declare.declaration" name="inject.declare.declaration"></a>**`declaration`** (function). Called before each level loads and returns a list of file names.

--- a/src/lua/api/inject.lua
+++ b/src/lua/api/inject.lua
@@ -18,9 +18,9 @@ Adds injections to every level, in addition to those named by its game flow.
 The function runs before each level loads its content. It can read the current
 settings and return a different list for each level.
 
-Return file names, not paths. The game searches for them in the same order as
-game-flow injections: in the mod first, then in the base game. Use
-`trx.path.resolve` to check whether a file exists first.]],
+Return file names, not paths. A file beside the script is searched first. Other
+files are searched in the same order as game-flow injections: in the mod first,
+then in the base game. Use `trx.path.resolve` to check whether a file exists.]],
   params = {
     {
       name = "declaration",

--- a/src/tests/harness/stubs_game_script.c
+++ b/src/tests/harness/stubs_game_script.c
@@ -4,16 +4,40 @@
 
 #include <harness/stubs_game_script.h>
 
+#include <trx/core/memory.h>
+#include <trx/game/lua/startup.h>
 #include <trx/game/paths.h>
 
 #include <stdio.h>
 
 static const char *m_ScriptDirs[GAME_DYNAMIC_PATH_NUMBER_OF] = {};
+static const char *m_OwnDir = nullptr;
 
 void FakeGameScript_SetScriptDir(
     const GAME_DYNAMIC_PATH path, const char *const dir)
 {
     m_ScriptDirs[path] = dir;
+}
+
+void FakeGameScript_SetOwnDir(const char *const dir)
+{
+    m_OwnDir = dir;
+}
+
+const char *LUA_GetStartupScriptDir(void)
+{
+    return m_OwnDir;
+}
+
+// Return the path when it names an openable file.
+char *GamePath_ResolveCase(const char *const path)
+{
+    FILE *const fp = fopen(path, "rb");
+    if (fp == nullptr) {
+        return nullptr;
+    }
+    fclose(fp);
+    return Memory_DupStr(path);
 }
 
 const char *GamePath_PeekResolve(

--- a/src/tests/harness/stubs_game_script.h
+++ b/src/tests/harness/stubs_game_script.h
@@ -6,3 +6,6 @@
 // require() real files. A source with no directory set resolves nothing, which
 // is what a test running no scripts wants.
 void FakeGameScript_SetScriptDir(GAME_DYNAMIC_PATH path, const char *dir);
+
+// Set the directory for relative names. Pass nullptr for a loose script.
+void FakeGameScript_SetOwnDir(const char *dir);

--- a/src/tests/trx/game/lua/common.c
+++ b/src/tests/trx/game/lua/common.c
@@ -31,6 +31,8 @@
 #define M_GAMES_DIR "lua_scripts_games"
 #define M_COMMON_DIR "lua_scripts_common"
 #define M_SCRIPTS_DIR "lua_scripts_engine"
+#define M_OWN_DIR "lua_scripts_own"
+#define M_OTHER_OWN_DIR "lua_scripts_own_other"
 
 typedef struct {
     char path[256];
@@ -86,13 +88,13 @@ static void M_ClearScripts(void)
     FakeGameScript_SetScriptDir(GAME_DYNAMIC_PATH_GAME_MODULE_FILE, nullptr);
     FakeGameScript_SetScriptDir(GAME_DYNAMIC_PATH_COMMON_MODULE_FILE, nullptr);
     FakeGameScript_SetScriptDir(GAME_DYNAMIC_PATH_GAME_SCRIPT_FILE, nullptr);
+    FakeGameScript_SetOwnDir(nullptr);
 }
 
 // A name carries directories of its own, so each of them is made in turn
 // before the file lands.
-static char *M_WriteScriptIn(
-    const GAME_DYNAMIC_PATH source, const char *const dir,
-    const char *const name, const char *const body)
+static char *M_WriteFileIn(
+    const char *const dir, const char *const name, const char *const body)
 {
     M_MakeDir(dir);
 
@@ -110,7 +112,14 @@ static char *M_WriteScriptIn(
     fputs(body, fp);
     fclose(fp);
 
-    char *const kept = M_Remember(path, false);
+    return M_Remember(path, false);
+}
+
+static char *M_WriteScriptIn(
+    const GAME_DYNAMIC_PATH source, const char *const dir,
+    const char *const name, const char *const body)
+{
+    char *const kept = M_WriteFileIn(dir, name, body);
     FakeGameScript_SetScriptDir(source, dir);
     return kept;
 }
@@ -126,6 +135,14 @@ static void M_WriteCommonScript(const char *const name, const char *const body)
 {
     M_WriteScriptIn(
         GAME_DYNAMIC_PATH_COMMON_MODULE_FILE, M_COMMON_DIR, name, body);
+}
+
+// Write a file beside the script that is running.
+static void M_WriteOwnScript(
+    const char *const dir, const char *const name, const char *const body)
+{
+    M_WriteFileIn(dir, name, body);
+    FakeGameScript_SetOwnDir(dir);
 }
 
 // What the engine runs rather than a script requires: _game.lua, and the level
@@ -373,6 +390,43 @@ TEST(a_directory_with_an_init_script_answers_to_its_name)
     M_Done();
 }
 
+// Resolve files beside a script with a relative name.
+TEST(a_relative_name_reaches_a_file_beside_it)
+{
+    M_Booted();
+    M_WriteOwnScript(M_OWN_DIR, "utils", "return { name = 'mine' }\n");
+    M_WriteOwnScript(
+        M_OWN_DIR, "net/http/init", "return { name = 'nested' }\n");
+
+    M_CheckEval("assert(require('.utils').name == 'mine')");
+    M_CheckEval("assert(require('.net.http').name == 'nested')");
+
+    M_Done();
+}
+
+// Keep relative modules separate when scripts use the same name.
+TEST(two_directories_requiring_one_name_are_handed_their_own_file)
+{
+    M_Booted();
+    M_WriteOwnScript(M_OWN_DIR, "utils", "return 'first'\n");
+    M_CheckEval("assert(require('.utils') == 'first')");
+
+    M_WriteOwnScript(M_OTHER_OWN_DIR, "utils", "return 'second'\n");
+    M_CheckEval("assert(require('.utils') == 'second')");
+
+    M_Done();
+}
+
+// Reject relative names from loose scripts.
+TEST(a_relative_name_is_refused_outside_a_directory)
+{
+    M_Booted();
+
+    M_CheckEvalFails("require('.utils')", "relative names work only");
+
+    M_Done();
+}
+
 // Refuse a file and directory with the same module name.
 TEST(a_script_beside_a_directory_of_the_same_name_is_refused)
 {
@@ -394,7 +448,8 @@ TEST(a_name_that_could_reach_outside_is_refused)
 
     M_CheckEval(
         "for _, name in ipairs({'../secret', 'tr1/my_module', '/etc/passwd',\n"
-        "    '..', 'tr1..a', '.my_module', 'tr1.', '', 'tr1\\\\a'}) do\n"
+        "    '..', '.', 'tr1..a', '.tr1..a', './my_module', 'tr1.', '',\n"
+        "    'tr1\\\\a'}) do\n"
         "  local ok, err = pcall(require, name)\n"
         "  assert(not ok, 'require accepted ' .. name)\n"
         "  assert(err:find('not a script name', 1, true), name)\n"

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -4,6 +4,7 @@
 #include <trx/core/benchmark.h>
 #include <trx/core/file.h>
 #include <trx/core/memory.h>
+#include <trx/core/strings.h>
 #include <trx/core/thread_pool.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
@@ -571,18 +572,26 @@ void Inject_SetDeclarationCollector(void (*const collect)(void))
     m_CollectDeclared = collect;
 }
 
-void Inject_AddDeclaredInjection(const char *const name)
+void Inject_AddDeclaredInjection(const char *const name, const char *const dir)
 {
-    const char *const path =
-        GamePath_TryResolve(GAME_DYNAMIC_PATH_INJECTION_FILE, name);
-    if (path == nullptr) {
-        LOG_WARNING("no injection named '%s' was found", name);
-        return;
+    char *own = nullptr;
+    if (dir != nullptr && strpbrk(name, "/\\") == nullptr) {
+        char *beside = String_Format("%s/%s", dir, name);
+        own = GamePath_ResolveCase(beside);
+        Memory_FreePointer(&beside);
+    }
+    if (own == nullptr) {
+        const char *const path =
+            GamePath_TryResolve(GAME_DYNAMIC_PATH_INJECTION_FILE, name);
+        if (path == nullptr) {
+            LOG_WARNING("no injection named '%s' was found", name);
+            return;
+        }
+        own = Memory_DupStr(path);
     }
     if (m_DeclaredPaths == nullptr) {
         m_DeclaredPaths = Vector_Create(sizeof(char *));
     }
-    char *const own = Memory_DupStr(path);
     Vector_Add(m_DeclaredPaths, &own);
 }
 

--- a/src/trx/game/inject/common.h
+++ b/src/trx/game/inject/common.h
@@ -12,9 +12,13 @@ void Inject_InitLevel(const GF_LEVEL *level, INJECTION_MODE mode);
 // named by the level's game flow and are collected for each level.
 void Inject_SetDeclarationCollector(void (*collect)(void));
 void Inject_CollectDeclarations(void);
-void Inject_AddDeclaredInjection(const char *name);
+
+// Add one declared injection. Search dir first for a plain file name. Use null
+// when the declaration comes from a loose script.
+void Inject_AddDeclaredInjection(const char *name, const char *dir);
 int32_t Inject_GetDeclaredCount(void);
 const char *Inject_GetDeclaredPath(int32_t idx);
+
 void Inject_AppendInjection(TRX_FILE *file);
 void Inject_AllInjections(void);
 void Inject_Cleanup(void);

--- a/src/trx/game/lua/capi/inject.c
+++ b/src/trx/game/lua/capi/inject.c
@@ -1,18 +1,25 @@
+#include <trx/core/memory.h>
 #include <trx/core/vector.h>
 #include <trx/game/console/common.h>
 #include <trx/game/inject.h>
 #include <trx/game/lua/registry.h>
+#include <trx/game/lua/startup.h>
 #include <trx/game/lua/utils.h>
 
 #include <lauxlib.h>
+
+typedef struct {
+    int32_t ref;
+    char *dir;
+} M_DECLARATION;
 
 static lua_State *m_L = nullptr;
 static VECTOR *m_Declarations = nullptr;
 
 // Read the injection names returned by a declaration.
-static void M_ReadList(const int32_t ref)
+static void M_ReadList(const M_DECLARATION *const decl)
 {
-    lua_rawgeti(m_L, LUA_REGISTRYINDEX, ref);
+    lua_rawgeti(m_L, LUA_REGISTRYINDEX, decl->ref);
     if (lua_pcall(m_L, 0, 1, 0) != LUA_OK) {
         Console_ShowError(
             "injection declaration error: %s", lua_tostring(m_L, -1));
@@ -33,7 +40,7 @@ static void M_ReadList(const int32_t ref)
         lua_rawgeti(m_L, -1, i);
         const char *const name = lua_tostring(m_L, -1);
         if (name != nullptr) {
-            Inject_AddDeclaredInjection(name);
+            Inject_AddDeclaredInjection(name, decl->dir);
         } else {
             Console_ShowError("an injection declaration must name files");
         }
@@ -46,7 +53,7 @@ static void M_Collect(void)
 {
     for (int32_t i = 0; m_Declarations != nullptr && i < m_Declarations->count;
          i++) {
-        M_ReadList(*(int32_t *)Vector_Get(m_Declarations, i));
+        M_ReadList(Vector_Get(m_Declarations, i));
     }
 }
 
@@ -55,11 +62,14 @@ static int M_L_Declare(lua_State *const L)
 {
     luaL_checktype(L, 1, LUA_TFUNCTION);
     if (m_Declarations == nullptr) {
-        m_Declarations = Vector_Create(sizeof(int32_t));
+        m_Declarations = Vector_Create(sizeof(M_DECLARATION));
     }
     lua_pushvalue(L, 1);
-    const int32_t ref = luaL_ref(L, LUA_REGISTRYINDEX);
-    Vector_Add(m_Declarations, (void *)&ref);
+    const M_DECLARATION decl = {
+        .ref = luaL_ref(L, LUA_REGISTRYINDEX),
+        .dir = Memory_DupStr(LUA_GetStartupScriptDir()),
+    };
+    Vector_Add(m_Declarations, (void *)&decl);
     return 0;
 }
 
@@ -79,6 +89,10 @@ static void M_Shutdown(void)
 {
     Inject_SetDeclarationCollector(nullptr);
     if (m_Declarations != nullptr) {
+        for (int32_t i = 0; i < m_Declarations->count; i++) {
+            M_DECLARATION *const decl = Vector_Get(m_Declarations, i);
+            Memory_FreePointer(&decl->dir);
+        }
         Vector_Free(m_Declarations);
         m_Declarations = nullptr;
     }

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -15,6 +15,7 @@
 #include <trx/game/lua/guard.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/sandbox.h>
+#include <trx/game/lua/startup.h>
 #include <trx/game/lua/utils.h>
 #include <trx/game/paths.h>
 
@@ -216,7 +217,8 @@ static RESULT M_RunTRXRuntimeScripts(lua_State *const L)
 // One or more segments joined by '.', as Lua names any other module:
 // "my_module", "my_group.my_module". The shape is what keeps a require inside
 // the directory it names - no empty segment to start, end or double a
-// separator with, so no "..", and no '/' at all to climb out with.
+// separator with, so no "..", and no '/' at all to climb out with. Check a
+// relative name without its leading dot, so "." and ".." are also refused.
 static bool M_IsScriptName(const char *const name)
 {
     size_t segment_len = 0;
@@ -272,10 +274,11 @@ static bool M_HasRoot(
 // directory, named as the game sits in games/, so a script says which game it
 // is reaching into and the answer does not depend on which game is running.
 // modules/ holds what a script requires; scripts/ holds what the engine runs,
-// and no name reaches it.
+// and no name reaches it. The returned path is temporary. Load the file before
+// formatting another path.
 static const char *M_ResolveScript(
     lua_State *const L, const char *const raw, const char *const name,
-    const size_t root_len, const char *const stem)
+    const size_t root_len, const char *const stem, const char *const own_dir)
 {
     // The pieces are spelled into Lua strings rather than buffers of our own:
     // the resolver hands back a pointer into its own storage, and this way
@@ -284,6 +287,30 @@ static const char *M_ResolveScript(
 
     // The dots the script wrote are the directories the file sits in.
     const char *const path_stem = luaL_gsub(L, stem, ".", "/");
+
+    if (own_dir != nullptr) {
+        const char *found[2] = { nullptr, nullptr };
+        for (int32_t i = 0; i < 2; i++) {
+            const char *const candidate = lua_pushfstring(
+                L, i == 0 ? "%s/%s.lua" : "%s/%s/init.lua", own_dir, path_stem);
+            char *resolved = GamePath_ResolveCase(candidate);
+            found[i] =
+                resolved != nullptr ? lua_pushstring(L, resolved) : nullptr;
+            Memory_FreePointer(&resolved);
+        }
+        if (found[0] != nullptr && found[1] != nullptr) {
+            luaL_error(
+                L,
+                "both a file and a directory exist for %s: %s and %s. Remove "
+                "one of them",
+                raw, found[0], found[1]);
+        }
+        const char *const own = found[0] != nullptr ? found[0] : found[1];
+        const char *const path =
+            own != nullptr ? String_FormatStatic("%s", own) : nullptr;
+        lua_settop(L, base);
+        return path;
+    }
 
     const bool is_common = M_HasRoot(name, root_len, M_COMMON_ROOT);
     const GAME_DYNAMIC_PATH source = is_common
@@ -321,41 +348,62 @@ static const char *M_ResolveScript(
     const char *const rel = found[0] != nullptr ? rels[0]
         : found[1] != nullptr                   ? rels[1]
                                                 : nullptr;
-    const char *const path =
+    const char *const resolved =
         rel != nullptr ? GamePath_PeekResolve(source, rel) : nullptr;
+    const char *const path =
+        resolved != nullptr ? String_FormatStatic("%s", resolved) : nullptr;
     lua_settop(L, base);
     return path;
 }
 
-// require(name): "tr3-la.acme" is games/tr3-la/modules/acme.lua, and
-// "common.acme" is the pool beside the engine. Runs the script once and hands
-// every later call what it returned.
+// Require a module by game name, common name or relative name. Run each module
+// once and return its result for later calls.
 static int M_L_Require(lua_State *const L)
 {
     // Report the spelling used by the script and use the lowered name to look
     // up the module.
     const char *const raw = luaL_checkstring(L, 1);
-    if (!M_IsScriptName(raw)) {
+    const bool is_own = raw[0] == '.';
+    if (!M_IsScriptName(is_own ? raw + 1 : raw)) {
         return luaL_error(L, "not a script name: %s", raw);
     }
 
     lua_settop(L, 1);
-    const char *const name = M_PushLowerName(L, raw);
+    const char *name = M_PushLowerName(L, is_own ? raw + 1 : raw);
 
-    const char *const sep = strchr(name, '.');
-    if (sep == nullptr) {
-        return luaL_error(
-            L, "a script name carries the directory it lives in: <game>.%s",
-            raw);
-    }
-    const size_t root_len = (size_t)(sep - name);
-    if (M_HasRoot(name, root_len, M_ENGINE_ROOT)) {
-        return luaL_error(
-            L,
-            "%s: " M_ENGINE_ROOT
-            ".* is the engine's own, reached as a "
-            "global rather than required",
-            raw);
+    const char *own_dir = nullptr;
+    const char *stem = nullptr;
+    size_t root_len = 0;
+    if (is_own) {
+        own_dir = LUA_GetStartupScriptDir();
+        if (own_dir == nullptr) {
+            return luaL_error(
+                L,
+                "%s: relative names work only while a directory script loads",
+                raw);
+        }
+        // Include the directory in the cache key so each of them gets its own
+        // copy of a module such as .utils.
+        name = lua_pushfstring(L, "%s/%s", own_dir, name);
+        lua_replace(L, 2);
+        stem = name + strlen(own_dir) + 1;
+    } else {
+        const char *const sep = strchr(name, '.');
+        if (sep == nullptr) {
+            return luaL_error(
+                L, "a script name carries the directory it lives in: <game>.%s",
+                raw);
+        }
+        root_len = (size_t)(sep - name);
+        if (M_HasRoot(name, root_len, M_ENGINE_ROOT)) {
+            return luaL_error(
+                L,
+                "%s: " M_ENGINE_ROOT
+                ".* is the engine's own, reached as a "
+                "global rather than required",
+                raw);
+        }
+        stem = sep + 1;
     }
 
     const LUA_CONTEXT context = LUA_GetScriptContext();
@@ -387,7 +435,8 @@ static int M_L_Require(lua_State *const L)
     }
     lua_pop(L, 1);
 
-    const char *const path = M_ResolveScript(L, raw, name, root_len, sep + 1);
+    const char *const path =
+        M_ResolveScript(L, raw, name, root_len, stem, own_dir);
     if (path == nullptr) {
         return luaL_error(L, "no such script: %s", raw);
     }

--- a/src/trx/game/lua/startup.c
+++ b/src/trx/game/lua/startup.c
@@ -12,24 +12,30 @@
 #include <stdlib.h>
 #include <string.h>
 
-static int M_CompareScriptPaths(const void *const a, const void *const b)
+#define M_ENTRY_POINT "init.lua"
+
+typedef struct {
+    char *path;
+    // Directory of the entry point, or null for a loose script.
+    char *dir;
+} M_SCRIPT;
+
+static const char *m_ScriptDir = nullptr;
+
+static int M_CompareScripts(const void *const a, const void *const b)
 {
-    return strcmp(*(const char *const *)a, *(const char *const *)b);
+    return strcmp(((const M_SCRIPT *)a)->path, ((const M_SCRIPT *)b)->path);
 }
 
-// Lists startup scripts in name order so recordings run the same way on every
-// machine.
-static VECTOR *M_ListStartupScripts(void)
+// Add loose Lua files in name order.
+static void M_AddScriptsFrom(VECTOR *const paths, const char *const dir_path)
 {
-    VECTOR *const paths = Vector_Create(sizeof(char *));
-    const char *const dir_path =
-        GamePath_PeekResolve(GAME_DYNAMIC_PATH_STARTUP_SCRIPT_DIR, "");
     if (dir_path == nullptr) {
-        return paths;
+        return;
     }
     FS_DIR *const dir = FS_OpenDirectory(dir_path);
     if (dir == nullptr) {
-        return paths;
+        return;
     }
 
     const char *entry;
@@ -37,13 +43,78 @@ static VECTOR *M_ListStartupScripts(void)
         if (!String_EndsWith(entry, ".lua")) {
             continue;
         }
-        char *const path = String_Format("%s/%s", dir_path, entry);
-        Vector_Add(paths, &path);
+        char *path = String_Format("%s/%s", dir_path, entry);
+        if (FS_DirExists(path)) {
+            Memory_FreePointer(&path);
+            continue;
+        }
+        const M_SCRIPT script = { .path = path, .dir = nullptr };
+        Vector_Add(paths, (void *)&script);
     }
     FS_CloseDirectory(dir);
     qsort(
-        Vector_GetData(paths), paths->count, sizeof(char *),
-        M_CompareScriptPaths);
+        Vector_GetData(paths), paths->count, sizeof(M_SCRIPT),
+        M_CompareScripts);
+}
+
+static int M_CompareNames(const void *const a, const void *const b)
+{
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+// List subdirectories in name order.
+static VECTOR *M_ListSubDirs(const char *const root)
+{
+    VECTOR *const names = Vector_Create(sizeof(char *));
+    FS_DIR *const dir = root == nullptr ? nullptr : FS_OpenDirectory(root);
+    if (dir == nullptr) {
+        return names;
+    }
+    const char *entry;
+    while ((entry = FS_ReadDirectory(dir)) != nullptr) {
+        if (strcmp(entry, ".") == 0 || strcmp(entry, "..") == 0) {
+            continue;
+        }
+        char *name = String_Format("%s/%s", root, entry);
+        if (FS_DirExists(name)) {
+            Vector_Add(names, &name);
+        } else {
+            Memory_FreePointer(&name);
+        }
+    }
+    FS_CloseDirectory(dir);
+    qsort(Vector_GetData(names), names->count, sizeof(char *), M_CompareNames);
+    return names;
+}
+
+// Add each subdirectory's entry point. Ignore directories without one.
+static void M_AddDirScripts(VECTOR *const paths, const char *const root)
+{
+    VECTOR *const dirs = M_ListSubDirs(root);
+    for (int32_t i = 0; i < dirs->count; i++) {
+        char *dir = *(char **)Vector_Get(dirs, i);
+        char *entry_point = String_Format("%s/" M_ENTRY_POINT, dir);
+        char *path = GamePath_ResolveCase(entry_point);
+        Memory_FreePointer(&entry_point);
+        if (path == nullptr) {
+            Memory_FreePointer(&dir);
+            continue;
+        }
+        const M_SCRIPT script = { .path = path, .dir = dir };
+        Vector_Add(paths, (void *)&script);
+    }
+    Vector_Free(dirs);
+}
+
+// List loose scripts before directory scripts.
+static VECTOR *M_ListStartupScripts(void)
+{
+    VECTOR *const paths = Vector_Create(sizeof(M_SCRIPT));
+    char *root = Memory_DupStr(
+        GamePath_PeekResolve(GAME_DYNAMIC_PATH_STARTUP_SCRIPT_DIR, ""));
+    M_AddScriptsFrom(paths, root);
+    M_AddDirScripts(paths, root);
+    Memory_FreePointer(&root);
     return paths;
 }
 
@@ -51,14 +122,22 @@ void LUA_RunStartupScripts(void)
 {
     VECTOR *const paths = M_ListStartupScripts();
     for (int32_t i = 0; i < paths->count; i++) {
-        char *const path = *(char **)Vector_Get(paths, i);
-        LOG_INFO("Running Lua startup script: %s", path);
-        LUA_RESULT res = LUA_EvalFile(path);
+        M_SCRIPT *const script = Vector_Get(paths, i);
+        LOG_INFO("Running Lua startup script: %s", script->path);
+        m_ScriptDir = script->dir;
+        LUA_RESULT res = LUA_EvalFile(script->path);
+        m_ScriptDir = nullptr;
         if (res.code != LUA_OK) {
             Console_ShowError("Lua startup script error: %s", res.message);
         }
         LUA_FreeResult(&res);
-        Memory_Free(path);
+        Memory_FreePointer(&script->path);
+        Memory_FreePointer(&script->dir);
     }
     Vector_Free(paths);
+}
+
+const char *LUA_GetStartupScriptDir(void)
+{
+    return m_ScriptDir;
 }

--- a/src/trx/game/lua/startup.h
+++ b/src/trx/game/lua/startup.h
@@ -1,5 +1,9 @@
 #pragma once
 
-// Runs every Lua script in the engine's scripts/ directory in name order.
-// Reports script errors on the console and continues with the remaining files.
+// Run loose scripts in name order, then each subdirectory's init.lua. Report
+// errors on the console and continue with the remaining scripts.
 void LUA_RunStartupScripts(void);
+
+// Return the directory of the running script, or null for a loose script. The
+// string remains valid until the script returns.
+const char *LUA_GetStartupScriptDir(void);

--- a/src/trx/game/paths.c
+++ b/src/trx/game/paths.c
@@ -1303,6 +1303,14 @@ char *GamePath_GuessExtension(const char *const path, const char **extensions)
     return M_GuessExtensionCached(path, extensions);
 }
 
+char *GamePath_ResolveCase(const char *const path)
+{
+    if (!m_Context.inited) {
+        GamePath_Init(m_Context.args);
+    }
+    return M_ResolveCasePathCached(path);
+}
+
 const char *GamePath_PeekResolveUserPath(
     const GAME_DYNAMIC_PATH path, const char *const input_path)
 {

--- a/src/trx/game/paths.h
+++ b/src/trx/game/paths.h
@@ -109,6 +109,10 @@ bool GamePath_Exists(GAME_DYNAMIC_PATH path, const char *rel);
 // must free.
 char *GamePath_GuessExtension(const char *path, const char **extensions);
 
+// Resolve every path component without regard to case. Return an owning path,
+// or nullptr if the path does not exist. The caller must free the result.
+char *GamePath_ResolveCase(const char *path);
+
 // Resolve a user-supplied path by trying:
 // 1. absolute path as-is
 // 2. current working directory for relative paths


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The script loader now also checks subdirectories under `scripts/`. If a directory contains `init.lua`, it is loaded after the loose scripts, in directory name order.

While a directory's `init.lua` is loading, relative lookups resolve from that directory:

- `trx.inject.declare` checks the current directory before falling back to the game's injections.
- `require` accepts a leading `.` to resolve a module from the current directory.

```lua
local config = require(".config")     -- scripts/example/config.lua
local helpers = require(".helpers")   -- scripts/example/helpers/init.lua
```

Relative modules are cached per directory, so identical module names in different directories remain separate. Relative `require` is only available from `init.lua` while it is loading.

Existing loose scripts under `scripts/` continue to load as before.