### PR TITLE
inject: let a file bring an animated texture range

### DIFF
--- a/src/trx/game/inject/editors/textures.c
+++ b/src/trx/game/inject/editors/textures.c
@@ -102,6 +102,32 @@ static void M_AnimTextureEdits(
     }
 }
 
+// Add a range of textures for a face to cycle through. Move each texture into
+// the space reserved for level textures.
+static void M_AnimTextureAdds(
+    const INJECTION_CONTEXT *const ctx, const INJECTION *const injection,
+    const int32_t data_count)
+{
+    const LEVEL_CONTEXT_INFO cached_info = Inject_GetCachedInfo();
+    for (int32_t i = 0; i < data_count; i++) {
+        const int32_t num_textures = File_ReadS32(injection->fp);
+        if (num_textures <= 0) {
+            continue;
+        }
+
+        int16_t *const textures = Memory_Alloc(sizeof(int16_t) * num_textures);
+        for (int32_t j = 0; j < num_textures; j++) {
+            textures[j] =
+                File_ReadS16(injection->fp) + cached_info.textures.object_count;
+        }
+        if (ctx->mode != INJECTION_MODE_STATS) {
+            Output_AddAnimatedTextureRange((int16_t)num_textures, textures);
+        }
+        Memory_Free(textures);
+    }
+}
+
 REGISTER_INJECT_EDITOR(IDT_TEXTURE_EDITS, M_TextureEdits)
 REGISTER_INJECT_EDITOR(IDT_SPRITE_EDITS, M_SpriteEdits)
 REGISTER_INJECT_EDITOR(IDT_ANIM_TEXTURES, M_AnimTextureEdits)
+REGISTER_INJECT_EDITOR(IDT_ANIM_TEXTURE_ADDS, M_AnimTextureAdds)

--- a/src/trx/game/inject/enum.h
+++ b/src/trx/game/inject/enum.h
@@ -101,7 +101,8 @@ typedef enum {
     IDT_PROPERTY_EDITS     = 39,
     IDT_SYMBOLS            = 40,
     IDT_NAMED_SAMPLE_INFOS = 41,
-    IDT_NUMBER_OF          = 42,
+    IDT_ANIM_TEXTURE_ADDS  = 42,
+    IDT_NUMBER_OF          = 43,
 } INJECTION_DATA_TYPE;
 
 typedef enum {

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -1369,6 +1369,34 @@ SPRITE_TEXTURE *Output_GetSpriteTexture(const int32_t texture_idx)
     return &m_SpriteTextures[texture_idx];
 }
 
+void Output_AddAnimatedTextureRange(
+    const int16_t num_textures, const int16_t *const textures)
+{
+    if (num_textures <= 0) {
+        return;
+    }
+
+    ANIMATED_TEXTURE_RANGE *const range = GameBuf_Alloc(
+        sizeof(ANIMATED_TEXTURE_RANGE), GBUF_ANIMATED_TEXTURE_RANGES);
+    range->num_textures = num_textures;
+    range->textures = GameBuf_Alloc(
+        sizeof(int16_t) * num_textures, GBUF_ANIMATED_TEXTURE_RANGES);
+    memcpy(range->textures, textures, sizeof(int16_t) * num_textures);
+    range->next_range = nullptr;
+
+    if (m_AnimTextureRanges == nullptr) {
+        m_AnimTextureRanges = range;
+        return;
+    }
+
+    // Append the range because callers walk the ranges in insertion order.
+    ANIMATED_TEXTURE_RANGE *tail = m_AnimTextureRanges;
+    while (tail->next_range != nullptr) {
+        tail = tail->next_range;
+    }
+    tail->next_range = range;
+}
+
 ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(const int32_t range_idx)
 {
     if (m_AnimTextureRanges == nullptr) {

--- a/src/trx/game/output/textures.h
+++ b/src/trx/game/output/textures.h
@@ -86,6 +86,12 @@ int32_t Output_GetObjectTextureCount(void);
 int32_t Output_GetSpriteTextureCount(void);
 OBJECT_TEXTURE *Output_GetObjectTexture(int32_t texture_idx);
 SPRITE_TEXTURE *Output_GetSpriteTexture(int32_t texture_idx);
+
+// Add a range of textures for a face to cycle through. Keep the level's ranges
+// before ranges added by injections.
+void Output_AddAnimatedTextureRange(
+    int16_t num_textures, const int16_t *textures);
+
 ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(int32_t range_idx);
 
 RGBA_8888 Output_RGB2RGBA(RGB_888 color);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

An injection could only animate texture ranges already in the level, and only when their counts matched. An injection may now add its own range, with its textures remapped into the space assigned by the level as the file is read.

Ref https://github.com/LostArtefacts/TRXInjectionTool/pull/367